### PR TITLE
feat(stella-protocol): name the lanes the two non-deck doors run in

### DIFF
--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -971,23 +971,28 @@ pub(crate) async fn run_goal_turn(
             // The skill's `effort:` override, for this arc.
             config.effort = Some(effort);
         }
-        // TODO(#6109): still the builder path, so this turn reports no lane.
-        // `stella goal` is a door rather than one of the seven lanes
-        // `BuiltinLane` names, and `Lead` is documented as the deck's turn —
-        // see `agent::turn`'s own note for the decision this waits on.
-        let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
-            .with_calibration(calibration)
-            // Every round's worker turn drains this, and only those. The
-            // verifier runs as a sub-agent off `Engine::assess`, which
-            // sees a parent's steering through
-            // `stella_core::subagent::ChildSteering` — soft stop
-            // forwarded, `drain_steering` refused — so a whistle cannot
-            // be eaten by the judge, and the person who sent it does not
-            // have to know a judge exists.
-            .with_steering(whistle.steering());
-        if let Some(hooks) = &cfg.hooks {
-            engine = engine.with_hooks(hooks, &hook_runner);
-        }
+        // Assembled rather than built up by optional builders: this arc is
+        // the `GoalArc` lane and says so, and every seam it leaves alone is a
+        // written `None` in `lane_capabilities::goal_arc`.
+        //
+        // Every round's worker turn drains the steering tap, and only those.
+        // The verifier runs as a sub-agent off `Engine::assess`, which sees a
+        // parent's steering through `stella_core::subagent::ChildSteering` —
+        // soft stop forwarded, `drain_steering` refused — so a whistle cannot
+        // be eaten by the judge, and the person who sent it does not have to
+        // know a judge exists.
+        let engine = Engine::assemble(
+            provider,
+            &tools,
+            config,
+            &TokioSleeper,
+            crate::lane_capabilities::goal_arc(
+                cfg.hooks.as_ref(),
+                &hook_runner,
+                calibration,
+                whistle.steering(),
+            ),
+        );
         engine
             .run_goal(
                 verifier,

--- a/crates/stella-cli/src/agent/goal/goal_wrapped.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped.rs
@@ -370,18 +370,24 @@ pub(crate) async fn run_goal_wrapped_turn(
         // The skill's `effort:` override, for this arc.
         config.effort = Some(effort);
     }
-    // TODO(#6109): still the builder path, so this turn reports no lane. Same
-    // door as `agent::goal`'s raw arm, under a wrapper plugin, and the same
-    // open question about which lane a non-interactive door runs in.
-    let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
-        .with_calibration(calibration)
-        // The arc's whistle (#4769), opened above and drained at every round's
-        // first step boundary — the wrapped arm drives its own rounds through
-        // this one engine, so one attachment covers all of them.
-        .with_steering(whistle.steering());
-    if let Some(hooks) = &cfg.hooks {
-        engine = engine.with_hooks(hooks, &hook_runner);
-    }
+    // The `GoalArc` lane — the same door as `agent::goal`'s raw arm, under a
+    // wrapper plugin, so it takes the same seams literal.
+    //
+    // The arc's whistle (#4769) is opened above and drained at every round's
+    // first step boundary. The wrapped arm drives its own rounds through this
+    // one engine, so one attachment covers all of them.
+    let engine = Engine::assemble(
+        provider,
+        &tools,
+        config,
+        &TokioSleeper,
+        crate::lane_capabilities::goal_arc(
+            cfg.hooks.as_ref(),
+            &hook_runner,
+            calibration,
+            whistle.steering(),
+        ),
+    );
 
     messages.push(CompletionMessage::user(
         stella_core::goal::goal_kickoff_text(goal),

--- a/crates/stella-cli/src/agent/turn.rs
+++ b/crates/stella-cli/src/agent/turn.rs
@@ -145,25 +145,27 @@ pub(crate) async fn run_turn(
             // The invoked skill's `effort:` override, for this turn.
             config.effort = Some(effort);
         }
-        // TODO(#6109): still the builder path, so this turn reports no lane.
-        // `stella run` is a door, not one of the seven lanes `BuiltinLane`
-        // names, and `Lead` documents itself as the deck's turn. Until it is
-        // settled whether that definition widens, whether an eighth case
-        // arrives, or whether these doors stay unattributed, guessing here
-        // would make the lane say something its own definition denies.
-        let mut engine = Engine::with_sleeper(provider, &permitted, config, &TokioSleeper)
-            .with_calibration(calibration)
-            .with_provider_outcomes(router)
-            .with_fallback_resolver(&fallback);
-        if let Some(requery) = &requery {
-            engine = engine.with_requery(requery);
-        }
-        if let Some(gate) = controls.gate.as_deref() {
-            engine = engine.with_gate(gate);
-        }
-        if let Some(steering) = controls.steering.as_deref() {
-            engine = engine.with_steering(steering);
-        }
+        // Assembled rather than built up by optional builders: this turn is
+        // the `RawTurn` lane and says so, and every seam it leaves alone is a
+        // written `None` in `lane_capabilities::raw_turn` rather than
+        // whatever a chain happened not to attach. This arm binds no hooks,
+        // because process-free authority strips the hook layer above it.
+        let engine = Engine::assemble(
+            provider,
+            &permitted,
+            config,
+            &TokioSleeper,
+            crate::lane_capabilities::raw_turn(
+                None,
+                calibration,
+                router,
+                &fallback,
+                requery
+                    .as_ref()
+                    .map(|requery| requery as &dyn stella_core::ports::SteeringRequery),
+                &controls,
+            ),
+        );
         engine.run_turn_with_sender(messages, budget, &tx).await
     } else {
         // Customs, the operator's switches, and the authorization gate,
@@ -185,26 +187,31 @@ pub(crate) async fn run_turn(
             // The invoked skill's `effort:` override, for this turn.
             config.effort = Some(effort);
         }
-        // Unattributed for the reason the process-free arm above gives: this
-        // is the same door, waiting on the same decision.
-        let mut engine = Engine::with_sleeper(provider, &tools, config, &TokioSleeper)
-            .with_calibration(calibration)
-            .with_provider_outcomes(router)
-            .with_fallback_resolver(&fallback);
-        if let Some(hooks) = &cfg.hooks {
-            engine = engine
-                .with_hooks(hooks, &hook_runner)
-                .with_hook_approval_route(&hook_approvals);
-        }
-        if let Some(requery) = &requery {
-            engine = engine.with_requery(requery);
-        }
-        if let Some(gate) = controls.gate.as_deref() {
-            engine = engine.with_gate(gate);
-        }
-        if let Some(steering) = controls.steering.as_deref() {
-            engine = engine.with_steering(steering);
-        }
+        // The `RawTurn` lane again — the same door as the arm above, with the
+        // hook layer this one keeps. The runner and the broker route ride
+        // together because the chain this replaces bound them together.
+        let engine = Engine::assemble(
+            provider,
+            &tools,
+            config,
+            &TokioSleeper,
+            crate::lane_capabilities::raw_turn(
+                cfg.hooks.as_ref().map(|hooks| {
+                    (
+                        hooks,
+                        &hook_runner as &dyn stella_core::HookRunner,
+                        &hook_approvals as &dyn stella_core::hooks::decision::ApprovalRoute,
+                    )
+                }),
+                calibration,
+                router,
+                &fallback,
+                requery
+                    .as_ref()
+                    .map(|requery| requery as &dyn stella_core::ports::SteeringRequery),
+                &controls,
+            ),
+        );
         engine.run_turn_with_sender(messages, budget, &tx).await
     };
     // This path owns its run — one raw engine turn, no pipeline above it — so

--- a/crates/stella-cli/src/lane_capabilities.rs
+++ b/crates/stella-cli/src/lane_capabilities.rs
@@ -3,9 +3,9 @@
 
 //! What each of this crate's turn lanes binds, and which lane it says it is.
 //!
-//! A lane is one place a turn runs. `stella_protocol::BuiltinLane` names
-//! seven. Four of them are built here: the deck's lead turn, a resumed turn,
-//! a deck worker lane, and a fleet attempt.
+//! A lane is one place a turn runs. `stella_protocol::BuiltinLane` names them
+//! all. Built here: the deck's lead turn, a resumed turn, a deck worker lane,
+//! a fleet attempt, the shared raw turn, and a judged goal arc.
 //!
 //! Each one goes to the engine through `Engine::assemble`. Its
 //! `TurnCapabilities` carries the lane name. The other way in,
@@ -17,15 +17,18 @@
 //! full. So a new slot on [`TurnCapabilities`] breaks this file until someone
 //! picks an answer for each lane. That is why the type has no `Default`.
 //!
-//! **One file, not four call sites.** Side by side, the four are easy to
-//! compare. And `subsession.rs` and `fleet_cmd.rs` both sit near the
+//! **One file, not a literal at each call site.** Side by side, the lanes are
+//! easy to compare. And `subsession.rs` and `fleet_cmd.rs` both sit near the
 //! file-size ceiling, with no room for a literal of their own.
 //!
 //! `stella_core`'s `driver::drive` puts the lane on `agent.turn.started`.
 //! `crates/stella-parity/src/lane.rs` holds every lane to having a producer
 //! or a written reason for having none.
 
-use stella_core::ports::{SteeringRequery, TurnGate, TurnSteering};
+use stella_core::hooks::decision::ApprovalRoute;
+use stella_core::ports::{
+    FallbackResolver, ProviderOutcomes, SteeringRequery, TurnControls, TurnGate, TurnSteering,
+};
 use stella_core::{CalibrationMap, HookRunner, Hooks, TurnCapabilities};
 use stella_protocol::{BuiltinLane, ModelCallRole, TurnLane};
 
@@ -134,9 +137,83 @@ pub(crate) fn fleet_attempt<'a>(
     }
 }
 
