### PR TITLE
feat(stella-learn): score a skill's body during selection, not only its summary

### DIFF
--- a/crates/stella-learn/src/skills.rs
+++ b/crates/stella-learn/src/skills.rs
@@ -450,6 +450,11 @@ pub struct SelectionConfig {
     /// recency/`AutoCreated` tie-break, never large enough to select a skill
     /// that is otherwise below `min_score`.
     pub auto_created_bonus: f64,
+    /// Weight for the body's own coverage score. Kept below 1.0 so a body
+    /// match never outranks a real summary or domain match. A strong body
+    /// match can still clear `min_score` on its own. See
+    /// [`select_skills_reporting`] for how the two combine.
+    pub body_weight: f64,
 }
 
 impl Default for SelectionConfig {
@@ -459,6 +464,7 @@ impl Default for SelectionConfig {
             min_score: 0.08,
             domain_boost: 0.5,
             auto_created_bonus: 0.02,
+            body_weight: 0.5,
         }
     }
 }
@@ -470,7 +476,9 @@ impl Default for SelectionConfig {
 pub struct SelectedSkill {
     pub skill: Skill,
     pub score: f64,
-    /// Prompt terms that overlapped the skill's name+description (sorted).
+    /// Prompt terms that overlapped the skill's summary (name+description)
+    /// or its body (sorted, deduplicated) — see [`select_skills_reporting`]
+    /// for why the body counts too.
     pub matched_terms: Vec<String>,
     /// Active domains the skill is tagged with (as authored on the skill).
     pub matched_domains: Vec<String>,
@@ -478,10 +486,11 @@ pub struct SelectedSkill {
 
 /// Select the skills most relevant to `prompt`, given the currently active
 /// `active_domains`. Pure scoring: lexical coverage of each skill's
-/// name+description by the prompt, plus a per-matched-domain boost, plus
-/// the small `AutoCreated` tie-break. Only skills scoring at least
-/// `config.min_score` are returned, top-k by `config.max_skills`, highest
-/// first (ties broken by name for determinism).
+/// name+description by the prompt, plus a smaller coverage score for its
+/// body, plus a per-matched-domain boost, plus the small `AutoCreated`
+/// tie-break. Only skills scoring at least `config.min_score` are returned,
+/// top-k by `config.max_skills`, highest first (ties broken by name for
+/// determinism).
 ///
 /// Scoring runs in `crate::mining::score_terms`'s space rather than the
 /// miners' `crate::mining::terms`. Both read Unicode since #3298; what
@@ -527,10 +536,17 @@ pub fn select_skills_reporting(
     for skill in skills {
         let haystack = format!("{} {}", skill.name, skill.description);
         let skill_terms: HashSet<String> = score_terms(&haystack).into_iter().collect();
+        // The body is scored on its own, not folded into `skill_terms`. A
+        // body is far longer than a summary. Folding it in would grow the
+        // haystack `coverage` divides by, so it would push every summary
+        // score toward zero instead of adding a signal.
+        let body_terms: HashSet<String> = score_terms(&skill.body).into_iter().collect();
 
         let mut matched_terms: Vec<String> =
             prompt_terms.intersection(&skill_terms).cloned().collect();
+        matched_terms.extend(prompt_terms.intersection(&body_terms).cloned());
         matched_terms.sort();
+        matched_terms.dedup();
 
         let matched_domains: Vec<String> = skill
             .domains
@@ -546,17 +562,21 @@ pub fn select_skills_reporting(
         // selection fire only on prompts about as short as a description, and
         // effectively never on a real one (#3243 D2).
         let lexical = coverage(&prompt_terms, &skill_terms);
+        // Same measure, over the body's own vocabulary, then cut by
+        // `body_weight` — see that field's doc comment for why.
+        let body_score = coverage(&prompt_terms, &body_terms) * config.body_weight;
         let domain_score = matched_domains.len() as f64 * config.domain_boost;
         let recency = if skill.origin == SkillOrigin::AutoCreated {
             config.auto_created_bonus
         } else {
             0.0
         };
-        let score = lexical + domain_score + recency;
+        let score = lexical + body_score + domain_score + recency;
 
         // A pure-lexical match hanging off a single shared term is noise
         // ("about", "something") no matter what jaccard says — require at
-        // least two shared terms unless a domain tag corroborates.
+        // least two shared terms (summary or body) unless a domain tag
+        // corroborates.
         let corroborated = !matched_domains.is_empty() || matched_terms.len() >= 2;
 
         // The floor reads the evidence-bearing half only. The AutoCreated
@@ -564,7 +584,7 @@ pub fn select_skills_reporting(
         // "never large enough to select a skill that is otherwise below
         // min_score" — letting it into the threshold gave freshly-mined
         // skills a LOWER selection floor than hand-authored ones.
-        if corroborated && lexical + domain_score >= config.min_score {
+        if corroborated && lexical + body_score + domain_score >= config.min_score {
             selected.push(SelectedSkill {
                 skill: skill.clone(),
                 score,
@@ -894,15 +914,18 @@ const SENTENCE_MIN_CHARS: usize = 24;
 
 /// The one-line description a mined candidate is **found** by.
 ///
-/// [`select_skills_reporting`] scores `name + description` and nothing else,
-/// so this string is half of a learned skill's entire searchable vocabulary —
-/// and the other half, [`candidate_id`], is a slug `slugify` truncates at 40
-/// characters. This used to be `"Learned from N observations."`: two words
-/// that match no prompt anyone will ever write, occupying the one field that
-/// decides whether the skill is reachable at all. A skill was therefore
-/// findable only through whatever fragment of its lesson survived those 40
-/// characters — the mechanism that mints skills and the mechanism that
-/// surfaces them tuned against each other (#5335).
+/// [`select_skills_reporting`] weighs `name + description` far more than the
+/// body, so this string is still the stronger half of a learned skill's
+/// searchable vocabulary. The other half, [`candidate_id`], is a slug
+/// `slugify` truncates at 40 characters. This used to be `"Learned from N
+/// observations."`: two words that match no prompt anyone will ever write.
+/// Back then the body carried no weight at all, so those two words were the
+/// whole vocabulary. A skill was therefore findable only through whatever
+/// fragment of its lesson survived those 40 characters — the mechanism that
+/// mints skills and the mechanism that surfaces them tuned against each other
+/// (#5335). A mined candidate's body is the lesson itself (see
+/// [`SkillCandidate::body`]), so this same text now reaches a prompt two
+/// ways: a strong path and a weak one.
 ///
 /// So the lesson describes itself: its first sentence, whitespace collapsed
 /// (the frontmatter writer emits `description:` on one line, and a lesson

--- a/crates/stella-learn/src/skills/tests.rs
+++ b/crates/stella-learn/src/skills/tests.rs
@@ -496,6 +496,74 @@ fn below_threshold_skills_are_excluded() {
     assert!(selected.is_empty());
 }
 
+// ---- the body scores too, not only name + description ----
+
+/// **Witness.** A skill whose description shares no word with the prompt is
+/// still selected when its *body* does.
+///
+/// Fails on base. Base read only `name + description`. This skill's
+/// description is about Python import style. Its body is about cutting a
+/// release. The prompt below is about a release. Base saw no shared words
+/// and dropped the skill. The body shares two words with the prompt:
+/// "release" and "changelog".
+#[test]
+fn a_skill_is_selected_when_only_its_body_matches_the_prompt() {
+    let mut release_skill = skill(
+        "python-import-style",
+        "Format Python imports with isort",
+        &[],
+        SkillOrigin::Workspace,
+    );
+    release_skill.body = "Tag the release, then update the changelog and push the tag.".to_string();
+
+    let selected = select_skills(
+        std::slice::from_ref(&release_skill),
+        "please cut a new release and update the changelog",
+        &[],
+        &SelectionConfig::default(),
+    );
+    assert_eq!(
+        selected.len(),
+        1,
+        "a body-only match must still select the skill: {selected:?}"
+    );
+    assert!(selected[0].matched_terms.contains(&"release".to_string()));
+    assert!(selected[0].matched_terms.contains(&"changelog".to_string()));
+}
+
+/// **Control, next to the witness above.** The same skill, with a long
+/// off-topic body, is *not* selected by the same prompt.
+///
+/// A long body has more words, so it has more chances to share a word with
+/// any prompt by luck. This proves a long body cannot buy a skill past the
+/// two-shared-word floor just by being long.
+#[test]
+fn a_long_unrelated_body_does_not_select_an_off_topic_skill() {
+    let mut release_skill = skill(
+        "python-import-style",
+        "Format Python imports with isort",
+        &[],
+        SkillOrigin::Workspace,
+    );
+    release_skill.body = "This skill explains how to configure isort so that Python \
+        imports are grouped into standard library, third party, and local sections, \
+        sorted alphabetically within each group, with a blank line between groups. \
+        Run isort on save and check the diff before committing any changes to shared \
+        modules."
+        .to_string();
+
+    let selected = select_skills(
+        std::slice::from_ref(&release_skill),
+        "please cut a new release and update the changelog",
+        &[],
+        &SelectionConfig::default(),
+    );
+    assert!(
+        selected.is_empty(),
+        "a long off-topic body must not buy a free pass past corroboration: {selected:?}"
+    );
+}
+
 #[test]
 fn top_k_is_respected() {
     let skills: Vec<Skill> = (0..5)
@@ -556,10 +624,11 @@ fn the_auto_created_bonus_cannot_lift_a_skill_over_the_floor() {
         min_score: 0.6,
         domain_boost: 0.5,
         auto_created_bonus: 0.2,
+        body_weight: 0.5,
     };
     // Names reuse description terms so both skills score over the same
     // four-term vocabulary: coverage = 2/4 = 0.5, below the 0.6 floor.
-    let skills = vec![
+    let mut skills = vec![
         skill(
             "quaxle-marlow",
             "quaxle fenwick marlow jubilant",
@@ -573,6 +642,14 @@ fn the_auto_created_bonus_cannot_lift_a_skill_over_the_floor() {
             SkillOrigin::AutoCreated,
         ),
     ];
+    // The shared `skill()` fixture's filler body ("body of <name>") would
+    // otherwise repeat "quaxle"/"marlow" from the name and add a body score
+    // on top of the lexical one — noise from the fixture, not something this
+    // test is about (the body-only path has its own tests above). An
+    // unrelated body keeps this test isolated to the bonus.
+    for s in &mut skills {
+        s.body = "lorem ipsum dolor sit amet".to_string();
+    }
     let selected = select_skills(&skills, "quaxle fenwick", &[], &config);
     assert!(
         selected.is_empty(),
@@ -1162,10 +1239,10 @@ const SQLX_LESSON: &str = "Always add a down migration to every schema change \
 ///
 /// It was not, and the reason was structural rather than a tuning miss. The
 /// miner wrote `description: "Learned from N observations."` while
-/// `select_skills_reporting` scores `name + description` and nothing else, so
-/// a learned skill's entire searchable vocabulary was its 40-character slug
-/// plus two words that match no prompt ever written. The mechanism that mints
-/// skills and the mechanism that surfaces them were tuned against each other.
+/// `select_skills_reporting` scored only `name + description`, so a learned
+/// skill's entire searchable vocabulary was its 40-character slug plus two
+/// words that match no prompt ever written. The mechanism that mints skills
+/// and the mechanism that surfaces them were tuned against each other.
 #[test]
 fn a_mined_skill_is_selected_for_a_prompt_about_its_own_lesson() {
     let obs: Vec<SkillObservation> = (1..=3).map(|i| observation(SQLX_LESSON, i)).collect();


### PR DESCRIPTION
## What

`select_skills_reporting` (`crates/stella-learn/src/skills.rs`) scored a
skill's `name + description` only. `SelectionConfig` gains a new
`body_weight` field (default `0.5`) and the loop now also scores the
skill's `body` on its own, weighted below the summary, so a skill whose
one-line description shares no words with the prompt but whose body plainly
does can still be selected.

## Why

Epic #3243 Phase 1 D2 asked for two changes to skill scoring: an
asymmetric score (shipped in #3296) and body scoring (never shipped — see
#6145). A summary is a one-liner; the body is where the actual procedure
lives, and it was invisible to selection.

## Design

Posted to #6145 before implementing (see that issue's comments). Chosen
option: score the body as its own signal rather than folding it into the
summary's haystack, and combine with a discount weight — matching the
issue's first suggested option.

- `coverage()` divides by the haystack's own vocabulary size. Concatenating
  a body (routinely far longer than a description) into the summary
  haystack would inflate that divisor for every skill and collapse the
  summary-only score toward zero for the whole set — moving the selection
  floor for every prompt at once, which is exactly the failure mode the
  issue warned about.
- Instead, `body_score = coverage(prompt_terms, body_terms) * body_weight`
  is added to the total alongside the unchanged summary `lexical` score.
- `matched_terms` (and the two-shared-term corroboration floor) now read
  from **either** half, so a body-only match can clear corroboration on its
  own.
- The `min_score` floor now reads `lexical + body_score + domain_score`
  (unchanged shape, body folded in).

## Witness

`a_skill_is_selected_when_only_its_body_matches_the_prompt` — fails on
`main` by construction: the fixture skill's description is about Python
import style (shares nothing with the prompt), the prompt is about cutting
a release, and only the body shares two words ("release", "changelog")
with it. On `main`, `matched_terms` is empty (summary-only), corroboration
never clears, and the skill is dropped regardless of what the body says.

## Control

`a_long_unrelated_body_does_not_select_an_off_topic_skill` — the same
fixture, but with a long, wordy, off-topic body. Proves a body cannot buy a
skill past the two-shared-term corroboration floor just by being long.

## Existing tests — one changed expectation, explained

`the_auto_created_bonus_cannot_lift_a_skill_over_the_floor` used the shared
`skill()` test helper's filler body (`"body of <name>"`), which happens to
repeat the skill's own name terms — exactly the terms its prompt matches.
With body scoring added, that incidental overlap alone pushed both fixture
skills over the test's floor, which is not what the test is about (it is
about the `AutoCreated` recency bonus, not body scoring). Gave both fixture
skills an explicit unrelated body (`"lorem ipsum dolor sit amet"`) so the
new signal doesn't confound it; the test's original assertion is otherwise
unchanged.

Every other selection test in `crates/stella-learn/src/skills/tests.rs` was
read against the new scoring by hand (fixture bodies are either a
single-token literal like `ALWAYS_REVIEW_DATABASES`/`"x".repeat(n)` that
tokenizes to one long non-matching term, or the generic `"body of <name>"`
filler whose terms don't overlap the prompts used) and confirmed
unaffected.

Tests deleted: None.

Closes #6145

## Summary by Sourcery

Score skill bodies separately from summaries during selection so relevant procedural content can surface otherwise unmatched skills.

New Features:
- Include skill body content as a weighted signal when selecting skills for a prompt.

Bug Fixes:
- Allow skills whose relevant procedures appear only in their body to be selected while retaining corroboration safeguards against unrelated matches.

Enhancements:
- Expose configurable body scoring with a default weight of 0.5 and include body matches in reported matched terms.

Tests:
- Add coverage for body-only skill selection and rejection of long unrelated bodies.
- Isolate the auto-created bonus test from incidental fixture-body matches.