### PR TITLE
feat(stella-cli,stella-learn): record a trial for a memory record and a mined rule

### DIFF
--- a/crates/stella-cli/src/command_deck/steering.rs
+++ b/crates/stella-cli/src/command_deck/steering.rs
@@ -47,7 +47,9 @@ pub(super) fn announce_session_steering(cfg: &Config, in_tx: &UnboundedSender<In
 /// unlike the withheld-checkout refusal it names no remedy to scroll back to.
 fn announce_holdout(cfg: &Config, in_tx: &UnboundedSender<Inbound>) {
     let rate = crate::memory::session_artifact_holdout_rate(&cfg.workspace_root);
-    if let Some(line) = stella_learn::holdout::disclosure(rate, "skill") {
+    // Three kinds share the schedule and take it in turn
+    // (`memory::trials::HOLDOUT_ARMS`), so the line names all three.
+    if let Some(line) = stella_learn::holdout::disclosure(rate, "memory, skill or record") {
         let _ = in_tx.send(Inbound::Notice(line));
     }
 }

--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -87,6 +87,10 @@ mod steering;
 pub(crate) use steering::SessionRequery;
 pub(crate) use steering::requery_for_turn;
 mod suppression;
+// The offered->selected join for the two kinds recall renders — a memory
+// record and a mined rule — and the turn-end write into the shared trial
+// ledger.
+mod trials;
 pub(crate) mod tuning;
 // Phase 4 (#715): context-use extraction — what a finished turn's frame
 // carried, and what the turn then said about it.
@@ -370,11 +374,14 @@ pub struct SessionMemory {
     holdout_turn: u64,
     /// Which holdout this turn is, counting from zero, or `None` when this
     /// turn holds nothing back. Set by `arm_recall_control()` alongside
-    /// `ab_suppressed`, read by [`Self::note_turn_skills`] when it picks the
-    /// skill to withhold.
+    /// `ab_suppressed`, and read wherever the withheld item is picked —
+    /// [`Self::note_turn_skills`] for a skill, `trials` for a memory or a
+    /// record.
     ///
     /// The ordinal rather than the rate and the turn, so the pick cannot
-    /// disagree with the arm about which schedule it is on.
+    /// disagree with the arm about which schedule it is on. It also says
+    /// which kind this holdout is for: the three take the schedule in turn
+    /// (`trials::HOLDOUT_ARMS`).
     holdout_ordinal: Option<u64>,
     /// Phase 3 (#714): `context.lifecycle.enabled`, read once at open. While
     /// this is off the learning loop runs exactly the lexical path that ships
@@ -418,6 +425,15 @@ pub struct SessionMemory {
     /// than a plain field because the consumer runs behind `&self` on the
     /// async episode path; it is touched twice a turn and never contended.
     turn_skill_join: std::sync::Mutex<Option<TurnSkillJoin>>,
+    /// The same join for the two kinds recall renders, plus the id this
+    /// turn's holdout settled on ([`trials`]).
+    ///
+    /// Its own cell rather than a share of [`Self::turn_skill_join`] because
+    /// the two are armed in different places: a skill join is noted once, by
+    /// the selection pass at turn start, while a memory or a record is noted
+    /// by every render the turn makes. A `Mutex` for the reason that one has
+    /// one — the consumer runs behind `&self` on the async episode path.
+    context_trials: std::sync::Mutex<trials::TurnContextTrials>,
     /// The session's time source (#2320) — the only one the learning loop is
     /// allowed to read.
     ///
@@ -657,6 +673,7 @@ impl SessionMemory {
                     task_id,
                     execution_id: None,
                     turn_skill_join: std::sync::Mutex::new(None),
+                    context_trials: std::sync::Mutex::new(trials::TurnContextTrials::default()),
                     clock,
                 })
             }
@@ -826,10 +843,16 @@ impl SessionMemory {
     /// shares, rather than the shortlist in front of it, which they do not. A
     /// turn whose pick was not going to be injected anyway holds nothing back:
     /// that costs the experiment samples and cannot cost it correctness. The
-    /// catalog is read only on a turn the schedule armed, which is one turn in
-    /// `context.retrieval.artifact_holdout_rate`.
+    /// catalog is read only on a turn the schedule armed and pointed at
+    /// skills, which is one holdout in the length of `trials::HOLDOUT_ARMS`.
     fn apply_holdout(&self, selection: &mut skills::SkillSelection) -> Option<String> {
         let ordinal = self.holdout_ordinal?;
+        // One item goes per turn, and three kinds share the schedule
+        // (`trials::HOLDOUT_ARMS`), so a turn the schedule points at a
+        // memory or a record holds no skill back.
+        if trials::holdout_kind(ordinal) != Some(stella_learn::ledger::ArtifactKind::Skill) {
+            return None;
+        }
         let loaded = self.load_skills();
         let names: Vec<&str> = loaded.iter().map(|s| s.name.as_str()).collect();
         let held = stella_learn::holdout::pick(ordinal, &names)?;
@@ -944,19 +967,7 @@ impl SessionMemory {
             stella_learn::ledger::ArtifactKind::Skill,
             &join.trigger_matched,
             &join.selected,
-            &stella_learn::skills::appraisal::SkillTrial {
-                task: appraisals::LIVE_WINDOW_TASK.to_string(),
-                // Overwritten per skill by `record_turn`; the value here is
-                // never read.
-                selected: false,
-                outcome: stella_learn::self_tuning::TaskOutcome {
-                    succeeded,
-                    cost_usd: 0.0,
-                    tokens: 0,
-                    retries: 0,
-                },
-                turns: 1,
-            },
+            &trials::live_trial(succeeded),
         );
     }
 
@@ -988,6 +999,10 @@ impl SessionMemory {
         // through here with the settled outcome, which makes this the one
         // seam that can turn the turn-start selection note into a trial.
         self.record_skill_trials(outcome == EpisodeOutcome::Success);
+        // The same seam for the two kinds recall renders. Beside the skill
+        // call rather than inside it: a turn can render a record without
+        // matching any skill trigger, and the reverse.
+        self.record_context_trials(outcome == EpisodeOutcome::Success);
 
         let mut summary: String = prompt.chars().take(240).collect();
         if prompt.chars().count() > 240 {

--- a/crates/stella-cli/src/memory/appraisals.rs
+++ b/crates/stella-cli/src/memory/appraisals.rs
@@ -23,11 +23,11 @@
 //! # One trial ledger, three kinds
 //!
 //! [`TRIALS_FILE`] holds a row per artifact per turn, keyed by
-//! [`stella_learn::ledger::ArtifactKind`] and an id. Skills are the only kind
-//! with a producer today. A memory record and a mined rule are recalled by
-//! `memory::recall`, which reports no join, so each needs a seam of its own
-//! before it can be written here. The key is shared so that when those seams
-//! land there is one ledger to read rather than three.
+//! [`stella_learn::ledger::ArtifactKind`] and an id. All three kinds have a
+//! producer: `SessionMemory::record_skill_trials` writes the skill rows, and
+//! `SessionMemory::record_context_trials` (`memory::trials`) writes the
+//! memory and rule rows from what each render offered and showed. One key,
+//! so [`sweep`] reads one ledger rather than three.
 //!
 //! [`LEGACY_TRIALS_FILE`] holds the rows a build that only knew skills wrote:
 //! a `skill` field and no kind. [`sweep`] reads both files and
@@ -219,7 +219,8 @@ pub fn queued_candidates(workspace_root: &Path) -> Vec<QueuedCandidate> {
 /// measured against itself. Wider and the baseline fills with turns the
 /// artifact could not have affected, which measures those turns rather than the
 /// artifact. For a skill that population is the skills whose trigger matched
-/// the prompt.
+/// the prompt; for a memory it is what the recall query answered; for a rule
+/// it is the records that applied to the turn's facts.
 pub fn record_turn(
     workspace_root: &Path,
     kind: ArtifactKind,

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -275,31 +275,6 @@ impl SessionMemory {
             super::records_refresh::rules_digest(&self.workspace_root);
     }
 
-    /// This turn's volatile record channel, rendered: the registry's volatile
-    /// channel, selected by `applies_to` against the turn's prompt and the
-    /// paths it names. `None` when this session has no records at all.
-    ///
-    /// Returns the registry alongside the render because the steering
-    /// adapters (`stella_records::adapt`) resolve the rendered handles
-    /// back through it for their token estimates — the render and the ledger
-    /// must come from one selection pass, not two.
-    fn turn_record_rendered(
-        &self,
-        prompt: &str,
-    ) -> Option<(stella_records::records::Registry, RenderedChannel)> {
-        // Cloned out of the lock rather than borrowed through it: the caller
-        // threads the registry across the rest of its selection pass, and a
-        // guard held that long would block a concurrent freshness swap.
-        let registry = self.record_registry.read().expect("records lock").clone()?;
-        let paths = turn_path_tokens(prompt);
-        let facts = stella_records::records::TurnFacts {
-            text: prompt,
-            paths: &paths,
-        };
-        let rendered = registry.render_volatile_for_turn(&facts, Some(RECORD_CHANNEL_BUDGET));
-        Some((registry, rendered))
-    }
-
     /// The record channel's section and eviction report, with an injectable
     /// diagnostic sink — the same split as
     /// [`Self::recalled_frames_reporting`] and for the same reason: the
@@ -321,7 +296,7 @@ impl SessionMemory {
         prompt: &str,
         mut report: impl FnMut(String),
     ) -> Option<String> {
-        let (registry, rendered) = self.turn_record_rendered(prompt)?;
+        let (registry, rendered) = self.turn_records_for_prompt(prompt)?;
         for drop in stella_records::adapt::record_drops(&registry, &rendered) {
             // A record channel drop is never also selected — the channel's
             // own budget cut it before the plane saw it.
@@ -415,7 +390,7 @@ impl SessionMemory {
         // tokens on every turn and is worth them on almost none — which is why it
         // is selected per turn: a record scoped by `applies_to` renders only when
         // this prompt names a matching path, task, or keyword.
-        let record = self.turn_record_rendered(prompt);
+        let record = self.turn_records_for_prompt(prompt);
 
         let signal = stella_core::steering::TurnSignal {
             prompt,
@@ -432,7 +407,8 @@ impl SessionMemory {
             eprintln!("  {} {message}", "!".yellow())
         });
 
-        let frames = kept_frames(&recall.frames, &set);
+        // The holdout's memory arm, and this turn's memory join, in one door.
+        let frames = self.withhold_held_memory(&recall.frames, kept_frames(&recall.frames, &set));
         let kept = kept_skills(&selected.selected, &set);
         let record_handles = record
             .as_ref()
@@ -550,23 +526,15 @@ impl SessionMemory {
                 paths.push(path.clone());
             }
         }
-        let registry = self.record_registry.read().expect("records lock").clone();
-        let record = registry.map(|registry| {
-            let facts = stella_records::records::TurnFacts {
-                text: prompt,
-                paths: &paths,
-            };
-            // The per-record half of the #4498 dedup: the channel renders
-            // as one budgeted block, so leaving out what the turn has seen
-            // means re-rendering without those records, not filtering a
-            // list — the exclusion door is the registry's.
-            let rendered = registry.render_volatile_for_turn_excluding(
-                &facts,
-                Some(RECORD_CHANNEL_BUDGET),
-                produced.records(),
-            );
-            (registry, rendered)
-        });
+        let facts = stella_records::records::TurnFacts {
+            text: prompt,
+            paths: &paths,
+        };
+        // The per-record half of the #4498 dedup, and the holdout's rule arm:
+        // the channel renders as one budgeted block, so leaving out what the
+        // turn has seen means re-rendering without those records, not
+        // filtering a list — the exclusion door is the registry's.
+        let record = self.turn_records_held(&facts, produced.records());
 
         let set = query_gathered_plane(
             signal,
@@ -581,14 +549,20 @@ impl SessionMemory {
 
         // The per-frame cut this block exists to make. It runs AFTER the plane
         // has packed, not before the query: the drop is about what the model
-        // has already been shown, and the ledger must still report the frame as
-        // selected — recall spent the tokens fetching it either way, and a
-        // ledger that quietly forgot the ones the render suppressed would
-        // under-report the fan-out the re-query paid for.
-        let frames: Vec<RecalledFrame> = kept_frames(&recall.frames, &set)
-            .into_iter()
-            .filter(|frame| !produced.has_frame(&super::steering::frame_handle(frame)))
-            .collect();
+        // has already been shown, and the recall telemetry must still report
+        // the frame — recall spent the tokens fetching it either way, and a
+        // report that quietly forgot the ones the render suppressed would
+        // under-report the fan-out the re-query paid for. The trial ledger is
+        // a different question and gets a different answer: `produced` frames
+        // were shown earlier this turn, so `withhold_held_memory` folds them
+        // into the turn's selected set even though this block leaves them out.
+        let frames = self.withhold_held_memory(
+            &recall.frames,
+            kept_frames(&recall.frames, &set)
+                .into_iter()
+                .filter(|frame| !produced.has_frame(&super::steering::frame_handle(frame)))
+                .collect(),
+        );
         let kept: Vec<skills::SelectedSkill> = kept_skills(&selected.selected, &set)
             .into_iter()
             .filter(|sel| !produced.has_skill(&sel.skill.name))
@@ -688,6 +662,8 @@ impl SessionMemory {
     /// that injects nothing anyway, and whether this is one is not settled
     /// until the plane arm is.
     fn arm_controls(&mut self, recall_rate: u32, holdout_rate: u32) -> bool {
+        // The join and the holdout pick belong to the turn that armed them.
+        self.reset_context_trials();
         let suppressed = self.maybe_suppress_recall(recall_rate);
         self.arm_artifact_holdout(holdout_rate);
         suppressed

--- a/crates/stella-cli/src/memory/trials.rs
+++ b/crates/stella-cli/src/memory/trials.rs
@@ -1,0 +1,306 @@
+//! Trials for the two things recall puts in front of the model: a memory
+//! record, and a mined rule.
+//!
+//! A trial says what a turn could have used, and what it did use.
+//! [`appraisals::sweep`] needs both. With only the second it has no control
+//! arm, so it can never say whether the thing helped.
+//!
+//! Skills got this seam first. `SessionMemory::note_turn_skills` notes the
+//! join at turn start, and `record_skill_trials` writes it at turn end. This
+//! is the same pair of moves for the other two kinds, whose half of the
+//! ledger had no producer and so stayed empty.
+//!
+//! # One pick per turn
+//!
+//! A turn can render more than once. The opening block runs one query, and a
+//! mid-turn re-query runs another. Each pass scores its own shortlist, so the
+//! two see different things. A holdout picked per pass could drop one record
+//! from the first block and a different one from the second, and the ledger
+//! would then describe neither turn. The skill arm hit that bug, and fixed
+//! it by sharing one pick across its passes.
+//!
+//! So the pick is made once, by the first pass that has something to pick
+//! from, and every later pass in the turn reads it back. The turn's offered
+//! set is the union of what the passes offered, and its selected set is the
+//! union of what they showed.
+//!
+//! # One item per turn
+//!
+//! [`stella_learn::holdout`] holds one item back per turn. That rule does
+//! not bend for a third kind. Hold a skill and a memory back on one turn,
+//! and every memory control turn is a skill control turn too. Then neither
+//! arm can say which one the outcome belongs to.
+//!
+//! So the three kinds take the schedule in turn. [`HOLDOUT_ARMS`] is the
+//! order, and `stella_learn::holdout::arm` says whose turn it is.
+
+use std::collections::HashSet;
+
+use stella_learn::ledger::ArtifactKind;
+use stella_learn::self_tuning::TaskOutcome;
+use stella_learn::skills::appraisal::SkillTrial;
+use stella_protocol::RecalledFrame;
+use stella_records::records::{Registry, RenderedChannel, TurnFacts};
+
+use super::recall::{RECORD_CHANNEL_BUDGET, turn_path_tokens};
+use super::steering::frame_handle;
+use super::{SessionMemory, appraisals};
+
+/// The kinds that take the holdout schedule in turn.
+///
+/// A kind's place in this list is the arm number
+/// `stella_learn::holdout::arm` returns. Skill is first because it was here
+/// first. It held the schedule alone. Move it now and every live workspace
+/// holds its next skill back on a different turn.
+pub(super) const HOLDOUT_ARMS: [ArtifactKind; 3] = [
+    ArtifactKind::Skill,
+    ArtifactKind::Memory,
+    ArtifactKind::Rule,
+];
+
+/// Which kind the `ordinal`-th holdout acts on.
+pub(super) fn holdout_kind(ordinal: u64) -> Option<ArtifactKind> {
+    stella_learn::holdout::arm(ordinal, HOLDOUT_ARMS.len())
+        .and_then(|arm| HOLDOUT_ARMS.get(arm).copied())
+}
+
+/// One turn of the live window, before `appraisals::record_turn` sets
+/// `selected` per artifact.
+///
+/// One shape for all three kinds. A row is the same row whatever the id
+/// names. A second copy of this literal is a second place for the window's
+/// task key to drift.
+pub(super) fn live_trial(succeeded: bool) -> SkillTrial {
+    SkillTrial {
+        task: appraisals::LIVE_WINDOW_TASK.to_string(),
+        // Set per artifact by `appraisals::record_turn`. This value is never
+        // read.
+        selected: false,
+        outcome: TaskOutcome {
+            succeeded,
+            cost_usd: 0.0,
+            tokens: 0,
+            retries: 0,
+        },
+        turns: 1,
+    }
+}
+
+/// What one kind's turn offered, and what it showed.
+#[derive(Debug, Default)]
+struct KindJoin {
+    offered: Vec<String>,
+    selected: Vec<String>,
+}
+
+impl KindJoin {
+    /// Fold one render pass in. Order is kept and repeats are dropped. The
+    /// ledger rows then land in the order the turn met them.
+    fn note(&mut self, offered: &[String], selected: &[String]) {
+        for id in offered {
+            if !self.offered.contains(id) {
+                self.offered.push(id.clone());
+            }
+        }
+        for id in selected {
+            if !self.selected.contains(id) {
+                self.selected.push(id.clone());
+            }
+        }
+    }
+}
+
+/// What this turn has to say about its memories and its rules.
+#[derive(Debug, Default)]
+pub(crate) struct TurnContextTrials {
+    memories: KindJoin,
+    rules: KindJoin,
+    /// What the holdout settled on. One pair, because one item goes per
+    /// turn: the kind whose turn it is, and the id it picked.
+    held: Option<(ArtifactKind, String)>,
+}
+
+impl TurnContextTrials {
+    /// This kind's join, to fold a pass into.
+    fn join_mut(&mut self, kind: ArtifactKind) -> Option<&mut KindJoin> {
+        match kind {
+            ArtifactKind::Memory => Some(&mut self.memories),
+            ArtifactKind::Rule => Some(&mut self.rules),
+            // Skills keep their own join on the session. It is armed at turn
+            // start by the selection pass, not by a render.
+            ArtifactKind::Skill => None,
+        }
+    }
+}
+
+impl SessionMemory {
+    /// Drop the turn's join and its holdout pick.
+    ///
+    /// Called where the turn arms its controls. A turn that never reaches an
+    /// episode then leaves no population for the next one.
+    pub(super) fn reset_context_trials(&self) {
+        if let Ok(mut guard) = self.context_trials.lock() {
+            *guard = TurnContextTrials::default();
+        }
+    }
+
+    /// The id this turn holds back for `kind`, settled from `population` the
+    /// first time a pass asks and read back after that.
+    ///
+    /// `None` on three counts: this turn is not a holdout turn, the schedule
+    /// is on another kind, or there was nothing to pick from.
+    fn held_for(&self, kind: ArtifactKind, population: &[String]) -> Option<String> {
+        let ordinal = self.holdout_ordinal?;
+        if holdout_kind(ordinal) != Some(kind) {
+            return None;
+        }
+        let mut guard = self.context_trials.lock().ok()?;
+        if guard.held.is_none() {
+            let ids: Vec<&str> = population.iter().map(String::as_str).collect();
+            guard.held =
+                stella_learn::holdout::pick(ordinal, &ids).map(|id| (kind, id.to_string()));
+        }
+        match &guard.held {
+            Some((held, id)) if *held == kind => Some(id.clone()),
+            _ => None,
+        }
+    }
+
+    /// Fold one render pass into this turn's join for `kind`.
+    fn note_context_trial(&self, kind: ArtifactKind, offered: &[String], selected: &[String]) {
+        let Ok(mut guard) = self.context_trials.lock() else {
+            return;
+        };
+        if let Some(join) = guard.join_mut(kind) {
+            join.note(offered, selected);
+        }
+    }
+
+    /// Take this turn's held-back memory out of a block about to render, and
+    /// note what the block offered and showed.
+    ///
+    /// `offered` is what the recall query answered. Both arms come from that
+    /// set. It takes in the frames the plane's budget then cut, because a
+    /// frame that lost its seat is still one this turn could have used.
+    /// `kept` is what the model is about to read.
+    ///
+    /// No per-turn notice here, unlike the skill arm. The deck says at boot
+    /// what the schedule costs. A memory handle is not a name a reader can
+    /// act on.
+    pub(super) fn withhold_held_memory(
+        &self,
+        offered: &[RecalledFrame],
+        kept: Vec<RecalledFrame>,
+    ) -> Vec<RecalledFrame> {
+        let population: Vec<String> = offered.iter().map(frame_handle).collect();
+        let shown = match self.held_for(ArtifactKind::Memory, &population) {
+            None => kept,
+            Some(held) => kept
+                .into_iter()
+                .filter(|frame| frame_handle(frame) != held)
+                .collect(),
+        };
+        let selected: Vec<String> = shown.iter().map(frame_handle).collect();
+        self.note_context_trial(ArtifactKind::Memory, &population, &selected);
+        shown
+    }
+
+    /// This turn's volatile record channel, with the holdout's pick left out
+    /// and the turn's join noted.
+    ///
+    /// The registry rides back with the render. The steering adapters
+    /// (`stella_records::adapt`) resolve the rendered handles through it for
+    /// their token estimates. The render and the ledger must come from one
+    /// selection pass, not two.
+    ///
+    /// A holdout turn renders twice. The channel is one budgeted block. A
+    /// record left out through the exclusion door lands in neither
+    /// `rendered` nor `dropped`. Read the population after that and it is
+    /// missing the one record the trial is about. So the first render leaves
+    /// nothing out and gives the population. The second is what the model
+    /// reads.
+    pub(super) fn turn_records_held(
+        &self,
+        facts: &TurnFacts<'_>,
+        already_rendered: &HashSet<String>,
+    ) -> Option<(Registry, RenderedChannel)> {
+        // Cloned out of the lock rather than borrowed through it. The caller
+        // threads the registry across the rest of its selection pass. A guard
+        // held that long would block a mid-session freshness swap.
+        let registry = self.record_registry.read().expect("records lock").clone()?;
+        let offered = registry.render_volatile_for_turn_excluding(
+            facts,
+            Some(RECORD_CHANNEL_BUDGET),
+            already_rendered,
+        );
+        let population: Vec<String> = offered
+            .rendered
+            .iter()
+            .chain(offered.dropped.iter())
+            .cloned()
+            .collect();
+        let rendered = match self.held_for(ArtifactKind::Rule, &population) {
+            None => offered,
+            Some(held) => {
+                let mut excluded = already_rendered.clone();
+                excluded.insert(held);
+                registry.render_volatile_for_turn_excluding(
+                    facts,
+                    Some(RECORD_CHANNEL_BUDGET),
+                    &excluded,
+                )
+            }
+        };
+        self.note_context_trial(ArtifactKind::Rule, &population, &rendered.rendered);
+        Some((registry, rendered))
+    }
+
+    /// [`Self::turn_records_held`] for a turn described by its prompt alone —
+    /// the facts the turn-opening block selects on.
+    pub(super) fn turn_records_for_prompt(
+        &self,
+        prompt: &str,
+    ) -> Option<(Registry, RenderedChannel)> {
+        let paths = turn_path_tokens(prompt);
+        let facts = TurnFacts {
+            text: prompt,
+            paths: &paths,
+        };
+        self.turn_records_held(&facts, &HashSet::new())
+    }
+
+    /// Append this turn's memory and rule trials to the shared ledger.
+    ///
+    /// Beside `record_skill_trials` on the episode seam. It takes the join
+    /// rather than reading it, so one turn writes its rows once.
+    ///
+    /// A turn that offered nothing of a kind writes nothing for that kind. It
+    /// is not evidence about any memory or any rule. Best effort, like every
+    /// ledger write here: a failed write must never fail its own turn.
+    pub(super) fn record_context_trials(&self, succeeded: bool) {
+        let Ok(mut guard) = self.context_trials.lock() else {
+            return;
+        };
+        let joins = std::mem::take(&mut *guard);
+        drop(guard);
+        let trial = live_trial(succeeded);
+        for (kind, join) in [
+            (ArtifactKind::Memory, &joins.memories),
+            (ArtifactKind::Rule, &joins.rules),
+        ] {
+            if join.offered.is_empty() {
+                continue;
+            }
+            appraisals::record_turn(
+                &self.workspace_root,
+                kind,
+                &join.offered,
+                &join.selected,
+                &trial,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/memory/trials/tests.rs
+++ b/crates/stella-cli/src/memory/trials/tests.rs
@@ -16,18 +16,23 @@ use crate::memory::{SessionMemory, appraisals};
 /// The lesson stored as a memory, and the prompt that recalls it.
 const LESSON: &str = "always use the obsolete frobnicator for database migrations";
 
-/// The handle of the one record the fixture registry holds.
-const RECORD_HANDLE: &str = "ctx.acme.staging-url";
-
 /// A workspace with a session memory over an empty context store.
 fn session(dir: &std::path::Path) -> SessionMemory {
     std::fs::create_dir_all(dir.join(".stella")).expect("stella dir");
     SessionMemory::open(dir, false).expect("session memory")
 }
 
-/// Hand the session one volatile record. It is unscoped, so it applies to
-/// every turn. The rule population is then one handle.
-fn with_one_record(memory: &mut SessionMemory) {
+/// Hand the session one volatile record, and give back the `^handle` the
+/// ledger files it under.
+///
+/// The handle is read off the loaded registry rather than spelled here. It
+/// is derived from the lineage and widens on a collision, so a literal in
+/// this file would be a second copy of a rule that lives in
+/// `stella_records::records::handle`.
+///
+/// The record is unscoped, so it applies to every turn. The rule population
+/// is then one handle.
+fn with_one_record(memory: &mut SessionMemory) -> String {
     let file = stella_learn::rules::RuleFile {
         path: ".stella/rules/ctx.acme.staging.toml".to_string(),
         contents: r#"
@@ -47,11 +52,18 @@ force = "may"
         .to_string(),
         contributed_by: None,
     };
-    memory.set_record_registry(stella_records::records::registry::load(
+    let registry = stella_records::records::registry::load(
         &[],
         &[file],
         &stella_records::records::Facts::default(),
-    ));
+    );
+    let handle = registry
+        .entries
+        .first()
+        .map(|entry| entry.record.handle.clone())
+        .expect("the fixture loads one record");
+    memory.set_record_registry(registry);
+    handle
 }
 
 /// Store the lesson as a recallable memory.
@@ -121,7 +133,7 @@ async fn a_recalled_memory_writes_a_treatment_arm_trial() {
 async fn a_rendered_record_writes_a_treatment_arm_trial() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut memory = session(dir.path());
-    with_one_record(&mut memory);
+    let handle = with_one_record(&mut memory);
 
     assert!(!memory.arm_controls_at(0, 0), "no control fires here");
     let block = memory
@@ -146,7 +158,7 @@ async fn a_rendered_record_writes_a_treatment_arm_trial() {
         .await;
 
     assert_eq!(
-        rows(dir.path(), "rule", RECORD_HANDLE),
+        rows(dir.path(), "rule", &handle),
         vec![true],
         "the rendered record is one row, in the with-rule arm"
     );
@@ -163,7 +175,7 @@ async fn a_rendered_record_writes_a_treatment_arm_trial() {
 async fn the_rule_arm_withholds_a_record_and_writes_its_control_arm() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut memory = session(dir.path());
-    with_one_record(&mut memory);
+    let handle = with_one_record(&mut memory);
 
     let mut rendered = Vec::new();
     for turn in 1..=6 {
@@ -197,7 +209,7 @@ async fn the_rule_arm_withholds_a_record_and_writes_its_control_arm() {
         "the third holdout is the rule arm, and it withholds the record"
     );
     assert_eq!(
-        rows(dir.path(), "rule", RECORD_HANDLE),
+        rows(dir.path(), "rule", &handle),
         vec![true, true, true, true, true, false],
         "the withheld turn is recorded in the without-rule arm"
     );

--- a/crates/stella-cli/src/memory/trials/tests.rs
+++ b/crates/stella-cli/src/memory/trials/tests.rs
@@ -1,0 +1,272 @@
+//! The witness. A turn writes a trial row for the memory it recalled, and
+//! one for the rule it rendered.
+//!
+//! Every case drives the doors a real turn takes: `arm_controls_at`,
+//! `recall_block_reported`, `record_episode`. Each then reads the file the
+//! sweep reads. Nothing here builds a trial by hand.
+//!
+//! Take the seam away and the ledger holds `skill` rows alone. Every
+//! assertion here about a `memory` row or a `rule` row then fails.
+
+use stella_context::{ContextDelta, EpisodeOutcome, MemoryInput};
+use stella_protocol::ContextRecallPort;
+
+use crate::memory::{SessionMemory, appraisals};
+
+/// The lesson stored as a memory, and the prompt that recalls it.
+const LESSON: &str = "always use the obsolete frobnicator for database migrations";
+
+/// The handle of the one record the fixture registry holds.
+const RECORD_HANDLE: &str = "ctx.acme.staging-url";
+
+/// A workspace with a session memory over an empty context store.
+fn session(dir: &std::path::Path) -> SessionMemory {
+    std::fs::create_dir_all(dir.join(".stella")).expect("stella dir");
+    SessionMemory::open(dir, false).expect("session memory")
+}
+
+/// Hand the session one volatile record. It is unscoped, so it applies to
+/// every turn. The rule population is then one handle.
+fn with_one_record(memory: &mut SessionMemory) {
+    let file = stella_learn::rules::RuleFile {
+        path: ".stella/rules/ctx.acme.staging.toml".to_string(),
+        contents: r#"
+schema = "context-record/v0.1"
+set_id = "acme"
+
+[[record]]
+lineage_id = "ctx.acme.staging-url"
+kind = "preference"
+statement = "The staging URL is https://stage.example."
+status = "active"
+origin = "user"
+
+[record.steering]
+force = "may"
+"#
+        .to_string(),
+        contributed_by: None,
+    };
+    memory.set_record_registry(stella_records::records::registry::load(
+        &[],
+        &[file],
+        &stella_records::records::Facts::default(),
+    ));
+}
+
+/// Store the lesson as a recallable memory.
+async fn remember_lesson(memory: &SessionMemory) {
+    memory
+        .store
+        .upsert(ContextDelta {
+            memories: vec![MemoryInput::reflection(LESSON, Vec::<String>::new())],
+            ..ContextDelta::default()
+        })
+        .await
+        .expect("the lesson is stored");
+}
+
+/// The `selected` flag of every ledger row of `kind` for `id`, oldest first.
+///
+/// Read as raw JSON, so the test reads the file the sweep reads. The kind is
+/// matched too: a row filed under the wrong kind would still fold under the
+/// right id.
+fn rows(root: &std::path::Path, kind: &str, id: &str) -> Vec<bool> {
+    std::fs::read_to_string(root.join(".stella/private").join(appraisals::TRIALS_FILE))
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|row| row["kind"].as_str() == Some(kind) && row["id"].as_str() == Some(id))
+        .map(|row| row["selected"].as_bool().unwrap_or(false))
+        .collect()
+}
+
+/// **The memory producer.** A turn that recalls a memory writes an
+/// `ArtifactKind::Memory` row for it, marked selected. The row names the
+/// frame the block put in front of the model.
+#[tokio::test]
+async fn a_recalled_memory_writes_a_treatment_arm_trial() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut memory = session(dir.path());
+    remember_lesson(&memory).await;
+
+    let handle = ContextRecallPort::recall(&memory, LESSON)
+        .await
+        .frames
+        .iter()
+        .find(|frame| frame.content.contains("frobnicator"))
+        .map(crate::memory::steering::frame_handle)
+        .expect("the lesson is recallable");
+
+    assert!(!memory.arm_controls_at(0, 0), "no control fires here");
+    let block = memory.recall_block_reported(LESSON, &[]).await;
+    assert!(
+        block.produced.has_frame(&handle),
+        "the block puts the memory in front of the model"
+    );
+    memory
+        .record_episode(LESSON, EpisodeOutcome::Success, &[], 1_000, None)
+        .await;
+
+    assert_eq!(
+        rows(dir.path(), "memory", &handle),
+        vec![true],
+        "the recalled memory is one row, in the with-memory arm"
+    );
+}
+
+/// **The rule producer.** A turn that renders a record writes an
+/// `ArtifactKind::Rule` row for it, marked selected.
+#[tokio::test]
+async fn a_rendered_record_writes_a_treatment_arm_trial() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut memory = session(dir.path());
+    with_one_record(&mut memory);
+
+    assert!(!memory.arm_controls_at(0, 0), "no control fires here");
+    let block = memory
+        .recall_block_reported("review the migrations", &[])
+        .await;
+    assert!(
+        block
+            .text
+            .as_deref()
+            .is_some_and(|text| text.contains("staging URL")),
+        "the record reaches the block: {:?}",
+        block.text
+    );
+    memory
+        .record_episode(
+            "review the migrations",
+            EpisodeOutcome::Success,
+            &[],
+            1_000,
+            None,
+        )
+        .await;
+
+    assert_eq!(
+        rows(dir.path(), "rule", RECORD_HANDLE),
+        vec![true],
+        "the rendered record is one row, in the with-rule arm"
+    );
+}
+
+/// **The rule holdout, end to end.** Six turns at a rate of 2 give three
+/// holdouts. The third is the rule arm. That turn holds the one record back
+/// and writes its control-arm row. The five turns before it rendered it.
+///
+/// Nothing else here could write that row. The plane rate is `0` and
+/// steering is on. The record is unscoped, so it applies to every turn, and
+/// the budget has nothing to cut it against.
+#[tokio::test]
+async fn the_rule_arm_withholds_a_record_and_writes_its_control_arm() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut memory = session(dir.path());
+    with_one_record(&mut memory);
+
+    let mut rendered = Vec::new();
+    for turn in 1..=6 {
+        assert!(
+            !memory.arm_controls_at(0, 2),
+            "the plane control is off for turn {turn}"
+        );
+        let block = memory
+            .recall_block_reported("review the migrations", &[])
+            .await;
+        rendered.push(
+            block
+                .text
+                .as_deref()
+                .is_some_and(|text| text.contains("staging URL")),
+        );
+        memory
+            .record_episode(
+                "review the migrations",
+                EpisodeOutcome::Success,
+                &[],
+                1_000,
+                None,
+            )
+            .await;
+    }
+
+    assert_eq!(
+        rendered,
+        vec![true, true, true, true, true, false],
+        "the third holdout is the rule arm, and it withholds the record"
+    );
+    assert_eq!(
+        rows(dir.path(), "rule", RECORD_HANDLE),
+        vec![true, true, true, true, true, false],
+        "the withheld turn is recorded in the without-rule arm"
+    );
+}
+
+/// **The memory holdout.** The second holdout is the memory arm. It holds
+/// back the one memory the query offers.
+///
+/// Only the last turn writes an episode. An episode is a recallable memory
+/// of its own. Write one each turn and the population grows, and the pick
+/// could land on an episode rather than the lesson.
+#[tokio::test]
+async fn the_memory_arm_withholds_a_memory_and_writes_its_control_arm() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut memory = session(dir.path());
+    remember_lesson(&memory).await;
+
+    let handle = ContextRecallPort::recall(&memory, LESSON)
+        .await
+        .frames
+        .iter()
+        .find(|frame| frame.content.contains("frobnicator"))
+        .map(crate::memory::steering::frame_handle)
+        .expect("the lesson is recallable");
+
+    let mut produced = Vec::new();
+    for turn in 1..=4 {
+        assert!(
+            !memory.arm_controls_at(0, 2),
+            "the plane control is off for turn {turn}"
+        );
+        let block = memory.recall_block_reported(LESSON, &[]).await;
+        produced.push(block.produced.has_frame(&handle));
+    }
+    memory
+        .record_episode(LESSON, EpisodeOutcome::Success, &[], 1_000, None)
+        .await;
+
+    assert_eq!(
+        produced,
+        vec![true, true, true, false],
+        "the second holdout is the memory arm, and it withholds the memory"
+    );
+    assert_eq!(
+        rows(dir.path(), "memory", &handle),
+        vec![false],
+        "the withheld turn is recorded in the without-memory arm"
+    );
+}
+
+/// A turn that offered nothing of a kind writes nothing for that kind. An
+/// empty row is evidence about no memory and no rule.
+#[tokio::test]
+async fn a_turn_with_nothing_to_offer_writes_no_row() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut memory = session(dir.path());
+
+    assert!(!memory.arm_controls_at(0, 0), "no control fires here");
+    let _ = memory.recall_block_reported("hello", &[]).await;
+    memory
+        .record_episode("hello", EpisodeOutcome::Success, &[], 1_000, None)
+        .await;
+
+    let ledger = dir
+        .path()
+        .join(".stella/private")
+        .join(appraisals::TRIALS_FILE);
+    assert!(
+        !ledger.exists(),
+        "an empty turn leaves the ledger alone: {ledger:?}"
+    );
+}

--- a/crates/stella-cli/src/settings/context.rs
+++ b/crates/stella-cli/src/settings/context.rs
@@ -321,7 +321,12 @@ pub struct RetrievalSettings {
     /// way to say so that is not a source edit.
     pub ab_recall_rate: u32,
     /// Per-artifact holdout: every `rate`-th eligible turn runs with **one**
-    /// matched skill held back, so that skill's own control arm exists.
+    /// matched artifact held back, so that artifact's own control arm exists.
+    ///
+    /// One artifact, not one of each kind. The three kinds that can be held
+    /// back — a skill, a memory record, a mined rule — take the schedule in
+    /// turn (`memory::trials::HOLDOUT_ARMS`), because a turn that withheld
+    /// one of each could not say which withholding its outcome belongs to.
     ///
     /// Distinct from [`Self::ab_recall_rate`], which withholds the whole
     /// steering plane. A plane-control turn can say only that recall helped;
@@ -374,7 +379,7 @@ pub const DEFAULT_RECALL_MAX_TOKENS: u32 = 1200;
 /// compile-time constant this setting replaces. 10 means every tenth turn in a
 /// workspace is a control turn; 0 disables the control.
 pub const DEFAULT_AB_RECALL_RATE: u32 = 10;
-/// Per-artifact holdout rate — 20 means one matched skill is held back on
+/// Per-artifact holdout rate — 20 means one matched artifact is held back on
 /// every twentieth eligible turn. `0` disables it. Twice the plane rate above,
 /// because the plane control already costs a turn in ten and the two prices
 /// add up.

--- a/crates/stella-learn/src/holdout.rs
+++ b/crates/stella-learn/src/holdout.rs
@@ -16,6 +16,9 @@
 //! skill, a memory, or a mined rule. [`crate::comparison`] keeps an arm
 //! opaque the same way, so one schedule serves all three.
 //!
+//! One item goes per turn, so the three take the schedule in turn. [`arm`]
+//! says whose turn it is.
+//!
 //! A holdout costs the user a little quality, on purpose. [`disclosure`] is
 //! the one sentence that says so.
 
@@ -44,6 +47,27 @@ pub fn is_scheduled(turn: u64, rate: u32) -> bool {
 pub fn ordinal(turn: u64, rate: u32) -> Option<u64> {
     let rate = u64::from(rate);
     (rate > 1 && turn.is_multiple_of(rate)).then(|| turn / rate - 1)
+}
+
+/// Which of `arms` populations the `ordinal`-th holdout acts on, or `None`
+/// when there are no populations to act on.
+///
+/// One item goes per turn, and a turn has more than one kind of thing to
+/// hold back. Hold one of each back together and every control turn for a
+/// memory is also a control turn for a skill, so neither arm can say which
+/// withholding the outcome belongs to. Taking the populations in turn keeps
+/// the turn readable and still gives each one an arm.
+///
+/// Opaque, like the rest of this file. An arm is a position in the caller's
+/// list. The caller owns what sits at each position.
+#[must_use]
+pub fn arm(ordinal: u64, arms: usize) -> Option<usize> {
+    if arms == 0 {
+        return None;
+    }
+    // The cast back is exact: the rest of the division is smaller than the
+    // number of arms, which came from a `usize`.
+    Some((ordinal % arms as u64) as usize)
 }
 
 /// Which item the `ordinal`-th holdout holds back, or `None` when there is
@@ -114,6 +138,21 @@ mod tests {
             assert_eq!(ordinal(4, rate), None, "rate {rate}");
             assert_eq!(disclosure(rate, "skill"), None, "rate {rate}");
         }
+    }
+
+    /// Each population gets the schedule in turn, and the rotation comes
+    /// back round.
+    #[test]
+    fn the_arms_take_the_schedule_in_turn() {
+        let arms: Vec<Option<usize>> = (0..4).map(|n| arm(n, 3)).collect();
+        assert_eq!(arms, vec![Some(0), Some(1), Some(2), Some(0)]);
+    }
+
+    /// A caller with no populations holds nothing back.
+    #[test]
+    fn no_arms_is_no_holdout() {
+        assert_eq!(arm(0, 0), None);
+        assert_eq!(arm(9, 0), None);
     }
 
     /// The rotation is the point. Three holdouts over three items cover all

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -633,8 +633,10 @@ what confirmation a blocking directive needs. Confidence values are on a `0`–`
     The measurement compares turns the skill's trigger matched *and* it was injected against
     turns the trigger matched and it was not. The second arm comes from two holdouts: the A/B
     recall control (`context.retrieval.ab_recall_rate`), which withholds the whole steering
-    plane, and the per-skill holdout (`context.retrieval.artifact_holdout_rate`), which
-    withholds one matched skill and leaves the rest of the turn alone. Set both to `0` and
+    plane, and the per-artifact holdout (`context.retrieval.artifact_holdout_rate`), which
+    withholds one matched artifact and leaves the rest of the turn alone. That holdout
+    serves memories, skills and records in turn, so a skill's own arm comes round every
+    third time it fires. Set both to `0` and
     there is no baseline to measure against: appraisals stay `Insufficient`, and nothing is
     promoted or retired on measurement.
   </OptionCard>

--- a/website/content/docs/context-engine.mdx
+++ b/website/content/docs/context-engine.mdx
@@ -246,9 +246,12 @@ set it to `0` to turn the experiment off.
 
 A control turn shows that recall helped. It cannot show *which* memory, skill or
 record did the helping, because it withheld all of them at once. So there is a second,
-smaller experiment beside it: every 20th other turn runs with exactly one matched skill
-held back, and the rest of the turn untouched. That turn is the control arm for that one
-skill, which is the comparison the skill promote and retire gate reads. stella says so
+smaller experiment beside it: every 20th other turn runs with exactly one matched
+artifact held back, and the rest of the turn untouched. That turn is the control arm
+for that one artifact, which is the comparison the promote and retire gate reads.
+One artifact, not one of each kind — the three kinds take the schedule in turn, so a
+turn that held a memory and a skill back at once could not say which one its outcome
+belongs to. stella says so
 when a session starts, and again on the turn it happens. Set
 `context.retrieval.artifact_holdout_rate` to change how often, or `0` to turn it off.
 A turn the recall control already took is skipped rather than counted, so the two


### PR DESCRIPTION
## What and why

The artifact trial ledger (`.stella/private/artifact_trials.jsonl`) has been keyed by `ArtifactKind` since #6093, and only skills ever wrote a row. A memory record and a mined rule were recalled and rendered with no join reported, so `appraisals::sweep` read an empty window for both kinds and neither could ever be measured. The holdout scheduler was already kind-opaque and would have withheld either one — it had no reason to, because nothing would have recorded the turn.

This adds the seam:

- **`crates/stella-cli/src/memory/trials.rs`** (new, plus `trials/tests.rs`) holds the per-turn offered→selected join for `ArtifactKind::Memory` and `ArtifactKind::Rule`, the per-kind holdout door, and the turn-end write.
- **Both render paths report.** `recall_block_reported` and the mid-turn `signal_recall_block` each call `withhold_held_memory` for frames and `turn_records_held` for the record channel. The memory population is `frame_handle` over everything the recall query answered; the rule population is `rendered + dropped` from a render that leaves nothing out. The withheld record leaves through `Registry::render_volatile_for_turn_excluding`, the door the issue names.
- **One pick per turn.** The pick is settled by the first pass that has something to pick from, and every later pass in the turn reads it back. The two passes score different shortlists, so a per-pass pick could drop one record from the opening block and a different one from the re-query, and the ledger would then describe neither turn — the shape #6073 fixed for skills. The turn's offered set is the union of what the passes offered; its selected set is the union of what they showed.
- **Turn end.** `record_episode` calls `record_context_trials` beside the existing `record_skill_trials`. A turn that offered nothing of a kind writes nothing for that kind.
- **One item per turn, still.** `stella_learn::holdout`'s own rule is "one item at most — hold two back and the turn cannot say which one the outcome belongs to". Holding one of each kind back on the same turn would make every memory control turn a skill control turn too, which confounds both arms. So the three kinds take the schedule in turn: a new kind-opaque `holdout::arm(ordinal, arms)` says whose turn it is, and `memory::trials::HOLDOUT_ARMS` fixes the order with `Skill` first so an existing workspace's next skill holdout does not move. `apply_holdout` returns `None` on a turn the schedule points elsewhere.

`recall.rs` sat about 26 lines under the 1500-line ratchet, which is why none of this landed there; deleting `turn_record_rendered` in favour of the new door leaves it smaller than it was (1474 → 1450).

## Witness mechanism

`crates/stella-cli/src/memory/trials/tests.rs`, five cases, each driving only production doors — `arm_controls_at`, `recall_block_reported`, `record_episode` — and then reading the raw JSONL the sweep reads, filtered on `kind` **and** `id`:

- `a_recalled_memory_writes_a_treatment_arm_trial` — one `memory` row, selected, and its id is the handle `RecalledBlock::produced` says the block showed.
- `a_rendered_record_writes_a_treatment_arm_trial` — one `rule` row, selected.
- `the_rule_arm_withholds_a_record_and_writes_its_control_arm` — six turns at rate 2 give three holdouts; the third is the rule arm. The record renders on five turns and not on the sixth, and the rows read `[true × 5, false]`. The plane rate is 0, steering is on, and the record is unscoped, so nothing else in the fixture could produce a `selected: false`.
- `the_memory_arm_withholds_a_memory_and_writes_its_control_arm` — four turns; the second holdout is the memory arm. Only the last turn writes an episode, because an episode is itself a recallable memory and writing one each turn would grow the population under the pick.
- `a_turn_with_nothing_to_offer_writes_no_row` — the ledger file is not even created.

**Why they fail on the old code by construction:** before this change the only producer of a ledger row is `SessionMemory::record_skill_trials`, which writes `ArtifactKind::Skill` and nothing else. Every assertion above reads rows filtered to `kind == "memory"` or `kind == "rule"`, so on `main` each of the four positive cases reads an empty vector against a non-empty expectation. The holdout half is likewise absent: `apply_holdout` is the only holdout consumer on `main` and it touches skills alone.

The pre-existing skill witness `a_holdout_turn_writes_a_control_arm_trial_for_the_skill_it_withheld` still passes under the rotation: its holdout lands on ordinal 0, which is the skill arm.

`stella-learn` gains `the_arms_take_the_schedule_in_turn` and `no_arms_is_no_holdout` for the new pure function.

## Exemplar

`crates/stella-cli/src/memory/learning/skill_lifecycle.rs`'s holdout witness is the shape the two control-arm cases copy: drive the production doors, read the ledger file, and close off every other route to the control arm in the fixture itself.

## Docs touched

`website/content/docs/context-engine.mdx` and `website/content/docs/configuration/settings.mdx` described the holdout as per-skill; both now say per-artifact and name the rotation. `settings/context.rs` and `memory/appraisals.rs` module docs said the same thing and are corrected. The deck's boot disclosure now names all three kinds.

## Tests deleted

None.

## Residue issues filed

None found that this change leaves behind. Two things it deliberately does not do, both already tracked elsewhere: memory retirement reading the shared sweep is #6069, and the sweep's per-kind retirement verbs are the epic's own next slice (#5200).

Closes #6096

## Summary by Sourcery

Measure recalled memories and rendered rules by recording their per-turn treatment and control trials in the shared artifact ledger.

New Features:
- Record appraisal trials for recalled memory records and rendered mined rules in the shared artifact trial ledger.
- Extend artifact holdouts to rotate across skills, memories, and rules while withholding at most one artifact per turn.

Bug Fixes:
- Ensure repeated recall and render passes contribute to a single per-turn offered and selected trial join.

Enhancements:
- Integrate memory and rule trial recording into the turn-end episode path and preserve the existing skill holdout schedule.
- Add production-door witnesses covering treatment and control arms, empty populations, and holdout rotation.

Documentation:
- Update holdout documentation and session disclosures to describe per-artifact rotation across memories, skills, and records.

Tests:
- Add end-to-end ledger tests for memory and rule trial production and their control arms.
- Add unit tests for rotating holdout arm selection.