+/// The shared raw turn — `BuiltinLane::RawTurn`.
+///
+/// The hooks arrive as one triple because this door binds all three together
+/// or none of them: the runner exists only where the config declares hooks,
+/// and the approval route is the broker surface those hooks park a
+/// `PreToolUse` decision on. Under process-free authority the door strips the
+/// hook layer outright and hands `None`.
+///
+/// `controls` is the pause gate and steering tap this turn's caller
+/// published, read here so the lane binds what the caller has rather than
+/// what a chain of optional calls happened to attach.
+pub(crate) fn raw_turn<'a>(
+    hooks: Option<(&'a Hooks, &'a dyn HookRunner, &'a dyn ApprovalRoute)>,
+    calibration: &'a CalibrationMap,
+    outcomes: &'a dyn ProviderOutcomes,
+    fallback: &'a dyn FallbackResolver,
+    requery: Option<&'a dyn SteeringRequery>,
+    controls: &'a TurnControls,
+) -> TurnCapabilities<'a> {
+    TurnCapabilities {
+        hooks: hooks.map(|(hooks, runner, _)| (hooks, runner)),
+        hook_approvals: hooks.map(|(_, _, route)| route),
+        calibration: Some(calibration),
+        gate: controls.gate.as_deref(),
+        steering: controls.steering.as_deref(),
+        requery,
+        // This door's observers ride the event stream, not the bus.
+        bus: None,
+        // The session router picks the worker model and keeps a breaker over
+        // it, so this door feeds outcomes back and re-resolves through the
+        // same router when a retry ladder runs out.
+        outcomes: Some(outcomes),
+        fallback: Some(fallback),
+        call_role: ModelCallRole::Worker,
+        lane: Some(TurnLane::Builtin(BuiltinLane::RawTurn)),
+    }
+}
+
+/// A judged multi-round goal arc — `BuiltinLane::GoalArc`.
+///
+/// Both arms of `stella goal` bind the same set, so both take this one
+/// literal: the raw arm, which drives its rounds inside `Engine::run_goal`,
+/// and the wrapped arm, which drives them itself under a plugin.
+pub(crate) fn goal_arc<'a>(
+    hooks: Option<&'a Hooks>,
+    runner: &'a dyn HookRunner,
+    calibration: &'a CalibrationMap,
+    steering: &'a dyn TurnSteering,
+) -> TurnCapabilities<'a> {
+    TurnCapabilities {
+        hooks: hooks.map(|hooks| (hooks, runner)),
+        // No approval route. A `PreToolUse` hook asking for approval gets the
+        // grant-path refusal instead of a prompt, which is what this door
+        // answers with or without the seam named here.
+        hook_approvals: None,
+        calibration: Some(calibration),
+        // Nobody can pause an arc. The whistle steers it and never stops it
+        // at a step boundary.
+        gate: None,
+        steering: Some(steering),
+        requery: None,
+        bus: None,
+        // An arc resolves its provider once and drives every round through
+        // it. There is no breaker to feed and nothing to re-resolve mid-turn.
+        outcomes: None,
+        fallback: None,
+        call_role: ModelCallRole::Worker,
+        lane: Some(TurnLane::Builtin(BuiltinLane::GoalArc)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use stella_core::ports::ResolvedFallback;
     use stella_tools::hook_runner::HostHookRunner;
 
     struct OpenGate;
@@ -158,11 +235,27 @@ mod tests {
         }
     }
 
-    /// **The lane witnesses.** Each of this crate's four lanes says which
+    struct QuietOutcomes;
+
+    impl ProviderOutcomes for QuietOutcomes {
+        fn record_success(&self, _provider_id: &str) {}
+
+        fn record_failure(&self, _provider_id: &str) {}
+    }
+
+    struct NoFallback;
+
+    impl FallbackResolver for NoFallback {
+        fn resolve_fallback(&self, _failed_provider_id: &str) -> Option<ResolvedFallback<'_>> {
+            None
+        }
+    }
+
+    /// **The lane witnesses.** Every lane this crate assembles says which
     /// lane it is.
     ///
