### PR TITLE
Every builtin turn lane says which lane it is

### DIFF
--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -52,8 +52,9 @@ fn tuned_engine_config(cfg: &Config, catalog_ref: (&str, &str)) -> EngineConfig 
         // reach that hazard and each is closed at its own end — a dispatched
         // sub-agent by `stella_core::subagent` (which strips the sink it is
         // handed), and a deck sub-session by `subsession_engine_config_for`
-        // (which the engine crate cannot see, because a sub-session is built
-        // through `Engine::with_sleeper` rather than `run_sub_agent`).
+        // (which the engine crate cannot see, because a sub-session assembles
+        // an engine for itself rather than being reached through
+        // `run_sub_agent`).
         //
         // A fleet worker is the third door and is closed the same way: it never
         // binds this handle either, and `crate::fleet_cmd::durability` mints it
@@ -232,9 +233,9 @@ pub(crate) fn engine_config_for(cfg: &Config) -> EngineConfig {
 /// lead's transcript and the lane's terminal path would `discard` the lead's
 /// point while the lead still needs it. `stella_core::subagent` names the same
 /// damage for a dispatched child reached through `run_sub_agent`; a
-/// sub-session reaches it through a different door — it is a full engine
-/// session built via `Engine::with_sleeper`, not a child, so the engine crate
-/// never sees a parent to strip the sink from.
+/// sub-session reaches it through a different door — it assembles a full
+/// engine session of its own, not a child, so the engine crate never sees a
+/// parent to strip the sink from.
 ///
 /// The fix here is to re-key, not strip: `durability` is the lane's OWN
 /// handle, bound by the caller (`crate::subsession::run_worker`) to its own

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -971,6 +971,10 @@ pub(crate) async fn run_goal_turn(
             // The skill's `effort:` override, for this arc.
             config.effort = Some(effort);
         }
+        // TODO(#6109): still the builder path, so this turn reports no lane.
+        // `stella goal` is a door rather than one of the seven lanes
+        // `BuiltinLane` names, and `Lead` is documented as the deck's turn —
+        // see `agent::turn`'s own note for the decision this waits on.
         let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
             .with_calibration(calibration)
             // Every round's worker turn drains this, and only those. The

--- a/crates/stella-cli/src/agent/goal/goal_wrapped.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped.rs
@@ -370,6 +370,9 @@ pub(crate) async fn run_goal_wrapped_turn(
         // The skill's `effort:` override, for this arc.
         config.effort = Some(effort);
     }
+    // TODO(#6109): still the builder path, so this turn reports no lane. Same
+    // door as `agent::goal`'s raw arm, under a wrapper plugin, and the same
+    // open question about which lane a non-interactive door runs in.
     let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
         .with_calibration(calibration)
         // The arc's whistle (#4769), opened above and drained at every round's

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -195,11 +195,16 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
         let hook_runner = HostHookRunner;
         let engine_config = engine_config_for(cfg);
         let state = stella_core::step::TurnState::from_checkpoint(checkpoint, &engine_config);
-        let mut engine = Engine::with_sleeper(&*provider, &tools, engine_config, &TokioSleeper)
-            .with_calibration(&calibration);
-        if let Some(hooks) = &cfg.hooks {
-            engine = engine.with_hooks(hooks, &hook_runner);
-        }
+        // Assembled, not built up by optional builders. This turn is the
+        // `Resume` lane and says so. `lane_capabilities::resume` answers
+        // every seam, so nothing is left to a chain.
+        let engine = Engine::assemble(
+            &*provider,
+            &tools,
+            engine_config,
+            &TokioSleeper,
+            crate::lane_capabilities::resume(cfg.hooks.as_ref(), &hook_runner, &calibration),
+        );
         drive_resumed_turn(&engine, state, &events).await
     };
 

--- a/crates/stella-cli/src/agent/tests/durability_isolation.rs
+++ b/crates/stella-cli/src/agent/tests/durability_isolation.rs
@@ -27,10 +27,10 @@
 //! different door — a real engine session on its own OS thread, dispatched
 //! *because* the lead is mid-turn, built from a clone of the lead's `Config` —
 //! but it DOES have an identity of its own: its lane id. So `run_worker`
-//! re-keys the sink to the lane's own handle instead of stripping it (#3233),
-//! and the engine crate still cannot see any of this — a sub-session goes
-//! through `Engine::with_sleeper` rather than `run_sub_agent` — so the line has
-//! to be drawn here, at the seam that builds its config.
+//! re-keys the sink to the lane's own handle instead of stripping it (#3233).
+//! The engine crate still cannot see any of this: a sub-session builds its own
+//! engine, not a child. So the line has to be drawn here, at the seam that
+//! builds its config.
 
 use super::*;
 
