### PR TITLE
fix(stella-cli,stella-parity): retire a memory on what the turns measured

### DIFF
--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -42,6 +42,13 @@ mod guarantees;
 #[cfg(test)]
 mod skill_lifecycle;
 
+/// The memory lifecycle twin: a recorded window demotes a mined memory and
+/// leaves a hand-written one alone. A child module for [`guarantees`]'s
+/// reason — it drives [`SessionMemory::auto_create_skills`] without widening
+/// its visibility.
+#[cfg(test)]
+mod memory_lifecycle;
+
 /// What [`SessionMemory::partition_known`] stores, diverts to the mining log,
 /// and drops. A child module for the same reason as [`guarantees`]: the split
 /// is private, and it is the split itself that needs pinning, not the turn
@@ -816,7 +823,7 @@ impl SessionMemory {
         // have ALL left the tree is stale by a reproducible check, needing no
         // model and no human. It writes the pruning-eligible verdict into the
         // ledger and retires through the same protected, reversible event
-        // writer as the health sweep below.
+        // writer as the measured sweep below.
         let vanished = super::validation::vanished_memories(&self.store, &self.workspace_root);
         if !vanished.is_empty() {
             super::validation::record_vanished_verdicts(&self.store, &vanished, &now);
@@ -837,12 +844,24 @@ impl SessionMemory {
             }
         }
 
-        let policy = super::tuning::selection_health_policy(&self.workspace_root);
-        let health = super::uses::selection_health(&self.store, policy);
-        if health.is_empty() {
+        // The measured half. Every turn's offered→shown join for a
+        // memory record lands in the shared artifact trial ledger, and this is
+        // the same `appraise` + `decide_demotion` pass the skill sweep runs —
+        // one appraisal engine, read through a kind filter. A record the
+        // ledger names but the store does not know gets no origin entry and is
+        // therefore kept, which is where a frame that carried a citation label
+        // instead of an id lands.
+        let origins = super::retirement::origins(&self.store);
+        let decisions = super::appraisals::sweep(
+            &self.workspace_root,
+            stella_learn::ledger::ArtifactKind::Memory,
+            &origins,
+            &stella_learn::skills::appraisal::AppraisalConfig::default(),
+        );
+        if decisions.is_empty() {
             return;
         }
-        let sweep = super::retirement::sweep(&self.store, &health, &now);
+        let sweep = super::retirement::sweep(&self.store, &decisions, &now);
         if quiet {
             return;
         }
@@ -854,7 +873,7 @@ impl SessionMemory {
         }
         for (record_id, protection) in &sweep.refused {
             eprintln!(
-                "memory: {record_id} is failing but is {} — left in place.",
+                "memory: {record_id} earned retirement but is {} — left in place.",
                 protection.as_str()
             );
         }

--- a/crates/stella-cli/src/memory/learning/memory_lifecycle.rs
+++ b/crates/stella-cli/src/memory/learning/memory_lifecycle.rs
@@ -1,0 +1,176 @@
+//! The memory lifecycle twin. A memory that stops helping is retired from
+//! what the turns measured. A memory a person wrote is not.
+//!
+//! The trials here are real ledger rows. `appraisals::record_turn` writes
+//! them, and `SessionMemory::auto_create_skills` reads them back. Both are
+//! production doors. Nothing hands the sweep a verdict.
+//!
+//! Recall notes what a turn offered and what it showed. That half has its own
+//! witness, in `memory::trials`.
+
+use std::path::Path;
+
+use stella_learn::ledger::ArtifactKind;
+
+use crate::memory::{SessionMemory, appraisals, retirement, trials};
+
+/// Turns per arm. The floor is five per arm. Eight is well clear of it, and
+/// it is the count `stella-learn` uses in its own `Harms` case.
+const TURNS_PER_ARM: usize = 8;
+
+/// A lesson the reflection loop would have mined.
+const MINED_LESSON: &str = "Regenerate gen/ rather than editing it by hand.";
+
+/// A note a person keeps. The words differ from the lesson above, so the
+/// store gives it a lineage of its own.
+const HAND_WRITTEN_NOTE: &str = "The billing webhook retries three times.";
+
+fn session(root: &Path) -> SessionMemory {
+    SessionMemory::open_with_workspace_skills(root, false, true).expect("session memory")
+}
+
+fn log_path(root: &Path) -> std::path::PathBuf {
+    root.join(".stella/private/reflections.jsonl")
+}
+
+/// Write one mined memory and one hand-written one. Returns their `nod_…`
+/// ids, in that order.
+async fn seed_memories(root: &Path) -> (String, String) {
+    let db = stella_store::workspace_private_sqlite_path(root, "context.db").expect("db path");
+    let context = stella_context::ContextStore::open(db).expect("context.db");
+    context
+        .upsert(stella_context::ContextDelta {
+            memories: vec![
+                stella_context::MemoryInput::reflection(MINED_LESSON, Vec::<String>::new()),
+                stella_context::MemoryInput::new(
+                    stella_context::MemoryKind::Note,
+                    HAND_WRITTEN_NOTE,
+                ),
+            ],
+            ..Default::default()
+        })
+        .await
+        .expect("seed the memories");
+
+    let nodes = context.memory_nodes().expect("memory nodes");
+    let id_of = |text: &str| {
+        nodes
+            .iter()
+            .find(|n| n.content.contains(text))
+            .unwrap_or_else(|| panic!("no node holds {text:?}"))
+            .public_id
+            .clone()
+    };
+    let ids = (id_of(MINED_LESSON), id_of(HAND_WRITTEN_NOTE));
+    drop(context);
+    ids
+}
+
+/// A window that says these records hurt. Every turn that showed them failed.
+/// Every turn that withheld them passed.
+///
+/// Both records ride every turn. Their rows are the same, so only the origin
+/// can tell them apart.
+fn record_a_harming_window(root: &Path, ids: &[String]) {
+    for _ in 0..TURNS_PER_ARM {
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Memory,
+            ids,
+            ids,
+            &trials::live_trial(false),
+        );
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Memory,
+            ids,
+            &[],
+            &trials::live_trial(true),
+        );
+    }
+}
+
+/// **The witness.** The mined memory is retired, and the reason names the
+/// measurement. The hand-written one carries the same rows and is kept.
+///
+/// Nothing here writes a `ContextUse` record. A retirement fed by
+/// `uses::selection_health` therefore reads an empty list and returns before
+/// it retires anything. So this test passes only where the trial rows are the
+/// evidence.
+#[tokio::test]
+async fn a_memory_that_stops_helping_is_retired_and_a_hand_written_one_is_kept() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let (mined, hand_written) = seed_memories(root).await;
+    record_a_harming_window(root, &[mined.clone(), hand_written.clone()]);
+
+    let mut memory = session(root);
+    memory.auto_create_skills(&log_path(root), true);
+
+    let retired = retirement::retired_ids(&memory.store);
+    assert!(
+        retired.contains(&mined),
+        "its own turns say withholding it won: {retired:?}"
+    );
+    assert!(
+        !retired.contains(&hand_written),
+        "a memory a person wrote is kept, whatever the numbers say"
+    );
+
+    // The reason names the measurement and the way back.
+    let standing = retirement::standings(&memory.store);
+    let reason = &standing
+        .get(&mined)
+        .expect("a standing for the retirement")
+        .reason;
+    assert!(
+        reason.contains("lift") && reason.contains("reaffirm"),
+        "the reason must say what measured it: {reason}"
+    );
+
+    // Retirement is not deletion. The record is still there to reaffirm.
+    assert!(retirement::reaffirm(
+        &memory.store,
+        &mined,
+        "still needed",
+        "2026-09-05T00:00:00Z"
+    ));
+    assert!(!retirement::retired_ids(&memory.store).contains(&mined));
+}
+
+/// A window with no separation retires nothing. Without it, the case above
+/// would pass on a sweep that retired every memory handed to it.
+#[tokio::test]
+async fn a_memory_the_turns_cannot_separate_is_left_alone() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let (mined, _hand_written) = seed_memories(root).await;
+
+    // Every turn passes, shown or withheld. Neither side wins. `Inert` needs
+    // a full window in both arms, and this is far short of one.
+    let ids = [mined.clone()];
+    for _ in 0..TURNS_PER_ARM {
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Memory,
+            &ids,
+            &ids,
+            &trials::live_trial(true),
+        );
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Memory,
+            &ids,
+            &[],
+            &trials::live_trial(true),
+        );
+    }
+
+    let mut memory = session(root);
+    memory.auto_create_skills(&log_path(root), true);
+
+    assert!(
+        retirement::retired_ids(&memory.store).is_empty(),
+        "no measurement, no retirement"
+    );
+}

