### PR TITLE
fix(stella-cli): clear the four defects the deck freeze investigation left behind

### DIFF
--- a/crates/stella-cli/src/agent/graph.rs
+++ b/crates/stella-cli/src/agent/graph.rs
@@ -641,12 +641,17 @@ pub(super) fn report_retired_vectors(
 /// `tokio::spawn`ed session task, and a bare `&mut dyn FnMut(_)` would make
 /// the whole future non-`Send` — the same trap `drive_index_blocking`
 /// documents above.
+///
+/// The pass itself runs on a thread of its own
+/// (`backfill::spawn_on_own_thread`): it is SQLite, file reads and HTTP
+/// interleaved, and as a task here it would hold this runtime's worker for
+/// every synchronous step. This task only relays what the thread reports.
 async fn backfill_vectors_quietly(
     root: &std::path::Path,
     status: &mut (dyn FnMut(InitLine) + Send),
     readiness: &mut (dyn FnMut(IndexReadiness) + Send),
 ) {
-    use crate::search_cmd::backfill::{BackfillOutcome, backfill_workspace_vectors};
+    use crate::search_cmd::backfill::{BackfillOutcome, spawn_on_own_thread};
     use crate::search_cmd::semantic::WarmOutcome;
 
     let stella_embed::Resolution::Configured(embedder) =
@@ -655,22 +660,36 @@ async fn backfill_vectors_quietly(
         return;
     };
 
+    // Read before the embedder crosses to its thread: the settled report at
+    // the end asks the store about this fingerprint.
+    let fingerprint = stella_embed::Embedder::fingerprint(embedder.as_ref()).id();
     let mut ticker = ProgressTicker::new(INDEX_PROGRESS_INTERVAL);
     // Every tick is the pass saying "still filling"; the settled report is
     // this function's last act, below, and belongs to nobody else — a pass
     // that declared itself settled from the inside would release the prompt
     // gate one batch before it was true.
-    let outcome = backfill_workspace_vectors(root, embedder.as_ref(), &mut |measured| {
-        readiness(measured);
-        if ticker.ready(Instant::now()) {
-            status(InitLine::Progress(format!(
-                "· semantic index: {} of {} files embedded…",
-                measured.indexed_files(),
-                measured.total_files
-            )));
+    let outcome = match spawn_on_own_thread(root.to_path_buf(), embedder) {
+        Ok(mut pass) => {
+            while let Some(measured) = pass.progress().await {
+                readiness(measured);
+                if ticker.ready(Instant::now()) {
+                    status(InitLine::Progress(format!(
+                        "· semantic index: {} of {} files embedded…",
+                        measured.indexed_files(),
+                        measured.total_files
+                    )));
+                }
+            }
+            pass.join().await.unwrap_or_else(|| {
+                BackfillOutcome::Unavailable(
+                    "the embedding pass ended without reporting".to_string(),
+                )
+            })
         }
-    })
-    .await;
+        Err(error) => BackfillOutcome::Unavailable(format!(
+            "cannot start the embedding pass's thread: {error}"
+        )),
+    };
 
     match &outcome {
         BackfillOutcome::Ran {
@@ -707,7 +726,6 @@ async fn backfill_vectors_quietly(
     // graph store. That is SQLite, so it runs on the blocking pool and not
     // on this task's worker. A report that could not run settles as unknown,
     // and unknown holds nothing. That is how `measure` fails too.
-    let fingerprint = stella_embed::Embedder::fingerprint(embedder.as_ref()).id();
     let report_root = root.to_path_buf();
     let measured =
         tokio::task::spawn_blocking(move || settled_readiness(&report_root, &fingerprint))

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -800,22 +800,26 @@ pub async fn run_deck_session(
     // default (`stella-dark`).
     theme_cmd::apply_persisted(cfg);
 
+    let dictation = voice::VoiceOptions::load(cfg);
     let opts = DeckOptions {
         debug_log_path: debug_log_path(),
         slash_commands: deck_slash_commands(&custom),
-        initial_graph: agent::graph_snapshot(&cfg.workspace_root),
+        // Seeded below, once the deck is up: reading the graph is SQLite, and
+        // reading it here delayed the first frame by however long it took.
+        initial_graph: None,
         recent_path: Some(palette_recent_path(&cfg.workspace_root)),
         no_anim,
         accessible,
         mouse_capture: mouse,
         mid_turn_prompt: steer::mid_turn_prompt_policy(cfg),
-        voice_enabled: voice::enabled(cfg),
-        voice_mode: voice::mode(cfg),
+        voice_enabled: dictation.enabled,
+        voice_mode: dictation.mode,
     };
     // The deck owns its channel ends and runs on its own thread, so nothing
     // the driver blocks on can hold a keystroke (`deck_thread`).
     let deck =
         deck_thread::spawn(opts, deck_rx, sub_tx).map_err(|e| format!("deck thread: {e}"))?;
+    graph_input::seed(cfg.workspace_root.clone(), in_tx.clone());
 
     // The launch cinematic: hold the splash's battle loop open over session
     // init and release it once BOTH async legs — the background code-graph

--- a/crates/stella-cli/src/command_deck/graph_input.rs
+++ b/crates/stella-cli/src/command_deck/graph_input.rs
@@ -15,6 +15,27 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::agent;
 
+/// Seed the GRAPH tab with the workspace's busiest neighborhood, off the
+/// driver task.
+///
+/// The read is SQLite over a store that can be hundreds of megabytes. Done on
+/// the driver task before the deck spawns, as `DeckOptions::initial_graph`
+/// invites, it cannot freeze a deck, since there is none yet, but it holds the
+/// first frame for as long as it takes. So the deck starts with no graph and
+/// this fills it in from the blocking pool, the same out-of-band refresh path
+/// a re-root answer takes. A workspace with no index sends nothing, and the
+/// tab shows its "run `stella init`" hint, as it does for any `None`.
+///
+/// Fire-and-forget by design: the deck does not wait on it, and a send that
+/// fails means the deck is already gone.
+pub(super) fn seed(workspace_root: std::path::PathBuf, in_tx: UnboundedSender<Inbound>) {
+    tokio::task::spawn_blocking(move || {
+        if let Some(snapshot) = agent::graph_snapshot(&workspace_root) {
+            let _ = in_tx.send(Inbound::GraphSnapshot(snapshot));
+        }
+    });
+}
+
 /// Answer a re-root request by requerying and pushing a fresh snapshot back,
 /// the same out-of-band refresh path `/init` uses.
 ///

--- a/crates/stella-cli/src/command_deck/voice.rs
+++ b/crates/stella-cli/src/command_deck/voice.rs
@@ -42,29 +42,52 @@ const DEFAULT_PROVIDER: &str = "openai";
 /// — the recorder stops accumulating even if the stop never arrives.
 const MAX_CAPTURE_SECS: u32 = 120;
 
-/// Whether dictation is switched on for this workspace (`voice.enabled`) —
-/// threaded into `DeckOptions` so the deck's machine never arms when holding
-/// space is meant to type spaces.
-pub(super) fn enabled(cfg: &Config) -> bool {
-    Settings::load(&cfg.workspace_root)
-        .ok()
-        .and_then(|s| s.voice.as_ref().and_then(|v| v.enabled))
-        .unwrap_or(false)
+/// The two `[voice]` values the deck is handed at start, read from one load
+/// of the settings stack.
+///
+/// One struct rather than one resolver per field: `run_deck_session` fills
+/// two `DeckOptions` fields from these, and a resolver per field read and
+/// merged the user, managed and project settings files once per field. The
+/// next voice setting is a field here, not a third load.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(super) struct VoiceOptions {
+    /// Whether dictation is switched on for this workspace (`voice.enabled`),
+    /// so the deck's machine never arms when holding space is meant to type
+    /// spaces.
+    pub(super) enabled: bool,
+    /// Which spacebar gesture dictates (`voice.mode`).
+    pub(super) mode: stella_tui::voice::VoiceMode,
 }
 
-/// Which spacebar gesture dictates (`voice.mode`), threaded into
-/// `DeckOptions` beside [`enabled`].
-///
-/// Validated here rather than stored typed, the house convention for a slug
-/// in settings: an unreadable value falls back to the default gesture, so a
-/// typo costs the mode a person asked for and never dictation itself.
-pub(super) fn mode(cfg: &Config) -> stella_tui::voice::VoiceMode {
-    Settings::load(&cfg.workspace_root)
-        .ok()
-        .and_then(|s| s.voice.as_ref().and_then(|v| v.mode.clone()))
-        .as_deref()
-        .and_then(stella_tui::voice::VoiceMode::parse)
-        .unwrap_or_default()
+impl VoiceOptions {
+    /// Read both values from `cfg`'s workspace, loading the settings stack
+    /// once.
+    pub(super) fn load(cfg: &Config) -> Self {
+        Self::from_loaded(Settings::load(&cfg.workspace_root).as_ref())
+    }
+
+    /// The pure half of [`Self::load`]: what one load of the settings stack
+    /// resolves to.
+    ///
+    /// An unreadable stack yields the defaults, dictation off on the hold
+    /// gesture, exactly as an absent `[voice]` section does: the deck must
+    /// start whatever a settings file holds, and the parse error is already
+    /// reported where the settings are loaded for everything else.
+    ///
+    /// The gesture is validated here rather than stored typed, the house
+    /// convention for a slug in settings: an unreadable value falls back to
+    /// the default gesture, so a typo costs the mode a person asked for and
+    /// never dictation itself.
+    fn from_loaded(loaded: Result<&Settings, &String>) -> Self {
+        let voice = loaded.ok().and_then(|settings| settings.voice.as_ref());
+        Self {
+            enabled: voice.and_then(|v| v.enabled).unwrap_or(false),
+            mode: voice
+                .and_then(|v| v.mode.as_deref())
+                .and_then(stella_tui::voice::VoiceMode::parse)
+                .unwrap_or_default(),
+        }
+    }
 }
 
 /// One in-flight capture, or nothing. Held by `run_deck_session` across the
@@ -585,6 +608,52 @@ mod tests {
             .unwrap();
         assert!(model_at < lang_at && lang_at < file_at);
         assert!(text.ends_with("\r\n--B--\r\n"));
+    }
+
+    /// **The witness for the one-load resolver.** Both deck values come out
+    /// of one loaded stack, and a stack that cannot be read yields the defaults: dictation
+    /// off, on the hold gesture. Driven through `Settings::load_from` on a
+    /// file that is not JSON, so the unreadable case is the real one and not
+    /// a hand-built `Err`.
+    #[test]
+    fn an_unreadable_settings_stack_yields_dictation_off_on_hold() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, "{ this is not json").unwrap();
+        let loaded = Settings::load_from(std::slice::from_ref(&path));
+        assert!(loaded.is_err(), "the fixture must be unreadable");
+        assert_eq!(
+            VoiceOptions::from_loaded(loaded.as_ref()),
+            VoiceOptions {
+                enabled: false,
+                mode: stella_tui::voice::VoiceMode::Hold,
+            }
+        );
+    }
+
+    #[test]
+    fn a_readable_voice_section_fills_both_deck_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"{"voice": {"enabled": true, "mode": "tap"}}"#).unwrap();
+        let loaded = Settings::load_from(std::slice::from_ref(&path));
+        assert_eq!(
+            VoiceOptions::from_loaded(loaded.as_ref()),
+            VoiceOptions {
+                enabled: true,
+                mode: stella_tui::voice::VoiceMode::Tap,
+            }
+        );
+        // A gesture slug nobody defined costs the gesture, never dictation.
+        std::fs::write(&path, r#"{"voice": {"enabled": true, "mode": "hum"}}"#).unwrap();
+        let loaded = Settings::load_from(std::slice::from_ref(&path));
+        assert_eq!(
+            VoiceOptions::from_loaded(loaded.as_ref()),
+            VoiceOptions {
+                enabled: true,
+                mode: stella_tui::voice::VoiceMode::Hold,
+            }
+        );
     }
 
     #[test]

--- a/crates/stella-graph/src/graph.rs
+++ b/crates/stella-graph/src/graph.rs
@@ -755,7 +755,20 @@ impl CodeGraph {
     /// Stop the watcher and background tasks. Idempotent. Dropping the watcher
     /// closes the event channel, so the debounce loop exits on its own; task
     /// handles are aborted as a backstop.
+    ///
+    /// This is also the writer's close, so it refreshes the planner's
+    /// statistics (`store::optimize`). An embedding pass writes tens of
+    /// thousands of vector rows through this handle. Nothing else analyzes
+    /// them. Best-effort: a failure here changes no data, and the next close
+    /// tries again. The wait is bounded by `busy_timeout`, and only another
+    /// process's open write can make it pay that.
     pub fn shutdown(&self) {
+        // Before the flag flips, so a handle shut down twice pays once. The
+        // optimize is cheap on an unchanged store, so a second call would
+        // only be a wasted lock.
+        if !self.inner.shutdown.load(Ordering::Relaxed) {
+            let _ = store::optimize(&self.inner.write_guard());
+        }
         // Set the shutdown flag *and* clear the watcher slot under one hold of
         // the watcher lock. `set_watcher` re-checks the flag under this same
         // lock, so install and shutdown serialize: a watcher installed
@@ -928,6 +941,66 @@ mod tests {
             files.len(),
             2,
             "only the first two indexed files may be visited: {files:?}"
+        );
+    }
+
+    /// **The witness for the planner's statistics.** A store that never runs
+    /// `ANALYZE` gives the planner no `sqlite_stat1` to read. An index pass
+    /// leaves statistics for the tables it filled. The writer's close leaves
+    /// them for the vector rows an embedding pass wrote through it, and
+    /// `code_graph_chunk_vectors` is one of those. `ANALYZE` writes no row for
+    /// an empty table. That is why the chunk half stores a vector first: the
+    /// row can only exist once the table holds something.
+    #[test]
+    fn an_index_pass_and_a_close_leave_planner_statistics_behind() {
+        let ws = TempDir::new().unwrap();
+        let dbdir = TempDir::new().unwrap();
+        let db = dbdir.path().join("codegraph.db");
+        std::fs::write(ws.path().join("a.rs"), "pub fn alpha() {}\n").unwrap();
+        let graph = CodeGraph::open(ws.path(), &db).unwrap();
+        graph.index_all().unwrap();
+
+        let stat_tables = |conn: &Connection| -> Vec<String> {
+            let mut stmt = conn
+                .prepare("SELECT DISTINCT tbl FROM sqlite_stat1 ORDER BY tbl")
+                .expect("sqlite_stat1 exists after an index pass");
+            stmt.query_map([], |row| row.get::<_, String>(0))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap()
+        };
+        assert!(
+            stat_tables(&graph.inner.read_guard()).contains(&"code_graph_files".to_string()),
+            "the index pass analyzed the tables it filled"
+        );
+
+        // The embedding pass writes vectors through the handle and then shuts
+        // it down; the close is what analyzes them.
+        let fingerprint = "test-model@1/4/l2";
+        let scan = graph.chunks_pending_embedding(fingerprint, 10).unwrap();
+        let file = &scan.files[0];
+        let rows: Vec<vectors::chunks::ChunkVector> = file
+            .chunks
+            .iter()
+            .map(|chunk| vectors::chunks::ChunkVector {
+                chunk_sha256: chunk.chunk_sha256.clone(),
+                name: chunk.name.clone(),
+                kind: chunk.kind.clone(),
+                start_line: chunk.start_line,
+                end_line: chunk.end_line,
+                vector: Some(vec![1.0, 0.0, 0.0, 0.0]),
+            })
+            .collect();
+        graph
+            .store_chunk_vectors(fingerprint, &file.path, &file.file_sha256, &rows)
+            .unwrap();
+        graph.shutdown();
+
+        let reopened = Connection::open(&db).unwrap();
+        assert!(
+            stat_tables(&reopened).contains(&"code_graph_chunk_vectors".to_string()),
+            "the writer's close analyzed the vector rows it wrote: {:?}",
+            stat_tables(&reopened)
         );
     }
 

--- a/crates/stella-graph/src/store.rs
+++ b/crates/stella-graph/src/store.rs
@@ -541,7 +541,37 @@ pub(crate) fn index_tree_with_progress(
     stats.files_pruned += prune_missing(&tx, &current)?;
 
     tx.commit()?;
+    // After the commit, never inside it: `PRAGMA optimize` runs `ANALYZE`,
+    // which writes `sqlite_stat1` and cannot run inside an open transaction.
+    // A refreshed index can only have moved the tables' row counts.
+    optimize(conn)?;
     Ok(stats)
+}
+
+/// Give the query planner statistics to plan from.
+///
+/// A store that has never run `ANALYZE` has no `sqlite_stat1` table, and the
+/// planner then picks indexes from their shape alone. That is how the coverage
+/// count in `vectors::chunks` landed on the fingerprint index and took eleven
+/// seconds a call. The covering index that fixed that one query gave the
+/// planner a match nothing else could beat; this gives it the numbers to get
+/// the next query right without one.
+///
+/// `PRAGMA optimize`, not a bare `ANALYZE`, because it analyzes only the
+/// tables whose statistics are missing or stale and bounds each run with its
+/// own temporary analysis limit, so it costs almost nothing on an unchanged
+/// store. Measured on 2026-09-05 over a copy of this repository's 195 MB
+/// graph: 0.26 s with no statistics at all, 3 ms on the run after. The
+/// `0x10000` bit is what SQLite's own guidance sets for a long-lived
+/// connection: it looks at every table's size rather than only the tables the
+/// connection has queried, which is what lets a writer that has only ever
+/// inserted into a table still analyze it.
+///
+/// Called on the writer's connection outside any transaction: after an index
+/// pass has committed, and when a graph shuts down.
+pub(crate) fn optimize(conn: &Connection) -> Result<(), GraphError> {
+    conn.execute_batch("PRAGMA optimize=0x10002;")?;
+    Ok(())
 }
 
 /// Apply a specific set of changed paths (from the watcher): index the ones

--- a/crates/stella-tools/src/search/backfill.rs
+++ b/crates/stella-tools/src/search/backfill.rs
@@ -45,15 +45,105 @@
 //! coverage of the *whole* tree for the cost of one row a file, so a pass
 //! interrupted halfway leaves an index that can answer roughly about
 //! everything rather than precisely about a tenth of it.
+//!
+//! # Where it runs
+//!
+//! On a thread of its own, under a runtime of its own ([`spawn_on_own_thread`]).
+//! The pass interleaves SQLite reads and writes, file reads and hashing, and
+//! the embedder's HTTP round trips, across three modules; run as a task on
+//! the session's runtime it held a worker for every one of the synchronous
+//! parts, and on 2026-09-05 one of those — a coverage count over the graph —
+//! took eleven seconds after every batch and kept the deck's keyboard dead for
+//! six minutes. The count is fast now and the deck runs on its own thread, so
+//! the freeze cannot recur; the pass blocking a worker was still the defect
+//! AGENTS.md architecture rule 2 names. A thread puts every
+//! synchronous call in the pass off the runtime by construction, including
+//! the next one somebody adds, where `spawn_blocking` around each call would
+//! have to be re-applied by hand and forgotten once.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use stella_embed::Embedder;
 use stella_graph::CodeGraph;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::oneshot;
 
 use super::engine::{ChunkWarmOutcome, warm_chunks_opened};
 use super::readiness::{IndexReadiness, measure};
 use super::semantic::{WarmOutcome, warm_opened};
+
+/// A backfill running on its own thread, started by [`spawn_on_own_thread`].
+///
+/// Progress and the outcome both cross back as messages, so the caller's
+/// callbacks run on the caller's runtime and the thread borrows nothing from
+/// it: the same shape lets the deck session forward readiness to the deck and
+/// would let `stella init` narrate through an emitter that is not `Send`.
+pub struct BackfillThread {
+    progress: UnboundedReceiver<IndexReadiness>,
+    done: oneshot::Receiver<BackfillOutcome>,
+}
+
+impl BackfillThread {
+    /// The next readiness report, or `None` once the pass has stopped
+    /// reporting. Every report is unsettled, as [`backfill_opened`] says.
+    pub async fn progress(&mut self) -> Option<IndexReadiness> {
+        self.progress.recv().await
+    }
+
+    /// Wait for the pass to end. `None` means the thread ended without
+    /// reporting, which only a panic in the pass does.
+    pub async fn join(self) -> Option<BackfillOutcome> {
+        // Anything still queued is the pass's business, not the caller's: a
+        // caller that stopped reading progress wants the outcome alone.
+        drop(self.progress);
+        self.done.await.ok()
+    }
+}
+
+/// Run [`backfill_workspace_vectors`] on a new thread under a current-thread
+/// runtime, reporting back over channels.
+///
+/// Fails only when the OS refuses the thread; then there is no pass, and the
+/// caller says so. A runtime that cannot be built is reported as
+/// [`BackfillOutcome::Unavailable`] through the same channel as any other
+/// outcome, because to the caller it is the same fact: nothing was filled.
+///
+/// The embedder is owned by the thread and dropped with it. An HTTP client
+/// pools connections on the runtime that opened them, so the client the pass
+/// uses must not outlive the pass's runtime — which is why the caller hands
+/// one over rather than lending the session's.
+pub fn spawn_on_own_thread(
+    root: PathBuf,
+    embedder: Box<dyn Embedder>,
+) -> std::io::Result<BackfillThread> {
+    let (progress_tx, progress) = tokio::sync::mpsc::unbounded_channel();
+    let (done_tx, done) = oneshot::channel();
+    std::thread::Builder::new()
+        .name("stella-embed-backfill".to_owned())
+        .spawn(move || {
+            let outcome = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime.block_on(backfill_workspace_vectors(
+                    &root,
+                    embedder.as_ref(),
+                    &mut |measured| {
+                        // A caller that stopped listening loses nothing it
+                        // wanted; the pass runs on regardless.
+                        let _ = progress_tx.send(measured);
+                    },
+                )),
+                Err(error) => BackfillOutcome::Unavailable(format!(
+                    "cannot start a runtime for the embedding pass: {error}"
+                )),
+            };
+            // The receiver reads a dropped sender as the thread ending
+            // without a report; a caller gone first has nothing to be told.
+            let _ = done_tx.send(outcome);
+        })?;
+    Ok(BackfillThread { progress, done })
+}
 
 /// What one backfill pass did.
 ///
@@ -265,6 +355,176 @@ mod tests {
             "the pass must run to exhaustion, not to a cap"
         );
         graph.shutdown();
+    }
+
+    /// [`indexed_fixture`] at the path a workspace's own pass opens
+    /// (`.stella/private/codegraph.db`), for the tests that run the pass from
+    /// the root rather than against a handle they hold. Closed on return: the
+    /// pass opens its own.
+    fn indexed_private_fixture(root: &Path, files: usize) {
+        for index in 0..files {
+            std::fs::write(
+                root.join(format!("file_{index}.rs")),
+                format!("pub fn thing_{index}() -> usize {{ {index} }}\n"),
+            )
+            .expect("write a fixture file");
+        }
+        let db_path = stella_store::workspace_private_sqlite_path(root, "codegraph.db")
+            .expect("the private store path");
+        let graph = CodeGraph::open(root, &db_path).expect("open the graph");
+        graph.index_all().expect("index the fixture");
+        graph.shutdown();
+    }
+
+    /// How long the blocking embedder holds whatever thread it runs on.
+    const HOLD: std::time::Duration = std::time::Duration::from_millis(500);
+
+    /// A backend that **blocks** its thread rather than awaiting: it wakes
+    /// the probe, then sleeps with `std::thread::sleep`. It stands in for
+    /// every synchronous step in the pass — the SQLite counts, the file
+    /// reads, the hashing — with a hold long enough to measure.
+    #[derive(Debug)]
+    struct BlockingEmbedder {
+        wake: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<std::time::Instant>>>,
+    }
+
+    #[async_trait]
+    impl Embedder for BlockingEmbedder {
+        fn fingerprint(&self) -> EmbedderFingerprint {
+            EmbedderFingerprint {
+                model_id: "blocking".into(),
+                revision: "1".into(),
+                dims: 2,
+                normalization: "l2".into(),
+            }
+        }
+
+        async fn embed(&self, texts: &[String]) -> Result<Vec<Embedding>, EmbedError> {
+            if let Some(wake) = self.wake.lock().expect("the wake slot").take() {
+                let _ = wake.send(std::time::Instant::now());
+                std::thread::sleep(HOLD);
+            }
+            let fingerprint = self.fingerprint().id();
+            Ok(texts
+                .iter()
+                .map(|text| {
+                    let mut vector = vec![text.len() as f32, 1.0];
+                    stella_embed::l2_normalize(&mut vector);
+                    Embedding {
+                        fingerprint: fingerprint.clone(),
+                        vector,
+                    }
+                })
+                .collect())
+        }
+
+        fn similarity_posture(&self) -> SimilarityPosture {
+            SimilarityPosture::Semantic {
+                admission_floor: 0.2,
+            }
+        }
+    }
+
+    /// One worker, so the thread the pass blocks — if it blocks a worker — is
+    /// the only worker there is. A probe task waits for the embedder's wake
+    /// and answers; returns how long the answer took from the wake.
+    fn probe_latency(
+        host: impl FnOnce(PathBuf, Box<dyn Embedder>) -> ProbeHandle,
+    ) -> std::time::Duration {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let root = workspace.path().canonicalize().expect("canonicalize");
+        indexed_private_fixture(&root, 2);
+        let (wake_tx, wake_rx) = tokio::sync::oneshot::channel();
+        let embedder: Box<dyn Embedder> = Box::new(BlockingEmbedder {
+            wake: std::sync::Mutex::new(Some(wake_tx)),
+        });
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("runtime");
+        runtime.block_on(async move {
+            let probe = tokio::spawn(async move {
+                let woken = wake_rx.await.expect("the embedder wakes the probe");
+                woken.elapsed()
+            });
+            let pass = host(root, embedder);
+            let latency = probe.await.expect("the probe answers");
+            pass.await;
+            latency
+        })
+    }
+
+    type ProbeHandle = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>;
+
+    /// **The witness for the thread.** The pass on its own thread blocks its own
+    /// thread and nothing else: a task on the session's runtime answers a
+    /// wake at once while the pass sits in a synchronous call.
+    #[test]
+    fn a_pass_on_its_own_thread_cannot_hold_a_runtime_worker() {
+        let latency = probe_latency(|root, embedder| {
+            let pass = spawn_on_own_thread(root, embedder).expect("thread");
+            Box::pin(async move {
+                let outcome = pass.join().await.expect("the pass reports");
+                assert!(
+                    matches!(outcome, BackfillOutcome::Ran { .. }),
+                    "{outcome:?}"
+                );
+            })
+        });
+        assert!(
+            latency < HOLD / 2,
+            "the probe waited {latency:?} on a worker the pass does not run on"
+        );
+    }
+
+    /// The hazard the witness above guards against, kept so the harness is
+    /// shown to tell the two apart: the same pass hosted as a task on the
+    /// runtime holds the one worker for the whole synchronous call, and the
+    /// probe waits out the hold. This is the shape the session task had.
+    #[test]
+    fn the_same_pass_as_a_runtime_task_holds_the_worker_for_the_whole_call() {
+        let latency = probe_latency(|root, embedder| {
+            let task = tokio::spawn(async move {
+                backfill_workspace_vectors(&root, embedder.as_ref(), &mut |_| {}).await
+            });
+            Box::pin(async move {
+                let _ = task.await;
+            })
+        });
+        assert!(
+            latency >= HOLD,
+            "a task-hosted pass let the probe answer in {latency:?}; the worker was not held and \
+             this test's premise has changed"
+        );
+    }
+
+    /// Progress crosses the thread boundary as messages and the outcome
+    /// follows them: what the session driver reads.
+    #[test]
+    fn progress_and_outcome_cross_back_from_the_thread() {
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let root = workspace.path().canonicalize().expect("canonicalize");
+        indexed_private_fixture(&root, 3);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        runtime.block_on(async move {
+            let mut pass =
+                spawn_on_own_thread(root, Box::new(CountingEmbedder::default())).expect("thread");
+            let mut ticks = 0usize;
+            while let Some(measured) = pass.progress().await {
+                assert!(!measured.settled, "the pass never declares itself settled");
+                ticks += 1;
+            }
+            assert!(ticks > 0, "a pass that embedded files must report");
+            let outcome = pass.join().await.expect("the pass reports");
+            assert!(
+                matches!(outcome, BackfillOutcome::Ran { .. }),
+                "{outcome:?}"
+            );
+        });
     }
 
     /// The lease is what stops two sessions on one workspace embedding the

--- a/crates/stella-tui/src/deck_shell.rs
+++ b/crates/stella-tui/src/deck_shell.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crossterm::event::{self, Event, KeyEventKind};
+use crossterm::event::{Event, KeyEventKind};
 use ratatui::backend::CrosstermBackend;
 use ratatui::text::{Line, Text};
 use ratatui::widgets::{Paragraph, Widget};
@@ -654,7 +654,9 @@ fn write_scrollback(
 /// Run the command deck to completion. [`Inbound`] envelopes stream in over
 /// `inbound`; the user's [`WorkspaceInput`]s stream out over `submissions`.
 /// Returns when the inbound stream closes or the user quits, having always
-/// restored the terminal first.
+/// restored the terminal first. Returns an error when the key reader stops on
+/// its own — the terminal could not be read, or stdin closed — so the driver
+/// can say why the deck ended instead of reporting a quit.
 pub async fn run_deck(
     opts: DeckOptions,
     mut inbound: UnboundedReceiver<Inbound>,
@@ -746,26 +748,14 @@ pub async fn run_deck(
     // `spawn_shell_command`) — persists across every dispatch this loop makes.
     let shell_active = Arc::new(AtomicUsize::new(0));
 
-    // Blocking crossterm reader → async loop, with a shutdown flag.
-    let (key_tx, mut key_rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
+    // Blocking crossterm reader → async loop, with a shutdown flag. The
+    // reader reports why it stopped, and the loop returns that report
+    // (`crate::key_reader`) — a lane that closes is never read as a quit.
     let shutdown = Arc::new(AtomicBool::new(false));
-    let reader_shutdown = shutdown.clone();
-    let reader = std::thread::spawn(move || {
-        while !reader_shutdown.load(Ordering::Relaxed) {
-            match event::poll(Duration::from_millis(50)) {
-                Ok(true) => match event::read() {
-                    Ok(ev) => {
-                        if key_tx.send(ev).is_err() {
-                            break;
-                        }
-                    }
-                    Err(_) => break,
-                },
-                Ok(false) => {}
-                Err(_) => break,
-            }
-        }
-    });
+    let (reader, mut key_rx) = crate::key_reader::spawn(shutdown.clone());
+    // Why the loop ended, when it ended on something other than a quit or
+    // the engine closing the stream. Returned after the terminal is restored.
+    let mut ended: io::Result<()> = Ok(());
 
     let mut tick = tokio::time::interval(TICK);
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -831,7 +821,18 @@ pub async fn run_deck(
                 }
             }
             maybe_key = key_rx.recv() => {
-                match maybe_key {
+                let event = match crate::key_reader::event(maybe_key) {
+                    Ok(event) => event,
+                    // The reader stopped — a terminal crossterm could not
+                    // parse, a stdin that closed, a thread that died. The
+                    // session ends as it did before, and now says why.
+                    Err(error) => {
+                        debug.note(&error.to_string());
+                        ended = Err(error);
+                        break 'run;
+                    }
+                };
+                match event {
                     // `⌃V`: explicit clipboard pull — the only way a *bitmap*
                     // (a copied screenshot) reaches the deck, since bracketed
                     // paste never carries one. The image payload is stored
@@ -842,7 +843,7 @@ pub async fn run_deck(
                     // The capture itself is blocking OS I/O, so it runs on
                     // the blocking pool and the result returns on `clip_rx` —
                     // the draw loop never waits on the clipboard.
-                    Some(Event::Key(key))
+                    Event::Key(key)
                         if key.kind != KeyEventKind::Release && is_clipboard_pull(key) =>
                     {
                         let tx = clip_tx.clone();
@@ -857,7 +858,7 @@ pub async fn run_deck(
                     // terminals without `REPORT_EVENT_TYPES` this arm never
                     // fires and the repeat-gap fallback in the tick arm ends
                     // the hold instead (`crate::voice`).
-                    Some(Event::Key(key)) if key.kind == KeyEventKind::Release => {
+                    Event::Key(key) if key.kind == KeyEventKind::Release => {
                         if is_plain_space(key) {
                             let cmd = ui.voice.space_release(model.now_ms);
                             apply_voice_cmd(cmd, &mut ui, &submissions);
@@ -868,11 +869,11 @@ pub async fn run_deck(
                     // tap mode it is the second tap, which ends the capture
                     // (`crate::voice::VoiceUi::swallowed_space`). Esc
                     // abandons the capture in both.
-                    Some(Event::Key(key)) if ui.voice.swallows_space() && is_plain_space(key) => {
+                    Event::Key(key) if ui.voice.swallows_space() && is_plain_space(key) => {
                         let cmd = ui.voice.swallowed_space(model.now_ms);
                         apply_voice_cmd(cmd, &mut ui, &submissions);
                     }
-                    Some(Event::Key(key))
+                    Event::Key(key)
                         if ui.voice.esc_cancels()
                             && key.code == crossterm::event::KeyCode::Esc =>
                     {
@@ -880,7 +881,7 @@ pub async fn run_deck(
                             let _ = submissions.send(WorkspaceInput::VoiceCancel);
                         }
                     }
-                    Some(Event::Key(key)) => {
+                    Event::Key(key) => {
                         // Snapshot for the voice observation below: dispatch
                         // decides where the key goes, and the composer's own
                         // growth says whether a plain space became text.
@@ -925,7 +926,7 @@ pub async fn run_deck(
                     // each of which would have submitted a separate prompt.
                     // Routed by the UI: the agent-definition editor claims
                     // it while open (`DeckUi::paste`).
-                    Some(Event::Paste(text)) => {
+                    Event::Paste(text) => {
                         ui.paste(&text);
                         // A paste is typing, not holding.
                         ui.voice.interrupt();
@@ -941,7 +942,7 @@ pub async fn run_deck(
                     // same `apply_deck_action` a key's is: a wheel notch over
                     // a modal overlay re-enters the key dispatch (synthesized
                     // arrows), so its action can be anything a key's can.
-                    Some(Event::Mouse(mouse)) => {
+                    Event::Mouse(mouse) => {
                         ui.notice.dismiss();
                         let width = terminal.size()?.width;
                         let action = crate::mouse::handle_deck_mouse(mouse, width, &model, &mut ui);
@@ -958,9 +959,7 @@ pub async fn run_deck(
                         }
                     }
                     // Resize / focus change: the next draw picks them up.
-                    Some(_) => {}
-                    // Reader thread ended (stdin closed).
-                    None => break 'run,
+                    _ => {}
                 }
             }
             maybe_local = local_rx.recv(), if local_open => {
@@ -1022,7 +1021,7 @@ pub async fn run_deck(
         debug.note(&format!("final scrollback flush failed: {error}"));
     }
     debug.note("deck session end");
-    Ok(())
+    ended
 }
 
 #[cfg(test)]

--- a/crates/stella-tui/src/key_reader.rs
+++ b/crates/stella-tui/src/key_reader.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The deck's key reader. A thread reads keys from crossterm, which blocks,
+//! and sends them down a channel the run loop selects on. This module also
+//! owns what the reader says when it stops.
+//!
+//! Suppose the reader hit a crossterm error and just broke out of its loop.
+//! The channel would close. The run loop would read `None` and stop too.
+//! `run_deck` would return `Ok(())`. The driver would report a clean exit.
+//! A terminal that sends bytes crossterm cannot parse would look like the
+//! user pressing quit. So would a stdin that closed under the deck. The deck
+//! opts into the kitty keyboard protocol, so a parse error is a real risk.
+//!
+//! So every way the reader can stop is a message. An error is sent before the
+//! thread ends. A channel that closes with no error sent is reported too,
+//! since only a dying thread does that. [`event`] is the one place the run
+//! loop reads the lane, so it cannot take either one for a quit.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use crossterm::event::{self as crossterm_event, Event};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+/// One message from the reader: a terminal event, or the error that stopped
+/// it. An `Err` is always the last message.
+pub type KeyRead = io::Result<Event>;
+
+/// How long one poll waits before the loop checks the shutdown flag again.
+/// Long enough that an idle deck does not spin. Short enough that a quit
+/// joins the thread with no visible pause.
+const POLL: Duration = Duration::from_millis(50);
+
+/// Start the reader thread. It runs until `shutdown` is set or crossterm
+/// fails. A failure is sent on the channel before the thread ends.
+pub fn spawn(
+    shutdown: Arc<AtomicBool>,
+) -> (std::thread::JoinHandle<()>, UnboundedReceiver<KeyRead>) {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let handle = std::thread::spawn(move || {
+        pump(
+            || match crossterm_event::poll(POLL)? {
+                true => crossterm_event::read().map(Some),
+                false => Ok(None),
+            },
+            &tx,
+            &shutdown,
+        );
+    });
+    (handle, rx)
+}
+
+/// The reader's loop over any source of events. The tests drive this seam.
+///
+/// `next` returns `Ok(Some(event))` for an event. It returns `Ok(None)` when a
+/// poll timed out. It returns `Err` when the terminal cannot be read. The
+/// loop forwards events until the run loop hangs up or `shutdown` is set. On
+/// an error it sends the error and ends. So the receiver always learns why
+/// the lane closed.
+fn pump(
+    mut next: impl FnMut() -> io::Result<Option<Event>>,
+    tx: &UnboundedSender<KeyRead>,
+    shutdown: &AtomicBool,
+) {
+    while !shutdown.load(Ordering::Relaxed) {
+        match next() {
+            Ok(Some(event)) => {
+                if tx.send(Ok(event)).is_err() {
+                    break;
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                // The receiver may be gone already. Then there is nobody to
+                // tell, and nothing is lost.
+                let _ = tx.send(Err(error));
+                break;
+            }
+        }
+    }
+}
+
+/// How the run loop reads one message off the lane.
+///
+/// `Some(Ok(event))` is an event to dispatch. `Some(Err)` is the reader
+/// saying why it stopped. `None` is the reader gone with no word. The last
+/// two become the error `run_deck` returns. Each names the key reader, so
+/// the driver's line says the reader ended and not that the user quit.
+pub fn event(read: Option<KeyRead>) -> io::Result<Event> {
+    match read {
+        Some(Ok(event)) => Ok(event),
+        Some(Err(error)) => Err(io::Error::new(
+            error.kind(),
+            format!("the deck's key reader stopped: {error}"),
+        )),
+        None => Err(io::Error::other(
+            "the deck's key reader ended without reporting why (stdin closed, or the reader thread died)",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(c: char) -> Event {
+        Event::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
+    }
+
+    /// **The reader half of the witness.** A source that fails hands the
+    /// channel the error, then closes it, in that order. A reader that drops
+    /// the error leaves the close as all the loop can see.
+    #[test]
+    fn a_failing_source_sends_its_error_before_the_channel_closes() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let shutdown = AtomicBool::new(false);
+        let mut reads = vec![
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unparsed escape",
+            )),
+            Ok(Some(key('a'))),
+        ]
+        .into_iter();
+        pump(
+            || {
+                reads
+                    .next_back()
+                    .expect("the source is asked twice at most")
+            },
+            &tx,
+            &shutdown,
+        );
+        drop(tx);
+
+        assert!(
+            matches!(rx.try_recv(), Ok(Ok(Event::Key(_)))),
+            "the key before the failure is delivered"
+        );
+        let error = rx
+            .try_recv()
+            .expect("the error is the next message")
+            .expect_err("an error");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            rx.try_recv().is_err(),
+            "nothing follows the error; the lane is closed"
+        );
+    }
+
+    /// The shutdown flag ends the reader with no message. That is the run
+    /// loop's own quit. It is not an error.
+    #[test]
+    fn shutdown_ends_the_reader_quietly() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let shutdown = AtomicBool::new(true);
+        pump(|| panic!("never polled once shut down"), &tx, &shutdown);
+        drop(tx);
+        assert!(rx.try_recv().is_err());
+    }
+
+    /// **The run-loop half of the witness.** A closed lane is an error that
+    /// names the reader, never a clean `Ok`. A reported error keeps its kind
+    /// and its text.
+    #[tokio::test]
+    async fn a_closed_lane_is_an_error_naming_the_reader_not_a_clean_exit() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<KeyRead>();
+        drop(tx);
+        let error = event(rx.recv().await).expect_err("a closed lane is not Ok");
+        assert!(error.to_string().contains("key reader"), "{error}");
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<KeyRead>();
+        tx.send(Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unparsed escape",
+        )))
+        .unwrap();
+        let error = event(rx.recv().await).expect_err("a reported error is returned");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("unparsed escape"), "{error}");
+        assert!(error.to_string().contains("key reader"), "{error}");
+
+        assert!(matches!(event(Some(Ok(key('q')))), Ok(Event::Key(_))));
+    }
+}

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -53,6 +53,7 @@ pub mod clipboard;
 pub mod composer;
 pub mod debug_log;
 pub mod input;
+pub mod key_reader;
 pub mod keymap;
 pub mod model;
 pub mod panel_guard;


### PR DESCRIPTION
## What & why

The deck freeze investigation (#5981) left four defects it could not fix in scope. This PR fixes all four. They share one origin and each is small, so they ship together; each has its own witness.

**The embedding backfill ran on the runtime worker (#5982).** The pass interleaves SQLite, file reads, hashing and HTTP across three modules. It now runs on a thread of its own under a current-thread runtime (`backfill::spawn_on_own_thread` in `crates/stella-tools/src/search/backfill.rs`). Progress and the outcome cross back as messages, so the session task only relays them. A thread rather than `spawn_blocking` around each call, because the next synchronous call added inside the pass is then off the runtime by construction. The deck's first graph snapshot moves off the driver task too: `initial_graph` starts `None` and `graph_input::seed` fills it from the blocking pool once the deck is up, so the first frame no longer waits on a SQLite read. The exemplar is `deck_thread.rs`, the same shape the freeze fix gave the deck.

**The key reader ended silently (#5983).** `crates/stella-tui/src/key_reader.rs` is a new flat sibling module (a `deck_shell/` folder would trip the module-siblings guard). The reader sends its crossterm error before it ends; `run_deck` returns it and writes it to the debug log, so the driver prints `deck terminal error: the deck's key reader stopped: …` instead of a clean exit.

**`codegraph.db` never ran `ANALYZE` (#5984).** `store::optimize` runs `PRAGMA optimize=0x10002` after every index pass commits and on `CodeGraph::shutdown`, the writer's close. The `0x10000` bit is SQLite's own recommendation for a long-lived connection: it checks every table's size, not only the tables the connection has queried, which is what lets a writer that has only inserted into a table still analyze it. Measured on a copy of this repository's 195 MB graph: 0.26 s with no statistics, 3 ms on the next run, and every table gained a row including `code_graph_chunk_vectors_coverage`. One fact the issue's DoD did not anticipate: `ANALYZE` writes no `sqlite_stat1` row for an empty table, so the chunk-vectors row appears after the first embedding pass closes the writer, not after a bare index pass. The witness stores a vector first for that reason.

**The deck loaded the settings stack twice (#5988).** `voice::VoiceOptions::load` reads both voice values from one `Settings::load`. `command_deck.rs` gains one line for it and one for the graph seed; the logic lives in the siblings.

Closes #5982
Closes #5983
Closes #5984
Closes #5988
Refs #6102

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

| Fix | Witness | Fails on main because |
|---|---|---|
| #5982 | `backfill::tests::a_pass_on_its_own_thread_cannot_hold_a_runtime_worker` (one-worker runtime, a probe task, an embedder that blocks its thread; the probe must answer inside half the hold). Its control `the_same_pass_as_a_runtime_task_holds_the_worker_for_the_whole_call` shows the harness tells the two apart. `progress_and_outcome_cross_back_from_the_thread` covers the channel shape. | `spawn_on_own_thread` does not exist |
| #5983 | `key_reader::tests::a_closed_lane_is_an_error_naming_the_reader_not_a_clean_exit` (the run loop's arm, driven with a closed channel) and `a_failing_source_sends_its_error_before_the_channel_closes` (the reader's loop, driven with a failing source) | the module does not exist; the old arm read `None` as a quit |
| #5984 | `graph::tests::an_index_pass_and_a_close_leave_planner_statistics_behind`; `vectors::chunks::tests::the_coverage_predicate_probes_its_own_index_not_the_fingerprint_scan` still passes with statistics present | `sqlite_stat1` does not exist, so the `prepare` panics |
| #5988 | `voice::tests::an_unreadable_settings_stack_yields_dictation_off_on_hold` and `a_readable_voice_section_fills_both_deck_values` | `VoiceOptions` does not exist |

Ran locally, scoped per SCR-001: `cargo test -p stella-tools backfill` (12 passed), `cargo test -p stella-tui key_reader` (3 passed), `cargo test -p stella-graph an_index_pass_and_a_close` and `cargo test -p stella-graph chunks` (1 and 4 passed), `cargo test -p stella-cli voice` (15 passed), `cargo clippy -p stella-tui -p stella-tools -p stella-graph -p stella-cli --all-targets -- -D warnings` clean, `make guards-fast` green. CI is the evidence for the rest.

## The gate

- [x] `cargo fmt --check`
- [x] clippy on the four touched crates locally; the workspace run is CI's
- [x] the touched crates' tests locally; the workspace run is CI's
- [x] Docs updated where behavior changed (doc comments; `run_deck`'s contract line names the new error return)
- [x] CLA signed
- [x] `Closes #N` appears both above and as commit trailers

## Nothing left behind

- [x] Filed: #6102 — `stella init`'s eager embedding pass still runs its SQLite and file reads on the runtime worker. Its progress emitter is not `Send` and its two rungs narrate separately, so it did not follow the session's pass onto the thread in this PR.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

- `command_deck.rs` grows by two lines (the voice load and the graph seed). It is 945 lines under its baseline ceiling after the earlier splits, and the logic sits in `voice.rs` and `graph_input.rs`.
- `CodeGraph::shutdown` now takes the write mutex once and waits on `busy_timeout` if another process holds an open write transaction. Only another process's `index_tree` transaction (seconds) can make it wait; every other write here is a short per-batch transaction.
- The embedder's `reqwest::Client` is owned by the backfill thread and dropped with its runtime; the client pools connections on the runtime that opened them, which is why the pass is handed a client rather than lent the session's. The session resolves a fresh embedder per pass already, so nothing else shared it.

## Summary by Sourcery

Prevent deck freezes and silent failures by isolating embedding work, reporting key-reader errors, refreshing SQLite statistics, and consolidating startup settings loading.

Bug Fixes:
- Run embedding backfills off the session runtime and move initial graph loading off the driver task to prevent deck freezes.
- Surface terminal and key-reader failures instead of treating them as clean deck exits.
- Refresh SQLite planner statistics after index passes and graph shutdowns.
- Load deck voice settings once while preserving safe defaults for unreadable or invalid configuration.

Enhancements:
- Improve deck startup responsiveness by performing graph seeding asynchronously and consolidating voice option resolution.

Tests:
- Add witness coverage for backfill thread isolation and cross-thread progress reporting, key-reader failure propagation, SQLite statistics generation, and consolidated voice settings resolution.