### PR TITLE
fix(stella-core): collapse the four dead model tiers Router still named

### DIFF
--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -441,15 +441,16 @@ pub(crate) struct EngineWiring {
 /// always the literal session-default `ModelRef` the pre-built primary
 /// provider is bound to, never an already-overridden ref, so this check
 /// stays "does this need a NEW adapter instance" regardless of which role is
-/// being pinned). `roles` lets one resolved model pin more than one router
-/// role at once (`Role::Plan` shares `Role::Worker`'s tier — see
-/// `resolve_engine_wiring`'s worker-override handling). Every failure here
-/// is soft — a missing credential or a build error pushes a notice and
-/// leaves every role in `roles` unpinned, degrading to `fallback` in the
-/// router, never a hard error. Returns the resolved [`ModelRef`] on success.
+/// being pinned). Every failure here is soft — a missing credential or a
+/// build error pushes a notice and leaves `role` unpinned, degrading to
+/// `fallback` in the router, never a hard error. Returns the resolved
+/// [`ModelRef`] on success.
+///
+/// Takes one `role`, not a slice: `Role::Worker` is the only router role
+/// this session ever pins.
 fn pin_role(
     wiring: &mut EngineWiring,
-    roles: &[Role],
+    role: Role,
     label: &str,
     spec: &crate::engine_config::ModelSpec,
     base_ref: &ModelRef,
@@ -474,10 +475,8 @@ fn pin_role(
     let pinned = ModelRef::new(entry.config.id, slug.clone());
     if pinned == *base_ref {
         // Same instance the primary resolver entry already serves: no new
-        // adapter needed, the pin(s) still record the explicit choice.
-        for &role in roles {
-            wiring.pins.pin(role, pinned.clone());
-        }
+        // adapter needed, the pin still records the explicit choice.
+        wiring.pins.pin(role, pinned.clone());
         return Some(pinned);
     }
     match build_provider_parts(
@@ -493,23 +492,16 @@ fn pin_role(
         stella_model::CacheTtl::default(),
     ) {
         Ok(provider) => {
-            for &role in roles {
-                wiring.pins.pin(role, pinned.clone());
-            }
+            wiring.pins.pin(role, pinned.clone());
             // A profile for the routed provider keeps the router's provider
             // list honest (breaker bookkeeping, `providers()` introspection,
-            // and — critically — the router's own unpinned-verifier cross-
-            // family lookup, which matches `resolve(Worker)`'s result against
-            // a profile's `worker_model` field) even though the pin itself
-            // short-circuits normal tiered resolution.
+            // and — critically — `resolve_cross_family`'s own lookup, which
+            // matches `resolve(Worker)`'s result against a profile's
+            // `worker_model` field) even though the pin itself short-circuits
+            // normal tiered resolution.
             wiring.profiles.push(
-                ProviderProfile::new(
-                    entry.config.id,
-                    pinned.clone(),
-                    pinned.clone(),
-                    pinned.clone(),
-                )
-                .with_family(provider_family(entry.config.id)),
+                ProviderProfile::new(entry.config.id, pinned.clone(), pinned.clone())
+                    .with_family(provider_family(entry.config.id)),
             );
             wiring.extra_providers.push((pinned.clone(), provider));
             Some(pinned)
@@ -547,14 +539,16 @@ fn pin_role(
 /// It resolved four more roles until #3908 — verifier, triage, research and
 /// plan, each from its own `pipeline_<role>_model` key, each pinned into the
 /// [`RoleTable`]. Those pins were **read by nothing**: the only live
-/// `Router::resolve` call sites are `SessionFallback::resolve_fallback`
-/// (`Role::Worker` alone) and [`resolve_cross_family_verifier`], and the
-/// latter builds its router with `RoleTable::new()`. So an operator could
+/// `Router::resolve` call site is `SessionFallback::resolve_fallback`
+/// (`Role::Worker` alone), and [`resolve_cross_family_verifier`] does not
+/// resolve a `Role` at all — it calls `Router::resolve_cross_family`, whose
+/// router it builds with `RoleTable::new()` regardless. So an operator could
 /// set `pipeline_verifier_model` and watch it resolve, log, and steer
 /// nothing — including at the one place a second model actually runs. The
 /// keys are retired (`settings::unknown`) rather than dropped in silence, and
 /// a model for a participant other than the session's own is now a
-/// plugin-declared seat ([`crate::agent::seats`]).
+/// plugin-declared seat ([`crate::agent::seats`]); the four now-unroutable
+/// `Role` options are gone too.
 ///
 /// The `Role::Worker` pin below survives because it is the one that was ever
 /// read. Pins deliberately bypass the circuit breaker (`RoleTable`
@@ -568,7 +562,6 @@ pub(crate) fn resolve_engine_wiring(
 
     let worker_profile = ProviderProfile::new(
         worker_ref.provider.clone(),
-        worker_ref.clone(),
         worker_ref.clone(),
         worker_ref.clone(),
     )
@@ -623,7 +616,7 @@ pub(crate) fn resolve_engine_wiring(
     let effective_worker_ref = match &worker_spec {
         Some(spec) => pin_role(
             &mut wiring,
-            &[Role::Worker],
+            Role::Worker,
             "model",
             spec,
             worker_ref,
@@ -744,50 +737,47 @@ pub(crate) fn provider_family(provider_id: &str) -> String {
 }
 
 /// A `ProviderProfile` for a discovered provider, using its `default_model`
-/// for all three role tiers (the finest model this layer knows without a
-/// per-role catalog) and [`provider_family`] for cross-family grouping.
+/// as both the worker and verifier model (the finest model this layer knows
+/// without a per-role catalog) and [`provider_family`] for cross-family
+/// grouping.
 fn profile_for(config: &crate::config::ProviderConfig) -> ProviderProfile {
     let model = ModelRef::new(config.id, config.default_model);
-    ProviderProfile::new(config.id, model.clone(), model.clone(), model)
-        .with_family(provider_family(config.id))
+    ProviderProfile::new(config.id, model.clone(), model).with_family(provider_family(config.id))
 }
 
-/// Resolve one seat's model, and build the adapter that serves it — the
-/// session's whole answer to "does this role run on a model of its own?".
+/// Resolve the goal loop's verifier seat, and build the adapter that serves
+/// it — the session's whole answer to "does verification run on a model of
+/// its own?".
 ///
-/// Builds a role [`Router`] whose most-preferred provider is the active worker
+/// Builds a [`Router`] whose most-preferred provider is the active worker
 /// (`worker_id`/`worker_model`, so the `--model` pin is honored) followed by
-/// every OTHER configured provider, then resolves `role` through it. What that
-/// buys depends on the role, and the difference is the router's to make, not
-/// this function's: `Role::Verifier` prefers a healthy provider whose family
-/// differs from the worker's (`Router::resolve_verifier`), while the tier roles
-/// take the most-preferred available provider's matching tier.
+/// every OTHER configured provider, then asks it for a provider in a
+/// different family than the worker's
+/// ([`Router::resolve_cross_family`]).
 ///
-/// - The router lands back on the worker's own provider → `None`, and no second
-///   adapter is built. This is the single-family case for the verifier and the
-///   ordinary case for every tier role today, because [`profile_for`] points a
-///   provider's three tiers at one `default_model`. A seat that cannot diverge
-///   says so by returning `None` rather than by building a duplicate adapter.
+/// - The router lands back on the worker's own provider → `None`, and no
+///   second adapter is built. This is the single-family case: a seat that
+///   cannot diverge says so by returning `None` rather than by building a
+///   duplicate adapter.
 /// - A distinct provider is selected → its concrete adapter and id.
 ///
-/// Returns `None` on ANY failure — degradation to the worker, a resolve error,
-/// an unknown provider, or an adapter build failure — so seat routing can never
-/// break the loop that asked for it. Every caller's `None` arm is "use the
-/// worker's provider", which is what the session did before seats existed.
-pub(crate) fn resolve_seat_provider(
-    role: Role,
+/// Returns `None` on ANY failure — degradation to the worker, a resolve
+/// error, an unknown provider, or an adapter build failure — so this can
+/// never break the loop that asked for it. The caller's `None` arm is "use
+/// the worker's provider", which is what the session did before this seat
+/// existed.
+///
+/// Takes no `role` parameter: the strategy this asks for — "a provider in a
+/// different family than this one" — is fixed, not one of several roles
+/// core routes generically.
+pub(crate) fn resolve_cross_family_verifier(
     worker_id: &str,
     worker_model: &str,
     configured: &[crate::config::ConfiguredProvider],
 ) -> Option<(Box<dyn Provider>, String)> {
     let worker_ref = ModelRef::new(worker_id, worker_model);
-    let worker_profile = ProviderProfile::new(
-        worker_id,
-        worker_ref.clone(),
-        worker_ref.clone(),
-        worker_ref,
-    )
-    .with_family(provider_family(worker_id));
+    let worker_profile = ProviderProfile::new(worker_id, worker_ref.clone(), worker_ref)
+        .with_family(provider_family(worker_id));
 
     let mut profiles = vec![worker_profile];
     for entry in configured {
@@ -802,7 +792,7 @@ pub(crate) fn resolve_seat_provider(
         profiles,
         CircuitBreaker::new(Box::new(SystemClock::new())),
     );
-    let decision = router.resolve(role).ok()?;
+    let decision = router.resolve_cross_family().ok()?;
 
     // Same provider as the worker → single-family/degraded: reuse the worker
     // provider directly, never build a duplicate.
@@ -828,22 +818,6 @@ pub(crate) fn resolve_seat_provider(
     )
     .ok()?;
     Some((seat, decision.model_ref.provider))
-}
-
-/// Resolve the VERIFIER seat for the goal loop.
-///
-/// The named entry point the goal loop calls, kept as its own function rather
-/// than open-coding [`resolve_seat_provider`]'s `Role::Verifier` at the call
-/// site: the goal loop prints an operator-facing notice about *cross-family
-/// verification specifically*, so the role it asks for is part of that
-/// surface's contract rather than an argument a later edit could quietly
-/// retune.
-pub(crate) fn resolve_cross_family_verifier(
-    worker_id: &str,
-    worker_model: &str,
-    configured: &[crate::config::ConfiguredProvider],
-) -> Option<(Box<dyn Provider>, String)> {
-    resolve_seat_provider(Role::Verifier, worker_id, worker_model, configured)
 }
 
 /// The session-scoped role [`Router`] for a bare (non-pipeline) loop — the

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -488,13 +488,13 @@ pub(crate) async fn run_raw_one_shot(
 
 /// Run a one-shot goal loop (non-interactive): work in judged rounds until
 /// a verifier model assesses the goal as met (`stella goal "…"`, and `stella
-/// monitor` composed on top of it). The verifier is routed by role: when a
-/// second provider family is configured (BYOK), `run_goal_turn` builds a
-/// role `Router` and resolves `Role::Verifier` to a DIFFERENT family than the
-/// worker for bias-resistant assessment; with a
-/// single family it stays the worker provider, identical to before. The
-/// worker turns get the full tool stack (built-ins + MCP + custom), same as
-/// `run_one_shot`.
+/// monitor` composed on top of it). The verifier is routed by a
+/// cross-family strategy, not a `Role`: when a second provider family is
+/// configured (BYOK), `run_goal_turn` builds a `Router` and resolves a
+/// provider in a DIFFERENT family than the worker for bias-resistant
+/// assessment (`Router::resolve_cross_family`); with a single family it
+/// stays the worker provider, identical to before. The worker turns get the
+/// full tool stack (built-ins + MCP + custom), same as `run_one_shot`.
 ///
 /// `pipeline` selects the driver for each working round (#3381). It has two
 /// arms, both live: `--pipeline classic` is refused at

--- a/crates/stella-cli/src/agent/tests/engine_wiring.rs
+++ b/crates/stella-cli/src/agent/tests/engine_wiring.rs
@@ -262,11 +262,6 @@ fn an_explicit_model_flag_outranks_the_settings_model() {
         model_ref,
         "worker turns must run on the flag-pinned model"
     );
-    assert_eq!(
-        router.resolve(Role::Plan).unwrap().model_ref,
-        model_ref,
-        "plan/witness turns ride the worker and must follow the flag too"
-    );
 
     // Silently dropping a configured setting is its own bug — say so.
     assert!(
@@ -322,10 +317,6 @@ fn worker_model_unset_falls_back_to_the_session_default() {
     assert!(
         wiring.pins.get(Role::Worker).is_none(),
         "no worker pin is recorded when unconfigured"
-    );
-    assert!(
-        wiring.pins.get(Role::Plan).is_none(),
-        "no plan pin is recorded when unconfigured"
     );
 }
 

--- a/crates/stella-core/src/driver/tests/provider_outcomes.rs
+++ b/crates/stella-core/src/driver/tests/provider_outcomes.rs
@@ -99,7 +99,7 @@ fn tier(provider: &str) -> ModelRef {
 /// Two configured providers, `primary` preferred — the router every test
 /// resolves against while turns feed its breaker.
 fn router() -> Router {
-    let profile = |id: &str| ProviderProfile::new(id, tier(id), tier(id), tier(id));
+    let profile = |id: &str| ProviderProfile::new(id, tier(id), tier(id));
     Router::new(
         RoleTable::new(),
         vec![profile("primary"), profile("standby")],

--- a/crates/stella-core/src/router.rs
+++ b/crates/stella-core/src/router.rs
@@ -52,24 +52,19 @@ pub struct ProviderProfile {
     /// `stella_protocol::Provider::id()` and is the key `CircuitBreaker`
     /// tracks state under.
     pub id: String,
-    /// Cross-family grouping key for verifier selection (§1: "prefer a
-    /// different family when ≥2 profiles with distinct family... are
-    /// available"). Two profiles sharing a `family` are treated as the
+    /// Cross-family grouping key for [`Router::resolve_cross_family`] (§1:
+    /// "prefer a different family when ≥2 profiles with distinct family...
+    /// are available"). Two profiles sharing a `family` are treated as the
     /// SAME family even if their `id`s differ — e.g. two OpenRouter-routed
     /// slugs of the same underlying model. Defaults to `id` via
     /// `ProviderProfile::new` when the caller has no finer concept.
     pub family: String,
-    /// Strongest available model for main coding/execution steps — the
-    /// `worker`/`plan` default.
+    /// Strongest available model for main coding/execution steps.
     pub worker_model: ModelRef,
-    /// Cheap/fast tier used for triage classification. May equal
-    /// `worker_model` when the provider has no separate fast tier — that's
-    /// the caller's choice when constructing the profile, not the router's
-    /// concern.
-    pub triage_model: ModelRef,
-    /// Model used when this provider is chosen as verifier: "never the same
-    /// instance as worker" — a fresh, separate call even when it
-    /// shares a slug with `worker_model`.
+    /// Model used when this provider is chosen by
+    /// [`Router::resolve_cross_family`]: "never the same instance as
+    /// worker" — a fresh, separate call even when it shares a slug with
+    /// `worker_model`.
     pub verifier_model: ModelRef,
 }
 
@@ -77,21 +72,15 @@ impl ProviderProfile {
     /// Construct a profile with `family` defaulting to `id` (the common
     /// case: one key = one family). Call `.with_family(..)` to override for
     /// providers that front more than one underlying model family, or that
-    /// should be grouped with another profile for verifier cross-family
-    /// selection.
-    pub fn new(
-        id: impl Into<String>,
-        worker_model: ModelRef,
-        triage_model: ModelRef,
-        verifier_model: ModelRef,
-    ) -> Self {
+    /// should be grouped with another profile for
+    /// [`Router::resolve_cross_family`] selection.
+    pub fn new(id: impl Into<String>, worker_model: ModelRef, verifier_model: ModelRef) -> Self {
         let id = id.into();
         let family = id.clone();
         Self {
             id,
             family,
             worker_model,
-            triage_model,
             verifier_model,
         }
     }
@@ -289,9 +278,10 @@ impl CircuitBreaker {
 /// `stella-cli`'s `SessionFallback::resolve_fallback` reads it and
 /// [`Self::reason`] reaches the wire from there (the module docs name the
 /// full chain, and why grepping this type's *name* will not find it).
-/// Never constructed for an intentional routing choice (e.g. verifier's
-/// cross-family preference) — only when the originally preferred provider
-/// was unavailable (L-M7: fallback is always visible, never silent).
+/// Never constructed for an intentional routing choice (e.g.
+/// [`Router::resolve_cross_family`]'s cross-family preference) — only when
+/// the originally preferred provider was unavailable (L-M7: fallback is
+/// always visible, never silent).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FallbackInfo {
     pub from: String,
@@ -299,7 +289,8 @@ pub struct FallbackInfo {
     pub reason: String,
 }
 
-/// The result of resolving one `Role`.
+/// The result of resolving one `Role`, or a provider via
+/// [`Router::resolve_cross_family`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouterDecision {
     /// The model to call.
@@ -355,6 +346,24 @@ pub enum RouterError {
         "no default model available for role `{role:?}` — pin one explicitly with RoleTable::pin"
     )]
     NoDefaultForRole { role: Role },
+}
+
+/// [`Router::resolve_cross_family`] failures. Not a [`RouterError`]: every
+/// option in that enum names a `Role`, and this resolution never does — it
+/// asks the configured providers a question ("is there a healthy one in a
+/// different family than the worker's?"), not a role lookup.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CrossFamilyError {
+    /// No `ProviderProfile`s were supplied at all.
+    #[error(
+        "no provider configured — configure at least one provider (BYOK key) before resolving a cross-family provider"
+    )]
+    NoProvidersConfigured,
+    /// Every configured provider's breaker is currently open.
+    #[error(
+        "all configured providers are circuit-broken — every breaker is open; wait for a cooldown or configure a healthy provider"
+    )]
+    AllProvidersUnavailable,
 }
 
 // Router
@@ -433,8 +442,7 @@ impl Router {
     }
 
     /// [`Router::resolve`] against an already-taken breaker guard — one lock
-    /// per resolution, and the verifier's recursive Worker resolution reuses
-    /// the guard instead of deadlocking on a second acquisition.
+    /// per resolution.
     fn resolve_with(
         &self,
         breaker: &CircuitBreaker,
@@ -445,25 +453,20 @@ impl Router {
         }
 
         match role {
-            Role::Worker | Role::Plan | Role::Research => {
-                self.resolve_tier(breaker, role, |p| &p.worker_model)
-            }
-            Role::Triage => self.resolve_tier(breaker, role, |p| &p.triage_model),
-            Role::Verifier => self.resolve_verifier(breaker),
+            Role::Worker => self.resolve_worker_tier(breaker, role),
             Role::Embed | Role::Vision | Role::Image | Role::Video => {
                 Err(RouterError::NoDefaultForRole { role })
             }
         }
     }
 
-    /// Shared logic for `Worker`/`Plan`/`Triage`: pick the most-preferred
-    /// available provider's tier model, falling back to the next available
-    /// one (and reporting it) when the preferred provider is breaker-open.
-    fn resolve_tier(
+    /// Pick the most-preferred available provider's worker model, falling
+    /// back to the next available one (and reporting it) when the preferred
+    /// provider is breaker-open.
+    fn resolve_worker_tier(
         &self,
         breaker: &CircuitBreaker,
         role: Role,
-        pick: impl Fn(&ProviderProfile) -> &ModelRef,
     ) -> Result<RouterDecision, RouterError> {
         if self.profiles.is_empty() {
             return Err(RouterError::NoProvidersConfigured { role });
@@ -471,13 +474,13 @@ impl Router {
 
         let preferred = &self.profiles[0];
         if breaker.is_available(&preferred.id) {
-            return Ok(RouterDecision::plain(pick(preferred).clone()));
+            return Ok(RouterDecision::plain(preferred.worker_model.clone()));
         }
 
         for candidate in &self.profiles[1..] {
             if breaker.is_available(&candidate.id) {
                 return Ok(RouterDecision {
-                    model_ref: pick(candidate).clone(),
+                    model_ref: candidate.worker_model.clone(),
                     fallback: Some(fallback_from(breaker, preferred, candidate)),
                     caveat: None,
                 });
@@ -487,11 +490,13 @@ impl Router {
         Err(RouterError::AllProvidersUnavailable { role })
     }
 
-    /// Verifier resolution (§1, §5, L-E11 "always on a different model than
-    /// the worker"): prefer a healthy provider whose `family` differs from the
-    /// family Worker *actually* resolves to right now; degrade — with a
-    /// caveat, never an error — to the same provider/family when it's the only
-    /// healthy option (L-M8: a single configured provider must still yield a
+    /// Resolve a provider whose family differs from the worker's (§1, §5,
+    /// L-E11 "always on a different model than the worker") — the selection
+    /// strategy `stella goal`'s verifier seat spends. Prefers a healthy
+    /// provider whose `family` differs from the family [`Role::Worker`]
+    /// *actually* resolves to right now; degrades — with a caveat, never an
+    /// error — to the same provider/family when it's the only healthy
+    /// option (L-M8: a single configured provider must still yield a
     /// working verifier).
     ///
     /// Selection is by **family**, not by slug: this returns the chosen
@@ -500,31 +505,51 @@ impl Router {
     /// separate call, not a separate model. When that happens the `caveat` says
     /// so, so "different model than the worker" is a preference the router
     /// reports on, never a guarantee it can make from one key.
-    fn resolve_verifier(&self, breaker: &CircuitBreaker) -> Result<RouterDecision, RouterError> {
+    ///
+    /// Not a [`Role`] option, and not reached through [`Router::resolve`]:
+    /// nothing pins it, and the only caller (`stella-cli`'s goal loop) always
+    /// wants exactly this strategy rather than a role that could be pinned to
+    /// something else. See [`CrossFamilyError`] for why its failures are not
+    /// a [`RouterError`].
+    pub fn resolve_cross_family(&self) -> Result<RouterDecision, CrossFamilyError> {
+        self.resolve_cross_family_with(&self.breaker())
+    }
+
+    /// [`Router::resolve_cross_family`] against an already-taken breaker
+    /// guard — one lock per resolution, and the recursive Worker resolution
+    /// below reuses the guard instead of deadlocking on a second
+    /// acquisition.
+    fn resolve_cross_family_with(
+        &self,
+        breaker: &CircuitBreaker,
+    ) -> Result<RouterDecision, CrossFamilyError> {
         if self.profiles.is_empty() {
-            return Err(RouterError::NoProvidersConfigured {
-                role: Role::Verifier,
-            });
+            return Err(CrossFamilyError::NoProvidersConfigured);
         }
 
-        // Availability is checked FIRST so an all-breakers-open state reports a
-        // `Verifier` failure — resolving Worker up front would propagate its `?`
-        // as `AllProvidersUnavailable { role: Worker }`, mislabeling a Verifier
-        // resolution with the wrong role.
+        // Availability is checked FIRST so an all-breakers-open state is
+        // reported here rather than by the Worker lookup below, whose own
+        // error this function does not propagate (see the `match` a few
+        // lines down).
         let available: Vec<&ProviderProfile> = self
             .profiles
             .iter()
             .filter(|p| breaker.is_available(&p.id))
             .collect();
         let Some(&first_healthy) = available.first() else {
-            return Err(RouterError::AllProvidersUnavailable {
-                role: Role::Verifier,
-            });
+            return Err(CrossFamilyError::AllProvidersUnavailable);
         };
 
         // What Worker actually resolves to right now (pin included) — the
-        // instance Verifier must never repeat.
-        let worker_decision = self.resolve_with(breaker, Role::Worker)?;
+        // instance this resolution must never repeat. This cannot actually
+        // fail: `profiles` is non-empty and `available` just proved at least
+        // one is healthy, so `resolve_worker_tier` always finds a candidate.
+        // The error arm exists only so this stays a typed `Result` rather
+        // than an `unwrap` on that reasoning (AGENTS.md #5).
+        let worker_decision = match self.resolve_with(breaker, Role::Worker) {
+            Ok(decision) => decision,
+            Err(_) => return Err(CrossFamilyError::AllProvidersUnavailable),
+        };
         let worker_family = self
             .profiles
             .iter()
@@ -639,7 +664,6 @@ mod tests {
         ProviderProfile::new(
             "zai",
             model("zai", "glm-5.2"),
-            model("zai", "glm-5.2-air"),
             model("zai", "glm-5.2-verifier"),
         )
     }
@@ -648,7 +672,6 @@ mod tests {
         ProviderProfile::new(
             "anthropic",
             model("anthropic", "claude-fable-5"),
-            model("anthropic", "claude-haiku"),
             model("anthropic", "claude-fable-5"),
         )
     }
@@ -688,7 +711,7 @@ mod tests {
     fn explicit_pin_wins_unconditionally_even_with_providers_and_open_breakers() {
         let mut table = RoleTable::new();
         let pinned = model("openrouter", "some/pinned-slug");
-        table.pin(Role::Verifier, pinned.clone());
+        table.pin(Role::Worker, pinned.clone());
 
         let clock = ManualClock::new(0);
         let mut breaker = breaker_with_clock(clock);
@@ -699,7 +722,7 @@ mod tests {
         }
 
         let router = Router::new(table, vec![zai_profile(), anthropic_profile()], breaker);
-        let decision = router.resolve(Role::Verifier).expect("pin always resolves");
+        let decision = router.resolve(Role::Worker).expect("pin always resolves");
         assert_eq!(decision.model_ref, pinned);
         assert_eq!(decision.fallback, None);
     }
@@ -717,7 +740,7 @@ mod tests {
     // -- Single-provider (BYOK-with-one-key, L-M8) ------------------------
 
     #[test]
-    fn single_provider_yields_a_fully_working_worker_triage_verifier_set() {
+    fn single_provider_yields_a_fully_working_worker_and_cross_family_set() {
         let router = Router::new(
             RoleTable::new(),
             vec![zai_profile()],
@@ -728,36 +751,21 @@ mod tests {
         assert_eq!(worker.model_ref, model("zai", "glm-5.2"));
         assert_eq!(worker.fallback, None);
 
-        let triage = router.resolve(Role::Triage).expect("triage resolves");
-        assert_eq!(triage.model_ref, model("zai", "glm-5.2-air"));
-
         let verifier = router
-            .resolve(Role::Verifier)
-            .expect("verifier must still resolve, not error, with only one provider");
+            .resolve_cross_family()
+            .expect("must still resolve, not error, with only one provider");
         assert_eq!(verifier.model_ref, model("zai", "glm-5.2-verifier"));
         assert_eq!(verifier.fallback, None);
         assert!(
             verifier.caveat.is_some(),
-            "single-provider verifier must flag the same-family degradation"
+            "single-provider cross-family resolution must flag the same-family degradation"
         );
     }
 
-    #[test]
-    fn plan_defaults_to_the_same_tier_as_worker() {
-        let router = Router::new(
-            RoleTable::new(),
-            vec![zai_profile()],
-            breaker_with_clock(ManualClock::new(0)),
-        );
-        let worker = router.resolve(Role::Worker).unwrap();
-        let plan = router.resolve(Role::Plan).unwrap();
-        assert_eq!(worker.model_ref, plan.model_ref);
-    }
-
-    // -- Multi-provider cross-family verifier --------------------------------
+    // -- Multi-provider cross-family selection -------------------------------
 
     #[test]
-    fn multi_provider_verifier_picks_a_different_family_than_worker() {
+    fn multi_provider_cross_family_picks_a_different_family_than_worker() {
         let router = Router::new(
             RoleTable::new(),
             vec![zai_profile(), anthropic_profile()],
@@ -767,12 +775,12 @@ mod tests {
         let worker = router.resolve(Role::Worker).unwrap();
         assert_eq!(worker.model_ref, model("zai", "glm-5.2"));
 
-        let verifier = router.resolve(Role::Verifier).unwrap();
+        let verifier = router.resolve_cross_family().unwrap();
         assert_eq!(verifier.model_ref, model("anthropic", "claude-fable-5"));
         assert_eq!(verifier.fallback, None);
         assert_eq!(
             verifier.caveat, None,
-            "cross-family verifier selection needs no degradation caveat"
+            "cross-family selection needs no degradation caveat"
         );
     }
 
@@ -791,14 +799,8 @@ mod tests {
             RouterError::NoProvidersConfigured { role: Role::Worker }
         );
         assert_eq!(
-            router.resolve(Role::Triage).unwrap_err(),
-            RouterError::NoProvidersConfigured { role: Role::Triage }
-        );
-        assert_eq!(
-            router.resolve(Role::Verifier).unwrap_err(),
-            RouterError::NoProvidersConfigured {
-                role: Role::Verifier
-            }
+            router.resolve_cross_family().unwrap_err(),
+            CrossFamilyError::NoProvidersConfigured
         );
     }
 
@@ -981,15 +983,20 @@ mod tests {
             router.resolve(Role::Worker).unwrap_err(),
             RouterError::AllProvidersUnavailable { role: Role::Worker }
         );
+        assert_eq!(
+            router.resolve_cross_family().unwrap_err(),
+            CrossFamilyError::AllProvidersUnavailable
+        );
     }
 
     #[test]
-    fn verifier_reports_both_fallback_and_same_family_caveat_when_only_the_worker_family_is_healthy()
+    fn cross_family_reports_both_fallback_and_same_family_caveat_when_only_the_worker_family_is_healthy()
      {
         // zai is broken; anthropic is the only healthy provider, and it's
         // also the family worker ends up resolving to (since zai is down).
-        // Verifier must report the breaker fallback (zai -> anthropic) AND
-        // flag that it's degraded to worker's own family.
+        // Cross-family resolution must report the breaker fallback
+        // (zai -> anthropic) AND flag that it's degraded to worker's own
+        // family.
         let clock = ManualClock::new(0);
         let mut breaker = breaker_with_clock(clock);
         for _ in 0..CircuitBreaker::DEFAULT_FAILURE_THRESHOLD {
@@ -1001,7 +1008,7 @@ mod tests {
             breaker,
         );
 
-        let verifier = router.resolve(Role::Verifier).unwrap();
+        let verifier = router.resolve_cross_family().unwrap();
         assert_eq!(verifier.model_ref, model("anthropic", "claude-fable-5"));
         let fallback = verifier
             .fallback

--- a/crates/stella-protocol/src/role.rs
+++ b/crates/stella-protocol/src/role.rs
@@ -9,46 +9,23 @@
 use serde::{Deserialize, Serialize};
 
 /// A functional role a model call fills. Never a model name.
+///
+/// Five options: `Worker`, plus four media roles
+/// (`Embed`/`Vision`/`Image`/`Video`). A cross-family verifier strategy
+/// lives in `stella-core` as `Router::resolve_cross_family`, a plain method
+/// rather than a role — "a different family than the worker's" is a
+/// question about the configured provider set, not about a model call's
+/// job. This type carries no entry in `docs/wire/`, and nothing in this
+/// workspace deserializes a `Role` from a settings file or a recorded
+/// stream — `RoleTable`'s pins are built fresh, in memory, every session.
+/// See `doc:roleless-core` §5 for the wider vocabulary this narrows.
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Role {
-    /// Main coding/execution steps.
+    /// Main coding/execution steps. The one role a live caller ever pins or
+    /// resolves.
     Worker,
-    /// Prompt classification, simple-prompt fast path, routing decisions.
-    Triage,
-    /// Planner (defaults to worker-class, separately overridable).
-    Plan,
-    /// The read-only research sub-agent answering a pre-plan question.
-    ///
-    /// Its own slot rather than a share of [`Self::Plan`]'s, because the two
-    /// have opposite cost profiles and a benchmark seat has to be able to
-    /// separate them: research is a fan-out of many short read-only calls,
-    /// while planning is one call that writes the work order. Sharing a slot
-    /// meant a run that turned the planner down turned the fan-out down with
-    /// it, and vice versa (#2374).
-    ///
-    /// Defaults to worker-class exactly as [`Self::Plan`] does, so an
-    /// unconfigured run resolves it to the same model it always did.
-    Research,
-    /// The independent capable model that completes verification. Fills every
-    /// half of the job: authors the witness test that arms the flip oracle,
-    /// repairs a witness that did not fail, renders the verdict on
-    /// inconclusive evidence, and steers a distressed worker. Selects among
-    /// best-of-N candidates. Never the same instance as `Worker` — that
-    /// independence is the whole point, and
-    /// `Pipeline::can_author_independent_witness` enforces it.
-    ///
-    /// This is the *only* slot for a non-worker capable model. Call sites name
-    /// the job (`ModelCallRole::Verdict`, `ModelCallRole::Plugin`), never a
-    /// second model identity: there is no separate "witness model" or
-    /// "verifier model".
-    ///
-    /// Aliased: this role shipped on the wire as `judge`, and it is persisted
-    /// in settings and role pins as well as in recorded streams. A bare rename
-    /// would silently orphan every existing pin.
-    #[serde(alias = "judge")]
-    Verifier,
     /// Context-plane embeddings.
     Embed,
     /// Image-input understanding.
@@ -105,10 +82,10 @@ mod tests {
 
     #[test]
     fn role_roundtrips_and_uses_snake_case() {
-        let json = serde_json::to_string(&Role::Verifier).unwrap();
-        assert_eq!(json, "\"verifier\"");
+        let json = serde_json::to_string(&Role::Worker).unwrap();
+        assert_eq!(json, "\"worker\"");
         let back: Role = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, Role::Verifier);
+        assert_eq!(back, Role::Worker);
     }
 
     #[test]
@@ -117,30 +94,5 @@ mod tests {
         // construct a "auto" ModelRef — the absence of Some(_) *is* auto.
         let auto: Option<ModelRef> = None;
         assert!(auto.is_none());
-    }
-}
-
-#[cfg(test)]
-mod rename_compat_tests {
-    use super::*;
-
-    /// **The rename's required property.** `Role::Verifier` shipped on the
-    /// wire as `judge`, and it is persisted in settings and role pins as well
-    /// as in recorded streams. Reading the old token is not a nicety — without
-    /// it every existing pin silently orphans and every stored session fails
-    /// to parse.
-    ///
-    /// Asserted in both directions: old data reads, and new data writes the
-    /// new name (an alias that quietly became the *output* name would leave
-    /// the rename half-done).
-    #[test]
-    fn the_old_wire_token_still_reads_and_the_new_one_is_what_we_write() {
-        let from_old: Role = serde_json::from_str("\"judge\"").expect("old streams still parse");
-        assert_eq!(from_old, Role::Verifier);
-        assert_eq!(
-            serde_json::to_string(&Role::Verifier).unwrap(),
-            "\"verifier\"",
-            "new writes use the new name"
-        );
     }
 }

--- a/docs/spec/roleless-core.md
+++ b/docs/spec/roleless-core.md
@@ -147,9 +147,15 @@ in `candidate_fanout.rs`, whose rule is the inverse; it has its own issue.
 
 ## 5. The four gaps
 
-- **A. Routing vocabulary.** *Mostly closed by slice 0.* What remains is
-  `ChildTurns::default_seats()` — core's list of acceptable plugin role words —
-  and `Router`'s per-tier match arms.
+- **A. Routing vocabulary.** *Closed.* Slice 1 deleted
+  `ChildTurns::default_seats()` — core's list of acceptable plugin role words.
+  `stella_protocol::Role` now keeps only `Worker` and the four media roles
+  (`Embed`/`Vision`/`Image`/`Video`); `Router`'s per-tier match arms collapsed
+  to one (`Worker`); and the cross-family verifier strategy moved off
+  `Role::Verifier` onto `Router::resolve_cross_family`, a plain method rather
+  than a role nothing else could be pinned to. None of the four retired
+  options ever crossed the wire, so removing them needed no serde alias and
+  no `docs/wire/` regeneration.
 - **B. Stage vocabulary.** The socket has four points (`before_turn`,
   `after_turn`, `judge`, `again?`) but no notion of a **named, ordered stage** a
   plugin adds. "Install triage and the turn gains a triage stage" needs stage

--- a/docs/spec/witness-protocol.md
+++ b/docs/spec/witness-protocol.md
@@ -121,7 +121,8 @@ From the draft, three principles carry over intact:
   it carries is an anecdote. (Fixes D3, D4.)
 - **P1 — Separation of authorship.** Whatever writes the code does not author
   what grades it. Stella already routes the witness author and verifier through
-  `Role::Verifier`'s cross-family preference; this document does not weaken that.
+  `Router::resolve_cross_family`'s cross-family preference; this document does
+  not weaken that.
 
 ## 4. The Feedback Airlock
 


### PR DESCRIPTION
## What and why

`Router::resolve_with` in `crates/stella-core/src/router.rs` still matched
`Role::Worker | Role::Plan | Role::Research`, `Role::Triage`, and
`Role::Verifier` as four separate tiers, picking a different
`ProviderProfile` field for each. The settings that fed the non-worker tiers
were retired by #3908, and every production `ProviderProfile` (built in
`stella-cli/src/agent/engine.rs`) already points `worker_model`,
`triage_model`, and `verifier_model` at the same value — so `Plan`,
`Research`, and `Triage` never diverged from `Worker`'s own resolution in a
running session. `Role::Verifier`'s cross-family selection is genuinely live
(`stella goal`'s verifier seat), but nothing ever resolved it as a *role*
that could be pinned to something else — it is a selection strategy.

## The fix

- `stella_protocol::Role` now carries five options: `Worker`, plus the four
  media roles (`Embed`/`Vision`/`Image`/`Video`). `Triage`, `Plan`,
  `Research`, and `Verifier` are gone.
- `ProviderProfile` drops the dead `triage_model` field; `ProviderProfile::new`
  takes `(id, worker_model, verifier_model)`.
- `Router::resolve_with` collapses to one live arm (`Role::Worker`) plus the
  unchanged `NoDefaultForRole` arm for the four media roles.
- `Role::Verifier`'s behavior moves off the enum entirely, onto a new
  `Router::resolve_cross_family()` that takes no role argument at all, with
  its own `CrossFamilyError` (deliberately not a `RouterError` — every
  `RouterError` variant names a `Role`, and this resolution never does).
- `stella-cli`'s `resolve_seat_provider(role: Role, ...)` had exactly one
  caller (`resolve_cross_family_verifier`, always passing `Role::Verifier`),
  so it folds into that caller rather than keeping a role parameter with one
  possible value.

## Deviation from the design pointer

The design pointer asked to "retire `stella_protocol::Role`'s mirror with
serde aliases so recorded streams still parse (the #3906 shape)" and to
regenerate `docs/wire/`. A workspace-wide grep shows this isn't needed for
*this* enum:

- `stella_protocol::Role` (the router role) has no entry anywhere in
  `docs/wire/` — the wire-schema exporter only walks `AgentEvent`'s payload
  graph, and `Role` never appears in it.
- Nothing in this workspace deserializes a `Role` from a settings file, a
  recorded stream, or any other external source. `RoleTable`'s pins are
  built fresh, in memory, from settings strings, every session
  (`resolve_engine_wiring`) — the enum itself never round-trips through
  serde in production.

So this is unlike `ModelCallRole`'s `judge` → `verifier` rename (#3906),
which really was on the wire and really needed the alias. Posted the design
pointer and this finding as a comment on #6071 before implementing.

The seat plane (`stella-cli`'s `agent::seats`, plugin-declared roles) is a
separate mechanism from this enum and is untouched — a plugin seat was never
routed through `stella_protocol::Role`.

## Witness

`crates/stella-core/src/router.rs`'s test suite exercises the collapsed
match arm and the new `CrossFamilyError` type. Every one of these fails to
*compile* on `main`, because `Role::Triage`/`Plan`/`Research`/`Verifier` and
`Router::resolve_verifier` don't exist there:

- `single_provider_yields_a_fully_working_worker_and_cross_family_set`
- `multi_provider_cross_family_picks_a_different_family_than_worker`
- `zero_providers_configured_is_a_named_error_not_a_panic` (now asserts
  `CrossFamilyError::NoProvidersConfigured` alongside `RouterError`)
- `all_providers_broken_is_a_named_error_not_a_silent_pick` (now also
  asserts `CrossFamilyError::AllProvidersUnavailable`)
- `cross_family_reports_both_fallback_and_same_family_caveat_when_only_the_worker_family_is_healthy`
  (renamed from the `verifier_reports_...` test, calls `resolve_cross_family()`)

## Tests deleted

Named here per `check-deleted-tests` / AGENTS.md's witness-test section:

- `crates/stella-protocol/src/role.rs`: `rename_compat_tests` module
  (`the_old_wire_token_still_reads_and_the_new_one_is_what_we_write`) —
  tested the `Role::Verifier`/`judge` serde alias, which is moot once
  `Role::Verifier` and its alias no longer exist. The grep above establishes
  nothing depended on that alias in production.
- `crates/stella-core/src/router.rs`:
  `single_provider_yields_a_fully_working_worker_triage_verifier_set` and
  `multi_provider_verifier_picks_a_different_family_than_worker` renamed
  (content preserved, `Triage` assertions dropped, `Role::Verifier` calls
  become `resolve_cross_family()` calls) —
  `single_provider_yields_a_fully_working_worker_and_cross_family_set` and
  `multi_provider_cross_family_picks_a_different_family_than_worker`.
  `verifier_reports_both_fallback_and_same_family_caveat_when_only_the_worker_family_is_healthy`
  renamed to `cross_family_reports_...` (same body, `resolve_cross_family()`).
  `plan_defaults_to_the_same_tier_as_worker` deleted outright — it asserted
  `Role::Plan` shares `Role::Worker`'s tier, which is no longer a
  distinction that exists to test.
- `crates/stella-cli/src/agent/tests/engine_wiring.rs`: two assertions (not
  whole test functions) removed from
  `an_explicit_model_flag_outranks_the_settings_model` and
  `worker_model_unset_falls_back_to_the_session_default` — both exercised
  `Role::Plan`, which no longer resolves.

## Docs

- `docs/spec/roleless-core.md` §5 gap A marked closed (was "mostly closed by
  slice 0; what remains is `ChildTurns::default_seats()` ... and `Router`'s
  per-tier match arms" — the seat-plane half already landed in slice 1, this
  PR closes the other half).
- `docs/spec/witness-protocol.md` repointed a citation of
  `Role::Verifier`'s cross-family preference at `Router::resolve_cross_family`.

## Gate

`make role-names` no longer exists — `scripts/check-role-names.sh` and its
`GATE_STEPS` entry were retired by #6107 (merged into `main` while this PR
was in flight; rebased onto it). `make retired-model-keys`
(`scripts/check-retired-model-keys.py`) passes unchanged. `make guards-fast`
is green locally (55 gate steps). CI has the compile + test evidence this
laptop cannot produce.

Closes #6071

## Summary by Sourcery

Collapse retired model tiers into worker-only routing and move verifier selection to an explicit cross-family strategy.

New Features:
- Add explicit cross-family provider resolution for verifier execution without representing it as a routable role.

Bug Fixes:
- Remove obsolete routing tiers and model settings that could imply unsupported or ineffective role-specific resolution.

Enhancements:
- Reduce the router role vocabulary to Worker and media roles, with worker-only tier resolution.
- Simplify provider profiles and engine wiring by removing the unused triage model and non-worker role pins.
- Introduce dedicated cross-family resolution errors and update verifier routing to use the strategy directly.

Documentation:
- Mark the routing-vocabulary gap as closed and update witness-protocol documentation to reference cross-family resolution.

Tests:
- Update router and engine-wiring tests for worker-only role resolution and cross-family verifier selection.

Chores:
- Remove obsolete serde compatibility coverage for the retired verifier role.