--- a/crates/stella-cli/src/memory/retirement.rs
+++ b/crates/stella-cli/src/memory/retirement.rs
@@ -3,6 +3,19 @@
 //! Context that repeatedly fails to help stops being selected — visibly, with
 //! reasons, and reversibly.
 //!
+//! # Two evidence sources, one door
+//!
+//! A memory leaves selection on one of two findings. [`sweep_vanished`] acts
+//! on a deterministic check: every path the memory names has left the tree.
+//! [`sweep`] acts on a measurement: the shared appraisal over the artifact
+//! trial ledger says withholding the record won, or that a full window in both
+//! arms found no contribution at all. Both write the same reversible event
+//! through the same protection predicate.
+//!
+//! A citation is not a third source. It is the model's own report about
+//! context it was handed, so it informs selection health and is shown to a
+//! reader; it retires nothing (see [`super::uses`]).
+//!
 //! # Retirement is derived, not stored
 //!
 //! A retirement is an immutable `promotion_event` carrying
@@ -39,9 +52,11 @@
 use std::collections::{HashMap, HashSet};
 
 use stella_context::ContextStore;
+use stella_learn::skills::SkillOrigin;
+use stella_learn::skills::appraisal::{DemotionDecision, DemotionReason, SkillAppraisal};
 use stella_records::context_record::{
     ContextRecordKind, LIFECYCLE_SCHEMA_VERSION, PromotionAction, PromotionActor,
-    PromotionEventRecord, SelectionHealth,
+    PromotionEventRecord,
 };
 
 /// How many promotion events one replay reads. Matches the proposals surface's
@@ -164,20 +179,58 @@ pub(crate) fn protection_for(
     }
 }
 
-/// The retirement a failing record has earned, or `None`.
+/// The `node.uri` scheme a memory's mirror node is keyed under. Stripping it
+/// yields the lineage [`ContextStore::memory_kind`] answers for.
+const MEMORY_URI_SCHEME: &str = "memory://";
+
+/// Which memory records the loop may retire on its own — the origin map
+/// [`super::appraisals::sweep`] reads.
+///
+/// Only a mined lesson is listed. A record with no entry is treated as
+/// hand-authored, and `decide_demotion` then keeps it whatever the numbers
+/// say, so an unreadable store, an unrecognised kind, or a frame whose handle
+/// names no node at all leaves the record protected rather than exposed.
+///
+/// The kind is asked per lineage rather than joined in one query so this reads
+/// the same "current revision" `stella memory edit` reads. A second definition
+/// of which revision counts could drift from the first.
+pub(crate) fn origins(store: &ContextStore) -> HashMap<String, SkillOrigin> {
+    let mut out = HashMap::new();
+    for node in store.memory_nodes().unwrap_or_default() {
+        let Some(lineage) = node
+            .uri
+            .as_deref()
+            .and_then(|uri| uri.strip_prefix(MEMORY_URI_SCHEME))
+        else {
+            continue;
+        };
+        let kind = store.memory_kind(lineage).ok().flatten();
+        if kind.as_deref() == Some(stella_context::MemoryKind::Reflection.as_str()) {
+            out.insert(node.public_id, SkillOrigin::AutoCreated);
+        }
+    }
+    out
+}
+
+/// The retirement a demoted record has earned, or `None`.
 ///
 /// Separated from the write so the decision is testable without a store, and
 /// so the reason is built in one place — a retirement with no legible cause is
 /// exactly what the gate criterion forbids.
