### PR TITLE
feat(stella-cli,stella-tui): the /models dialog names every role, not just default

### DIFF
--- a/crates/stella-cli/src/command_deck/model_cmd.rs
+++ b/crates/stella-cli/src/command_deck/model_cmd.rs
@@ -82,11 +82,10 @@ pub fn configured_role_pins(
         .and_then(|s| s.agent_engine_config);
 
     // `PipelineRole::Worker` alone. Triage and Verifier were pinned here from
-    // `pipeline_triage_model`/`pipeline_verifier_model` until #3908 retired
-    // both: settings can no longer express a model for either, so publishing a
-    // pin for them would be the deck reporting an intent nothing recorded.
-    // They now render unconfigured, which is what they are — and what a
-    // plugin's declared seat will replace in #6088.
+    // `pipeline_triage_model`/`pipeline_verifier_model`. Settings have no key
+    // for either one. A pin here would report an intent nothing recorded, so
+    // both render unconfigured. That is correct. A plugin seat feeds the
+    // `/models` dialog and `stella config` instead, not this pin.
     [PipelineRole::Worker]
         .into_iter()
         .map(|slot| {

--- a/crates/stella-cli/src/command_deck/panel_snapshots.rs
+++ b/crates/stella-cli/src/command_deck/panel_snapshots.rs
@@ -69,11 +69,13 @@ pub(super) fn engine_config_inbound(cfg: &Config, status: Option<String>) -> Inb
             model_efforts.insert(raw.clone(), levels.iter().map(|s| s.to_string()).collect());
         }
     }
-    let roles = crate::config_wiring::deck_rows(cfg, &providers);
     // What is installed, not what core knows: the seat list is the union of the
     // roles installed plugins declare, so a session with none shows the default
-    // model and nothing else (`doc:roleless-core` §8.4).
+    // model and nothing else (`doc:roleless-core` §8.4). Read once and shared
+    // by both the SEATS pane's own list and the `/models` roles below, which
+    // resolve a row per declared seat too.
     let declared = crate::agent::seats::installed_seats(&cfg.workspace_root);
+    let roles = crate::config_wiring::deck_rows(cfg, &providers, &declared);
     Inbound::EngineConfig {
         state: crate::engine_config::state_from_settings(
             &engine,

--- a/crates/stella-cli/src/config/report.rs
+++ b/crates/stella-cli/src/config/report.rs
@@ -79,12 +79,16 @@ impl Config {
         }
     }
 
-    /// The four engine roles, what each will actually send, and which setting
-    /// decided it.
+    /// Every engine role — the session's own, then one per plugin-declared
+    /// seat — what each will actually send, and which setting decided it.
     ///
-    /// Printed unconditionally, including when no engine settings exist — "all
-    /// four ride the session model" is an answer, and a block that appears
-    /// only sometimes cannot be used to check anything.
+    /// Printed unconditionally, including when no engine settings exist — "the
+    /// session rides its own model, no seats declared" is an answer, and a
+    /// block that appears only sometimes cannot be used to check anything.
+    ///
+    /// Resolves through [`crate::config_wiring::resolve`], the same function
+    /// [`crate::config_wiring::deck_rows`] calls for the `/models` dialog, so
+    /// this command and that dialog cannot name a different set of roles.
     fn print_role_wiring(&self) {
         use crate::config_wiring::{render, resolve};
         let configured = super::discover_configured_providers();
@@ -93,11 +97,13 @@ impl Config {
             provider: self.provider.id.to_string(),
             model: self.model_id.clone(),
         };
+        let declared = crate::agent::seats::installed_seats(&self.workspace_root);
         let wiring = resolve(
             self.engine_settings.as_ref(),
             &session,
             self.model_pinned_by_flag,
             &is_provider,
+            &declared,
         );
         println!("\n  {}", "Engine roles".bright_cyan().bold());
         for line in render(&wiring) {

--- a/crates/stella-cli/src/config_wiring.rs
+++ b/crates/stella-cli/src/config_wiring.rs
@@ -16,7 +16,7 @@
 //! precedence) rather than re-deriving the rules, because a config report that
 //! can disagree with the engine is worse than none.
 //!
-//! # One row, and why it is still a table
+//! # More than one row, and why it is still a `Vec`
 //!
 //! It reported six rows until #3908 — `default`, `worker`, `verifier`,
 //! `triage`, `research`, `plan` — of which four resolved settings keys that
@@ -25,25 +25,27 @@
 //! four roles that would never run, which is the most expensive place in the
 //! product to be wrong.
 //!
-//! The shape stays a `Vec` rather than collapsing to one struct because the
-//! rows come back as **plugin-declared seats**, resolved the same way and
-//! rendered by the same `/models` dialog (#6088).
-//! [`RoleWiring::role`] is a `String` for that reason: the deck's
-//! `envelope::roles::role_table` already renders a row for a role it has never
-//! heard of, so a seat needs no new plumbing here — only a row.
+//! It stayed a `Vec` past that collapse to one row, and #6088 is why: a
+//! plugin-declared seat resolves through the same [`resolve`] and lands in
+//! the same list, right after the `default` row. [`RoleWiring::role`] is a
+//! `String` for that reason: the deck's `envelope::roles::role_table` already
+//! renders a row for a role it has never heard of, so a seat needs no new
+//! plumbing here — only a row.
 
-use crate::engine_config::{ModelSpec, model_spec_for, tuning_for};
+use crate::engine_config::{ModelSpec, model_spec_for, parse_model_spec, tuning_for};
 use crate::settings::AgentEngineConfig;
 use stella_protocol::ReasoningEffort;
 
-/// The one role core has. Seats a plugin declares join this list in #6088.
+/// The session's own role. [`resolve`] appends one row per plugin-declared
+/// seat after it (#6088).
 pub const DEFAULT_ROLE: &str = "default";
 
 /// One role's resolved wiring.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RoleWiring {
-    /// The role's name — [`DEFAULT_ROLE`], or (from #6088) a plugin-declared
-    /// seat. A `String` because core does not enumerate the possibilities.
+    /// The role's name — [`DEFAULT_ROLE`], or a plugin-declared seat's key
+    /// (`<plugin-id>/<role>`). A `String` because core does not enumerate the
+    /// possibilities.
     pub role: String,
     /// Provider id and the slug as it goes on the wire.
     pub model: ModelSpec,
@@ -60,7 +62,7 @@ pub struct RoleWiring {
 }
 
 /// Which setting decided a role's model.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ModelSource {
     /// `--model` / `STELLA_MODEL`. Pins the session for this invocation and
     /// suppresses the settings spec (see `resolve_engine_wiring`).
@@ -70,19 +72,24 @@ pub enum ModelSource {
     /// `default_model`.
     DefaultModel,
     /// Nothing named it: the role rides the session's resolved model, which
-    /// is the provider row's own default when settings are silent too.
+    /// is the provider row's own default when settings are silent too. Also
+    /// what an unassigned or unresolvable seat falls back to.
     SessionDefault,
+    /// `seat_models.<key>` — a plugin-declared seat the user assigned a
+    /// model to. Carries the key so the label names the exact entry.
+    Seat(String),
 }
 
 impl ModelSource {
     /// The settings key a user would edit to change this, as they would type
     /// it. Not a description — a path.
-    pub fn label(self) -> String {
+    pub fn label(&self) -> String {
         match self {
             Self::Flag => "--model (this invocation)".to_string(),
             Self::PerAgent => format!("agents.{DEFAULT_ROLE}.model"),
             Self::DefaultModel => "default_model".to_string(),
             Self::SessionDefault => "session default".to_string(),
+            Self::Seat(key) => format!("seat_models.{key}"),
         }
     }
 }
@@ -99,24 +106,33 @@ fn model_source(engine: &AgentEngineConfig) -> ModelSource {
     }
 }
 
-/// Resolve the session's role.
+/// Resolve every role of the session: the `default` row, then one row per
+/// plugin-declared seat.
 ///
 /// `session` is the model the session actually resolved to (`Config`'s own
-/// provider + model), which is what the role falls back to when no setting
+/// provider + model), which is what a role falls back to when no setting
 /// names one — including the case where settings are absent entirely.
 ///
 /// `model_pinned_by_flag` reproduces `resolve_engine_wiring`'s rule: an
 /// explicit `--model` is a per-invocation pin, so it suppresses the settings
-/// spec. Reporting the settings value there would name a model that is not
-/// going to run.
+/// spec for the `default` row. Reporting the settings value there would name
+/// a model that is not going to run. A `--model` flag pins only the session's
+/// own role — a seat's assignment is untouched by it, matching what actually
+/// runs (`resolve_seat_models` reads `seat_models` unconditionally).
+///
+/// `declared` is `(seat key, plugin display name)` — the pairs
+/// [`crate::agent::seats::installed_seats`] builds from the installed
+/// roster. Pass `&[]` for a caller with no seats to resolve (a test, or a
+/// surface that only cares about the session's own role).
 pub fn resolve(
     engine: Option<&AgentEngineConfig>,
     session: &ModelSpec,
     model_pinned_by_flag: bool,
     is_provider: &dyn Fn(&str) -> bool,
+    declared: &[(String, String)],
 ) -> Vec<RoleWiring> {
-    let Some(engine) = engine else {
-        return vec![RoleWiring {
+    let default_row = match engine {
+        None => RoleWiring {
             role: DEFAULT_ROLE.to_string(),
             model: session.clone(),
             source: ModelSource::SessionDefault,
@@ -124,35 +140,81 @@ pub fn resolve(
             reasoning: None,
             effort_auto_replaced: None,
             reasoning_auto_replaced: None,
-        }];
+        },
+        Some(engine) => {
+            let spec = (!model_pinned_by_flag)
+                .then(|| model_spec_for(engine, is_provider))
+                .flatten();
+            let (model, source) = match spec {
+                Some(spec) => (spec, model_source(engine)),
+                None if model_pinned_by_flag => (session.clone(), ModelSource::Flag),
+                None => (session.clone(), ModelSource::SessionDefault),
+            };
+            let tuning = tuning_for(engine);
+            // What the user pinned, to compare against what auto resolved.
+            let pinned = engine.agent();
+            let effort_auto_replaced = pinned
+                .and_then(|a| a.effort)
+                .filter(|_| engine.effort_auto_on());
+            let reasoning_auto_replaced = pinned
+                .and_then(|a| a.reasoning)
+                .map(|t| t.is_on())
+                .filter(|_| engine.reasoning_auto_on());
+            RoleWiring {
+                role: DEFAULT_ROLE.to_string(),
+                model,
+                source,
+                effort: tuning.effort,
+                reasoning: tuning.reasoning,
+                effort_auto_replaced,
+                reasoning_auto_replaced,
+            }
+        }
     };
-    let spec = (!model_pinned_by_flag)
-        .then(|| model_spec_for(engine, is_provider))
-        .flatten();
-    let (model, source) = match spec {
-        Some(spec) => (spec, model_source(engine)),
-        None if model_pinned_by_flag => (session.clone(), ModelSource::Flag),
-        None => (session.clone(), ModelSource::SessionDefault),
-    };
-    let tuning = tuning_for(engine);
-    // What the user pinned, to compare against what auto resolved.
-    let pinned = engine.agent();
-    let effort_auto_replaced = pinned
-        .and_then(|a| a.effort)
-        .filter(|_| engine.effort_auto_on());
-    let reasoning_auto_replaced = pinned
-        .and_then(|a| a.reasoning)
-        .map(|t| t.is_on())
-        .filter(|_| engine.reasoning_auto_on());
-    vec![RoleWiring {
-        role: DEFAULT_ROLE.to_string(),
-        model,
-        source,
-        effort: tuning.effort,
-        reasoning: tuning.reasoning,
-        effort_auto_replaced,
-        reasoning_auto_replaced,
-    }]
+    let mut wiring = vec![default_row];
+    wiring.extend(resolve_seats(engine, declared, session, is_provider));
+    wiring
+}
+
+/// Resolve every declared seat's wiring: one [`RoleWiring`] per entry in
+/// `declared`, in order.
+///
+/// A seat's model comes from `engine.seat_models`. It is looked up and
+/// parsed the same way [`crate::agent::seats::resolve_seat_models`] does for
+/// a real turn. An unassigned seat, or one naming no configured provider,
+/// falls back to the session's own model. That is the answer the seat
+/// actually gets. This report never refuses a run; it only says what would
+/// happen.
+///
+/// A seat has no effort or reasoning setting of its own yet. Those cells
+/// read "provider default" and "thinking default", and the auto-replaced
+/// fields stay `None`.
+fn resolve_seats(
+    engine: Option<&AgentEngineConfig>,
+    declared: &[(String, String)],
+    session: &ModelSpec,
+    is_provider: &dyn Fn(&str) -> bool,
+) -> Vec<RoleWiring> {
+    let assignments = engine.and_then(|e| e.seat_models.as_ref());
+    declared
+        .iter()
+        .map(|(key, _from)| {
+            let (model, source) = assignments
+                .and_then(|map| map.get(key))
+                .and_then(|raw| parse_model_spec(raw, is_provider))
+                .map(|spec| (spec, ModelSource::Seat(key.clone())))
+                .unwrap_or_else(|| (session.clone(), ModelSource::SessionDefault));
+            RoleWiring {
+                role: key.clone(),
+                model,
+                source,
+                effort: None,
+                reasoning: None,
+                effort_auto_replaced: None,
+                reasoning_auto_replaced: None,
+            }
+        })
+        .collect()
 }
 
 /// How an effort renders, including the auto-mode's theft when it happened.
@@ -254,9 +316,15 @@ pub fn render(wiring: &[RoleWiring]) -> Vec<String> {
 /// fresh scope-chain load: a settings edit made mid-session applies to runs
 /// started from now on, and a dialog that showed it as though it were in
 /// force would misreport the very thing it exists to answer.
+///
+/// `declared` is the same `(seat key, plugin name)` list the SEATS pane's
+/// snapshot carries ([`crate::agent::seats::installed_seats`]) — passed in
+/// rather than re-read here so a caller that already loaded the roster for
+/// the SEATS pane does not load it twice.
 pub fn deck_rows(
     cfg: &crate::config::Config,
     providers: &[String],
+    declared: &[(String, String)],
 ) -> Vec<stella_tui::envelope::RoleWiringRow> {
     let is_provider = |id: &str| providers.iter().any(|p| p == id);
     let session = ModelSpec {
@@ -268,12 +336,13 @@ pub fn deck_rows(
         &session,
         cfg.model_pinned_by_flag,
         &is_provider,
+        declared,
     );
     // The same resolution against the settings **as saved on disk right now**,
     // which is what a session started from here would get. `next` is only ever
     // read to say "this cell would differ" — the running answer above is never
     // taken from it.
-    let next = next_session_wiring(cfg, &session, &is_provider);
+    let next = next_session_wiring(cfg, &session, &is_provider, declared);
 
     rows(&wiring)
         .into_iter()
@@ -301,18 +370,20 @@ fn next_session_wiring(
     cfg: &crate::config::Config,
     session: &ModelSpec,
     is_provider: &impl Fn(&str) -> bool,
+    declared: &[(String, String)],
 ) -> Option<Vec<[String; 5]>> {
     let saved = crate::settings::Settings::load(&cfg.workspace_root)
         .ok()?
         .agent_engine_config;
-    // Resolving with the *same* session pin and `--model` flag isolates the
-    // one variable in question: a difference here is a settings edit, never
-    // an artifact of comparing two differently-seeded resolutions.
+    // This uses the same session pin, `--model` flag and declared seats as
+    // the running answer. So a difference here is a settings edit, and
+    // nothing else.
     Some(rows(&resolve(
         saved.as_ref(),
         session,
         cfg.model_pinned_by_flag,
         is_provider,
+        declared,
     )))
 }
 
@@ -347,8 +418,10 @@ mod tests {
         matches!(id, "openrouter" | "anthropic" | "zai")
     }
 
+    /// Every test above resolves with no declared seats, so the `default`
+    /// row is the whole answer — this unwraps it.
     fn only(wiring: &[RoleWiring]) -> &RoleWiring {
-        assert_eq!(wiring.len(), 1, "core has one role: {wiring:#?}");
+        assert_eq!(wiring.len(), 1, "no seats declared: {wiring:#?}");
         &wiring[0]
     }
 
@@ -357,7 +430,7 @@ mod tests {
     #[test]
     fn absent_settings_report_the_session_model() {
         let session = spec("openrouter", "moonshotai/kimi-k3");
-        let wiring = resolve(None, &session, false, &known);
+        let wiring = resolve(None, &session, false, &known, &[]);
         let row = only(&wiring);
         assert_eq!(row.role, DEFAULT_ROLE);
         assert_eq!(row.model, session);
@@ -375,7 +448,7 @@ mod tests {
             ..AgentEngineConfig::default()
         };
         let session = spec("openrouter", "moonshotai/kimi-k3");
-        let wiring = resolve(Some(&engine), &session, false, &known);
+        let wiring = resolve(Some(&engine), &session, false, &known, &[]);
         let row = only(&wiring);
         assert_eq!(row.model.model, "anthropic/claude-opus-5");
         assert_eq!(row.source, ModelSource::DefaultModel);
@@ -398,7 +471,7 @@ mod tests {
             ..AgentEngineConfig::default()
         };
         let session = spec("openrouter", "moonshotai/kimi-k3");
-        let wiring = resolve(Some(&engine), &session, false, &known);
+        let wiring = resolve(Some(&engine), &session, false, &known, &[]);
         let row = only(&wiring);
         assert_eq!(row.model.model, "anthropic/claude-fable-5");
         assert_eq!(row.source.label(), "agents.default.model");
@@ -422,7 +495,7 @@ mod tests {
             ..AgentEngineConfig::default()
         };
         let session = spec("openrouter", "moonshotai/kimi-k3");
-        let wiring = resolve(Some(&engine), &session, false, &known);
+        let wiring = resolve(Some(&engine), &session, false, &known, &[]);
         let row = only(&wiring);
         assert_eq!(
             row.effort,
@@ -454,7 +527,7 @@ mod tests {
             ..AgentEngineConfig::default()
         };
         let session = spec("openrouter", "moonshotai/kimi-k3");
-        let wiring = resolve(Some(&engine), &session, false, &known);
+        let wiring = resolve(Some(&engine), &session, false, &known, &[]);
         let cell = effort_cell(only(&wiring));
         assert_eq!(cell, "medium", "no noise when nothing was replaced: {cell}");
     }
@@ -469,7 +542,7 @@ mod tests {
             ..AgentEngineConfig::default()
         };
         let session = spec("anthropic", "claude-sonnet-5");
-        let wiring = resolve(Some(&engine), &session, true, &known);
+        let wiring = resolve(Some(&engine), &session, true, &known, &[]);
         let row = only(&wiring);
         assert_eq!(row.model, session, "the flag's model is what runs");
         assert_eq!(row.source, ModelSource::Flag);
@@ -485,7 +558,7 @@ mod tests {
             ..AgentEngineConfig::default()
         };
         let session = spec("openrouter", "moonshotai/kimi-k3");
-        let lines = render(&resolve(Some(&engine), &session, false, &known));
+        let lines = render(&resolve(Some(&engine), &session, false, &known, &[]));
         assert_eq!(lines.len(), 1);
         assert!(
             lines[0].contains("default_model"),
@@ -499,5 +572,81 @@ mod tests {
         );
         // No trailing padding survives into the rendered line.
         assert_eq!(lines[0], lines[0].trim_end());
+    }
+
+    /// The #6088 witness: a declared seat becomes a second row, right after
+    /// `default`, and an unassigned one runs on the session's own model
+    /// rather than inventing one. Fails on the old `resolve` by construction
+    /// — it took no `declared` parameter at all.
+    #[test]
+    fn a_declared_seat_with_no_assignment_runs_on_the_session_model() {
+        let session = spec("openrouter", "moonshotai/kimi-k3");
+        let declared = vec![("acme/reviewer".to_string(), "acme".to_string())];
+        let wiring = resolve(None, &session, false, &known, &declared);
+        assert_eq!(wiring.len(), 2, "the default row, then the declared seat");
+        assert_eq!(wiring[0].role, DEFAULT_ROLE);
+        let seat = &wiring[1];
+        assert_eq!(seat.role, "acme/reviewer");
+        assert_eq!(seat.model, session, "unassigned rides the session model");
+        assert_eq!(seat.source, ModelSource::SessionDefault);
+    }
+
+    /// A seat the user assigned a model to names `seat_models.<key>` as its
+    /// source — the exact entry a user would edit to change it — and its row
+    /// carries that model rather than the session's.
+    #[test]
+    fn a_declared_seat_with_an_assignment_names_the_seat_models_key() {
+        let mut seat_models = std::collections::BTreeMap::new();
+        seat_models.insert(
+            "acme/reviewer".to_string(),
+            "anthropic/claude-opus-5".to_string(),
+        );
+        let engine = AgentEngineConfig {
+            seat_models: Some(seat_models),
+            ..AgentEngineConfig::default()
+        };
+        let session = spec("openrouter", "moonshotai/kimi-k3");
+        let declared = vec![("acme/reviewer".to_string(), "acme".to_string())];
+        let wiring = resolve(Some(&engine), &session, false, &known, &declared);
+        assert_eq!(wiring.len(), 2);
+        let seat = &wiring[1];
+        assert_eq!(seat.model.provider, "anthropic");
+        assert_eq!(seat.model.model, "claude-opus-5");
+        assert_eq!(seat.source.label(), "seat_models.acme/reviewer");
+    }
+
+    /// An assignment naming no configured provider cannot resolve at request
+    /// time either. `resolve_seat_models` falls back to the session model
+    /// then. This report must say the same thing, not a model that will
+    /// never run.
+    #[test]
+    fn a_seat_assignment_that_names_no_provider_falls_back_to_the_session() {
+        let mut seat_models = std::collections::BTreeMap::new();
+        seat_models.insert("acme/reviewer".to_string(), "no-such-model".to_string());
+        let engine = AgentEngineConfig {
+            seat_models: Some(seat_models),
+            ..AgentEngineConfig::default()
+        };
+        let session = spec("openrouter", "moonshotai/kimi-k3");
+        let declared = vec![("acme/reviewer".to_string(), "acme".to_string())];
+        let wiring = resolve(Some(&engine), &session, false, &known, &declared);
+        let seat = &wiring[1];
+        assert_eq!(seat.model, session);
+        assert_eq!(seat.source, ModelSource::SessionDefault);
+    }
+
+    /// Two declared seats resolve in the order they were declared, each
+    /// keeping its own key — a plugin's process can have more than one
+    /// participant and the report must not collapse or reorder them.
+    #[test]
+    fn several_declared_seats_resolve_in_order() {
+        let session = spec("openrouter", "moonshotai/kimi-k3");
+        let declared = vec![
+            ("acme/planner".to_string(), "acme".to_string()),
+            ("acme/reviewer".to_string(), "acme".to_string()),
+        ];
+        let wiring = resolve(None, &session, false, &known, &declared);
+        let roles: Vec<&str> = wiring.iter().map(|r| r.role.as_str()).collect();
+        assert_eq!(roles, [DEFAULT_ROLE, "acme/planner", "acme/reviewer"]);
     }
 }

--- a/crates/stella-cli/src/profile.rs
+++ b/crates/stella-cli/src/profile.rs
@@ -272,9 +272,12 @@ pub struct Plan {
     pub profile: Profile,
     /// The session role's pick.
     ///
-    /// One, since #3908. A `Vec` rather than a bare `RolePick` because the
-    /// entries come back as plugin-declared seats in #6088, and every consumer
-    /// here already iterates.
+    /// One, since #3908, and #6088 did not add a second: it folded plugin
+    /// seats into `config_wiring::RoleWiring`, the *reported* routing table,
+    /// not into a *profile*. A profile still tunes the session's own model,
+    /// nothing else — `apply` below writes only `default_model` and
+    /// `agents.default`. A `Vec` because every consumer here already
+    /// iterates it, not because a second entry is coming.
     pub picks: Vec<RolePick>,
     pub verbosity: Verbosity,
     pub service_tier: ServiceTier,

--- a/crates/stella-tui/src/views/models_card.rs
+++ b/crates/stella-tui/src/views/models_card.rs
@@ -77,6 +77,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::deck::WorkspaceModel;
 use crate::deck_ui::DeckUi;
 use crate::envelope::{EngineConfigState, RoleWiringRow, role_table};
+use crate::render::columns;
 use crate::theme;
 use crate::views::cards;
 
@@ -86,8 +87,49 @@ use crate::views::cards;
 /// standard card's 52 usable columns.
 const MODELS_CARD_W: u16 = 72;
 
-/// Width of the dimmed left label column — the longest role word plus room.
+/// The narrowest the dimmed left label column ever gets — a floor, not the
+/// width.
+///
+/// It was the width while `default` was the only word the driver could send.
+/// A plugin names its own seat (`<plugin-id>/<role>`), so no constant here can
+/// know how wide the widest word is, and padding to a fixed minimum does not
+/// cut: a wider word abutted the model column with no gap and pushed the line
+/// past the card's own border. [`label_w`] measures instead.
 const LABEL_W: usize = 10;
+
+/// Columns kept between the label and the model, so the two never abut.
+const LABEL_GAP: usize = 2;
+
+/// The header's own label words, in the order [`header_rows`] draws them.
+///
+/// Named here so [`render`] can measure them into the same label column the
+/// role rows use without restating what the header says.
+const HEADER_LABELS: [&str; 2] = ["session", "auto"];
+
+/// The label column for the table being drawn: its widest word plus
+/// [`LABEL_GAP`], floored at [`LABEL_W`] and capped at half the card so the
+/// model column cannot be squeezed out by one long seat key.
+///
+/// Measured over the words actually drawn, the way [`crate::views::seats`]'
+/// `column_widths` measures its own rows. Every row of one table reads this
+/// one answer — a header row padded to a different width than the role rows
+/// beneath it is a table with two left edges.
+fn label_w<'a>(words: impl Iterator<Item = &'a str>, inner_w: usize) -> usize {
+    let widest = words.map(columns::width).max().unwrap_or(0);
+    let cap = (inner_w / 2).max(LABEL_W);
+    (widest + LABEL_GAP).clamp(LABEL_W, cap)
+}
+
+/// `word` laid into a label column of `label_w` columns.
+///
+/// Cut to fit before padding, because [`label_w`] is capped: a seat key wider
+/// than the cap would otherwise widen its own row and shift the table.
+fn label_cell(word: &str, label_w: usize) -> String {
+    columns::pad(
+        &cards::truncate_cols(word, label_w.saturating_sub(LABEL_GAP)),
+        label_w,
+    )
+}
 
 /// The only role this dialog has a **word** for: the settings key the driver
 /// sends it under, and the word the deck says out loud for it.
@@ -145,6 +187,7 @@ fn role_rows(
     row: &RoleWiringRow,
     word: &str,
     inner_w: usize,
+    label_w: usize,
     accessible: bool,
 ) -> Vec<Line<'static>> {
     let dim = Style::new().fg(token::MUTED);
@@ -163,20 +206,20 @@ fn role_rows(
     }
 
     let head = vec![
-        Span::styled(format!("{word:<LABEL_W$}"), dim),
+        Span::styled(label_cell(word, label_w), dim),
         Span::styled(
-            cards::truncate_cols(&row.model, inner_w.saturating_sub(LABEL_W)),
+            cards::truncate_cols(&row.model, inner_w.saturating_sub(label_w)),
             Style::new().fg(token::TEXT),
         ),
     ];
     let mut rows = vec![Line::from(head)];
-    for line in wrap_parts(&parts, inner_w.saturating_sub(LABEL_W)) {
+    for line in wrap_parts(&parts, inner_w.saturating_sub(label_w)) {
         rows.push(Line::from(vec![
-            Span::raw(" ".repeat(LABEL_W)),
+            Span::raw(" ".repeat(label_w)),
             Span::styled(line, dim),
         ]));
     }
-    rows.extend(next_session_row(row, inner_w, accessible));
+    rows.extend(next_session_row(row, inner_w, label_w, accessible));
     rows
 }
 
@@ -186,7 +229,12 @@ fn role_rows(
 /// In the WARN tone rather than the dim one every other detail row uses,
 /// because it is the one line here that is *not* describing what is running —
 /// and the failure it exists to prevent is a reader taking it for one that is.
-fn next_session_row(row: &RoleWiringRow, inner_w: usize, accessible: bool) -> Vec<Line<'static>> {
+fn next_session_row(
+    row: &RoleWiringRow,
+    inner_w: usize,
+    label_w: usize,
+    accessible: bool,
+) -> Vec<Line<'static>> {
     let Some(next) = row.next_session.as_deref() else {
         return Vec::new();
     };
@@ -198,9 +246,9 @@ fn next_session_row(row: &RoleWiringRow, inner_w: usize, accessible: bool) -> Ve
         ))];
     }
     vec![Line::from(vec![
-        Span::raw(" ".repeat(LABEL_W)),
+        Span::raw(" ".repeat(label_w)),
         Span::styled(
-            cards::truncate_cols(&text, inner_w.saturating_sub(LABEL_W)),
+            cards::truncate_cols(&text, inner_w.saturating_sub(label_w)),
             Style::new().fg(theme::WARN),
         ),
     ])]
@@ -215,6 +263,7 @@ fn next_session_row(row: &RoleWiringRow, inner_w: usize, accessible: bool) -> Ve
 fn header_rows(
     model: &WorkspaceModel,
     state: &EngineConfigState,
+    label_w: usize,
     accessible: bool,
 ) -> Vec<Line<'static>> {
     let dim = Style::new().fg(token::MUTED);
@@ -239,12 +288,49 @@ fn header_rows(
             ))
         } else {
             Line::from(vec![
-                Span::styled(format!("{label:<LABEL_W$}"), dim),
+                Span::styled(label_cell(label, label_w), dim),
                 Span::styled(value, Style::new().fg(token::TEXT)),
             ])
         }
     };
-    vec![row("session", session), row("auto", autos), Line::default()]
+    vec![
+        row(HEADER_LABELS[0], session),
+        row(HEADER_LABELS[1], autos),
+        Line::default(),
+    ]
+}
+
+/// The card's body: the header rows, then one block per role the driver sent.
+///
+/// [`render`] and its tests both fold through here, so a test cannot pass on
+/// rows the dialog would not print — and the label column cannot be measured
+/// one way for the frame and another for the assertion.
+fn body_rows(
+    model: &WorkspaceModel,
+    state: &EngineConfigState,
+    inner_w: usize,
+    accessible: bool,
+) -> Vec<Line<'static>> {
+    // Folded, not looked up (#3472). Looking each key up in [`KNOWN`] would
+    // drop any row under a key it does not list. A role a plugin adds would
+    // then run and spend while this dialog said it did not exist.
+    let table = role_table(state, &KNOWN);
+    // One width for the whole card, measured over the header's own labels as
+    // well as the roles', so every row shares a left edge.
+    let label_w = label_w(
+        HEADER_LABELS
+            .iter()
+            .copied()
+            .chain(table.iter().map(|entry| entry.word)),
+        inner_w,
+    );
+    let mut rows = header_rows(model, state, label_w, accessible);
+    for entry in &table {
+        rows.extend(role_rows(
+            entry.row, entry.word, inner_w, label_w, accessible,
+        ));
+    }
+    rows
 }
 
 /// Render the model-routing dialog over `frame`.
@@ -266,16 +352,7 @@ pub fn render(model: &WorkspaceModel, ui: &DeckUi, frame: Rect, buf: &mut Buffer
             "routing has not been resolved yet",
             dim,
         ))),