-    /// This fails on a tree where the four sites use `Engine::with_sleeper`.
-    /// The reason is structural, not behavioural. That call takes no lane and
+    /// This fails on a tree whose sites use `Engine::with_sleeper`. The
+    /// reason is structural, not behavioural. That call takes no lane and
     /// always writes `lane: None`. There is no function to call, and nothing
     /// that could answer.
     ///
@@ -174,6 +267,7 @@ mod tests {
         let calibration = CalibrationMap::default();
         let gate = OpenGate;
         let steering = QuietSteering;
+        let unbound = TurnControls::none();
 
         let rows = [
             (
@@ -195,6 +289,24 @@ mod tests {
                 "fleet_attempt",
                 fleet_attempt(None, &runner, &calibration, &gate).lane,
                 BuiltinLane::FleetWorker,
+            ),
+            (
+                "raw_turn",
+                raw_turn(
+                    None,
+                    &calibration,
+                    &QuietOutcomes,
+                    &NoFallback,
+                    None,
+                    &unbound,
+                )
+                .lane,
+                BuiltinLane::RawTurn,
+            ),
+            (
+                "goal_arc",
+                goal_arc(None, &runner, &calibration, &steering).lane,
+                BuiltinLane::GoalArc,
             ),
         ];
 
@@ -239,6 +351,128 @@ mod tests {
         assert!(
             fleet.steering.is_none(),
             "a fleet attempt has no input channel to steer from",
+        );
+
+        let controls = TurnControls::none()
+            .with_gate(Arc::new(OpenGate))
+            .with_steering(Arc::new(QuietSteering));
+        let raw = raw_turn(
+            None,
+            &calibration,
+            &QuietOutcomes,
+            &NoFallback,
+            None,
+            &controls,
+        );
+        assert!(raw.calibration.is_some());
+        assert!(
+            raw.outcomes.is_some() && raw.fallback.is_some(),
+            "the raw turn reports call outcomes to its session router and \
+             re-resolves through it when a retry ladder runs out",
+        );
+        assert!(
+            raw.gate.is_some() && raw.steering.is_some(),
+            "the gate and the tap are whatever the caller published",
+        );
+        assert!(raw.hooks.is_none() && raw.hook_approvals.is_none());
+
+        let unbound = TurnControls::none();
+        let bare = raw_turn(
+            None,
+            &calibration,
+            &QuietOutcomes,
+            &NoFallback,
+            None,
+            &unbound,
+        );
+        assert!(
+            bare.gate.is_none() && bare.steering.is_none(),
+            "a caller that published neither must not grow one here",
+        );
+
+        let arc = goal_arc(None, &runner, &calibration, &steering);
+        assert!(arc.calibration.is_some() && arc.steering.is_some());
+        assert!(
+            arc.gate.is_none(),
+            "an arc is steered and never paused, so a gate here would park \
+             where nothing parked before",
+        );
+        assert!(
+            arc.outcomes.is_none() && arc.fallback.is_none(),
+            "an arc resolves its provider once and drives every round on it",
+        );
+    }
+
+    /// Every call site this crate reads back, as
+    /// `(crate-relative path, source)`.
+    fn door_sources() -> [(&'static str, &'static str); 3] {
+        [
+            ("agent/turn.rs", include_str!("agent/turn.rs")),
+            ("agent/goal.rs", include_str!("agent/goal.rs")),
+            (
+                "agent/goal/goal_wrapped.rs",
+                include_str!("agent/goal/goal_wrapped.rs"),
+            ),
+        ]
+    }
+
+    /// **The call-site witnesses.** Each door that is not the deck reaches
+    /// the engine through `Engine::assemble` and its own seams.
+    ///
+    /// Fails on a tree where the three files build with the sleeper
+    /// constructor: that call takes no lane, so it writes `lane: None` and no
+    /// argument can say otherwise. The needles are built rather than written
+    /// out, so `turn_files`' driver fence reads this file as prose about a
+    /// constructor instead of a door that builds one.
+    #[test]
+    fn each_door_that_is_not_the_deck_assembles_through_its_lane() {
+        let blessed = format!("Engine::{}(", "assemble");
+        let builder = format!("Engine::with_{}(", "sleeper");
+        let seams = [
+            ("agent/turn.rs", "lane_capabilities::raw_turn("),
+            ("agent/goal.rs", "lane_capabilities::goal_arc("),
+            ("agent/goal/goal_wrapped.rs", "lane_capabilities::goal_arc("),
+        ];
+
+        for (path, source) in door_sources() {
+            assert!(
+                source.contains(&blessed),
+                "{path} drives a turn and must assemble it, or its turns \
+                 report no lane at all",
+            );
+            assert!(
+                !source.contains(&builder),
+                "{path} is back on the builder path, which takes no lane and \
+                 lands every turn it drives in the `null` group",
+            );
+            let seam = seams
+                .iter()
+                .find(|(name, _)| *name == path)
+                .map(|(_, seam)| *seam)
+                .expect("every door source names its seams");
+            assert!(
+                source.contains(seam),
+                "{path} must build its seams through `{seam}`, so what it \
+                 binds is one written literal rather than a chain",
+            );
+        }
+    }
+
+    /// `agent/turn.rs` assembles twice — once with the hook layer stripped by
+    /// process-free authority and once with it. Both arms are the same door
+    /// and must name the same lane.
+    #[test]
+    fn both_arms_of_the_raw_door_assemble() {
+        let source = door_sources()
+            .into_iter()
+            .find(|(path, _)| *path == "agent/turn.rs")
+            .map(|(_, source)| source)
+            .expect("the raw door is one of the sources");
+        let arms = source.matches("lane_capabilities::raw_turn(").count();
+        assert_eq!(
+            arms, 2,
+            "the raw door has a process-free arm and an ordinary one; both \
+             assemble, and an arm that stopped would report no lane",
         );
     }
 }

--- a/crates/stella-parity/src/lane.rs
+++ b/crates/stella-parity/src/lane.rs
@@ -3,7 +3,7 @@
 
 //! The turn-lane matrix — which builtin lanes say which lane they are.
 //!
-//! `stella_protocol::BuiltinLane` names seven places a turn runs.
+//! `stella_protocol::BuiltinLane` names every place a turn runs.
 //! `Engine::assemble` lets each of them put its own name on
 //! `agent.turn.started`. Having a name and saying it are two facts. A site
 //! that builds its engine with `Engine::with_sleeper` writes `lane: None` and
@@ -127,6 +127,24 @@ pub const LANES: &[Lane] = &[
             witness: "a_served_turn_declares_the_serve_session_lane",
         },
     },