-pub(crate) fn retirement_reason(health: &SelectionHealth) -> Option<String> {
-    if !health.failing {
+pub(crate) fn retirement_reason(decision: &DemotionDecision) -> Option<String> {
+    let DemotionDecision::Demote { reason } = decision else {
         return None;
-    }
-    Some(format!(
-        "not helpful in {} of {} assessed uses across {} task(s) — \
-         auto-retired by the efficacy loop; reaffirm to restore",
-        health.not_helpful, health.assessed_uses, health.distinct_tasks
-    ))
+    };
+    Some(match reason {
+        DemotionReason::Harmful { lift } => format!(
+            "withholding it improved outcomes on the turns it was offered on \
+             (lift {lift:.3}) — auto-retired by the efficacy loop; reaffirm to restore"
+        ),
+        DemotionReason::Inert { trials } => format!(
+            "no measurable contribution across {trials} recorded turns — \
+             auto-retired by the efficacy loop; reaffirm to restore"
+        ),
+    })
 }
 
 /// Outcome of one retirement sweep, for reporting.
@@ -185,43 +238,58 @@ pub(crate) fn retirement_reason(health: &SelectionHealth) -> Option<String> {
 pub(crate) struct RetirementSweep {
     /// Records newly retired.
     pub(crate) retired: Vec<String>,
-    /// Records that were failing but are protected, with why. Reported rather
-    /// than silently skipped — a sweep that quietly declines to act on half its
-    /// candidates reads as "nothing was failing", which is a different claim.
+    /// Records that earned retirement but are protected, with why. Reported
+    /// rather than silently skipped — a sweep that quietly declines to act on
+    /// half its candidates reads as "nothing earned it", a different claim.
     pub(crate) refused: Vec<(String, RetirementProtection)>,
 }
 
-/// Retire every failing, unprotected record. Returns what it did.
+/// Retire every demoted, unprotected record. Returns what it did.
+///
+/// The input is what [`super::appraisals::sweep`] returned for
+/// [`stella_learn::ledger::ArtifactKind::Memory`]: one appraisal per record
+/// the trial ledger holds evidence for, paired with the keep-or-demote
+/// decision its origin allows. A record is retired only when the measurement
+/// says withholding it wins — or that it contributes nothing over a full
+/// window — **and** `decide_demotion` found it auto-created. A person's own
+/// memory is kept whatever the numbers say.
 ///
 /// The actor is [`PromotionActor::System`] and the enforcement is `None`: a
 /// system event may never carry blocking enforcement, and the constructor
 /// refuses one that tries.
 pub(crate) fn sweep(
     store: &ContextStore,
-    health: &[SelectionHealth],
+    decisions: &[(SkillAppraisal, DemotionDecision)],
     occurred_at: &str,
 ) -> RetirementSweep {
     let standings = standings(store);
     let mut sweep = RetirementSweep::default();
-    for record in health {
-        let Some(reason) = retirement_reason(record) else {
+    for (appraisal, decision) in decisions {
+        let Some(reason) = retirement_reason(decision) else {
             continue;
         };
-        if let Some(protection) = protection_for(standings.get(&record.context_record_id)) {
-            sweep
-                .refused
-                .push((record.context_record_id.clone(), protection));
+        // `SkillAppraisal::skill` is the id the sweep appraised. For this kind
+        // that is the memory record's `nod_…` public id.
+        let record_id = &appraisal.skill;
+        if let Some(protection) = protection_for(standings.get(record_id)) {
+            // `AlreadyRetired` is the steady state: a retired record's trial
+            // rows stay in the ledger, so every later sweep re-earns the same
+            // demotion. Only a *new* refusal is worth reporting, for
+            // [`sweep_vanished`]'s reason.
+            if protection != RetirementProtection::AlreadyRetired {
+                sweep.refused.push((record_id.clone(), protection));
+            }
             continue;
         }
         if record_decision(
             store,
-            &record.context_record_id,
+            record_id,
             PromotionAction::Retired,
             PromotionActor::System,
             &reason,
             occurred_at,
         ) {
-            sweep.retired.push(record.context_record_id.clone());
+            sweep.retired.push(record_id.clone());
         }
     }
     sweep
@@ -232,10 +300,10 @@ pub(crate) fn sweep(
 ///
 /// Same single protection predicate, same reversible `PromotionEvent`, same
 /// system actor; only the trigger differs. It deliberately does not wait for
-/// the health fold's `min_attributable_uses` floor: that floor guards against
-/// noisy per-turn judgements, and a file-existence check re-run N times is one
-/// fact, not N pieces of evidence. The reason names every missing path, so the
-/// retirement is legible without the ledger.
+/// [`sweep`]'s evidence floor: that floor guards against noisy per-turn
+/// judgements, and a file-existence check re-run N times is one fact, not N
+/// pieces of evidence. The reason names every missing path, so the retirement
+/// is legible without the ledger.
 pub(crate) fn sweep_vanished(
     store: &ContextStore,
     vanished: &[super::validation::VanishedMemory],

--- a/crates/stella-cli/src/memory/retirement/tests.rs
+++ b/crates/stella-cli/src/memory/retirement/tests.rs
@@ -2,13 +2,18 @@
 //! provably never touches a protected record.
 
 use stella_context::ContextStore;
+use stella_learn::skills::appraisal::{AppraisalConfig, SkillTrial, appraise, decide_demotion};
 use stella_records::context_record::{
-    DirectiveEnforcement, PromotionAction, PromotionActor, PromotionEventRecord, SelectionHealth,
+    DirectiveEnforcement, PromotionAction, PromotionActor, PromotionEventRecord,
 };
 
 use super::*;
 
 const AT: &str = "2026-07-26T00:00:00Z";
+
+/// Turns per arm. Above the five-per-arm evidence floor, and the same count
+/// `stella-learn`'s own `Harms` fixture uses.
+const TURNS_PER_ARM: usize = 8;
 
 fn store() -> (tempfile::TempDir, ContextStore) {
     let dir = tempfile::tempdir().expect("workspace");
@@ -16,40 +21,54 @@ fn store() -> (tempfile::TempDir, ContextStore) {
     (dir, store)
 }
 
-/// A record whose evidence says it is failing.
-fn failing(record_id: &str) -> SelectionHealth {
-    SelectionHealth {
-        context_record_id: record_id.into(),
-        uses: 10,
-        distinct_tasks: 4,
-        assessed_uses: 5,
-        helpful: 0,
-        not_helpful: 5,
-        neutral: 0,
-        not_helpful_ratio: 1.0,
-        eligible_assessed: 5,
-        eligible_not_helpful: 5,
-        attributable: true,
-        failing: true,
+/// One recorded turn: whether the record was shown, and how the turn ended.
+fn turn(shown: bool, succeeded: bool) -> SkillTrial {
+    SkillTrial {
+        selected: shown,
+        ..super::super::trials::live_trial(succeeded)
     }
 }
 
-/// A record that is doing fine.
-fn healthy(record_id: &str) -> SelectionHealth {
-    SelectionHealth {
-        context_record_id: record_id.into(),
-        uses: 10,
-        distinct_tasks: 4,
-        assessed_uses: 5,
-        helpful: 5,
-        not_helpful: 0,
-        neutral: 0,
-        not_helpful_ratio: 0.0,
-        eligible_assessed: 5,
-        eligible_not_helpful: 0,
-        attributable: true,
-        failing: false,
-    }
+/// A window whose turns say withholding the record won.
+fn harming_window() -> Vec<SkillTrial> {
+    (0..TURNS_PER_ARM)
+        .flat_map(|_| [turn(true, false), turn(false, true)])
+        .collect()
+}
+
+/// A window whose turns say showing it won.
+fn helping_window() -> Vec<SkillTrial> {
+    (0..TURNS_PER_ARM)
+        .flat_map(|_| [turn(true, true), turn(false, false)])
+        .collect()
+}
+
+/// What the shared sweep hands [`sweep`]: the appraisal of a window and the
+/// keep-or-demote decision the record's origin allows.
+fn decided(
+    record_id: &str,
+    origin: SkillOrigin,
+    trials: Vec<SkillTrial>,
+) -> (SkillAppraisal, DemotionDecision) {
+    let appraisal = appraise(record_id, &trials, &AppraisalConfig::default());
+    let decision = decide_demotion(origin, &appraisal);
+    (appraisal, decision)
+}
+
+/// A mined record whose recorded turns earn its retirement.
+fn demoting(record_id: &str) -> (SkillAppraisal, DemotionDecision) {
+    let decided = decided(record_id, SkillOrigin::AutoCreated, harming_window());
+    assert!(
+        decided.1.is_demotion(),
+        "the fixture must be a real demotion, got {:?}",
+        decided.1
+    );
+    decided
+}
+
+/// A mined record the measurement leaves alone.
+fn keeping(record_id: &str) -> (SkillAppraisal, DemotionDecision) {
+    decided(record_id, SkillOrigin::AutoCreated, helping_window())
 }
 
 /// Put a standing on the log so the protection check has something to read.
@@ -88,7 +107,7 @@ fn given_standing(
 #[test]
 fn a_failing_record_is_retired_with_a_legible_reason() {
     let (_dir, store) = store();
-    let sweep = sweep(&store, &[failing("nod_a")], AT);
+    let sweep = sweep(&store, &[demoting("nod_a")], AT);
 
     assert_eq!(sweep.retired, vec!["nod_a".to_string()]);
     assert!(retired_ids(&store).contains("nod_a"));
@@ -98,15 +117,15 @@ fn a_failing_record_is_retired_with_a_legible_reason() {
     let reason = &standing.get("nod_a").expect("standing").reason;
     assert!(!reason.trim().is_empty());
     assert!(
-        reason.contains("not helpful in 5 of 5"),
-        "the reason must say what the evidence was, got: {reason}"
+        reason.contains("lift"),
+        "the reason must say what the measurement was, got: {reason}"
     );
 }
 
 #[test]
 fn a_healthy_record_is_never_retired() {
     let (_dir, store) = store();
-    let sweep = sweep(&store, &[healthy("nod_a")], AT);
+    let sweep = sweep(&store, &[keeping("nod_a")], AT);
 
     assert!(sweep.retired.is_empty());
     assert!(retired_ids(&store).is_empty());
@@ -115,23 +134,22 @@ fn a_healthy_record_is_never_retired() {
 #[test]
 fn a_record_nobody_assessed_is_never_retired() {
     let (_dir, store) = store();
-    // Rendered constantly, judged never. Disuse is not a negative.
-    let silent = SelectionHealth {
-        context_record_id: "nod_a".into(),
-        uses: 500,
-        distinct_tasks: 40,
-        assessed_uses: 0,
-        helpful: 0,
-        not_helpful: 0,
-        neutral: 0,
-        not_helpful_ratio: 0.0,
-        eligible_assessed: 0,
-        eligible_not_helpful: 0,
-        attributable: false,
-        failing: false,
-    };
+    // Offered constantly, measured never. Disuse is not a negative, and an
+    // empty window is `Insufficient` rather than `Inert`.
+    let silent = decided("nod_a", SkillOrigin::AutoCreated, Vec::new());
 
     assert!(sweep(&store, &[silent], AT).retired.is_empty());
+}
+
+#[test]
+fn a_hand_written_record_is_never_retired_whatever_the_numbers_say() {
+    let (_dir, store) = store();
+    // The same window that retires a mined record, against one a person
+    // wrote. `decide_demotion` checks the origin before it reads a verdict.
+    let hand_written = decided("nod_a", SkillOrigin::Workspace, harming_window());
+
+    assert!(sweep(&store, &[hand_written], AT).retired.is_empty());
+    assert!(retired_ids(&store).is_empty());
 }
 
 #[test]
@@ -145,7 +163,7 @@ fn a_user_confirmed_record_is_provably_never_retired() {
         None,
     );
 
-    let sweep = sweep(&store, &[failing("nod_a")], AT);
+    let sweep = sweep(&store, &[demoting("nod_a")], AT);
     assert!(sweep.retired.is_empty());
     assert_eq!(
         sweep.refused,
@@ -165,7 +183,7 @@ fn a_published_record_is_provably_never_retired() {
         None,
     );
 
-    let sweep = sweep(&store, &[failing("nod_a")], AT);
+    let sweep = sweep(&store, &[demoting("nod_a")], AT);
     assert!(sweep.retired.is_empty());
     assert_eq!(sweep.refused[0].1, RetirementProtection::Published);
 }
@@ -183,7 +201,7 @@ fn a_blocking_record_is_provably_never_retired() {
         Some(DirectiveEnforcement::Blocking),
     );
 
-    let sweep = sweep(&store, &[failing("nod_a")], AT);
+    let sweep = sweep(&store, &[demoting("nod_a")], AT);
     assert!(sweep.retired.is_empty());
     assert_eq!(sweep.refused[0].1, RetirementProtection::Blocking);
 }
@@ -202,14 +220,14 @@ fn a_system_auto_activation_is_not_a_confirmation_and_stays_retirable() {
         None,
     );
 
-    let sweep = sweep(&store, &[failing("nod_a")], AT);
+    let sweep = sweep(&store, &[demoting("nod_a")], AT);
     assert_eq!(sweep.retired, vec!["nod_a".to_string()]);
 }
 
 #[test]
 fn retirement_is_reversible_by_reaffirming() {
     let (_dir, store) = store();
-    sweep(&store, &[failing("nod_a")], AT);
+    sweep(&store, &[demoting("nod_a")], AT);
     assert!(retired_ids(&store).contains("nod_a"));
 
     assert!(reaffirm(&store, "nod_a", "still needed", AT));
@@ -222,7 +240,7 @@ fn retirement_is_reversible_by_reaffirming() {
 #[test]
 fn reaffirming_outranks_without_erasing() {
     let (_dir, store) = store();
-    sweep(&store, &[failing("nod_a")], AT);
+    sweep(&store, &[demoting("nod_a")], AT);
     reaffirm(&store, "nod_a", "still needed", AT);
 
     // Both acts remain readable — the ledger is append-only and nothing was
@@ -243,12 +261,12 @@ fn reaffirming_outranks_without_erasing() {
 #[test]
 fn a_reaffirmed_record_can_be_retired_again_if_it_keeps_failing() {
     let (_dir, store) = store();
-    sweep(&store, &[failing("nod_a")], AT);
+    sweep(&store, &[demoting("nod_a")], AT);
     reaffirm(&store, "nod_a", "give it another chance", AT);
 
     // Reaffirmation is not permanent immunity — the loop stays live. Use a
     // distinct timestamp so the second retirement is a different record.
-    let again = sweep(&store, &[failing("nod_a")], "2026-07-27T00:00:00Z");
+    let again = sweep(&store, &[demoting("nod_a")], "2026-07-27T00:00:00Z");
     assert_eq!(again.retired, vec!["nod_a".to_string()]);
     assert!(retired_ids(&store).contains("nod_a"));
 }
@@ -256,11 +274,21 @@ fn a_reaffirmed_record_can_be_retired_again_if_it_keeps_failing() {
 #[test]
 fn retiring_an_already_retired_record_is_refused_not_duplicated() {
     let (_dir, store) = store();
-    sweep(&store, &[failing("nod_a")], AT);
+    sweep(&store, &[demoting("nod_a")], AT);
 
-    let again = sweep(&store, &[failing("nod_a")], "2026-07-27T00:00:00Z");
+    let again = sweep(&store, &[demoting("nod_a")], "2026-07-27T00:00:00Z");
     assert!(again.retired.is_empty());
-    assert_eq!(again.refused[0].1, RetirementProtection::AlreadyRetired);
+    // Reported nowhere either. A retired record's trials stay in the ledger,
+    // so every later sweep re-earns the same demotion, and reporting it would
+    // print one line per turn forever.
+    assert!(again.refused.is_empty());
+    let events = store
+        .records_of_kind_in_append_order(
+            stella_records::context_record::ContextRecordKind::PromotionEvent.as_str(),
+            100,
+        )
+        .expect("read");
+    assert_eq!(events.len(), 1, "no second retirement event");
 }
 
 #[test]
@@ -276,7 +304,7 @@ fn a_refused_retirement_is_reported_rather_than_silently_skipped() {
 
     let sweep = sweep(
         &store,
-        &[failing("nod_protected"), failing("nod_ordinary")],
+        &[demoting("nod_protected"), demoting("nod_ordinary")],
         AT,
     );
     assert_eq!(sweep.retired, vec!["nod_ordinary".to_string()]);
@@ -290,7 +318,7 @@ fn a_refused_retirement_is_reported_rather_than_silently_skipped() {
 #[test]
 fn retirement_never_deletes_the_record() {
     let (_dir, store) = store();
-    sweep(&store, &[failing("nod_a")], AT);
+    sweep(&store, &[demoting("nod_a")], AT);
 
     // Retirement writes one event and touches nothing else. The ledger is
     // append-only at the database, so this is checked twice — but "never
@@ -306,6 +334,6 @@ fn retirement_never_deletes_the_record() {
 
 #[test]
 fn a_retirement_reason_is_only_produced_for_a_failing_record() {
-    assert!(retirement_reason(&healthy("nod_a")).is_none());
-    assert!(retirement_reason(&failing("nod_a")).is_some());
+    assert!(retirement_reason(&keeping("nod_a").1).is_none());
+    assert!(retirement_reason(&demoting("nod_a").1).is_some());
 }

--- a/crates/stella-cli/src/memory/uses.rs
+++ b/crates/stella-cli/src/memory/uses.rs
@@ -75,9 +75,11 @@ const EXTRACTION_BATCH: u32 = 64;
 /// it unhelpful, which retires it, which destroys the evidence that the reading
 /// was wrong.
 ///
-/// So citations inform selection health and stay fully visible, and cannot on
-/// their own remove anything. They still drive the shipped quarantine loop
-/// exactly as before — that path is untouched.
+/// So the citation class is **display-only**: it folds into selection
+/// health, health is shown by `stella memory retired` and the Observatory, and
+/// nothing reads it to remove anything. Retirement measures instead — see
+/// [`super::retirement`]. The shipped quarantine loop still runs off citations
+/// exactly as before; that path is untouched.
 const METHOD_AGENT_SELF_REPORT: &str =
     stella_records::context_record::ContextEvaluationMethod::AGENT_SELF_REPORT;
 
@@ -369,6 +371,11 @@ const HEALTH_READ_LIMIT: usize = 20_000;
 /// is order-independent by construction — so this is a projection of the
 /// ledger's contents and nothing else. Recomputing it is the only way to read
 /// it; there is no stored copy that could disagree.
+///
+/// Read by `stella memory retired` for its evidence lines and by the
+/// Observatory's context panel. Retirement does not read it: what a citation
+/// establishes is reference, not effect, so the measured sweep decides and
+/// this explains.
 pub(crate) fn selection_health(
     context: &ContextStore,
     policy: SelectionHealthPolicy,

--- a/crates/stella-cli/src/memory/uses/tests.rs
+++ b/crates/stella-cli/src/memory/uses/tests.rs
@@ -4,7 +4,6 @@
 use stella_context::ContextStore;
 use stella_records::context_record::{
     ContextRecordKind, ContextUse, ContextUseEvaluation, ContextUseFeedback, ContextUseKind,
-    SelectionHealth,
 };
 use stella_store::{ContextBlockRow, MemoryCitationRow, Store};
 
@@ -317,15 +316,17 @@ fn a_record_rendered_twice_in_one_turn_is_one_use() {
     assert_eq!(uses(&context).len(), 1);
 }
 
-/// The phase's observable behavior, end to end: context that repeatedly fails
-/// to help stops being selected — visibly, with a reason, and reversibly.
+/// Citations are display-only: they fold into selection health, health is
+/// shown, and no record leaves selection because of one.
 ///
-/// This is the one test that would fail if any single deliverable regressed,
-/// so it exercises the real pipeline rather than any component in isolation:
-/// turns run and are cited (D1/D2), the ledger is folded into health (D4), and
-/// the sweep acts on it (D5) under opportunity-aware rules (D3).
+/// Turns run and are cited (D1/D2) and the ledger folds into health (D4) under
+/// opportunity-aware rules (D3). Retirement reads the measured appraisal over
+/// the trial ledger, which this fixture writes nothing into, so no policy a
+/// workspace could set turns these citations into a retirement.
+/// `a_memory_that_stops_helping_is_retired_and_a_hand_written_one_is_kept`
+/// (`memory/learning/memory_lifecycle.rs`) is the other side of it.
 #[test]
-fn citations_alone_never_retire_and_a_strong_verdict_retires_restorably() {
+fn citations_are_display_only_and_retire_nothing() {
     use stella_records::context_record::SelectionHealthPolicy;
 
     let (_dir, store, context) = workspace();
@@ -374,50 +375,12 @@ fn citations_alone_never_retire_and_a_strong_verdict_retires_restorably() {
         "trace correlation alone must not be enough to retire"
     );
     assert!(!good.failing);
+
+    // Six cited turns for each record, and the retirement plane is untouched.
+    // Health is not one of its inputs, so there is no policy a workspace could
+    // set that would turn these citations into a retirement.
     assert!(
-        super::super::retirement::sweep(&context, &health, "2026-07-26T00:00:00Z")
-            .retired
-            .is_empty(),
+        super::super::retirement::retired_ids(&context).is_empty(),
         "nothing may be retired on citation evidence alone"
-    );
-
-    // Now the case the deliverable IS about: a stronger evidence source — one
-    // that recorded an observable effect and a real method — judged it
-    // unhelpful. That is what retirement acts on.
-    let strong = SelectionHealth {
-        context_record_id: "nod_bad".into(),
-        uses: 6,
-        distinct_tasks: 6,
-        assessed_uses: 6,
-        helpful: 0,
-        not_helpful: 6,
-        neutral: 0,
-        not_helpful_ratio: 1.0,
-        eligible_assessed: 5,
-        eligible_not_helpful: 5,
-        attributable: true,
-        failing: true,
-    };
-    let sweep = super::super::retirement::sweep(&context, &[strong], "2026-07-26T00:00:00Z");
-    assert_eq!(sweep.retired, vec!["nod_bad".to_string()]);
-
-    // Excluded from automatic selection…
-    let retired = super::super::retirement::retired_ids(&context);
-    assert!(retired.contains("nod_bad"));
-    assert!(
-        !retired.contains("nod_good"),
-        "a record that kept helping must be untouched"
-    );
-
-    // …still explicitly retrievable, and restorable.
-    assert!(super::super::retirement::reaffirm(
-        &context,
-        "nod_bad",
-        "still needed",
-        "2026-07-27T00:00:00Z"
-    ));
-    assert!(
-        !super::super::retirement::retired_ids(&context).contains("nod_bad"),
-        "reaffirming must return it to selection"
     );
 }

--- a/crates/stella-cli/src/memory_retire_cmd.rs
+++ b/crates/stella-cli/src/memory_retire_cmd.rs
@@ -59,8 +59,9 @@ pub fn run_memory_retired() -> Result<(), String> {
     // itself guarantees.
     retired.sort_by(|a, b| a.0.cmp(b.0));
 
-    // The evidence behind each decision, so "why" is answerable here rather
-    // than only in the ledger.
+    // What the turns said about each record, shown beside the reason. It is
+    // context for a reader, not what decided the retirement — the reason on
+    // the event is that, and it says so in its own words.
     let policy = crate::memory::tuning::selection_health_policy(&workspace_root);
     let health = uses::selection_health(&store, policy);
 
@@ -70,7 +71,7 @@ pub fn run_memory_retired() -> Result<(), String> {
         println!("    reason: {}", event.reason);
         if let Some(h) = health.iter().find(|h| &h.context_record_id == *record_id) {
             println!(
-                "    evidence: {} of {} assessed uses not helpful, {} uses across {} task(s)",
+                "    citations: {} of {} assessed uses not helpful, {} uses across {} task(s)",
                 h.not_helpful, h.assessed_uses, h.uses, h.distinct_tasks
             );
         }
@@ -82,12 +83,11 @@ pub fn run_memory_retired() -> Result<(), String> {
 /// `stella memory retire <id> --reason` — a person's explicit judgement that a
 /// memory has stopped earning its place.
 ///
-/// This is the evidence tier the automatic sweep cannot reach on its own. A
-/// citation is an `agent_self_report` and is deliberately not pruning-eligible
-/// (see [`crate::memory::uses`]), so until a deterministic or external evidence
-/// source is wired, a human is the one source strong enough to retire
-/// something. That is the correct default: the loop shows its work and a person
-/// decides.
+/// The sweeps reach two findings ([`crate::memory::retirement`]). Every path
+/// a memory names is gone. Or its recorded turns say withholding it won. A
+/// citation reaches neither, so it retires nothing (see
+/// [`crate::memory::uses`]). This is the door for the rest: a memory nothing
+/// has measured, or one the loop may not touch because a person wrote it.
 pub fn run_memory_retire(id: &str, reason: &str) -> Result<(), String> {
     if reason.trim().is_empty() {
         return Err("a retirement must carry a reason".into());

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -293,14 +293,17 @@ evolution_surfaces! {
     /// What Stella remembers between turns.
     Memory => "memory",
         EvolutionPosture::Shipped {
-            mechanism: "a memory whose every named path has vanished is retired by the \
-                        post-turn sweep, with the missing paths in the reason. The citation \
-                        fold is built and cannot fire: trace correlation records a neutral \
-                        verdict rather than `not_helpful` by design, so citations alone never \
-                        reach `failing`, and nothing writes `memory_citations` in the first \
-                        place (#4862). Path-anchor validation is the only evidence source \
-                        that retires anything today",
-            witness: "a_vanished_memory_is_retired_with_the_missing_paths_in_the_reason",
+            mechanism: "two evidence sources, one door. Each turn records which memory \
+                        records it could show and which it showed. That join lands in the \
+                        shared artifact trial ledger. The post-turn sweep then runs the same \
+                        `appraise` + `decide_demotion` pass the skill sweep runs. A record \
+                        whose turns say withholding it won is retired. A record a person \
+                        wrote is kept, whatever the numbers say. Beside that, a memory whose \
+                        named paths have all gone is retired by a plain file check, with the \
+                        missing paths in the reason. Citations only show: they fold into \
+                        selection health, health is displayed, and nothing reads it to retire \
+                        anything",
+            witness: "a_memory_that_stops_helping_is_retired_and_a_hand_written_one_is_kept",
         },
         EvolutionTiming::BetweenTurns,
         ImpactClass::RecallBias,
@@ -502,8 +505,11 @@ pub const UNWITNESSED_EVOLUTION_BASELINE: usize = 0;
 /// check it asserts the row's own mechanism.** A row is a claim like any other
 /// (CLAUDE.md), and the name of a test is not evidence for it.
 #[cfg(test)]
-fn evolution_sources() -> [&'static str; 13] {
+fn evolution_sources() -> [&'static str; 14] {
     [
+        // The Memory row's witness. A window of real turns retires a mined
+        // memory, and leaves a hand-written one alone.
+        include_str!("../../stella-cli/src/memory/learning/memory_lifecycle.rs"),
         // The Delivery row's witness: what the backlog picks and the
         // ledger row it writes, proven on a fixture tracker.
         include_str!("../../stella-cli/src/self_driving_cmd/ready.rs"),

--- a/website/content/docs/commands/memory.mdx
+++ b/website/content/docs/commands/memory.mdx
@@ -140,9 +140,9 @@ reports it as unhelpful, the memory gets retired, and the evidence that the mode
 disappears. stella closes that loop on purpose.
 
 Only one place in the code decides this: the check that says whether a given feedback method is
-allowed to retire a record. Retirement requires a person's judgment or another reliable source. If
-you're adding a new kind of feedback, that's the one check to update, and self-reports should never
-be let through it.
+allowed to retire a record. An automatic retirement needs a measurement over recorded turns, or a
+plain file check. Anything weaker needs a person. If you're adding a new kind of feedback, that's
+the one check to update, and self-reports should never be let through it.
 </Callout>
 
 ### `stella memory retire <id> --reason <why>`
@@ -153,7 +153,9 @@ Stop stella from selecting a memory automatically. You can undo this later.
 stella memory retire nod_9f2c1a --reason "the API it describes was replaced in 0.6"
 ```
 
-`--reason` is **required**. An empty reason is rejected, because a retirement needs a clear cause you can look back on later. Citations alone can't retire a memory, so a person's judgment is the strongest evidence stella currently has. The loop shows its work, and you make the call.
+`--reason` is **required**. An empty reason is rejected, because a retirement needs a clear cause you can look back on later.
+
+Citations alone can't retire a memory. stella retires one on its own in two cases: the turns that showed it did worse than the turns that withheld it, or every file it names has gone. It never retires a memory you wrote yourself. Everything else is your call, and this is how you make it.
 
 Some records can't be retired at all:
 


### PR DESCRIPTION
## What and why

Memory retirement read selection health, folded from citations. #5989 retired
`ObservationSource::MemoryCitation` because nothing in a real turn ever produced
a citation, so the only evidence source that retired a memory was the path-anchor
check. A memory that was present, wrong, and quietly costing tokens was retired
by nothing.

It now reads the same appraisal the skill sweep reads.

- **`crates/stella-cli/src/memory/retirement.rs`** — `sweep` takes
  `&[(SkillAppraisal, DemotionDecision)]` instead of `&[SelectionHealth]`, and
  `retirement_reason` reads a `DemotionReason` (`Harmful` names the lift,
  `Inert` names the trial count). `protection_for` is still the one predicate
  every retirement passes through. `AlreadyRetired` is suppressed from the
  refusal report for `sweep_vanished`'s reason: a retired record's trial rows
  stay in the ledger, so every later sweep re-earns the same demotion and a
  report would be one line per turn forever.
- **`retirement::origins`** — the origin map `appraisals::sweep` reads. A
  memory whose current revision is `MemoryKind::Reflection` is mined and maps
  to `SkillOrigin::AutoCreated`. Anything else gets no entry, and
  `appraisals::sweep` reads an absent id as hand-authored, so `decide_demotion`
  keeps it whatever the numbers say. An unreadable store, an unrecognised kind,
  and a frame handle that names no node all land on the protected side.
- **`crates/stella-cli/src/memory/learning.rs`** — `retire_failing_context`
  calls `appraisals::sweep(root, ArtifactKind::Memory, &origins, …)` and hands
  the decisions to `retirement::sweep`. #6114 gave `ArtifactKind::Memory` a
  producer, which is what this depended on.
- **The citation class is display-only.** `uses::selection_health` still feeds
  `stella memory retired`'s evidence lines and the Observatory's context panel;
  nothing reads it to retire anything. `uses.rs`, `memory_retire_cmd.rs` and
  `website/content/docs/commands/memory.mdx` say so.
- **`crates/stella-parity/src/evolution.rs`** — the `Memory` row stops
  recording the gap, names both evidence sources, and names the new witness.
  `evolution_sources()` gains the file that holds it.

No hysteresis on the memory side, unlike skills'
`demote_after_consecutive_negatives`, and no appraisal rows written for memories:
`consecutive_negative_appraisals` filters `skill_appraisals.jsonl` on a bare id
with no kind in the key, so recording memory verdicts there before #6103 lands
would let a memory and a skill sharing an id fold into one run. #6132 is where
the bar itself gets decided.

## Witness mechanism

`crates/stella-cli/src/memory/learning/memory_lifecycle.rs`:
`a_memory_that_stops_helping_is_retired_and_a_hand_written_one_is_kept`.

It seeds two memory records in a real workspace — one `reflection`, one `note`
— writes sixteen real ledger rows for **both** through the production writer
`appraisals::record_turn` (eight turns that showed them and failed, eight that
withheld them and passed), then drives the production door
`auto_create_skills`. The mined record is retired with the lift in its reason
and reaffirms back into selection; the hand-written record carries
byte-identical rows and is kept, so origin is the only thing that separates
them.

**Why it fails on the old code by construction:** the replaced path read
`uses::selection_health`, folded from `ContextUse` records. This fixture writes
none, so that sweep saw an empty list and returned before it retired anything.
Trial rows were not an input to retirement at all, so no arrangement of them
could have retired the record.

`a_memory_the_turns_cannot_separate_is_left_alone` is the negative control: a
window where every turn passes, shown or withheld, retires nothing — so the
case above cannot be passing on a sweep that retires whatever it is handed.

`retirement/tests.rs` now builds its decisions by running `appraise` +
`decide_demotion` over a trial window rather than hand-building a
`SelectionHealth` literal, which is #5198's complaint about the old Memory-row
witness. It gains
`a_hand_written_record_is_never_retired_whatever_the_numbers_say`.

## Exemplar

`crates/stella-cli/src/memory/learning/skill_lifecycle.rs`'s
`a_promoted_skill_that_stops_helping_is_demoted_and_no_longer_selected` — the
same shape one kind over: drive the production doors, read the real ledger, and
close off every other route to the outcome inside the fixture.

## Tests deleted

`citations_alone_never_retire_and_a_strong_verdict_retires_restorably`
(`crates/stella-cli/src/memory/uses/tests.rs`) is **renamed** to
`citations_are_display_only_and_retire_nothing`. Its first half — six cited
turns retire nothing — is kept and is now the whole claim. Its second half
reached a retirement by hand-building a `SelectionHealth { failing: true, .. }`
literal no production path can produce, which is the exact test #5198 named;
the real thing it was standing in for is the witness above.

## Residue issues filed

- #6132 — retiring a memory takes one bad window; retiring a skill takes three.
  Blocked by #6103, which keys the appraisal ledger by artifact kind.

Closes #6069

## Summary by Sourcery

Retire mined memories based on measured turn effectiveness while keeping citations informational and protecting user-authored records.

New Features:
- Retire auto-created reflection memories when measured turn outcomes show that withholding them improves results or they provide no measurable contribution, while preserving hand-written memories.

Bug Fixes:
- Prevent memory retirement from relying on citation-derived selection health, which could not represent actual turn effectiveness.

Enhancements:
- Route memory retirement through the shared appraisal and demotion decision flow used by skills, preserve protection and reversible retirement behavior, and suppress repeated reports for already-retired records.
- Clarify that citation health is display-only and update retirement reasons, command output, parity metadata, and user documentation accordingly.

Documentation:
- Update memory retirement documentation to describe measured-turn and vanished-path retirement rules and the protection of hand-written memories.

Tests:
- Add production-path lifecycle coverage proving measured retirement of mined memories, preservation of hand-written memories, and no retirement when outcomes cannot distinguish usefulness.
- Update retirement tests to use real appraisals and decisions, cover hand-written protection, and verify repeated demotions do not produce duplicate refusal reports.