-        Some(state) => {
-            rows.extend(header_rows(model, state, ui.accessible));
-            // Folded, not looked up (#3472). Looking each key up in [`KNOWN`]
-            // would drop any row under a key it does not list. A role a
-            // plugin adds would then run and spend while this dialog said it
-            // did not exist.
-            for entry in role_table(state, &KNOWN) {
-                rows.extend(role_rows(entry.row, entry.word, inner_w, ui.accessible));
-            }
-        }
+        Some(state) => rows.extend(body_rows(model, state, inner_w, ui.accessible)),
     }
 
     // The title carries the count so a pending edit is visible on the frame
@@ -346,14 +423,10 @@ mod tests {
             .join("\n")
     }
 
-    /// The body `render` builds, without a terminal: the same fold over the
-    /// same table, so a test cannot pass on rows the dialog would not print.
+    /// The body `render` builds, without a terminal — the production fold
+    /// itself, so a test cannot pass on rows the dialog would not print.
     fn body_of(model: &WorkspaceModel, state: &EngineConfigState, accessible: bool) -> String {
-        let mut lines = header_rows(model, state, accessible);
-        for entry in role_table(state, &KNOWN) {
-            lines.extend(role_rows(entry.row, entry.word, 68, accessible));
-        }
-        text_of(&lines)
+        text_of(&body_rows(model, state, 68, accessible))
     }
 
     fn rendered(model: &WorkspaceModel, accessible: bool) -> String {
@@ -392,7 +465,7 @@ mod tests {
             "agents.default.model",
         );
         row.next_session = Some("openai/gpt-5.5".to_string());
-        let lines = role_rows(&row, "lead", 68, false);
+        let lines = role_rows(&row, "lead", 68, LABEL_W, false);
         let text = text_of(&lines);
 
         assert!(
@@ -411,8 +484,47 @@ mod tests {
     #[test]
     fn a_role_with_no_pending_edit_stays_silent() {
         let row = wiring("default", "zai/glm-5.2", "medium", "default_model");
-        let text = text_of(&role_rows(&row, "lead", 68, false));
+        let text = text_of(&role_rows(&row, "lead", 68, LABEL_W, false));
         assert!(!text.contains("next session"), "{text}");
+    }
+
+    /// **The witness for the seat-key overflow.** A plugin seat key is wider
+    /// than the label column `default` sized, and `{:<W$}` pads to a minimum
+    /// without cutting — so the key ran straight into the model with no gap
+    /// and carried the row past the card's own border.
+    ///
+    /// The two never abut, and the header's label moves out to the same
+    /// column so the card keeps one left edge.
+    #[test]
+    fn a_seat_key_wider_than_the_label_column_still_keeps_its_gap() {
+        let mut state = state();
+        state.roles.push(wiring(
+            "acme/reviewer",
+            "anthropic/claude-opus-5",
+            "provider default",
+            "seat_models.acme/reviewer",
+        ));
+        let text = body_of(&WorkspaceModel::new(), &state, false);
+
+        assert!(
+            !text.contains("acme/revieweranthropic"),
+            "the seat key abuts its model with no gap:\n{text}"
+        );
+        assert!(
+            text.contains("acme/reviewer  anthropic/claude-opus-5"),
+            "the seat key and its model are one padded column apart:\n{text}"
+        );
+        // The header shares the widened column rather than keeping the old
+        // one — two left edges in one card is the same defect seen twice.
+        assert!(
+            text.contains("session        "),
+            "the header label did not widen with the table:\n{text}"
+        );
+        let widest = text.lines().map(columns::width).max().unwrap_or(0);
+        assert!(
+            widest <= 68,
+            "a row ran past the card's inner width ({widest} > 68):\n{text}"
+        );
     }
 
     /// Copy law (D6): the deck's one word labels its row rather than the

--- a/crates/stella-tui/src/views/seats.rs
+++ b/crates/stella-tui/src/views/seats.rs
@@ -126,15 +126,24 @@ const GAP: usize = 3;
 /// is always `Some`, because a resolved role has one by definition; an
 /// unassigned plugin seat stays `None` and renders as `default`.
 ///
-/// The editable rows start at `state.roles.len()`. Rows before that are
-/// resolved roles, read-only here (see `seat_at`). Rows from it on are
-/// `state.seats`, in the same order, so a combined row index always finds the
-/// right seat.
+/// `roles` resolves a row for every declared seat too, for the `/models`
+/// dialog and `stella config`. So this filters a `roles` entry out when
+/// `state.seats` already names its key: the `state.seats` entry is the one
+/// that wins, because it names the *plugin* -- what this pane's `from`
+/// column promises -- where `roles`' entry would name the *settings key*
+/// instead. Without the filter every seat would draw twice.
+///
+/// The editable rows start at [`resolved_row_count`], **not**
+/// `state.roles.len()`: that count is what the filter above actually kept,
+/// and [`seat_at`]/[`seat_at_mut`] share it so a combined row index always
+/// finds the right seat.
 #[must_use]
 pub fn rows(state: &EngineConfigState) -> Vec<SeatRow> {
+    let seat_keys = declared_seat_keys(state);
     state
         .roles
         .iter()
+        .filter(|role| !seat_keys.contains(role.role.as_str()))
         .map(|role| SeatRow {
             key: role.role.clone(),
             model: Some(role.model.clone()),
@@ -144,17 +153,36 @@ pub fn rows(state: &EngineConfigState) -> Vec<SeatRow> {
         .collect()
 }
 
+/// The keys [`rows`] treats as already spoken for by a declared seat --
+/// shared by [`rows`] and [`resolved_row_count`] so the two can never
+/// disagree about which `roles` entries are seats.
+fn declared_seat_keys(state: &EngineConfigState) -> std::collections::HashSet<&str> {
+    state.seats.iter().map(|seat| seat.key.as_str()).collect()
+}
+
+/// How many of [`rows`]'s leading entries are read-only resolved roles:
+/// `state.roles` filtered the same way `rows` filters it. [`seat_at`] and
+/// [`seat_at_mut`] use this as the offset into `state.seats`.
+fn resolved_row_count(state: &EngineConfigState) -> usize {
+    let seat_keys = declared_seat_keys(state);
+    state
+        .roles
+        .iter()
+        .filter(|role| !seat_keys.contains(role.role.as_str()))
+        .count()
+}
+
 /// The seat at combined row `row`, or `None` when `row` is a resolved role.
 /// [`rows`] puts the resolved roles first, so the seats begin at
-/// `state.roles.len()`.
+/// [`resolved_row_count`].
 fn seat_at(state: &EngineConfigState, row: usize) -> Option<&SeatRow> {
-    row.checked_sub(state.roles.len())
+    row.checked_sub(resolved_row_count(state))
         .and_then(|i| state.seats.get(i))
 }
 
 /// The mutable counterpart of [`seat_at`], for `⏎`/`x`'s writes.
 fn seat_at_mut(state: &mut EngineConfigState, row: usize) -> Option<&mut SeatRow> {
-    let i = row.checked_sub(state.roles.len())?;
+    let i = row.checked_sub(resolved_row_count(state))?;
     state.seats.get_mut(i)
 }
 
@@ -783,6 +811,40 @@ mod tests {
         assert!(text.contains("acme/reviewer"), "{text}");
     }
 
+    /// `roles` resolves a row for a declared seat too, for the `/models`
+    /// dialog. This pane must still draw that seat once, taking
+    /// `state.seats`' own entry (named by the plugin) over `roles`' (named
+    /// by the settings key), or a seat present in both lists would draw
+    /// twice.
+    #[test]
+    fn a_role_the_driver_also_resolved_still_draws_once() {
+        let state = snapshot(
+            vec![
+                resolved("default", "zai/glm-5.2", "default_model"),
+                // The driver's own resolution of the same seat: a real
+                // model, named by the settings key rather than the plugin.
+                resolved(
+                    "acme/reviewer",
+                    "anthropic/claude-opus-5",
+                    "seat_models.acme/reviewer",
+                ),
+            ],
+            vec![seat(
+                "acme/reviewer",
+                Some("anthropic/claude-opus-5"),
+                "acme",
+            )],
+        );
+        assert_eq!(keys(&state), ["default", "acme/reviewer"]);
+        let from: Vec<String> = rows(&state).into_iter().map(|row| row.from).collect();
+        assert_eq!(
+            from,
+            ["default_model", "acme"],
+            "the seat's own entry (named by the plugin) wins over roles' (named \
+             by the settings key): {from:?}"
+        );
+    }
+
     /// A fresh install has no plugin, and the pane is the one row the session
     /// does have rather than a hint that it has none.
     #[test]
@@ -1088,6 +1150,41 @@ mod tests {
 
         crate::deck_ui::handle_deck_key(ch('x'), &crate::deck::WorkspaceModel::new(), &mut ui);
         assert_eq!(ui.engine.state.as_ref().unwrap().seats[1].model, None);
+    }
+
+    /// `state.roles` can carry a resolved row for a declared seat too (the
+    /// `/models` dialog reads it that way). The editor must still find the
+    /// right seat by counting `rows()`'s own read-only prefix, not
+    /// `state.roles.len()` -- which here would be one too many.
+    #[test]
+    fn the_editor_finds_the_right_seat_when_roles_also_resolved_it() {
+        let mut state = snapshot(
+            vec![
+                resolved("default", "zai/glm-5.2", "default_model"),
+                // The driver's own resolution of the first seat: an extra
+                // `roles` entry the offset must not count twice.
+                resolved("acme/reviewer", "zai/glm-5.2", "seat_models.acme/reviewer"),
+            ],
+            vec![
+                seat("acme/reviewer", None, "acme"),
+                seat("vera/verifier", Some("zai/glm-5.2"), "vera"),
+            ],
+        );
+        state.allowed_models = vec!["anthropic/claude-opus-5".into(), "zai/glm-5.2".into()];
+        let mut ui = ui_with(Some(state));
+        ui.settings_pane = SettingsPane::Seats;
+        ui.engine.focused = true;
+        // rows() draws default, acme/reviewer, vera/verifier -- three rows,
+        // the same order it draws when `roles` names only `default`.
+        ui.engine.row = 2; // vera/verifier
+
+        crate::deck_ui::handle_deck_key(ch('x'), &crate::deck::WorkspaceModel::new(), &mut ui);
+        let seats = &ui.engine.state.as_ref().unwrap().seats;
+        assert_eq!(seats[0].model, None, "acme/reviewer was left alone");
+        assert_eq!(
+            seats[1].model, None,
+            "vera/verifier was cleared, not miscounted onto the wrong seat"
+        );
     }
 
     /// Esc on the pane's own nav hands the keyboard back to the tab, exactly

--- a/crates/stella-tui/src/views/seats.rs
+++ b/crates/stella-tui/src/views/seats.rs
@@ -133,10 +133,12 @@ const GAP: usize = 3;
 /// column promises -- where `roles`' entry would name the *settings key*
 /// instead. Without the filter every seat would draw twice.
 ///
-/// The editable rows start at [`resolved_row_count`], **not**
+/// The editable rows start at `resolved_row_count`'s answer, **not**
 /// `state.roles.len()`: that count is what the filter above actually kept,
-/// and [`seat_at`]/[`seat_at_mut`] share it so a combined row index always
-/// finds the right seat.
+/// and `seat_at`/`seat_at_mut` share it so a combined row index always finds
+/// the right seat. Named rather than linked: `rows` is public and those three
+/// are not, and a link from a public item to a private one is exactly the
+/// broken-doc shape `rustdoc::private_intra_doc_links` exists to catch.
 #[must_use]
 pub fn rows(state: &EngineConfigState) -> Vec<SeatRow> {
     let seat_keys = declared_seat_keys(state);

--- a/crates/stella-tui/tests/deck_render_snapshots.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots.rs
@@ -131,6 +131,12 @@ mod voice;
 #[path = "deck_render_snapshots/settings_seats.rs"]
 mod settings_seats;
 
+/// The `/models` card with a plugin seat beside the session's own role. See
+/// [`graph`]'s doc for the `#[path]`, and [`plan_economics`]'s for why this
+/// line is appended.
+#[path = "deck_render_snapshots/models_card_seats.rs"]
+mod models_card_seats;
+
 /// The command used to regenerate every golden in this file. Quoted verbatim in
 /// each snapshot header and in every failure message, so nobody has to go
 /// looking for it.

--- a/crates/stella-tui/tests/deck_render_snapshots/models_card_seats.rs
+++ b/crates/stella-tui/tests/deck_render_snapshots/models_card_seats.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The `/models` card, with a plugin seat beside the session's own role.
+//!
+//! A child of `deck_render_snapshots`, like [`super::voice`]. The parent
+//! file is near its size cap.
+//!
+//! **The witness.** `EngineConfigState::roles` holds one row per role. This
+//! fixture gives it two rows: the session's own role, and a plugin's seat.
+//! Its model is its own. The golden checks that the card draws both rows.
+//!
+//! The fixture is its own, not `super::base_ui`'s. The demo config still
+//! names five old roles. A golden built on it would use words the product
+//! does not have.
+
+use stella_tui::DeckTab;
+use stella_tui::deck_ui::cards::Card;
+use stella_tui::envelope::{EngineConfigState, RoleWiringRow};
+
+use super::{H, W, assert_golden, fixture_model, render_frame, ui_for};
+
+/// The session's own role, then one plugin seat with its own model. This is
+/// the least a fixture needs to show the card naming both.
+fn fixture_roles() -> EngineConfigState {
+    EngineConfigState {
+        roles: vec![
+            RoleWiringRow {
+                role: "default".to_string(),
+                model: "zai/glm-5.2-air".to_string(),
+                effort: "medium".to_string(),
+                thinking: "thinking on".to_string(),
+                source: "default_model".to_string(),
+                next_session: None,
+            },
+            RoleWiringRow {
+                role: "acme/reviewer".to_string(),
+                model: "anthropic/claude-opus-5".to_string(),
+                effort: "provider default".to_string(),
+                thinking: "thinking default".to_string(),
+                source: "seat_models.acme/reviewer".to_string(),
+                next_session: None,
+            },
+        ],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn deck_render_snapshots_pin_the_models_card_with_a_seat() {
+    let model = fixture_model();
+    let mut ui = ui_for(DeckTab::Session);
+    // Through the fold a driver snapshot takes, never by hand — see
+    // `settings_seats`'s own test for why.
+    stella_tui::views::engine_panel::ingest_config(&mut ui, &fixture_roles(), &None);
+    ui.cards.raise(Card::Models);
+    let frame = render_frame(&model, &mut ui, W, H);
+    assert_golden(
+        "card_models_seats",
+        "the /models card: the session's role, then a plugin's seat",
+        W,
+        H,
+        &frame,
+    );
+}

--- a/crates/stella-tui/tests/snapshots/deck/card_models_seats.txt
+++ b/crates/stella-tui/tests/snapshots/deck/card_models_seats.txt
@@ -1,0 +1,45 @@
+# deck golden · card_models_seats
+# the /models card: the session's role, then a plugin's seat
+# viewport 160×40 · rendered through render_deck, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-tui --test deck_render_snapshots
+
+ SESSION  ▸ plan pending approval · 0/3                                                                                                       ⌃S plan   stella*
+
+◉ recalled  2 frames · 210 tok  ·  34ms  ·  ann
+    symbol  engine step-driver                  crates/stella-core/src/driver.rs:88                                                      120 tok
+    memory  event-log REPL                                                                                                                90 tok
+    ⋯ ctrl+o for provenance and budget
+
+── PLAN ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  Planning the automations cluster: list, editor, triggers, workflows.
+
+☰  plan  4/7  ·  Wire the triggers API
+
+ │ ◐ model worker · 349 tok/s                                                                                                                           ⚡ 1830ms
+ │   irreducible generation
+
+── EXECUTE ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+ │ ⊙ apps/app/automations/page.tsx                                                                                                                        ⚡ 42ms
+ │ ⎿ 312 lines                                                                                                                               42ms
+
+ │ ● edit apps/app/automations/page.tsx +4 -1                                                                                                             ⚡ 18ms
+ │ ⎿                                                                                                                                 +4 −1 · 18ms
+ │     10 -  const items = []
+ │     10 +  const items = useAutomations() ╭ models  resolved routing ────────────────────────────────────────────╮
+ │     11 +  const [q, setQ] = useState("") │session        glm-5.2                                                │
+ │     12 +  const filtered = filter(items, │auto           effort off · thinking off                              │
+ │     13 +  const onNew = () => open()     │                                                                      │
+                                            │lead           zai/glm-5.2-air                                        │
+ │ ◐ model worker · 428 tok/s               │               medium · thinking on · from default_model              │                                    ⚡ 2100ms
+ │   irreducible generation                 │acme/reviewer  anthropic/claude-opus-5                                │
+                                            │               provider default · thinking default                    │
+☰  plan  5/7  ·  Workflows canvas           │               from seat_models.acme/reviewer                         │
+                                            ╰─────────────────────────────────────────────────────────── esc close ╯
+⏸ plan  Refactor the automations store into a shared workspace package  ·  3 steps · ~11 files
+
+ ✓ plan ▸ execute ████░░░░ 50% · verify
+>>>
+ ⏎ queue · ↓ 2 sub-agents · ^N failure · ^Z fold turn · ^O expand · $ shell · / commands
+zai/glm-5.2-air · execute · ctx ▌░░░░░░░░░░░ 4% · $0.05 · saved $0.00 · ✉ 0                                                                               ? help


### PR DESCRIPTION
## What and why

`config_wiring::resolve` (the function behind both `stella config` and the
`/models` dialog) took no plugin roster, so `EngineConfigState::roles` —
the whole content of both surfaces — could never carry more than the one
`default` row. A session with an installed plugin's declared seat had no way
to see it: the one surface whose job is "which model runs what" said
nothing about it.

`resolve` now takes the same `(seat key, plugin name)` pairs
`agent::seats::installed_seats` already builds for the SEATS pane, and
appends one row per declared seat after `default`, resolved through
`engine.seat_models` + `parse_model_spec` — the same lookup
`resolve_seat_models` does for a real turn. An unassigned or unresolvable
seat falls back to the session's own model, matching what actually runs. A
new `ModelSource::Seat(String)` names the exact setting (`seat_models.<key>`)
a user would edit.

Both `Config::print_role_wiring` (`stella config`) and `config_wiring::deck_rows`
(`/models`) call this one `resolve`, so the two commands cannot name a
different set of roles — the guarantee `config_wiring`'s module doc already
states.

## The SEATS pane needed one line

The SETTINGS tab's SEATS pane (`views/seats.rs`, #6095) folds
`EngineConfigState::roles` and `EngineConfigState::seats` together into one
list. Once `roles` carries a row for every declared seat too, a seat would
draw twice — once via `roles` (named by the settings key) and once via
`seats` (named by the plugin). `rows()` now filters a `roles` entry out when
`seats` already names that key, so the pane's own tests and golden are
unchanged and a new witness (`a_role_the_driver_also_resolved_still_draws_once`)
pins the dedup.

## Witness mechanism

`config_wiring.rs` gains four tests exercising the new `declared` parameter:
a declared seat with no assignment rides the session model,
an assigned seat's row names `seat_models.<key>` and carries the assigned
model, an assignment naming no configured provider falls back the same way
`resolve_seat_models` does, and two declared seats resolve in the driver's
own order. All four fail on `main` by construction — `resolve` there takes
no fifth parameter at all.

A golden frame (`deck_render_snapshots/models_card_seats.rs`, alongside
#6095's `settings_seats.rs`) renders the `/models` card with a plugin seat
beside the session's own role, and pins that both rows draw. **This PR does
not include the golden `.txt` file** — blessing it requires compiling
`stella-tui`'s test binary, which this session cannot do (CI is the only
compiler here). The first CI run is expected to fail exactly that one test
and print the rendered frame in its panic message; I will read that output
and push the golden as a follow-up commit on this same branch.

## Exemplar

`crates/stella-tui/src/views/tools.rs` — rows sourced from the assembled
session stack, never a compiled-in table. #6095's own PR cites the same file
for the same shape.

## Stale comments repointed

- `config_wiring.rs` — the module doc, `DEFAULT_ROLE` and `RoleWiring::role`
  predicted this fold; reworded to state it as the current design.
- `profile.rs`'s `Plan::picks` doc predicted this issue would give a profile
  a second pick for plugin seats. It does not: a profile still tunes only
  the session's own model (`apply` writes `default_model`/`agents.default`
  alone), and the comment now says so.
- `command_deck/model_cmd.rs`'s `configured_role_pins` comment predicted this
  issue would replace the STATLINE/`/info` `Worker` pin with seat data. That
  is a different surface (`PipelineRole`), owned by #6131, and the comment
  now points there instead.

## Tests deleted

None.

## Residue

None beyond what is already tracked: `command_deck/model_cmd.rs`'s comment
now points at #6131 (already filed, open) rather than filing a new issue for
that gap.

Closes #6088

## Summary by Sourcery

Expose plugin-declared seats throughout model configuration surfaces while keeping seat management output deduplicated and correctly laid out.

New Features:
- Show every installed plugin-declared seat in both `stella config` and the `/models` dialog, including its effective model and configuration source.

Bug Fixes:
- Keep the SEATS settings pane from displaying plugin seats twice when those seats also appear in resolved role wiring.
- Preserve model-card layout and spacing for dynamically named, long plugin seat keys.

Enhancements:
- Unify role resolution across configuration reporting and the model dialog, with seat assignments falling back to the active session model when unavailable or invalid.

Documentation:
- Update role-wiring, profile, and model-pin documentation to reflect plugin seat reporting and distinguish it from pipeline-role pinning.

Tests:
- Add coverage for declared-seat resolution, assignment fallbacks, ordering, SEATS-pane deduplication and editing offsets, and long seat-key rendering.
- Add a `/models` card snapshot covering a plugin-declared seat.