@@ -129,9 +129,8 @@ fn a_sub_sessions_turn_cannot_destroy_the_leads_resume_point() {
          so the two must never share one `CHECKPOINT_BLOB` — and the loser \
          would be the turn a human is waiting on. `stella-core::subagent` \
          strips the sink for a dispatched child, which has no identity of its \
-         own to re-key to; a sub-session reaches the same door through \
-         `Engine::with_sleeper` instead of `run_sub_agent`, but DOES have an \
-         identity — its lane id — so it must re-key rather than share.",
+         own to re-key to. A sub-session builds its own engine, and DOES have \
+         an identity — its lane id — so it must re-key rather than share.",
     );
     assert!(
         lane_record.checkpoint().is_none(),

--- a/crates/stella-cli/src/agent/turn.rs
+++ b/crates/stella-cli/src/agent/turn.rs
@@ -145,6 +145,12 @@ pub(crate) async fn run_turn(
             // The invoked skill's `effort:` override, for this turn.
             config.effort = Some(effort);
         }
+        // TODO(#6109): still the builder path, so this turn reports no lane.
+        // `stella run` is a door, not one of the seven lanes `BuiltinLane`
+        // names, and `Lead` documents itself as the deck's turn. Until it is
+        // settled whether that definition widens, whether an eighth case
+        // arrives, or whether these doors stay unattributed, guessing here
+        // would make the lane say something its own definition denies.
         let mut engine = Engine::with_sleeper(provider, &permitted, config, &TokioSleeper)
             .with_calibration(calibration)
             .with_provider_outcomes(router)
@@ -179,6 +185,8 @@ pub(crate) async fn run_turn(
             // The invoked skill's `effort:` override, for this turn.
             config.effort = Some(effort);
         }
+        // Unattributed for the reason the process-free arm above gives: this
+        // is the same door, waiting on the same decision.
         let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
             .with_calibration(calibration)
             .with_provider_outcomes(router)

--- a/crates/stella-cli/src/command_deck/lead_turn.rs
+++ b/crates/stella-cli/src/command_deck/lead_turn.rs
@@ -158,16 +158,28 @@ pub(super) async fn run_lead_turn(
             // The scoped skill's `effort:` override, for this turn.
             engine_config.effort = Some(effort);
         }
-        let mut engine = Engine::with_sleeper(provider, &scoped_tap, engine_config, &TokioSleeper)
-            .with_calibration(calibration)
-            .with_steering(steering.as_ref())
-            .with_gate(pause.turn_gate());
-        if let Some(hooks) = &cfg.hooks {
-            engine = engine.with_hooks(hooks, &hook_runner);
-        }
-        if let Some(requery) = &requery {
-            engine = engine.with_requery(requery); // #3243 Phase 3
-        }
+        // Assembled rather than built up by optional builders (#6056): this
+        // turn is the `Lead` lane and now says so, and every seam it does not
+        // take is a written `None` in `lane_capabilities::lead` rather than
+        // whatever the builder chain happened not to attach. The conditional
+        // `with_hooks` / `with_requery` calls this replaces bound exactly the
+        // same two seams, which is why both arrive as `Option`s.
+        let engine = Engine::assemble(
+            provider,
+            &scoped_tap,
+            engine_config,
+            &TokioSleeper,
+            crate::lane_capabilities::lead(
+                cfg.hooks.as_ref(),
+                &hook_runner,
+                calibration,
+                pause.turn_gate(),
+                &**steering,
+                requery
+                    .as_ref()
+                    .map(|requery| requery as &dyn stella_core::ports::SteeringRequery),
+            ),
+        );
         let outcome = engine.run_turn_with_sender(messages, budget, &events).await;
         // The turn's plan graph, mirrored beside the board it was built from
         // (#5037): every revision, the `[:NEXT]` chain each of them authored,

--- a/crates/stella-cli/src/durability.rs
+++ b/crates/stella-cli/src/durability.rs
@@ -77,9 +77,9 @@ use stella_store::work_journal::WorkJournal;
 ///   so it is independently resumable instead of a second writer of the lead's
 ///   one resume point. The
 ///   re-key still has to happen at this seam, invisible to `stella-core`: a
-///   sub-session is a full engine session built through `Engine::with_sleeper`,
-///   not a child reached through `run_sub_agent`, so the engine crate never
-///   sees a parent (or a sibling lane) to arbitrate between.
+///   sub-session is a full engine session it assembles for itself, not a child
+///   reached through `run_sub_agent`, so the engine crate never sees a parent
+///   (or a sibling lane) to arbitrate between.
 ///
 /// An unbind would not help with any of them, and would cost something real: it
 /// would open a window where a turn still in flight finds `sink()` empty and

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -75,6 +75,7 @@ use stella_tui::{FleetDashResult, FleetMsg, FleetStatus};
 use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::config::Config;
+use crate::lane_capabilities;
 use crate::runtime::{SystemClock, TokioSleeper, WallClock};
 // The trait is in scope for `AttemptPointStream::publish` below — a fleet
 // attempt publishes its own channel across the dispatch's points (#4730).
@@ -1135,12 +1136,10 @@ async fn run_task(
                 config.effort = Some(effort);
             }
             let calibration = agent::seed_calibration(&store, &cfg);
-            let mut engine = Engine::with_sleeper(&*provider, &scoped, config, &TokioSleeper)
-                .with_gate(gate.as_ref())
-                .with_calibration(&calibration);
-            if let Some(hooks) = &cfg.hooks {
-                engine = engine.with_hooks(hooks, &hook_runner);
-            }
+            let hooks = cfg.hooks.as_ref();
+            let seams =
+                lane_capabilities::fleet_attempt(hooks, &hook_runner, &calibration, gate.as_ref());
+            let engine = Engine::assemble(&*provider, &scoped, config, &TokioSleeper, seams);
             // A fleet worker owns its lane's stage vocabulary — the opener is
             // here; the closer rides `worker_event_sender` below, ahead of
             // the engine's `TurnComplete` (#3416, #3428).

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -975,9 +975,15 @@ fn a_fleet_attempt_reflects_before_its_spend_is_read() {
 /// `seed_calibration` is called somewhere in the file.
 ///
 /// Before this fix, `fleet_cmd.rs` never called `seed_calibration` in
-/// shipping code. Its `Engine::with_sleeper` construction never chained
-/// `.with_calibration(...)` either. This test fails on both counts against
-/// that tree.
+/// shipping code, and the engine it built was handed no calibration map.
+/// This test fails on both counts against that tree.
+///
+/// The anchor is the capability call the attempt builds its seams with. The
+/// property is the one it always was: the seeded map has to reach the seams
+/// *this* attempt runs with, not merely appear somewhere in the file. Which
+/// lane those seams declare, and which of them they carry, is
+/// `crate::lane_capabilities`'s own pair of tests — a value a test can hold
+/// rather than a string it has to read.
 #[test]
 fn a_fleet_worker_seeds_and_applies_token_drift_calibration() {
     const FLEET: &str = include_str!("../fleet_cmd.rs");
@@ -989,33 +995,33 @@ fn a_fleet_worker_seeds_and_applies_token_drift_calibration() {
              resolved config, the same call every other door onto Engine makes",
         );
 
-    // Anchored on the exact `Engine::with_sleeper` construction `run_task`
-    // builds inside its raced block, not a copy-pasted reference elsewhere in
-    // the file — a rename of this call site breaks the compile as well as
-    // this find.
-    let engine_ctor = FLEET
-        .find("Engine::with_sleeper(&*provider, &scoped, config, &TokioSleeper)")
-        .expect("run_task must still build its engine through Engine::with_sleeper");
+    // Anchored on the exact call `run_task` builds its seams with, not a
+    // reference elsewhere in the file — a rename breaks the compile as well
+    // as this find.
+    let seams = FLEET
+        .find("lane_capabilities::fleet_attempt(")
+        .expect("run_task must build its seams through lane_capabilities::fleet_attempt");
     assert!(
-        seed < engine_ctor,
-        "calibration must be seeded before the engine that consumes it is built"
+        seed < seams,
+        "calibration must be seeded before the seams that carry it are built"
     );
 
-    // The chain this construction opens runs to its first `;` — `with_hooks`
-    // reassigns `engine` in a separate statement below, so bounding the
-    // search there is what keeps this from passing on a `.with_calibration(...)`
-    // written anywhere later in the function instead of on this construction.
-    let chain_end = engine_ctor
-        + FLEET[engine_ctor..]
-            .find(';')
-            .expect("the Engine::with_sleeper statement terminates");
-    let chain = &FLEET[engine_ctor..chain_end];
+    let call_end = seams
+        + FLEET[seams..]
+            .find(");")
+            .expect("the fleet_attempt call terminates");
+    let call = &FLEET[seams..call_end];
     assert!(
-        chain.contains(".with_calibration(&calibration)"),
-        "run_task's own Engine::with_sleeper(...) construction must chain \
-         .with_calibration(&calibration) — every other door onto Engine does, \
-         and a fleet worker hitting the same providers needs the same \
-         output-ceiling correction. Chain was:\n{chain}"
+        call.contains("&calibration"),
+        "run_task's own fleet_attempt(...) call must hand the seeded map to \
+         the engine — every other door onto Engine does, and a fleet worker \
+         hitting the same providers needs the same output-ceiling correction. \
+         Call was:\n{call}"
+    );
+
+    assert!(
+        FLEET.contains("Engine::assemble(&*provider, &scoped, config, &TokioSleeper, seams)"),
+        "the seams built above must be the ones the attempt's engine runs with"
     );
 }
 

--- a/crates/stella-cli/src/lane_capabilities.rs
+++ b/crates/stella-cli/src/lane_capabilities.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What each of this crate's turn lanes binds, and which lane it says it is.
+//!
+//! A lane is one place a turn runs. `stella_protocol::BuiltinLane` names
+//! seven. Four of them are built here: the deck's lead turn, a resumed turn,
+//! a deck worker lane, and a fleet attempt.
+//!
+//! Each one goes to the engine through `Engine::assemble`. Its
+//! `TurnCapabilities` carries the lane name. The other way in,
+//! `Engine::with_sleeper` and a chain of `with_*` calls, cannot: it always
+//! writes `lane: None`. A turn with no lane lands in the `null` group with
+//! every other one, and a report keyed by lane then has nothing to show.
+//!
+//! Each function below answers every seam. Every literal is written out in
+//! full. So a new slot on
+//! [`TurnCapabilities`](stella_core::TurnCapabilities) breaks this file until
+//! someone picks an answer for each lane. That is why the type has no
+//! `Default`.
+//!
+//! **One file, not four call sites.** Side by side, the four are easy to
+//! compare. And `subsession.rs` and `fleet_cmd.rs` both sit near the
+//! file-size ceiling, with no room for a literal of their own.
+//!
+//! `stella_core`'s `driver::drive` puts the lane on `agent.turn.started`.
+//! `crates/stella-parity/src/lane.rs` holds every lane to having a producer
+//! or a written reason for having none.
+
+use stella_core::ports::{SteeringRequery, TurnGate, TurnSteering};
+use stella_core::{CalibrationMap, HookRunner, Hooks, TurnCapabilities};
+use stella_protocol::{BuiltinLane, ModelCallRole, TurnLane};
+
+/// The deck's lead turn — `BuiltinLane::Lead`.
+///
+/// `hooks` and `requery` are `Option`s because the deck binds them only
+/// sometimes. Hooks exist when the config declares them. The re-query plane
+/// exists when the session has a memory to query.
+pub(crate) fn lead<'a>(
+    hooks: Option<&'a Hooks>,
+    runner: &'a dyn HookRunner,
+    calibration: &'a CalibrationMap,
+    gate: &'a dyn TurnGate,
+    steering: &'a dyn TurnSteering,
+    requery: Option<&'a dyn SteeringRequery>,
+) -> TurnCapabilities<'a> {
+    TurnCapabilities {
+        hooks: hooks.map(|hooks| (hooks, runner)),
+        // The deck parks a `PreToolUse` approval on its own responder. The
+        // broker route is the one-shot door's answer, not the deck's.
+        hook_approvals: None,
+        calibration: Some(calibration),
+        gate: Some(gate),
+        steering: Some(steering),
+        requery,
+        // The deck's observers ride the event stream, not the bus.
+        bus: None,
+        // The deck picks its provider once per session. There is no router
+        // breaker to feed, and nothing to re-resolve mid-turn.
+        outcomes: None,
+        fallback: None,
+        call_role: ModelCallRole::Worker,
+        lane: Some(TurnLane::Builtin(BuiltinLane::Lead)),
+    }
+}
+
+/// A turn replayed from a checkpoint — `BuiltinLane::Resume`.
+pub(crate) fn resume<'a>(
+    hooks: Option<&'a Hooks>,
+    runner: &'a dyn HookRunner,
+    calibration: &'a CalibrationMap,
+) -> TurnCapabilities<'a> {
+    TurnCapabilities {
+        hooks: hooks.map(|hooks| (hooks, runner)),
+        hook_approvals: None,
+        calibration: Some(calibration),
+        // A resumed turn has no live operator channel. It replays a
+        // checkpoint to its end and returns. Nothing to park on, and nothing
+        // to steer with.
+        gate: None,
+        steering: None,
+        requery: None,
+        bus: None,
+        outcomes: None,
+        fallback: None,
+        call_role: ModelCallRole::Worker,
+        lane: Some(TurnLane::Builtin(BuiltinLane::Resume)),
+    }
+}
+
+/// A deck worker lane — `BuiltinLane::SubSession`.
+pub(crate) fn sub_session<'a>(
+    calibration: &'a CalibrationMap,
+    gate: &'a dyn TurnGate,
+    steering: &'a dyn TurnSteering,
+) -> TurnCapabilities<'a> {
+    TurnCapabilities {
+        // Not bound, and not a new gap. A lane's hooks are the session's,
+        // and the lead turn that spawned it runs them. Wiring them onto a
+        // worker lane is its own decision.
+        hooks: None,
+        hook_approvals: None,
+        calibration: Some(calibration),
+        gate: Some(gate),
+        steering: Some(steering),
+        requery: None,
+        bus: None,
+        outcomes: None,
+        fallback: None,
+        call_role: ModelCallRole::Worker,
+        lane: Some(TurnLane::Builtin(BuiltinLane::SubSession)),
+    }
+}
+
+/// One fleet attempt — `BuiltinLane::FleetWorker`.
+pub(crate) fn fleet_attempt<'a>(
+    hooks: Option<&'a Hooks>,
+    runner: &'a dyn HookRunner,
+    calibration: &'a CalibrationMap,
+    gate: &'a dyn TurnGate,
+) -> TurnCapabilities<'a> {
+    TurnCapabilities {
+        hooks: hooks.map(|hooks| (hooks, runner)),
+        hook_approvals: None,
+        calibration: Some(calibration),
+        gate: Some(gate),
+        // A fleet worker has no input channel. Nobody is at a keyboard to
+        // steer it, so this stays unbound.
+        steering: None,
+        requery: None,
+        bus: None,
+        outcomes: None,
+        fallback: None,
+        call_role: ModelCallRole::Worker,
+        lane: Some(TurnLane::Builtin(BuiltinLane::FleetWorker)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_tools::hook_runner::HostHookRunner;
+
+    struct OpenGate;
+
+    #[async_trait::async_trait]
+    impl TurnGate for OpenGate {
+        async fn wait_if_paused(&self) {}
+    }
+
+    struct QuietSteering;
+
+    impl TurnSteering for QuietSteering {
+        fn drain_steering(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn soft_stop_requested(&self) -> bool {
+            false
+        }
+    }
+
+    /// **The lane witnesses.** Each of this crate's four lanes says which
+    /// lane it is.
+    ///
+    /// This fails on a tree where the four sites use `Engine::with_sleeper`.
+    /// The reason is structural, not behavioural. That call takes no lane and
+    /// always writes `lane: None`. There is no function to call, and nothing
+    /// that could answer.
+    ///
+    /// `stella-core`'s `a_turn_stamps_the_lane_that_assembled_it` covers what
+    /// a named lane then does: it reaches `agent.turn.started` on the wire.
+    #[test]
+    fn every_lane_this_crate_assembles_declares_itself() {
+        let runner = HostHookRunner;
+        let calibration = CalibrationMap::default();
+        let gate = OpenGate;
+        let steering = QuietSteering;
+
+        let rows = [
+            (
+                "lead",
+                lead(None, &runner, &calibration, &gate, &steering, None).lane,
+                BuiltinLane::Lead,
+            ),
+            (
+                "resume",
+                resume(None, &runner, &calibration).lane,
+                BuiltinLane::Resume,
+            ),
+            (
+                "sub_session",
+                sub_session(&calibration, &gate, &steering).lane,
+                BuiltinLane::SubSession,
+            ),
+            (
+                "fleet_attempt",
+                fleet_attempt(None, &runner, &calibration, &gate).lane,
+                BuiltinLane::FleetWorker,
+            ),
+        ];
+
+        for (name, declared, expected) in rows {
+            assert_eq!(
+                declared,
+                Some(TurnLane::Builtin(expected)),
+                "the `{name}` lane must name itself, or its turns land in \
+                 the `null` group with every door that names none",
+            );
+        }
+    }
+
+    /// A lane must not quietly gain or lose a seam. Moving a site onto
+    /// `Engine::assemble` may not change one of these. An engine that gained
+    /// a gate would park where nothing parked before. One that lost its
+    /// calibration map would start each turn from a raw estimate.
+    #[test]
+    fn each_lane_binds_what_its_call_site_bound_before() {
+        let runner = HostHookRunner;
+        let calibration = CalibrationMap::default();
+        let gate = OpenGate;
+        let steering = QuietSteering;
+
+        let deck = lead(None, &runner, &calibration, &gate, &steering, None);
+        assert!(deck.calibration.is_some() && deck.gate.is_some() && deck.steering.is_some());
+        assert!(deck.requery.is_none(), "no plane was handed in");
+        assert!(deck.hooks.is_none(), "no hooks were given");
+
+        let replayed = resume(None, &runner, &calibration);
+        assert!(replayed.calibration.is_some());
+        assert!(
+            replayed.gate.is_none() && replayed.steering.is_none(),
+            "a replayed turn binds neither, and must not grow one here",
+        );
+
+        let worker = sub_session(&calibration, &gate, &steering);
+        assert!(worker.calibration.is_some() && worker.gate.is_some() && worker.steering.is_some(),);
+
+        let fleet = fleet_attempt(None, &runner, &calibration, &gate);
+        assert!(fleet.calibration.is_some() && fleet.gate.is_some());
+        assert!(
+            fleet.steering.is_none(),
+            "a fleet attempt has no input channel to steer from",
+        );
+    }
+}

--- a/crates/stella-cli/src/lane_capabilities.rs
+++ b/crates/stella-cli/src/lane_capabilities.rs
@@ -14,10 +14,8 @@
 //! every other one, and a report keyed by lane then has nothing to show.
 //!
 //! Each function below answers every seam. Every literal is written out in
-//! full. So a new slot on
-//! [`TurnCapabilities`](stella_core::TurnCapabilities) breaks this file until
-//! someone picks an answer for each lane. That is why the type has no
-//! `Default`.
+//! full. So a new slot on [`TurnCapabilities`] breaks this file until someone
+//! picks an answer for each lane. That is why the type has no `Default`.
 //!
 //! **One file, not four call sites.** Side by side, the four are easy to
 //! compare. And `subsession.rs` and `fleet_cmd.rs` both sit near the

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -73,6 +73,7 @@ mod ingest_cmd;
 mod inspect;
 mod interactive;
 mod issue_provider;
+mod lane_capabilities;
 mod mcp_cmd;
 mod memory;
 mod memory_cmd;

--- a/crates/stella-cli/src/subagent.rs
+++ b/crates/stella-cli/src/subagent.rs
@@ -639,6 +639,12 @@ impl SessionSubAgents {
                 // propagates the gate as-is and narrows the steering to
                 // `ChildSteering`, so this is what makes a child pausable and
                 // stoppable without letting it steal the parent's messages.
+                //
+                // Still the builder path, and it names no lane on purpose:
+                // this engine never drives a turn of its own. `run_sub_agent`
+                // assembles the child that does, and that child stamps
+                // `BuiltinLane::SubagentFork`. A lane declared here would
+                // reach no `agent.turn.started` at all.
                 let engine = Engine::with_sleeper(&*provider, child_tools, config, &TokioSleeper)
                     .with_turn_controls(&controls);
                 // `catch_unwind` so a panic INSIDE the turn cannot skip the

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -1157,7 +1157,11 @@ async fn run_worker(
             .with_steering(tap.clone()),
     );
     let raced = {
-        let engine = Engine::with_sleeper(
+        // Assembled rather than built up by optional builders: this lane is
+        // the `SubSession` lane and says so, and
+        // `lane_capabilities::sub_session` answers every seam — calibration,
+        // gate, steering — rather than only the ones a chain attached.
+        let engine = Engine::assemble(
             &*provider,
             &permitted,
             // Never `engine_config_for`: that attaches the LEAD session's
@@ -1166,10 +1170,8 @@ async fn run_worker(
             // `subsession_engine_config_for`.
             recorder.wrap(agent::subsession_engine_config_for(cfg, &lane_durability)),
             &TokioSleeper,
-        )
-        .with_calibration(&calibration)
-        .with_gate(gate.as_ref())
-        .with_steering(tap.as_ref());
+            crate::lane_capabilities::sub_session(&calibration, gate.as_ref(), tap.as_ref()),
+        );
         // The run-terminal `Complete` this lane's deck row settles on is
         // synthesized by its forwarder when the stream closes (#3379), so this
         // sender needs no ending wrapper — only the lane's task tag, which is

--- a/crates/stella-cli/src/turn_files.rs
+++ b/crates/stella-cli/src/turn_files.rs
@@ -789,23 +789,32 @@ mod tests {
     /// Keyed on the engine construction rather than on a turn-entry spelling,
     /// because the drivers do not agree on one: `run_turn_with_sender`,
     /// `run_goal` and the resume path are three different entries and
-    /// `Engine::with_sleeper` is the one thing all of them do first.
+    /// building an engine is the one thing all of them do first.
+    ///
+    /// **Both** constructors count: `Engine::with_sleeper` and
+    /// [`stella_core::Engine::assemble`], the blessed one a named lane uses.
+    /// A fence that saw only one spelling would read every driver on the
+    /// other as not building an engine at all.
     ///
     /// Shipping files only. A `#[cfg(test)]` engine is a fixture, and the
     /// question here is which *door* drives a turn.
     #[test]
     fn every_engine_driver_declares_what_it_owes_the_ledger() {
         // Built rather than written out, so this file is not its own match,
-        // and with the open paren so a doc comment naming the constructor is
+        // and with the open paren so a doc comment naming a constructor is
         // prose rather than a driver.
-        let builds = format!("Engine::with_{}(", "sleeper");
+        let constructors = [
+            format!("Engine::with_{}(", "sleeper"),
+            format!("Engine::{}(", "assemble"),
+        ];
+        let builds = |body: &str| constructors.iter().any(|ctor| body.contains(ctor));
         let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
 
         for (file, posture) in ENGINE_DRIVERS {
             let body = std::fs::read_to_string(src.join(file))
                 .unwrap_or_else(|e| panic!("cannot read {file}: {e}"));
             assert!(
-                body.contains(&builds),
+                builds(&body),
                 "{file} is declared a turn driver ({posture:?}) and no longer \
                  builds an engine. A stale row is worse than no row: it makes \
                  the list look complete while the door it stood for has moved."
@@ -831,7 +840,7 @@ mod tests {
 
         for path in shipping_sources(&src) {
             let body = std::fs::read_to_string(&path).expect("a listed source");
-            if !body.contains(&builds) {
+            if !builds(&body) {
                 continue;
             }
             let relative = path

--- a/crates/stella-core/src/subagent/tests/seams.rs
+++ b/crates/stella-core/src/subagent/tests/seams.rs
@@ -396,3 +396,56 @@ async fn subagent_start_and_stop_hooks_fire_around_a_child_turn() {
         "{payloads:?}"
     );
 }
+
+// ---- the lane a fork declares -----------------------------------------
+
+/// **The fork's lane witness.** A child's turn says which lane it ran in, so
+/// a reader can group a delegated turn apart from the parent's.
+///
+/// Fails on a tree whose `Engine::assemble` carries no lane: the field is not
+/// on the engine, so `agent.turn.started` has no `lane` key to read at all.
+///
+/// The bus is attached to the PARENT, and the child inherits it — which is
+/// why one turn opens on it here rather than two: this parent never drives a
+/// turn of its own.
+#[tokio::test]
+async fn a_forked_child_stamps_the_subagent_fork_lane() {
+    let bus = HookBus::new("fork-lane-test");
+    let seen: std::sync::Arc<Mutex<Vec<serde_json::Value>>> =
+        std::sync::Arc::new(Mutex::new(Vec::new()));
+    let sink = std::sync::Arc::clone(&seen);
+    bus.on(crate::bus::names::AGENT_TURN_STARTED, move |event| {
+        sink.lock().unwrap().push(event.payload.clone());
+        Ok(())
+    })
+    .detach();
+
+    let parent_provider = ScriptedProvider::new(vec![]);
+    let child_provider = ScriptedProvider::new(vec![Ok(text_result("done", 0.01))]);
+    let tools = MixedTools::default();
+    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep)
+        .with_bus(&bus);
+    let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    parent
+        .run_sub_agent(
+            SubAgentHost::new(&child_provider),
+            &SubAgentSpec::read_only("laned", "work"),
+            &mut budget,
+            &tx,
+        )
+        .await;
+
+    let lanes: Vec<serde_json::Value> = seen
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|payload| payload.get("lane").cloned())
+        .collect();
+    assert_eq!(
+        lanes,
+        vec![serde_json::json!({ "builtin": "subagent_fork" })],
+        "the child's turn must name the lane that assembled it",
+    );
+}

--- a/crates/stella-engine/src/lib.rs
+++ b/crates/stella-engine/src/lib.rs
@@ -213,6 +213,13 @@ pub use stella_core::driver::output_budget_recovery::SessionOutputCeilings;
 pub use stella_core::driver::{
     Engine, EngineConfig, SOFT_STOP_REASON, TurnHalt, TurnOutcome, step_cap_reason,
 };
+// `Engine::assemble` is the blessed constructor, and its one non-port
+// parameter is a `TurnCapabilities`. Without the type here a host could name
+// the method and never call it — obligation 1 of the closure rule, read at the
+// parameter. `OwnedTurnCapabilities` rides along because a host that builds
+// its seams with no frame above holding them is the case that struct exists
+// for, which is exactly an out-of-process host.
+pub use stella_core::driver::capabilities::{OwnedTurnCapabilities, TurnCapabilities};
 pub use stella_core::estimator::CalibrationMap;
 pub use stella_core::event_sender::{EventSendError, EventSender};
 pub use stella_core::loop_detect::LoopDetectionConfig;

--- a/crates/stella-parity/src/lane.rs
+++ b/crates/stella-parity/src/lane.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The turn-lane matrix — which builtin lanes say which lane they are.
+//!
+//! `stella_protocol::BuiltinLane` names seven places a turn runs.
+//! `Engine::assemble` lets each of them put its own name on
+//! `agent.turn.started`. Having a name and saying it are two facts. A site
+//! that builds its engine with `Engine::with_sleeper` writes `lane: None` and
+//! cannot say anything. Its turns then land in one `null` bucket. This table
+//! keeps the two facts together.
+//!
+//! Same instrument as the two matrices beside it, pointed at lanes. One row
+//! per case. A witness test per row, named and checked. The compiler enforces
+//! that no case is missed. A lane with no producer needs a
+//! [`LaneBinding::NoProducer`] row and a reason.
+//!
+//! **What it does not prove.** A `Bound` row's `how` is prose for a reviewer.
+//! The checks are narrower: the named site really spells its lane, and the
+//! named witness really exists. That is enough to make an author say who
+//! stamps a lane. It is also enough to fail when a site goes back to the
+//! builder path.
+
+use stella_protocol::BuiltinLane;
+
+/// Whether a lane has a producer, and what proves it.
+#[derive(Debug)]
+pub enum LaneBinding {
+    /// Some assembly site stamps this lane.
+    Bound {
+        /// The workspace-relative file whose source names the lane. Checked:
+        /// this file must spell `BuiltinLane::<variant>`.
+        site: &'static str,
+        /// How the lane reaches the engine, as prose for the reader.
+        how: &'static str,
+        /// Name of the test that proves the site names this lane. Checked
+        /// for existence, as the two matrices beside this one check theirs.
+        witness: &'static str,
+    },
+    /// Nothing stamps this lane and nothing will. The row carries the reason
+    /// and the decision it cites. This is not "not yet": a lane waiting on
+    /// something else would be a different posture, and there is none here.
+    NoProducer {
+        /// Why nothing produces it, with the decision cited.
+        reason: &'static str,
+    },
+}
+
+/// One builtin lane and how it is produced.
+#[derive(Debug)]
+pub struct Lane {
+    /// The builtin lane this row is about.
+    pub lane: BuiltinLane,
+    /// Whether something stamps it, and what proves that.
+    pub binding: LaneBinding,
+}
+
+/// Every builtin lane, with its producer or its written reason for having
+/// none.
+///
+/// The tests below check both directions. Every [`BuiltinLane`] gets exactly
+/// one row. Every row's claim is checked against the source it names.
+pub const LANES: &[Lane] = &[
+    Lane {
+        lane: BuiltinLane::Lead,
+        binding: LaneBinding::Bound {
+            site: "crates/stella-cli/src/lane_capabilities.rs",
+            how: "the deck's lead turn, assembled in `command_deck::lead_turn` from \
+                  `lane_capabilities::lead`",
+            witness: "every_lane_this_crate_assembles_declares_itself",
+        },
+    },
+    Lane {
+        lane: BuiltinLane::Resume,
+        binding: LaneBinding::Bound {
+            site: "crates/stella-cli/src/lane_capabilities.rs",
+            how: "a turn replayed from a checkpoint, assembled in `agent::resume` from \
+                  `lane_capabilities::resume`",
+            witness: "every_lane_this_crate_assembles_declares_itself",
+        },
+    },
+    Lane {
+        lane: BuiltinLane::SubSession,
+        binding: LaneBinding::Bound {
+            site: "crates/stella-cli/src/lane_capabilities.rs",
+            how: "a deck worker lane, assembled in `subsession::run_worker` from \
+                  `lane_capabilities::sub_session`",
+            witness: "every_lane_this_crate_assembles_declares_itself",
+        },
+    },
+    Lane {
+        lane: BuiltinLane::SubagentFork,
+        binding: LaneBinding::Bound {
+            site: "crates/stella-core/src/subagent.rs",
+            how: "the child `Engine::run_sub_agent` forks — the first lane to stamp itself, \
+                  and the reason the engine carries the field at all",
+            witness: "a_forked_child_stamps_the_subagent_fork_lane",
+        },
+    },
+    Lane {
+        lane: BuiltinLane::FleetWorker,
+        binding: LaneBinding::Bound {
+            site: "crates/stella-cli/src/lane_capabilities.rs",
+            how: "one fleet attempt, assembled in `fleet_cmd::run_task` from \
+                  `lane_capabilities::fleet_attempt`",
+            witness: "every_lane_this_crate_assembles_declares_itself",
+        },
+    },
+    Lane {
+        lane: BuiltinLane::PipelineStage,
+        binding: LaneBinding::NoProducer {
+            reason: "the built-in staged pipeline this case was named for is gone from the \
+                     workspace, and a verification plugin's stage turn is a plugin lane: it \
+                     arrives as `TurnLane::Plugin` carrying the id its manifest declared. So \
+                     there is no producer to re-home onto this case. It is kept for reading \
+                     rather than writing — `BuiltinLane` is closed with no `serde(other)`, so \
+                     deleting it would fail a recording made before the removal outright \
+                     instead of demoting it. Refs #3881",
+        },
+    },
+    Lane {
+        lane: BuiltinLane::ServeSession,
+        binding: LaneBinding::Bound {
+            site: "crates/stella-serve/src/session.rs",
+            how: "a turn a remote host drives over the wire, assembled from \
+                  `session::served_capabilities`",
+            witness: "a_served_turn_declares_the_serve_session_lane",
+        },
+    },
+];
+
+/// The row for `lane`, or `None`. The tests below make every builtin lane
+/// resolve, so a `None` means the caller named something that is not a lane.
+#[must_use]
+pub fn row(lane: BuiltinLane) -> Option<&'static Lane> {
+    LANES.iter().find(|row| row.lane == lane)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every file a row may name as a site or a witness home, as
+    /// `(workspace-relative path, source)`.
+    ///
+    /// Source text, not the module tree. `provider_parity` names the trade.
+    /// A site or a witness that moves out of this list fails loudly. Extend
+    /// the list to fix it. It never fails silently.
+    fn lane_sources() -> [(&'static str, &'static str); 4] {
+        [
+            // Where four of this workspace's lanes declare what they bind,
+            // and where their shared witness lives.
+            (
+                "crates/stella-cli/src/lane_capabilities.rs",
+                include_str!("../../stella-cli/src/lane_capabilities.rs"),
+            ),
+            // The fork's own assembly.
+            (
+                "crates/stella-core/src/subagent.rs",
+                include_str!("../../stella-core/src/subagent.rs"),
+            ),
+            // The fork's witness lives in a split-out test module, which
+            // `include_str!` of the parent does not pull in.
+            (
+                "crates/stella-core/src/subagent/tests/seams.rs",
+                include_str!("../../stella-core/src/subagent/tests/seams.rs"),
+            ),
+            // The served turn's assembly and its witness, in one file.
+            (
+                "crates/stella-serve/src/session.rs",
+                include_str!("../../stella-serve/src/session.rs"),
+            ),
+        ]
+    }
+
+    fn source_named(path: &str) -> &'static str {
+        lane_sources()
+            .into_iter()
+            .find(|(name, _)| *name == path)
+            .map(|(_, source)| source)
+            .unwrap_or_else(|| {
+                panic!("a lane row names `{path}`, which `lane_sources` does not carry")
+            })
+    }
+
+    /// Completeness, from the compiler's side and the table's.
+    ///
+    /// The match has no `_` arm. A case added to [`BuiltinLane`] breaks this
+    /// file until somebody says what produces it. That is what a closed enum
+    /// is for.
+    #[test]
+    fn every_builtin_lane_has_exactly_one_row() {
+        for builtin in BuiltinLane::ALL {
+            match builtin {
+                BuiltinLane::Lead
+                | BuiltinLane::Resume
+                | BuiltinLane::SubSession
+                | BuiltinLane::SubagentFork
+                | BuiltinLane::FleetWorker
+                | BuiltinLane::PipelineStage
+                | BuiltinLane::ServeSession => {}
+            }
+            let rows = LANES.iter().filter(|row| row.lane == builtin).count();
+            assert_eq!(rows, 1, "`{builtin}` must have exactly one row, has {rows}");
+            assert!(row(builtin).is_some());
+        }
+        assert_eq!(
+            LANES.len(),
+            BuiltinLane::ALL.len(),
+            "a row names something that is not a builtin lane",
+        );
+    }
+
+    /// **The matrix witness.** Every `Bound` row's site really spells its
+    /// lane.
+    ///
+    /// On a tree where only the fork stamps itself, this fails for the other
+    /// five rows at once. A site that builds its engine with
+    /// `Engine::with_sleeper` takes no lane, so it never spells one.
+    #[test]
+    fn every_bound_lane_is_stamped_at_its_site() {
+        for row in LANES {
+            let LaneBinding::Bound { site, .. } = &row.binding else {
+                continue;
+            };
+            let needle = format!("BuiltinLane::{:?}", row.lane);
+            assert!(
+                source_named(site).contains(&needle),
+                "`{}` is declared bound at {site}, which does not name `{needle}` — a lane \
+                 whose site stopped stamping it reports `null` like an unattributed door",
+                row.lane,
+            );
+        }
+    }
+
+    /// Every `Bound` row's witness must exist.
+    #[test]
+    fn every_lane_witness_exists() {
+        for row in LANES {
+            let LaneBinding::Bound { witness, .. } = &row.binding else {
+                continue;
+            };
+            let needle = format!("fn {witness}(");
+            assert!(
+                lane_sources()
+                    .iter()
+                    .any(|(_, source)| source.contains(&needle)),
+                "witness for `{}` not found: {witness}",
+                row.lane,
+            );
+        }
+    }
+
+    /// A `NoProducer` row must name its reason and cite the decision, and
+    /// nothing in the tree may quietly start stamping it.
+    #[test]
+    fn a_lane_with_no_producer_says_why_and_has_none() {
+        for row in LANES {
+            let LaneBinding::NoProducer { reason } = &row.binding else {
+                continue;
+            };
+            assert!(
+                reason.contains("Refs #"),
+                "`{}` has no producer and cites no decision. A silence is what this \
+                 matrix exists to refuse.",
+                row.lane,
+            );
+            let needle = format!("BuiltinLane::{:?}", row.lane);
+            for (path, source) in lane_sources() {
+                assert!(
+                    !source.contains(&needle),
+                    "{path} stamps `{needle}`, which is declared to have no producer. \
+                     Either the site is wrong or the row is — say which.",
+                );
+            }
+        }
+    }
+}

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -41,6 +41,7 @@
 //! `docs/spec/engine-embedding.md`.
 
 pub mod evolution;
+pub mod lane;
 
 /// How one capability ships on one surface.
 #[derive(Debug)]

--- a/crates/stella-serve/src/session.rs
+++ b/crates/stella-serve/src/session.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant};
 use stella_core::EngineConfig;
 use stella_core::event_sender::RunEnding;
 use stella_core::ports::{AuthzGate, NoAuthz, Principal};
-use stella_engine::{BudgetGuard, CancelToken, Engine, EventSender, TurnOutcome};
+use stella_engine::{BudgetGuard, CancelToken, Engine, EventSender, TurnCapabilities, TurnOutcome};
 use stella_protocol::{
     AgentEvent, CompletionMessage, CompletionResult, ProviderError, ToolContract, ToolOutput,
 };
@@ -736,15 +736,17 @@ fn run_session(
         // Every attachment below is by reference for the engine's lifetime, so
         // the owners have to outlive it — hence the bindings above rather than
         // temporaries here.
-        let mut engine = Engine::with_sleeper(&provider, tool_view, spec.config.clone(), &sleeper)
-            .with_gate(&gate)
-            .with_steering(&*steering);
-        if let Some(bus) = &bus {
-            engine = engine.with_bus(bus);
-        }
-        if let Some(calibration) = &spec.calibration {
-            engine = engine.with_calibration(calibration);
-        }
+        //
+        // Assembled rather than built up by optional builders: this turn is
+        // the `ServeSession` lane and says so, and `served_capabilities`
+        // answers every seam rather than only the ones a chain attached.
+        let engine = Engine::assemble(
+            &provider,
+            tool_view,
+            spec.config.clone(),
+            &sleeper,
+            served_capabilities(spec.calibration.as_deref(), &gate, &*steering, bus.as_ref()),
+        );
 
         // Two mutually exclusive modes: plain turn, judged goal run (#1297).
         let outcome = match &spec.goal {
@@ -830,6 +832,43 @@ fn run_session(
         // registered here is work being thrown away, and `clear` reports it.
         pending.clear();
     });
+}
+
+/// What a served turn binds, and which lane it says it is.
+///
+/// A value rather than a builder chain so both halves are checkable: a test
+/// can hold the seams in its hand, and a slot added to [`TurnCapabilities`]
+/// stops this function compiling until somebody decides what a served turn
+/// does with it — the whole reason that type has no `Default`.
+///
+/// `calibration` and `bus` are `Option`s because the host supplies them or
+/// does not: a map is only useful across turns, and the bus exists only when
+/// the deployment installed an extension.
+fn served_capabilities<'a>(
+    calibration: Option<&'a stella_core::estimator::CalibrationMap>,
+    gate: &'a dyn stella_engine::TurnGate,
+    steering: &'a dyn stella_engine::TurnSteering,
+    bus: Option<&'a stella_core::bus::HookBus>,
+) -> TurnCapabilities<'a> {
+    TurnCapabilities {
+        // The host runs its own hooks on its own side of the wire; this engine
+        // holds no ambient authority to run a command with.
+        hooks: None,
+        hook_approvals: None,
+        calibration,
+        gate: Some(gate),
+        steering: Some(steering),
+        requery: None,
+        bus,
+        outcomes: None,
+        // The host owns the model calls, so re-resolving a provider mid-turn
+        // is its decision rather than this engine's.
+        fallback: None,
+        call_role: stella_protocol::ModelCallRole::Worker,
+        lane: Some(stella_protocol::TurnLane::Builtin(
+            stella_protocol::BuiltinLane::ServeSession,
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -979,5 +1018,75 @@ mod tests {
         };
         assert_eq!(calls.load(Ordering::SeqCst), 2);
         assert_eq!(text, "ran a second step the halt should have prevented");
+    }
+
+    struct OpenGate;
+
+    #[async_trait]
+    impl stella_engine::TurnGate for OpenGate {
+        async fn wait_if_paused(&self) {}
+    }
+
+    struct QuietSteering;
+
+    impl stella_engine::TurnSteering for QuietSteering {
+        fn drain_steering(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn soft_stop_requested(&self) -> bool {
+            false
+        }
+    }
+
+    /// **The lane witness.** A served turn declares the `ServeSession` lane,
+    /// so a host grouping turns by lane sees this one as its own bucket
+    /// rather than as an unattributed `null`.
+    ///
+    /// Fails on a tree that builds this engine with `Engine::with_sleeper`,
+    /// for a structural reason: that constructor has no parameter that could
+    /// carry a lane and writes `None`, so there is no `served_capabilities`
+    /// to call and nothing that could answer. What the value then does is
+    /// `stella-core`'s `a_turn_stamps_the_lane_that_assembled_it`.
+    #[test]
+    fn a_served_turn_declares_the_serve_session_lane() {
+        let gate = OpenGate;
+        let steering = QuietSteering;
+
+        let seams = served_capabilities(None, &gate, &steering, None);
+
+        assert_eq!(
+            seams.lane,
+            Some(stella_protocol::TurnLane::Builtin(
+                stella_protocol::BuiltinLane::ServeSession
+            )),
+        );
+    }
+
+    /// A served turn must not quietly gain or lose a seam. An engine that
+    /// gained a gate would park where nothing parked before, and one that
+    /// lost the host's calibration map would start every turn from an
+    /// uncorrected estimate.
+    #[test]
+    fn a_served_turn_binds_what_its_call_site_bound_before() {
+        let gate = OpenGate;
+        let steering = QuietSteering;
+
+        let host_supplied_nothing = served_capabilities(None, &gate, &steering, None);
+        assert!(host_supplied_nothing.gate.is_some() && host_supplied_nothing.steering.is_some());
+        assert!(
+            host_supplied_nothing.calibration.is_none() && host_supplied_nothing.bus.is_none(),
+            "a host that supplied neither must not be given one",
+        );
+        assert!(
+            host_supplied_nothing.hooks.is_none(),
+            "the host runs its own hooks; this engine has no authority to",
+        );
+
+        let calibration = stella_core::estimator::CalibrationMap::default();
+        let bus = stella_core::bus::HookBus::new("serve-lane-test");
+        let host_supplied_both =
+            served_capabilities(Some(&calibration), &gate, &steering, Some(&bus));
+        assert!(host_supplied_both.calibration.is_some() && host_supplied_both.bus.is_some());
     }
 }

--- a/crates/stella-serve/src/subagents.rs
+++ b/crates/stella-serve/src/subagents.rs
@@ -259,6 +259,11 @@ impl SubAgentDispatcher for ServedSubAgents {
                     // prompt — and the reason nesting is structurally capped
                     // at one level: `delegate` is not in this view.
                     let read_only = ReadOnlyTools::new(&*tools);
+                    // The builder path, naming no lane on purpose: this engine
+                    // never drives a turn of its own. `run_sub_agent` assembles
+                    // the child that does, and that child stamps
+                    // `BuiltinLane::SubagentFork` — a lane declared here would
+                    // reach no `agent.turn.started` at all.
                     let engine = Engine::with_sleeper(
                         &*provider,
                         &read_only,


### PR DESCRIPTION
## What and why

`stella_protocol::BuiltinLane` names seven places a turn runs, and
`Engine::assemble` lets each of them put its own name on `agent.turn.started`.
Only one site did: the subagent fork. Every other site built its engine with
`Engine::with_sleeper`, which takes no lane parameter and writes `lane: None`
by construction — so their turns all landed in the `null` bucket, and the lane
matrix #3274 planned had rows with nothing to read.

Five sites now assemble and name their lane:

| Lane | Site |
|---|---|
| `Lead` | `crates/stella-cli/src/command_deck/lead_turn.rs` |
| `Resume` | `crates/stella-cli/src/agent/resume.rs` |
| `SubSession` | `crates/stella-cli/src/subsession.rs` |
| `FleetWorker` | `crates/stella-cli/src/fleet_cmd.rs` |
| `ServeSession` | `crates/stella-serve/src/session.rs` |

`SubagentFork` already stamped itself. `PipelineStage` gets no producer, and
that is the tree's own recorded decision rather than a gap this PR left:
`crates/stella-protocol/src/lane.rs` states that the crate the case was named
for was deleted (#3865) and that a verification plugin's stage turn arrives as
`TurnLane::Plugin`, so there is nothing to re-home onto the builtin case
(#3881). The maintainer pointer asked for "the plugin-stage lane" to be
stamped too; the code says otherwise, and this PR follows the code.

## Where the capability sets live

Two new files, and the reason for each is structural:

- `crates/stella-cli/src/lane_capabilities.rs` — the four CLI lanes, one
  function each. `subsession.rs` (1485/1500) and `fleet_cmd.rs` (1500/1500)
  both sat at or beside the file-size ceiling on `main`, so a capability
  literal at either call site had no room. `fleet_cmd.rs` comes out smaller
  than it went in (1500 → 1499); `subsession.rs` grows by two (1485 → 1487)
  and stays under the 1500 limit. Neither is grandfathered, no baseline entry
  was added, and no ceiling was raised — the `file size ratchet` check passes.
- `crates/stella-parity/src/lane.rs` — the lane matrix. One row per
  `BuiltinLane`, each `Bound` row naming a site, a `how`, and a witness; the
  `PipelineStage` row is a `NoProducer` carrying its reason. Exemplar: the two
  matrices beside it in the same crate (`CAPABILITIES` in `lib.rs` and
  `evolution.rs`) — same three instruments, same `include_str!` witness sweep.

## Witness mechanism — why each fails on `main`

Values, not strings, wherever a test could hold one:

- `every_lane_this_crate_assembles_declares_itself` and
  `each_lane_binds_what_its_call_site_bound_before`
  (`crates/stella-cli/src/lane_capabilities.rs`) — call each of the four
  constructors and assert the lane and the seams. **On `main` the file does
  not exist and there is no function to call**, because `Engine::with_sleeper`
  has no parameter that could carry a lane.
- `a_served_turn_declares_the_serve_session_lane` and
  `a_served_turn_binds_what_its_call_site_bound_before`
  (`crates/stella-serve/src/session.rs`) — the same, for the served turn.
- `a_forked_child_stamps_the_subagent_fork_lane`
  (`crates/stella-core/src/subagent/tests/seams.rs`) — a **behavioural**
  witness: a `HookBus` on the parent, one real `run_sub_agent`, and the single
  `agent.turn.started` it sees carries `{"builtin":"subagent_fork"}`. Fails on
  a tree where the engine has no lane field, because the payload has no `lane`
  key at all.
- `every_bound_lane_is_stamped_at_its_site`
  (`crates/stella-parity/src/lane.rs`) — reads each row's named source and
  requires it to spell `BuiltinLane::<variant>`. On `main` this fails for five
  of the six bound rows at once; only `subagent.rs` spells one.
- `every_builtin_lane_has_exactly_one_row` matches `BuiltinLane` with no `_`
  arm, so an eighth case breaks the build until somebody says what produces it.

`a_turn_stamps_the_lane_that_assembled_it`
(`crates/stella-core/src/driver/tests/lifecycle_bus.rs`) already covered what a
declared lane then does on the wire, and is untouched.

## Nothing a site bound before was dropped

Each moved site's `EngineConfig`, `with_*` chain and `attach_turn_controls`
call were read and carried through unchanged. The
`*_binds_what_its_call_site_bound_before` tests pin that per lane, in both
directions — a gate that appeared where none was bound, or a calibration map
that vanished, fails them.

## Sites deliberately left on `Engine::with_sleeper`, each with a written reason

- **Fork hosts** — `crates/stella-cli/src/subagent.rs` and
  `crates/stella-serve/src/subagents.rs`. Neither engine ever drives a turn of
  its own: `run_sub_agent` assembles the child that does, and that child stamps
  `SubagentFork`. A lane declared here would reach no `agent.turn.started`.
- **The non-interactive doors** — `agent/turn.rs` (both arms), `agent/goal.rs`
  and `agent/goal/goal_wrapped.rs`. These run the session's top-level turn, but
  `BuiltinLane::Lead` documents itself as the deck's turn and
  `doc:turn-lane-assembly` §2 names only `command_deck.rs` for that row.
  Stamping them `Lead` would make the lane contradict its own definition, and
  inventing an eighth case is a wire change outside this slice. Each carries a
  `TODO(#6109)` naming the open decision.

## Other changes this forced

- `crates/stella-cli/src/turn_files.rs`'s
  `every_engine_driver_declares_what_it_owes_the_ledger` fence keyed on
  `Engine::with_sleeper(` alone. It now counts both constructors — otherwise
  every migrated driver would have read as "no longer builds an engine".
- `crates/stella-cli/src/fleet_cmd/tests.rs`'s
  `a_fleet_worker_seeds_and_applies_token_drift_calibration` anchored on the
  old builder chain text. Re-anchored on the capability call; same property,
  same name.
- `stella-engine` re-exports `TurnCapabilities` and `OwnedTurnCapabilities`.
  That crate's closure rule says a host must be able to construct every value
  an exported entry point accepts; `Engine::assemble` was exported and its one
  non-port parameter was not nameable, so the method could be called by nobody.
- Stale prose in `durability.rs`, `agent/engine.rs` and
  `agent/tests/durability_isolation.rs` said a sub-session is "built through
  `Engine::with_sleeper`". It is not any more.

## Evidence

CI on this branch. `make guards-fast` and `./scripts/check-file-size.sh` are
green locally (`check-file-size: OK — nothing went over by this change`); no
workspace build was run on the maintainer's machine, per CLAUDE.md.

Tests deleted: None.

Residue filed: #6109 (which lane the four non-interactive CLI doors run in).

Closes #6056
Refs #3274, Refs #3386, Refs #3387, Refs #3410, Refs #3881

## Summary by Sourcery

Stamp builtin lane identities on supported turn-start events and establish coverage checks for every lane producer.

New Features:
- Add lane-aware engine assembly for lead, resume, sub-session, fleet worker, and served turns so their start events identify the builtin lane.

Bug Fixes:
- Prevent migrated turn types from being grouped under an unattributed null lane.

Enhancements:
- Centralize per-lane capability bindings and add a parity matrix documenting every builtin lane, including the intentionally producerless pipeline stage.
- Expose turn capability types through stella-engine and retain explicit documentation for intentionally unattributed entry points.

Documentation:
- Update stale documentation and comments to describe independently assembled sub-session engines and the remaining lane decision for non-interactive doors.

Tests:
- Add structural and behavioral witnesses verifying lane declarations, preserved capability bindings, fork lane stamping, served lane stamping, and complete builtin-lane coverage.
- Update engine-driver and fleet calibration source checks for the assembled constructor and capability-based wiring.