### PR TITLE
fix(stella-fleet): hold one git worktree command at a time per repo

### DIFF
--- a/crates/stella-fleet/README.md
+++ b/crates/stella-fleet/README.md
@@ -112,6 +112,7 @@ is nearest today — split it before it crosses.
 | [`src/ledger.rs`](src/ledger.rs) | `fleet.db`: schema, migrations, and every read/write of runs, tasks, attempts, commits, lineage and spend. |
 | [`src/ledger/lease.rs`](src/ledger/lease.rs) | Dispatch claims (#1136): the check-and-set, expiring lease on one unit of dispatch — `claim_dispatch` / `renew_dispatch` / `release_dispatch` and the reads a human or a dispatcher asks "who is on this?" with. |
 | [`src/git.rs`](src/git.rs) | The `GitCli` port, `SystemGitCli`, and `WorktreeManager` — worktree create/remove/discard/list plus the pathspec-only commit helper. `with_worktrees_root`/`with_branch_prefix` move a caller out of the `.stella/worktrees/` + `fleet/` namespace `gc.rs` reclaims by, and `discard` force-removes where `remove` refuses: both exist for `stella-cli`'s best-of-N candidate substrate (#3892), whose output is uncommitted bytes by construction and whose losers are meant to be thrown away. |
+| [`src/git/worktree_lock.rs`](src/git/worktree_lock.rs) | The one door every `git worktree …` command in this crate goes through. Git takes no lock on `.git/worktrees/`, so two overlapping `worktree add` calls can read each other's half-written bookkeeping; this holds them apart with a per-repo-root mutex in the process and an `O_CREAT|O_EXCL` lock file under `.stella/private/` across processes, and retries once on git's transient signatures. |
 | [`src/gc.rs`](src/gc.rs) | `Gc::sweep` — the conservative reclaim of finished worktrees and `fleet/*` branches behind `stella fleet clean` (#1217). Nothing in flight, dirty, or unmerged goes without `--force`; every kept candidate carries a `KeepReason`. |
 | [`src/monitor.rs`](src/monitor.rs) | The `GhCli` port and `Monitor`: live PR reconciliation, the CI poll loop, the pure `decide` cap state machine, and the `AgentEvent` emit-shape helpers. |
 | [`src/cache_schedule.rs`](src/cache_schedule.rs) | `warmest_first` — the pure, no-I/O ordering heuristic for equal-priority runnable sessions. |
@@ -323,6 +324,16 @@ Two gaps:
   integration ref as `contained_in`, since it has no `Worktree` value to
   read a `base_ref` from. Every other caller leaves `contained_in` at its
   default, which falls back to `Worktree::base_ref`.
+- **One `git worktree` command at a time per repository.** `WorktreeManager::create`,
+  `discard`, `remove_worktree_and_branch` and `Gc::sweep`'s prune and list all run
+  through `git/worktree_lock.rs`'s `run_worktree`, which holds a per-repository lock
+  for the length of the command. Concurrent callers of `create` are therefore safe:
+  a wave of width N issues its adds one at a time. What stays concurrent is the
+  work — the workers themselves take no lock, and only the tree cutting is
+  exclusive. The in-process half is a guarantee; the lock file that extends it to a
+  second `stella` process is best effort and proceeds rather than failing a
+  dispatch when it cannot be taken.
+
 - **`WorktreeManager::commit_paths` has no product caller yet.** It is
   exercised only by this crate's own tests, and it ships anyway because it is
   the only place here that encodes the pathspec discipline — `git add --

--- a/crates/stella-fleet/src/gc.rs
+++ b/crates/stella-fleet/src/gc.rs
@@ -33,7 +33,7 @@ use std::path::{Path, PathBuf};
 
 use crate::git::{
     GitCli, RemoveOutcome, WorktreeError, ensure_ok, is_contained_in, parse_worktree_list,
-    remove_worktree_and_branch,
+    remove_worktree_and_branch, worktree_lock,
 };
 
 /// Milliseconds in a day — the unit [`GcOptions::min_age_days`] is expressed
@@ -283,11 +283,12 @@ impl<G: GitCli> Gc<G> {
         // deleted: without this they are listed forever and every later
         // `git worktree add` reasons about a checkout that is not there.
         if !opts.dry_run {
-            let out = self
-                .git
-                .run(&self.repo_root, &["worktree", "prune"])
-                .await
-                .map_err(WorktreeError::from)?;
+            // Under the worktree lock: prune rewrites the same
+            // `.git/worktrees` directory a concurrent dispatch is adding to.
+            let out =
+                worktree_lock::run_worktree(&self.git, &self.repo_root, &["worktree", "prune"])
+                    .await
+                    .map_err(WorktreeError::from)?;
             ensure_ok(out, "worktree prune").map_err(GcError::from)?;
         }
 
@@ -313,11 +314,15 @@ impl<G: GitCli> Gc<G> {
         base_ref: &str,
         now_ms: u64,
     ) -> Result<Vec<WorktreeVerdict>, GcError> {
-        let out = self
-            .git
-            .run(&self.repo_root, &["worktree", "list", "--porcelain"])
-            .await
-            .map_err(WorktreeError::from)?;
+        // Under the lock as well: the read of `.git/worktrees` is the half
+        // that lost run 9255, not the write.
+        let out = worktree_lock::run_worktree(
+            &self.git,
+            &self.repo_root,
+            &["worktree", "list", "--porcelain"],
+        )
+        .await
+        .map_err(WorktreeError::from)?;
         let out = ensure_ok(out, "worktree list --porcelain").map_err(GcError::from)?;
         let entries = parse_worktree_list(&out.stdout);
 

--- a/crates/stella-fleet/src/git.rs
+++ b/crates/stella-fleet/src/git.rs
@@ -21,6 +21,8 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use tokio::process::Command;
 
+pub(crate) mod worktree_lock;
+
 /// The port every git command goes through. The real implementation
 /// ([`SystemGitCli`]) spawns `git`; tests inject fakes that record the
 /// invocation and return canned output.
@@ -403,13 +405,15 @@ impl<G: GitCli> WorktreeManager<G> {
         let dir = self.worktrees_root.join(&slug);
         let branch = format!("{}{slug}", self.branch_prefix);
         let dir_str = path_arg(&dir)?;
-        let out = self
-            .git
-            .run(
-                &self.repo_root,
-                &["worktree", "add", dir_str, "-b", &branch, base_ref],
-            )
-            .await?;
+        // Through the worktree lock, never straight to `GitCli`: two adds
+        // that overlap read each other's half-written `.git/worktrees`
+        // bookkeeping and one of them dies.
+        let out = worktree_lock::run_worktree(
+            &self.git,
+            &self.repo_root,
+            &["worktree", "add", dir_str, "-b", &branch, base_ref],
+        )
+        .await?;
         ensure_ok(
             out,
             &format!("worktree add {dir_str} -b {branch} {base_ref}"),
@@ -471,13 +475,12 @@ impl<G: GitCli> WorktreeManager<G> {
         // No `?` on either arm — that is the whole point. A `?` on the first
         // would skip the second on a spawn failure, which is precisely the
         // case where both are most likely to be needed.
-        let removed = match self
-            .git
-            .run(
-                &self.repo_root,
-                &["worktree", "remove", "--force", path_str],
-            )
-            .await
+        let removed = match worktree_lock::run_worktree(
+            &self.git,
+            &self.repo_root,
+            &["worktree", "remove", "--force", path_str],
+        )
+        .await
         {
             Ok(out) => ensure_ok(out, &format!("worktree remove --force {path_str}")).map(|_| ()),
             Err(error) => Err(error.into()),
@@ -598,7 +601,10 @@ pub(crate) async fn remove_worktree_and_branch(
         args.push("--force");
     }
     args.push(path_str);
-    let out = git.run(repo_root, &args).await?;
+    // `worktree remove` rewrites the same `.git/worktrees` directory a
+    // concurrent `worktree add` is laying down, so it takes the same lock —
+    // this covers `WorktreeManager::remove` and `Gc`'s sweep in one place.
+    let out = worktree_lock::run_worktree(git, repo_root, &args).await?;
     ensure_ok(out, &args.join(" "))?;
 
     // A branch outside the caller's own namespace is never a delete

--- a/crates/stella-fleet/src/git/worktree_lock.rs
+++ b/crates/stella-fleet/src/git/worktree_lock.rs
@@ -1,0 +1,231 @@
+//! One `git worktree` command at a time, per repo.
+//!
+//! Git keeps worktree notes in `.git/worktrees/<name>/`. It takes no lock
+//! while it writes them. Two `git worktree add` calls that start together can
+//! read each other's half-written files.
+//!
+//! Run 9255 caught that. The second add died on
+//! `failed to read .git/worktrees/<sibling>/commondir: Success`. The errno is
+//! `Success` because the read came up short. The fleet lost a whole task.
+//!
+//! [`run_worktree`] is the one door every `git worktree …` call here goes
+//! through. No two of them run against one repo root at once. Workers are not
+//! held apart. Only the tree cutting is, so the turns in those trees still run
+//! side by side.
+//!
+//! There are two ways to collide, so there are two locks.
+//!
+//! One is for this process. Each repo root gets a `tokio::sync::Mutex`, handed
+//! out by a shared map. A [`WorktreeManager`](super::WorktreeManager) and a
+//! [`Gc`](crate::gc::Gc) on one repo take the same one. This half always
+//! holds.
+//!
+//! The other is for a second `stella`. It is a lock file under
+//! `<repo_root>/.stella/private/`. Making a file with `O_CREAT|O_EXCL` is
+//! atomic on every disk we run on, and it needs no new crate.
+//! `stella-graph`'s `ManifestLock` is the same trick, and this copies it.
+//! This half is best effort. If the file cannot be made, or the wait runs out,
+//! the command goes ahead. Losing a task to a slow peer would be worse.
+//!
+//! [`Fleet`](crate::fleet::Fleet) holds its own locks over quick writes and
+//! never across an `.await`. This one is held across the git call, which is
+//! the point.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex as SyncMutex};
+use std::time::{Duration, Instant, SystemTime};
+
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+use super::{GitCli, GitError, GitOutput};
+
+/// How long to honour another process's lock file. It is long because the
+/// holder is checking out a tree, and a big repo takes minutes.
+const LOCK_WAIT: Duration = Duration::from_secs(300);
+
+/// A lock file older than this was left by a process that died. Break it.
+const LOCK_STALE: Duration = Duration::from_secs(1800);
+
+/// How often a waiter tries the create again.
+const LOCK_POLL: Duration = Duration::from_millis(25);
+
+/// How long to wait before the one retry of a flaky git call.
+const RETRY_PAUSE: Duration = Duration::from_millis(50);
+
+/// The mutexes, one per repo root. Nothing is ever dropped from the map. A run
+/// drives few repos, and dropping a key would hand a waiting caller a fresh
+/// lock.
+static REPO_LOCKS: LazyLock<SyncMutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>> =
+    LazyLock::new(|| SyncMutex::new(HashMap::new()));
+
+/// The map key for `repo_root`. It is the real path when the path resolves, so
+/// two spellings of one repo share a lock. A `/var` symlink on macOS and a
+/// relative path are both that case. A root that is not there yet keeps the
+/// path as given.
+fn lock_key(repo_root: &Path) -> PathBuf {
+    std::fs::canonicalize(repo_root).unwrap_or_else(|_| repo_root.to_path_buf())
+}
+
+fn repo_mutex(repo_root: &Path) -> Arc<AsyncMutex<()>> {
+    let mut registry = REPO_LOCKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    Arc::clone(registry.entry(lock_key(repo_root)).or_default())
+}
+
+/// Held for one `git worktree` call. Dropped in field order: the lock file
+/// first, then the mutex.
+struct WorktreeGuard {
+    /// `None` when the lock file could not be taken. The module docs say why
+    /// that goes ahead.
+    _file: Option<LockFile>,
+    _process: OwnedMutexGuard<()>,
+}
+
+impl WorktreeGuard {
+    async fn acquire(repo_root: &Path) -> Self {
+        let process = repo_mutex(repo_root).lock_owned().await;
+        // A root that is not on disk is a stand-in a test passed in, and there
+        // is nothing to lock. Asked here, or the create below would make
+        // `/repo` for real on a machine where the tests run as root.
+        let file = if repo_root.is_dir() {
+            LockFile::acquire(&lock_path(repo_root)).await
+        } else {
+            None
+        };
+        Self {
+            _file: file,
+            _process: process,
+        }
+    }
+}
+
+/// The half that holds off a second `stella`. Deleted on drop.
+struct LockFile {
+    path: PathBuf,
+}
+
+impl Drop for LockFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Where the lock file lives. `.stella/private/` is owner-only, the generated
+/// `.stella/.gitignore` covers it, and the fleet ledger sits there too.
+fn lock_path(repo_root: &Path) -> PathBuf {
+    repo_root
+        .join(".stella")
+        .join("private")
+        .join("worktree.lock")
+}
+
+impl LockFile {
+    /// Take the lock file. Give up after [`LOCK_WAIT`]. Give up at once when
+    /// the folder cannot be made at all, which a read-only tree hits.
+    async fn acquire(path: &Path) -> Option<Self> {
+        Self::acquire_within(path, LOCK_WAIT, LOCK_STALE).await
+    }
+
+    /// [`Self::acquire`] with both bounds passed in, so a test can prove them
+    /// in milliseconds rather than in minutes.
+    async fn acquire_within(path: &Path, wait: Duration, stale: Duration) -> Option<Self> {
+        let parent = path.parent()?;
+        create_private_dir(parent).ok()?;
+        let deadline = Instant::now() + wait;
+        loop {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+            {
+                Ok(_) => {
+                    return Some(Self {
+                        path: path.to_path_buf(),
+                    });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if is_stale(path, stale) {
+                        // If another waiter breaks it first, the next turn of
+                        // the loop races for it as usual.
+                        let _ = std::fs::remove_file(path);
+                        continue;
+                    }
+                    if Instant::now() >= deadline {
+                        return None;
+                    }
+                    tokio::time::sleep(LOCK_POLL).await;
+                }
+                Err(_) => return None,
+            }
+        }
+    }
+}
+
+/// Make `dir` owner-only. Same shape as `stella-cli`'s settings helper. On
+/// unix the mode is set as the folder is made, so it is never open to other
+/// users. Other systems get their own default.
+fn create_private_dir(dir: &Path) -> std::io::Result<()> {
+    if dir.is_dir() {
+        return Ok(());
+    }
+    let mut builder = std::fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    builder.create(dir)
+}
+
+/// Is this lock file old enough to count as junk? A date we cannot read, or
+/// one in the future, says no. Keeping a lock we cannot age out costs one slow
+/// call. Breaking one we should have kept costs the race.
+fn is_stale(path: &Path, stale: Duration) -> bool {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age > stale)
+}
+
+/// Could a peer's writes have caused this git failure? Then it is worth one
+/// retry. A real clash, such as `'<path>' already exists`, is not on the list.
+/// It fails once and is reported once.
+fn is_transient(stderr: &str) -> bool {
+    let lowered = stderr.to_ascii_lowercase();
+    // `index.lock` and `unable to create` are git's words for a held index.
+    // `commondir` is the short read from run 9255.
+    ["index.lock", "unable to create", "commondir"]
+        .iter()
+        .any(|needle| lowered.contains(needle))
+}
+
+/// Run one `git worktree …` call with this repo's lock held. Retry once when
+/// git failed for a reason [`is_transient`] knows.
+///
+/// If the retry fails too, the caller sees the first error. The retry is there
+/// to beat a clash, not to rename the error when it did not help.
+pub(crate) async fn run_worktree(
+    git: &dyn GitCli,
+    repo_root: &Path,
+    args: &[&str],
+) -> Result<GitOutput, GitError> {
+    let _guard = WorktreeGuard::acquire(repo_root).await;
+    let first = git.run(repo_root, args).await?;
+    if first.success || !is_transient(&first.stderr) {
+        return Ok(first);
+    }
+    tokio::time::sleep(RETRY_PAUSE).await;
+    let second = git.run(repo_root, args).await?;
+    if second.success {
+        Ok(second)
+    } else {
+        Ok(first)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-fleet/src/git/worktree_lock/tests.rs
+++ b/crates/stella-fleet/src/git/worktree_lock/tests.rs
@@ -1,0 +1,233 @@
+//! What the lock holds apart, and what it leaves alone.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use tempfile::TempDir;
+
+use super::*;
+use crate::git::WorktreeManager;
+
+/// How many calls a fake saw at once, and the peak.
+#[derive(Default)]
+struct Overlap {
+    in_flight: AtomicUsize,
+    peak: AtomicUsize,
+}
+
+/// A [`GitCli`] that stays inside every command for `hold`. Callers the lock
+/// does not hold back pile up in there.
+struct OverlapGit {
+    overlap: Arc<Overlap>,
+    hold: Duration,
+}
+
+#[async_trait]
+impl GitCli for OverlapGit {
+    async fn run(&self, _repo: &Path, _args: &[&str]) -> Result<GitOutput, GitError> {
+        let now = self.overlap.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.overlap.peak.fetch_max(now, Ordering::SeqCst);
+        tokio::time::sleep(self.hold).await;
+        self.overlap.in_flight.fetch_sub(1, Ordering::SeqCst);
+        Ok(GitOutput::ok(""))
+    }
+}
+
+/// The witness for the race. Eight tasks go into one manager at once. The
+/// fake sleeps inside `worktree add`. With no lock, all eight sit in the
+/// command together and the peak is eight.
+///
+/// Run 9255 is what that costs: git read a sibling's half-written
+/// `.git/worktrees/<name>/commondir` and the run lost a task.
+///
+/// The fake's `await` makes the overlap, so no race has to be won. Without
+/// the lock this test fails every time, not most of the time.
+#[tokio::test]
+async fn concurrent_creates_never_overlap_a_worktree_add() {
+    let repo = TempDir::new().expect("temp repo root");
+    let overlap = Arc::new(Overlap::default());
+    let manager = WorktreeManager::new(
+        OverlapGit {
+            overlap: Arc::clone(&overlap),
+            hold: Duration::from_millis(20),
+        },
+        repo.path(),
+    );
+
+    let ids: Vec<String> = (0..8).map(|n| format!("t{n}")).collect();
+    let created = futures_util::future::join_all(ids.iter().map(|id| manager.create(id, "base")))
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("every dispatch creates its tree");
+
+    assert_eq!(
+        overlap.peak.load(Ordering::SeqCst),
+        1,
+        "two `git worktree add` calls were in flight against one repository"
+    );
+    let paths: HashSet<_> = created.iter().map(|tree| tree.path.clone()).collect();
+    assert_eq!(paths.len(), 8, "every worker needs a tree of its own");
+    let branches: HashSet<_> = created.iter().map(|tree| tree.branch.clone()).collect();
+    assert_eq!(branches.len(), 8);
+}
+
+/// The control. Same fake, same eight callers, no lock in the path. The peak
+/// is eight. An unlocked `create` reaches the same number, so the counter is
+/// known to climb.
+#[tokio::test]
+async fn the_fake_reports_overlap_when_nothing_holds_the_callers_apart() {
+    let repo = TempDir::new().expect("temp repo root");
+    let overlap = Arc::new(Overlap::default());
+    let git = OverlapGit {
+        overlap: Arc::clone(&overlap),
+        hold: Duration::from_millis(20),
+    };
+    // `status --porcelain` is a worker's own check. It never touches
+    // `.git/worktrees`, so it takes no lock.
+    let statuses = futures_util::future::join_all(
+        (0..8).map(|_| git.run(repo.path(), &["status", "--porcelain"])),
+    )
+    .await;
+    assert!(statuses.iter().all(Result::is_ok));
+    assert_eq!(overlap.peak.load(Ordering::SeqCst), 8);
+}
+
+#[tokio::test]
+async fn the_lock_file_is_taken_and_released() {
+    let repo = TempDir::new().expect("temp repo root");
+    let path = lock_path(repo.path());
+    let held = LockFile::acquire(&path).await.expect("lock file");
+    assert!(path.exists());
+    drop(held);
+    assert!(!path.exists());
+}
+
+/// A live lock file is honoured until the wait runs out. Then the waiter goes
+/// ahead without it, rather than losing the task.
+#[tokio::test]
+async fn a_live_lock_file_is_honoured_then_given_up_on() {
+    let repo = TempDir::new().expect("temp repo root");
+    let path = lock_path(repo.path());
+    let _held = LockFile::acquire(&path).await.expect("lock file");
+    let second =
+        LockFile::acquire_within(&path, Duration::from_millis(50), Duration::from_secs(1800)).await;
+    assert!(second.is_none());
+}
+
+/// A lock file left by a dead process is broken, not kept forever.
+#[tokio::test]
+async fn a_stale_lock_file_is_broken() {
+    let repo = TempDir::new().expect("temp repo root");
+    let path = lock_path(repo.path());
+    // What a process that died leaves behind.
+    create_private_dir(path.parent().expect("lock parent")).expect("private dir");
+    std::fs::write(&path, b"").expect("stale lock file");
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let taken =
+        LockFile::acquire_within(&path, Duration::from_secs(5), Duration::from_millis(1)).await;
+    assert!(taken.is_some(), "a stale lock must not wedge dispatch");
+}
+
+/// A `GitCli` that replays a list of outputs and counts its calls.
+struct ScriptedRuns {
+    outputs: SyncMutex<Vec<GitOutput>>,
+    calls: AtomicUsize,
+}
+
+impl ScriptedRuns {
+    fn new(outputs: Vec<GitOutput>) -> Self {
+        Self {
+            outputs: SyncMutex::new(outputs),
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl GitCli for ScriptedRuns {
+    async fn run(&self, _repo: &Path, _args: &[&str]) -> Result<GitOutput, GitError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let mut outputs = self
+            .outputs
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if outputs.is_empty() {
+            return Ok(GitOutput::ok(""));
+        }
+        Ok(outputs.remove(0))
+    }
+}
+
+#[tokio::test]
+async fn a_transient_failure_is_retried_once() {
+    let repo = TempDir::new().expect("temp repo root");
+    let git = ScriptedRuns::new(vec![
+        GitOutput::failed(
+            128,
+            "fatal: unable to create '.git/index.lock': File exists",
+        ),
+        GitOutput::ok(""),
+    ]);
+    let out = run_worktree(&git, repo.path(), &["worktree", "add", "/tmp/x"])
+        .await
+        .expect("git ran");
+    assert!(out.success);
+    assert_eq!(git.calls.load(Ordering::SeqCst), 2);
+}
+
+/// A retry that does not help reports the first failure, not the second. The
+/// retry is there to beat a clash, not to rename the error.
+#[tokio::test]
+async fn a_retry_that_fails_reports_the_first_error() {
+    let repo = TempDir::new().expect("temp repo root");
+    let git = ScriptedRuns::new(vec![
+        GitOutput::failed(128, "fatal: failed to read .git/worktrees/t1/commondir"),
+        GitOutput::failed(1, "second"),
+    ]);
+    let out = run_worktree(&git, repo.path(), &["worktree", "add", "/tmp/x"])
+        .await
+        .expect("git ran");
+    assert!(!out.success);
+    assert!(out.stderr.contains("commondir"));
+    assert_eq!(out.code, Some(128));
+}
+
+#[tokio::test]
+async fn a_real_collision_is_not_retried() {
+    let repo = TempDir::new().expect("temp repo root");
+    let git = ScriptedRuns::new(vec![GitOutput::failed(
+        128,
+        "fatal: '/tmp/x' already exists",
+    )]);
+    let out = run_worktree(&git, repo.path(), &["worktree", "add", "/tmp/x"])
+        .await
+        .expect("git ran");
+    assert!(!out.success);
+    assert_eq!(git.calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn transient_signatures_are_the_ones_a_peer_could_have_caused() {
+    assert!(is_transient(
+        "fatal: Unable to create '.git/index.lock': File exists"
+    ));
+    assert!(is_transient(
+        "fatal: failed to read .git/worktrees/t1-abc/commondir: Success"
+    ));
+    assert!(!is_transient("fatal: '/tmp/x' already exists"));
+    assert!(!is_transient("fatal: invalid reference: nope"));
+}
+
+#[test]
+fn one_repository_root_maps_to_one_mutex() {
+    let repo = TempDir::new().expect("temp repo root");
+    let nested = repo.path().join("sub");
+    std::fs::create_dir_all(&nested).expect("nested dir");
+    let direct = repo_mutex(&nested);
+    let round_about = repo_mutex(&nested.join("..").join("sub"));
+    assert!(Arc::ptr_eq(&direct, &round_about));
+}


### PR DESCRIPTION
## What

`git/worktree_lock.rs` is now the one door every `git worktree …` call in
`stella-fleet` goes through. No two of them run against one repository root at
once.

Call sites moved onto it: `WorktreeManager::create`, `WorktreeManager::discard`,
`remove_worktree_and_branch` (which is both `WorktreeManager::remove` and
`Gc`'s sweep, so the third DoD bullet is answered by covering one routine), and
`Gc::sweep`'s `worktree prune` and `worktree list --porcelain`. The guard is
taken at the leaf only and never nested, so there is no reentrancy path to
deadlock on.

## Why

Git keeps its worktree bookkeeping in `.git/worktrees/<name>/` and takes no
lock while it writes there, so two `git worktree add` calls that start together
can read each other's half-written files. `ci` run 9255 caught exactly that: the
second add died on
`failed to read .git/worktrees/<sibling>/commondir: Success` — errno `Success`
is git reporting a short read — and a fleet wave lost a whole task to a
`dispatch failed`. A user running `stella fleet --max-concurrency 2` loses a
task the same way.

## Mechanism

Two locks, because there are two ways to collide.

- **In one process**: a `tokio::sync::Mutex` per repository root, handed out by
  a process-wide map, so a `WorktreeManager` and a `Gc` pointed at one repo take
  the same one. This half is a guarantee. The key is the canonicalized path when
  the path resolves, so two spellings of one repo share a lock.
- **Across processes**: an `O_CREAT|O_EXCL` lock file under
  `<repo_root>/.stella/private/`, bounded on both sides — a waiter gives up
  after 300s and proceeds, and a lock file older than 1800s is broken as the
  residue of a dead process. This half is best effort and proceeds rather than
  failing a dispatch, because losing a task to a slow peer is worse than the
  race being narrowed.

Plus one retry when git failed with a signature another process's bookkeeping
could have caused (`index.lock`, `unable to create`, the `commondir` short read
from run 9255). The first error is what the caller sees if the retry fails too.
A real collision (`'<path>' already exists`) is not on that list, so it fails
once and is reported once.

**Exemplar**: `stella-graph`'s `ManifestLock`
(`crates/stella-graph/src/manifest.rs`) — this workspace's existing answer to
"exclusive without a platform-specific dependency", including the bounded-wait
and stale-break shape. No new dependency.

## Witness mechanism — why it fails on `main` by construction

`concurrent_creates_never_overlap_a_worktree_add`
(`crates/stella-fleet/src/git/worktree_lock/tests.rs`) drives a recording
`GitCli` that counts how many calls are inside `run` at once and keeps the peak.
It sleeps 20ms inside the call. Eight `create` calls are driven concurrently
against one manager with `join_all`.

Without the lock, all eight futures are polled into `run` before any sleep
finishes, so the peak is 8 and the assertion of 1 fails — every time, not most
of the time, because the overlap is made by the fake's `await` rather than by
winning a race. This is what the issue's own "Constraints" section asked for
instead of a loop that usually fails.

Its control, `the_fake_reports_overlap_when_nothing_holds_the_callers_apart`,
runs the same fake and the same eight callers with the lock out of the path and
asserts a peak of 8 — so the witness is measuring a counter that can climb.

Beside it: the lock file is taken and released; a live lock file is honoured
until the wait runs out and then proceeds; a stale one is broken; a transient
failure is retried once; a retry that fails reports the first error; a real
collision is not retried; and one repository root maps to one mutex through two
spellings of its path.

## One correction to the design pointer

The pointer asked for "a unique path derived from the attempt id (never a shared
temp name)". The code already does that and it is not where the defect is:
`worktree_slug` gives every task a `<stem>-<64-bit hash>` directory, and the two
paths in the failing run (`t1-14591e8e7e85d4c7`, `t2-14591f8e7e85d67a`) were
already distinct. The failure was t2 **reading** t1's half-written `commondir`,
not a path collision. No path change lands; the serialization is the whole fix.

## File placement

New logic lands in a sibling submodule (`src/git/worktree_lock.rs` +
`worktree_lock/tests.rs`), not in `git.rs`. No `stella-fleet` file is on
`scripts/file-size-baseline.txt` and this change adds none — `check-file-size`
is green and reports no new crossing.

## Docs

`crates/stella-fleet/README.md` gains the module's row in the file map and an
invariant bullet stating the guarantee (one `git worktree` command at a time per
repo) and what it deliberately leaves alone (the workers). The module doc states
both at the call site.

## Residue filed

- #6134 — `stella-cli`'s self-driving loop shells out to `git worktree
  add`/`remove`/`prune` through its own synchronous helper and does not take
  this lock, so it can still collide with itself or with a fleet run in the same
  clone. Not fixed here: the lock is `async` and `pub(crate)`, and both of those
  are crate-boundary decisions rather than lines of code.

Tests deleted: None

Closes #6127

## Summary by Sourcery

Prevent concurrent `git worktree` commands from interfering with one another within a repository while keeping worker execution concurrent.

Bug Fixes:
- Serialize all `git worktree` operations per repository to prevent concurrent worktree bookkeeping corruption and dispatch failures.
- Retry transient Git worktree failures once while preserving the original error when the retry also fails.

Enhancements:
- Coordinate worktree commands with an in-process per-repository mutex and a best-effort cross-process lock with bounded waits and stale-lock recovery.
- Route worktree creation, removal, discard, pruning, and listing through the shared locking boundary.

Documentation:
- Document the worktree serialization invariant and add the locking module to the fleet file map.

Tests:
- Add deterministic concurrency coverage and tests for lock-file lifecycle, stale-lock handling, retry behavior, collision handling, and repository path canonicalization.