+    Lane {
+        lane: BuiltinLane::RawTurn,
+        binding: LaneBinding::Bound {
+            site: "crates/stella-cli/src/lane_capabilities.rs",
+            how: "the shared raw turn, assembled in both arms of `agent::turn::run_turn` from \
+                  `lane_capabilities::raw_turn`",
+            witness: "each_door_that_is_not_the_deck_assembles_through_its_lane",
+        },
+    },
+    Lane {
+        lane: BuiltinLane::GoalArc,
+        binding: LaneBinding::Bound {
+            site: "crates/stella-cli/src/lane_capabilities.rs",
+            how: "a judged goal arc, assembled in `agent::goal` and its wrapped arm from \
+                  `lane_capabilities::goal_arc`",
+            witness: "each_door_that_is_not_the_deck_assembles_through_its_lane",
+        },
+    },
 ];
 
 /// The row for `lane`, or `None`. The tests below make every builtin lane
@@ -148,8 +166,8 @@ mod tests {
     /// the list to fix it. It never fails silently.
     fn lane_sources() -> [(&'static str, &'static str); 4] {
         [
-            // Where four of this workspace's lanes declare what they bind,
-            // and where their shared witness lives.
+            // Where most of this workspace's lanes declare what they bind,
+            // and where their shared witnesses live.
             (
                 "crates/stella-cli/src/lane_capabilities.rs",
                 include_str!("../../stella-cli/src/lane_capabilities.rs"),
@@ -198,7 +216,9 @@ mod tests {
                 | BuiltinLane::SubagentFork
                 | BuiltinLane::FleetWorker
                 | BuiltinLane::PipelineStage
-                | BuiltinLane::ServeSession => {}
+                | BuiltinLane::ServeSession
+                | BuiltinLane::RawTurn
+                | BuiltinLane::GoalArc => {}
             }
             let rows = LANES.iter().filter(|row| row.lane == builtin).count();
             assert_eq!(rows, 1, "`{builtin}` must have exactly one row, has {rows}");

--- a/crates/stella-protocol/src/lane.rs
+++ b/crates/stella-protocol/src/lane.rs
@@ -3,8 +3,8 @@
 //! A **lane** is one place a turn runs. There is exactly one step loop
 //! (`stella-core`'s `driver::drive`); what differs between an interactive turn, a
 //! fleet worker and a pipeline stage is not the loop but *which of the loop's
-//! optional capabilities that run was assembled with*. Today there are seven
-//! such assembly sites and, before this module, none of them had a name —
+//! optional capabilities that run was assembled with*. [`BuiltinLane`] names
+//! every such site in this tree. Before this module none of them had a name,
 //! which is why no matrix over them could have rows and no surface could
 //! group by lane (`doc:turn-lane-assembly` §2).
 //!
@@ -12,14 +12,14 @@
 //!
 //! Deferring this one is expensive (`doc:turn-lane-assembly` §9.1, §10.3).
 //!
-//! - **[`BuiltinLane`] is closed** over the seven in-tree sites. That is what
+//! - **[`BuiltinLane`] is closed** over this tree's own sites. That is what
 //!   lets a later slice make "adding a capability without deciding it for
 //!   every lane" a compile error: the compiler can see every case, so an
 //!   exhaustive `match` or destructuring covers the whole set.
 //! - **[`TurnLane`] is open** — it carries a [`LaneId`] arm for a lane
 //!   contributed by a plugin manifest, which by construction is not known at
 //!   compile time. Adding that arm today costs one enum case; retrofitting
-//!   it after seven lanes and a parity matrix are written against a closed
+//!   it after the lanes and a parity matrix are written against a closed
 //!   enum is a matrix rewrite.
 //!
 //! The two arms do not have the same guarantee, and the type says so rather
@@ -79,11 +79,26 @@ impl std::fmt::Display for LaneId {
     }
 }
 
-/// The seven in-tree turn-assembly sites, named.
+/// The in-tree turn-assembly sites, named.
 ///
 /// Closed on purpose — see the module doc. The assembly site each case
 /// refers to is named in its own doc comment so the mapping survives a file
 /// move, which a line number would not.
+///
+/// # Why the doors that are not the deck got cases of their own
+///
+/// `stella run` and `stella goal` assemble their own engines, and neither is
+/// the deck's turn. Three answers were open for them: widen [`Self::Lead`] to
+/// cover any top-level turn, give them cases, or leave them with no lane.
+///
+/// Cases won, because a lane is what a turn binds and these two bind
+/// different sets. [`Self::RawTurn`] binds the session router's call outcomes
+/// and its mid-turn fallback; the deck binds neither. [`Self::GoalArc`] binds
+/// steering and calibration and nothing else. Folded into [`Self::Lead`], a
+/// report grouped by lane could not tell a person typing at the deck from a
+/// scripted run, and the row for the merged lane could not say what the lane
+/// binds. Left with no lane, every turn either door drives lands in the
+/// `null` group, which is the gap this type exists to close.
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -123,6 +138,14 @@ pub enum BuiltinLane {
     /// A turn driven by a remote host over the wire (`stella-serve`'s
     /// `session`).
     ServeSession,
+    /// The shared raw turn (`stella-cli`'s `agent::turn`) — the entry point
+    /// `stella run`, the interactive door that does not draw the deck
+    /// (`agent::run_interactive`), and `stella run` under a wrapper plugin
+    /// all reach.
+    RawTurn,
+    /// A judged multi-round goal arc — `stella goal` (`stella-cli`'s
+    /// `agent::goal`), with or without a wrapper plugin above it.
+    GoalArc,
 }
 
 impl BuiltinLane {
@@ -131,7 +154,7 @@ impl BuiltinLane {
     /// Written as an exhaustive array so a new case that is not added here
     /// is caught by [`Self::ALL`]'s own test rather than silently narrowing
     /// every caller that enumerates lanes.
-    pub const ALL: [Self; 7] = [
+    pub const ALL: [Self; 9] = [
         Self::Lead,
         Self::Resume,
         Self::SubSession,
@@ -139,6 +162,8 @@ impl BuiltinLane {
         Self::FleetWorker,
         Self::PipelineStage,
         Self::ServeSession,
+        Self::RawTurn,
+        Self::GoalArc,
     ];
 
     /// The lane's wire spelling.
@@ -156,6 +181,8 @@ impl BuiltinLane {
             Self::FleetWorker => "fleet_worker",
             Self::PipelineStage => "pipeline_stage",
             Self::ServeSession => "serve_session",
+            Self::RawTurn => "raw_turn",
+            Self::GoalArc => "goal_arc",
         }
     }
 }
@@ -174,7 +201,7 @@ impl std::fmt::Display for BuiltinLane {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TurnLane {
-    /// One of the seven in-tree assembly sites.
+    /// One of this tree's own assembly sites.
     Builtin(BuiltinLane),
     /// A lane contributed by a plugin manifest. Not known at compile time.
     Plugin(LaneId),
@@ -270,7 +297,9 @@ mod tests {
                 | BuiltinLane::SubagentFork
                 | BuiltinLane::FleetWorker
                 | BuiltinLane::PipelineStage
-                | BuiltinLane::ServeSession => {}
+                | BuiltinLane::ServeSession
+                | BuiltinLane::RawTurn
+                | BuiltinLane::GoalArc => {}
             }
         }
         let mut seen = BuiltinLane::ALL.to_vec();

--- a/docs/spec/turn-lane-assembly.md
+++ b/docs/spec/turn-lane-assembly.md
@@ -76,6 +76,17 @@ Plus `stella-core/src/goal.rs:240`, which is a lane-shaped *derivation*
 (`with_turn_instance`) rather than a fresh assembly, and is the one site that
 already does the right thing.
 
+> **The table above missed two sites, and they are now named.** `stella run`
+> assembles its own engine in `stella-cli/src/agent/turn.rs` — twice, once
+> under process-free authority — and `stella goal` assembles one in
+> `agent/goal.rs` and again in its wrapped arm. Each binds a set no row above
+> binds: the raw turn takes the session router's call outcomes and its
+> mid-turn fallback, and the goal arc takes steering and calibration alone. So
+> they are lanes of their own rather than the deck's, and
+> `stella_protocol::BuiltinLane` carries `RawTurn` and `GoalArc` for them.
+> `BuiltinLane`'s own doc comment carries the argument. Everything else in
+> §1–§3 stays as it was measured.
+
 ---
 
 ## 3. Three vocabularies, twelve slots, no table

--- a/docs/spec/turn-loop-wrappers.md
+++ b/docs/spec/turn-loop-wrappers.md
@@ -218,7 +218,7 @@ hand-rolled child engine silently drops all three, and goal mode shipped with
 exactly that bug. If a plugin can only get an engine through one blessed
 constructor, that whole class stops being possible. #3274 is the epic that makes
 lane assembly a single place; this is the reason it has to cover plugin lanes
-and not just the seven builtin ones.
+and not just the builtin ones.
 
 ---
 


### PR DESCRIPTION
## What

`stella run` and `stella goal` each assemble their own engine, and neither was one of the lanes `BuiltinLane` named. Both built through `Engine::with_sleeper`, which takes no lane, so every turn they drove reported `lane: null` and landed in one bucket with every other door that names none.

#6109 asked which of three answers to take. This takes the second: two new builtin lanes, `RawTurn` and `GoalArc`, and all four call sites moved onto `Engine::assemble`.

## Why not the other two

**Widen `Lead`.** A lane is defined by what a turn binds. `agent/turn.rs` binds the session router's call outcomes and its mid-turn fallback resolver; `command_deck`'s lead turn binds neither. Merged under one name, a report grouped by lane cannot tell a person typing at the deck from a scripted run, and the row for the merged lane cannot say what the lane binds.

**Leave them unattributed.** Every turn either door drives stays in the `null` group, which is the reporting gap the type exists to close.

**Two cases rather than one `Door`.** The two doors bind different sets, for the same reason: `agent/goal.rs` binds steering and calibration only — no outcomes, no fallback, no re-query. One shared name would be a row that cannot describe itself.

The argument is written on `BuiltinLane` itself, where a reader of the type finds it, and the §2 enumeration in `doc:turn-lane-assembly` now carries a note saying it missed these two sites. Both cases are **appended**, so the derived `Ord` and `ALL`'s order are unchanged for every case already recorded.

## Binding is preserved, site by site

#6056's rule was that migrating a site must not change what it binds.

- `agent/turn.rs`, process-free arm: calibration, outcomes, fallback, plus re-query / gate / steering when the caller has them. No hooks — that arm strips the hook layer.
- `agent/turn.rs`, ordinary arm: the same, plus hooks. The hooks, runner and broker approval route ride as one triple because the chain being replaced bound all three inside one `if let`, so the type now makes that coupling impossible to get wrong. The gate and tap are read off the same `TurnControls` the old chain read.
- `agent/goal.rs` and `agent/goal/goal_wrapped.rs`: calibration, the whistle's steering tap, hooks when the config declares them. Both arms bind the same set, so both take one `lane_capabilities::goal_arc` literal.

## Witness mechanism

`each_door_that_is_not_the_deck_assembles_through_its_lane` (`crates/stella-cli/src/lane_capabilities.rs`) reads the three call-site files back with `include_str!` and asserts each one names `Engine::assemble`, does **not** name the builder constructor, and builds its seams through its own `lane_capabilities::` function. It fails on the tree before this change by construction: all three files called `Engine::with_sleeper` and none named `Engine::assemble`. `both_arms_of_the_raw_door_assemble` pins that the raw door assembles twice rather than once, so a later change cannot drop one arm back to the builder unnoticed.

Its needles are built with `format!` rather than written out, so `turn_files.rs`'s `every_engine_driver_declares_what_it_owes_the_ledger` reads this file as prose about a constructor instead of a door that builds one.

Beside it, `every_lane_this_crate_assembles_declares_itself` and `each_lane_binds_what_its_call_site_bound_before` gain rows for both new lanes, and `stella-parity`'s `every_bound_lane_is_stamped_at_its_site` / `every_lane_witness_exists` cover the two new matrix rows.

## Exemplar

`crates/stella-cli/src/lane_capabilities.rs` itself — the one-file-of-literals shape #6056 established for the four lanes already there. The call sites follow `command_deck/lead_turn.rs`.

## Evidence

Locally: `cargo fmt --all`, `make guards-fast`, `make invariants`, `make doc-links`, `make wire-schema` (which compiles `stella-protocol` with the `schema` feature, so it exercises the enum change), `./scripts/check-file-size.sh`, `make line-citations`, `python3 scripts/check-prose.py` — all green. No ceiling in `scripts/file-size-baseline.txt` was raised. The build and test evidence is this PR's CI run.

Tests deleted: None.

## Remaining work filed

#6164 — delete the `Engine::with_*` shims. After this lands the callers left are `stella-cli/src/subagent.rs` and `stella-serve/src/subagents.rs` (host engines that drive no turn of their own) plus roughly forty `stella-core` test sites. That sweep also has to edit `stella-parity`'s `COMPOSITION_SEAMS` and several `engine_entries` rows, so it is its own change rather than a tail on this one.

Closes #6109
Refs #3274, #6056

## Summary by Sourcery

Name and explicitly assemble the raw run and judged goal doors so their turns are accurately identified and grouped by lane.

New Features:
- Add `RawTurn` and `GoalArc` builtin lanes for turns driven by `stella run` and `stella goal`.
- Stamp raw turns and goal arcs with their lane identity and preserve their distinct capability bindings.

Bug Fixes:
- Ensure `stella run` and `stella goal` turns are included in lane-based reporting instead of being grouped as unattributed turns.

Enhancements:
- Migrate the affected engine assembly sites to the explicit lane capability model.
- Extend lane parity and structural witnesses to cover both new lanes and all raw-turn and goal-arc call sites.

Documentation:
- Document the new lane assignments and the rationale for treating the non-deck doors as separate lanes.

Tests:
- Add coverage verifying lane declarations, capability bindings, and assembly of both raw-turn arms and both goal-arc call sites.