### PR TITLE
feat(stella-cli): read the rule half of the trial ledger

### DIFF
--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -78,6 +78,9 @@ mod records_refresh;
 pub(crate) mod replay;
 // Phase 4 (#715): reversible retirement of context that stops helping.
 pub(crate) mod retirement;
+// The reader of the rule half of the trial ledger — the retraction sweep, and
+// the grade a measured window earns.
+pub(crate) mod rule_efficacy;
 pub(crate) mod rules_mining;
 pub(crate) mod self_tuning;
 pub(crate) mod skill_files;

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -49,6 +49,13 @@ mod skill_lifecycle;
 #[cfg(test)]
 mod memory_lifecycle;
 
+/// The rule lifecycle twin: a measured window retracts a mined rule, leaves a
+/// hand-written one alone, and earns the grade a directive costs. A child
+/// module for [`guarantees`]'s reason — it drives
+/// [`SessionMemory::auto_create_skills`] without widening its visibility.
+#[cfg(test)]
+mod rule_lifecycle;
+
 /// What [`SessionMemory::partition_known`] stores, diverts to the mining log,
 /// and drops. A child module for the same reason as [`guarantees`]: the split
 /// is private, and it is the split itself that needs pinning, not the turn
@@ -879,6 +886,38 @@ impl SessionMemory {
         }
     }
 
+    /// Retract every mined rule whose own turns say it stopped helping — the
+    /// rule twin of [`Self::retire_failing_context`].
+    ///
+    /// The third consumer of the shared trial ledger. Rules produced rows and
+    /// read none, so a third of what the holdout schedule costs bought
+    /// nothing. The work is [`super::rule_efficacy::sweep`]; this is the seam
+    /// that runs it and says what it did.
+    ///
+    /// Gated on `include_workspace_skills` for the reason `induce_rules` is.
+    /// A workspace this session may not take prompts from never loads its
+    /// records into the prompt, so there is no steering to remove — and
+    /// rewriting its Git-tracked governance files uninvited would be the same
+    /// escalation the write gate refuses in the other direction.
+    fn retract_failing_rules(&self, quiet: bool) {
+        if !self.include_workspace_skills {
+            return;
+        }
+        let sweep = super::rule_efficacy::sweep(&self.workspace_root);
+        if quiet {
+            return;
+        }
+        for lineage in &sweep.retracted {
+            eprintln!(
+                "rules: retracted {lineage} — it stopped helping. The record file keeps \
+                 the statement, marked retracted."
+            );
+        }
+        for (lineage, why) in &sweep.refused {
+            eprintln!("rules: {lineage} earned retraction and could not be written: {why}");
+        }
+    }
+
     /// Write out whichever candidates the caller decided to keep, under the
     /// per-session cap and the no-clobber guard.
     ///
@@ -1020,6 +1059,7 @@ impl SessionMemory {
             super::uses::extract_context_uses(&store, &self.store);
         }
         self.retire_failing_context(quiet);
+        self.retract_failing_rules(quiet);
 
         // 1. Evidence → typed, redacted, replay-idempotent observations.
         super::observations::extract_reflection_observations(&self.store, log_path);
@@ -1145,6 +1185,20 @@ impl SessionMemory {
             if !self.include_workspace_skills {
                 continue;
             }
+            // The grade the gate weighs: the stronger of two
+            // derivations against two sources — the same `published_grade`
+            // fold `stella proposals keep` uses for the mining and the
+            // reviewer. Here the second source is the environment: a rule
+            // whose own recorded turns confidently beat the turns that
+            // withheld it stands on `EnvironmentObservation`, which is what a
+            // steering directive costs. With no measured window the mining
+            // grade is all there is — `ModelCritique` for a reflection lesson
+            // — and the gate refuses it. Each half is read off records rather
+            // than asserted here.
+            let grade = stella_records::context_record::published_grade(
+                rule.proposal.provenance,
+                super::rule_efficacy::measured_grade(&self.workspace_root, &rule.candidate.id),
+            );
             // `Agent`: nobody is in the loop for an auto-activation. The
             // evidence gate is asked inside the writer, and on
             // reflection-mined evidence it says no — so this arm reports the
@@ -1152,7 +1206,7 @@ impl SessionMemory {
             match super::rules_mining::write_rule(
                 &self.workspace_root,
                 &rule.candidate,
-                rule.proposal.provenance,
+                grade,
                 stella_protocol::provenance::PublicationAuthority::Agent,
             ) {
                 Ok(RulePublication::Written(path)) => {

--- a/crates/stella-cli/src/memory/learning/rule_lifecycle.rs
+++ b/crates/stella-cli/src/memory/learning/rule_lifecycle.rs
@@ -1,0 +1,245 @@
+//! The rule lifecycle twin. A mined rule that stops helping is retracted from
+//! what the turns measured. A rule a person wrote is not.
+//!
+//! The trials here are real ledger rows. `appraisals::record_turn` writes
+//! them, and `SessionMemory::auto_create_skills` reads them back. Both are
+//! production doors. Nothing hands the sweep a verdict.
+//!
+//! Recall notes what a turn offered and what it showed. That half has its own
+//! witness, in `memory::trials`.
+
+use std::path::Path;
+
+use stella_learn::ledger::ArtifactKind;
+use stella_records::context_record::RecordStatus;
+
+use crate::memory::{SessionMemory, appraisals, trials};
+
+/// Turns per arm. The floor is five per arm. Eight is well clear of it, and
+/// it is the count the memory twin uses.
+const TURNS_PER_ARM: usize = 8;
+
+/// The handle of the rule the loop mined. It is the last part of the lineage,
+/// which is what the render pass cites and so what the trial rows are keyed
+/// by.
+const MINED: &str = "regenerate-gen";
+
+/// The handle of the rule a person wrote. Same rows, different origin.
+const HAND_WRITTEN: &str = "billing-retries";
+
+/// Both records, in one published file.
+///
+/// One file rather than two, so the retraction has a sibling record to leave
+/// alone: the writer rewrites the whole file, and a rebuild from the one
+/// resolved record would drop the other.
+const PUBLISHED: &str = r#"schema = "context-record/v0.1"
+set_id = "acme"
+
+[[record]]
+lineage_id = "ctx.acme.regenerate-gen"
+kind = "rule"
+statement = "Regenerate gen/ rather than editing it by hand."
+status = "active"
+origin = "inferred"
+
+[record.steering]
+force = "may"
+
+[[record]]
+lineage_id = "ctx.acme.billing-retries"
+kind = "rule"
+statement = "Retry the billing webhook three times."
+status = "active"
+origin = "user"
+
+[record.steering]
+force = "may"
+"#;
+
+fn session(root: &Path) -> SessionMemory {
+    SessionMemory::open_with_workspace_skills(root, false, true).expect("session memory")
+}
+
+fn log_path(root: &Path) -> std::path::PathBuf {
+    root.join(".stella/private/reflections.jsonl")
+}
+
+/// Publish both records under `.stella/rules/`.
+fn publish_rules(root: &Path) {
+    let dir = root.join(".stella").join("rules");
+    std::fs::create_dir_all(&dir).expect("the rules directory");
+    std::fs::write(dir.join("acme.toml"), PUBLISHED).expect("publish the records");
+}
+
+/// The status the file on disk now carries for `lineage`.
+fn status_of(root: &Path, lineage: &str) -> Option<RecordStatus> {
+    let body = std::fs::read_to_string(root.join(".stella/rules/acme.toml")).expect("the file");
+    let file: stella_records::ingest::record::ContextFile =
+        toml::from_str(&body).expect("the file still parses");
+    file.records
+        .iter()
+        .find(|record| record.lineage_id == lineage)
+        .expect("the record is still in the file")
+        .status
+}
+
+/// A window that says these rules hurt. Every turn that showed them failed.
+/// Every turn that withheld them passed.
+///
+/// Both rules ride every turn. Their rows are the same, so only the origin
+/// can tell them apart.
+fn record_a_harming_window(root: &Path, ids: &[String]) {
+    for _ in 0..TURNS_PER_ARM {
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Rule,
+            ids,
+            ids,
+            &trials::live_trial(false),
+        );
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Rule,
+            ids,
+            &[],
+            &trials::live_trial(true),
+        );
+    }
+}
+
+/// **The witness.** The mined rule is retracted, and the ledger says who did
+/// it and why. The hand-written one carries the same rows and is kept.
+///
+/// It fails on the code this landed against by construction (`#6143`): nothing
+/// there passes `ArtifactKind::Rule` to a sweep, so no rule trial is ever read
+/// and both records stay active.
+#[test]
+fn a_mined_rule_that_stops_helping_is_retracted_and_a_hand_written_one_is_kept() {
+    let _env = crate::test_env::lock();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    // The registry reads the user tier too, so point it at an empty fixture:
+    // a record in the developer's own `~/.stella/rules` must not join this
+    // measurement.
+    let _home = crate::test_env::home_sandbox(&root.join("home"));
+    publish_rules(root);
+    record_a_harming_window(root, &[MINED.to_string(), HAND_WRITTEN.to_string()]);
+
+    let mut memory = session(root);
+    memory.auto_create_skills(&log_path(root), true);
+
+    assert_eq!(
+        status_of(root, "ctx.acme.regenerate-gen"),
+        Some(RecordStatus::Retracted),
+        "its own turns say withholding it won"
+    );
+    assert_eq!(
+        status_of(root, "ctx.acme.billing-retries"),
+        Some(RecordStatus::Active),
+        "a rule a person wrote is kept, whatever the numbers say"
+    );
+
+    // Retraction appends. The governance ledger names the lineage and says
+    // what measured it.
+    let ledger = std::fs::read_to_string(root.join(".stella/rules/promotions.jsonl"))
+        .expect("the promotion ledger");
+    assert!(
+        ledger.contains("ctx.acme.regenerate-gen") && ledger.contains("lift"),
+        "the ledger must carry the retraction and its reason: {ledger}"
+    );
+    assert!(
+        !ledger.contains("ctx.acme.billing-retries"),
+        "nothing was decided about the hand-written rule: {ledger}"
+    );
+
+    // A second sweep re-earns the same verdict from the same rows and writes
+    // nothing: a retracted record is not active, so the sweep leaves it alone.
+    let before = std::fs::read_to_string(root.join(".stella/rules/promotions.jsonl")).unwrap();
+    memory.auto_create_skills(&log_path(root), true);
+    let after = std::fs::read_to_string(root.join(".stella/rules/promotions.jsonl")).unwrap();
+    assert_eq!(before, after, "a retraction happens once");
+}
+
+/// A window with no separation retracts nothing. Without it, the case above
+/// would pass on a sweep that retracted every rule handed to it.
+#[test]
+fn a_rule_the_turns_cannot_separate_is_left_alone() {
+    let _env = crate::test_env::lock();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let _home = crate::test_env::home_sandbox(&root.join("home"));
+    publish_rules(root);
+
+    // Every turn passes, shown or withheld. Neither side wins. `Inert` needs
+    // a full window in both arms, and this is far short of one.
+    let ids = [MINED.to_string()];
+    for _ in 0..TURNS_PER_ARM {
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Rule,
+            &ids,
+            &ids,
+            &trials::live_trial(true),
+        );
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Rule,
+            &ids,
+            &[],
+            &trials::live_trial(true),
+        );
+    }
+
+    let mut memory = session(root);
+    memory.auto_create_skills(&log_path(root), true);
+
+    assert_eq!(
+        status_of(root, "ctx.acme.regenerate-gen"),
+        Some(RecordStatus::Active),
+        "no measurement, no retraction"
+    );
+    assert!(
+        !root.join(".stella/rules/promotions.jsonl").exists(),
+        "nothing was decided, so nothing is written"
+    );
+}
+
+/// The grade half. A rule whose own turns say it helps earns
+/// `EnvironmentObservation`, which is what a steering directive costs. One
+/// with rows that say nothing earns no grade at all, so the mining grade is
+/// what the gate weighs and the gate refuses it.
+#[test]
+fn a_measured_rule_earns_the_grade_a_directive_costs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    // Shown and it passed; withheld and it failed. That is the rule helping.
+    let ids = [MINED.to_string()];
+    for _ in 0..TURNS_PER_ARM {
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Rule,
+            &ids,
+            &ids,
+            &trials::live_trial(true),
+        );
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Rule,
+            &ids,
+            &[],
+            &trials::live_trial(false),
+        );
+    }
+
+    assert_eq!(
+        crate::memory::rule_efficacy::measured_grade(root, MINED),
+        Some(stella_protocol::provenance::ProvenanceGrade::EnvironmentObservation),
+        "the environment answered, which is the grade a directive costs"
+    );
+    assert_eq!(
+        crate::memory::rule_efficacy::measured_grade(root, HAND_WRITTEN),
+        None,
+        "a rule with no rows has no measured window"
+    );
+}

--- a/crates/stella-cli/src/memory/rule_efficacy.rs
+++ b/crates/stella-cli/src/memory/rule_efficacy.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What a rule's own turns say about it.
+//!
+//! `memory::trials` writes one row per rule per turn. The row says what the
+//! turn could show, and what it showed. Nothing read those rows. This module
+//! reads them, for two answers.
+//!
+//! **Is the rule still earning its place?** [`sweep`] runs the same
+//! `appraise` and `decide_demotion` pass the skill and memory sweeps run. A
+//! mined rule the turns say is hurting gets retracted. A rule a person wrote
+//! is kept, whatever the numbers say.
+//!
+//! **Has the rule paid what a directive costs?** [`measured_grade`] turns a
+//! `Helps` verdict into `EnvironmentObservation`. That is the bar
+//! `SteeringDirective` sets. Reflection prose grades `ModelCritique`, and the
+//! gate still says no to it.
+//!
+//! # The id a trial row is filed under
+//!
+//! The render handle, like `^pkg-manager`. It is what the render pass knows.
+//! The door that retracts a rule takes a lineage instead. So [`lineages`]
+//! joins the two, off the registry the origins came from. A handle grows
+//! longer when a second lineage ends in the same word. That re-keys a window
+//! nobody touched (`#6161`). The join keeps it a lost window, not a
+//! retraction of the wrong record.
+//!
+//! # Nothing here writes to a skill ledger
+//!
+//! `SkillAppraisal::skill` is a bare string. `appraisals::record_demotion`
+//! files under a `skill:<name>` lineage. A rule id in either would clash with
+//! a skill of the same name (`#6103`). So this writes to neither. A verdict is
+//! acted on and never stored, the way the memory sweep acts on one. A
+//! retraction is filed under the record's own `lineage_id`, which is unique in
+//! the workspace.
+//!
+//! # A candidate with no window
+//!
+//! A rule that never rendered has no arms. [`measured_grade`] answers `None`
+//! for it, and the mining grade is refused as before. A window comes from the
+//! turns after a first publication. So this path cannot start the loop by
+//! itself. The skill queue has the same shape, and answers with a bootstrap
+//! switch. That is the wrong answer for something that steers, and `#6162` is
+//! where a better one is being picked.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use stella_learn::ledger::ArtifactKind;
+use stella_learn::skills::SkillOrigin;
+use stella_learn::skills::appraisal::{
+    AppraisalConfig, DemotionDecision, DemotionReason, SkillVerdict,
+};
+use stella_protocol::provenance::ProvenanceGrade;
+use stella_records::context_record::{Origin, RecordStatus};
+use stella_records::records::{Registry, Trust};
+
+use super::appraisals;
+
+/// Which rules the loop may retract on its own — the origin map
+/// [`appraisals::sweep`] reads.
+///
+/// A record that misses any test below is left out. `decide_demotion` then
+/// keeps it, which is the safe way to fail.
+///
+/// * The loop wrote it (`origin = "inferred"`).
+/// * It is a repository record. One in the user's own `~/.stella/rules` is not
+///   this workspace's to rewrite.
+/// * No plugin shipped it. `stella plugin remove` is that door.
+/// * It is still active. A rule already retracted is not retracted twice.
+pub(crate) fn origins(registry: &Registry) -> HashMap<String, SkillOrigin> {
+    let mut out = HashMap::new();
+    for entry in &registry.entries {
+        let record = &entry.record;
+        let mined = record.record.origin == Some(Origin::Inferred)
+            && record.trust == Trust::Project
+            && record.contributed_by.is_none()
+            && matches!(record.record.status, None | Some(RecordStatus::Active));
+        if mined {
+            out.insert(record.handle.clone(), SkillOrigin::AutoCreated);
+        }
+    }
+    out
+}
+
+/// Handle to `lineage_id`, for every record the registry loaded.
+///
+/// The trial ledger names a rule by its handle. Every door on the other side
+/// names it by lineage — the retraction, the promotion ledger, the file. This
+/// is where the two meet.
+pub(crate) fn lineages(registry: &Registry) -> HashMap<String, String> {
+    registry
+        .entries
+        .iter()
+        .map(|entry| {
+            (
+                entry.record.handle.clone(),
+                entry.record.record.lineage_id.clone(),
+            )
+        })
+        .collect()
+}
+
+/// The retraction a demoted rule has earned, or `None`.
+///
+/// Split from the write, so the choice can be tested with no workspace on
+/// disk, and so the reason is built in one place. A retraction whose cause
+/// nobody can read is what the ledger exists to stop.
+pub(crate) fn retraction_reason(decision: &DemotionDecision) -> Option<String> {
+    let DemotionDecision::Demote { reason } = decision else {
+        return None;
+    };
+    Some(match reason {
+        DemotionReason::Harmful { lift } => format!(
+            "holding it back improved the turns it was offered on (lift {lift:.3}). \
+             The efficacy loop retracted it. The file keeps the statement; set its \
+             `status` back to `active` to put it back."
+        ),
+        DemotionReason::Inert { trials } => format!(
+            "no measured gain across {trials} recorded turns. The efficacy loop \
+             retracted it. The file keeps the statement; set its `status` back to \
+             `active` to put it back."
+        ),
+    })
+}
+
+/// What one sweep did, for reporting.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct RetractionSweep {
+    /// The lineages just retracted.
+    pub(crate) retracted: Vec<String>,
+    /// Lineages that earned a retraction the writer could not make, and why.
+    /// Reported, not dropped: a sweep that quietly skips half its findings
+    /// reads as "nothing earned it", which is a different claim.
+    pub(crate) refused: Vec<(String, String)>,
+}
+
+/// Appraise every rule the trial ledger has rows for. Retract the mined ones
+/// whose own turns say they stopped helping.
+///
+/// The registry is read from disk, not taken from the session. The file says
+/// what is published, which is why `proposals_cmd::retract` reads the rules
+/// directory too.
+pub(crate) fn sweep(workspace_root: &Path) -> RetractionSweep {
+    let registry = crate::context_records::load_registry(workspace_root);
+    let origins = origins(&registry);
+    let lineages = lineages(&registry);
+    let mut out = RetractionSweep::default();
+    for (appraisal, decision) in appraisals::sweep(
+        workspace_root,
+        ArtifactKind::Rule,
+        &origins,
+        &AppraisalConfig::default(),
+    ) {
+        let Some(reason) = retraction_reason(&decision) else {
+            continue;
+        };
+        // `SkillAppraisal::skill` is the id the sweep judged. For this kind
+        // that is the record's render handle.
+        let Some(lineage) = lineages.get(&appraisal.skill) else {
+            // The ledger names a handle no record carries now. There is
+            // nothing to retract, and nothing is wrong: an append-only ledger
+            // outlives what it describes.
+            continue;
+        };
+        match crate::proposals_cmd::retract_published(workspace_root, lineage, &reason) {
+            Ok((retracted, _path)) => out.retracted.push(retracted),
+            Err(why) => out.refused.push((lineage.clone(), why)),
+        }
+    }
+    out
+}
+
+/// The grade `rule_id`'s own turns have earned, or `None`.
+///
+/// `EnvironmentObservation` on [`SkillVerdict::Helps`] alone. The turns that
+/// showed the rule beat the turns that withheld it, on rows the render pass
+/// wrote. That is the environment answering. It is what the grade means, and
+/// why a directive costs it.
+///
+/// Every other verdict answers `None`, a guard-blocked lift included. The
+/// caller then falls back on the mining grade, which the gate refuses. A rule
+/// with no rows answers `None` too, so a candidate nobody measured publishes
+/// nothing.
+pub(crate) fn measured_grade(workspace_root: &Path, rule_id: &str) -> Option<ProvenanceGrade> {
+    // The origin here is a stand-in. This reads the verdict and drops the
+    // decision beside it.
+    let origins = HashMap::from([(rule_id.to_string(), SkillOrigin::AutoCreated)]);
+    let (appraisal, _) = appraisals::sweep(
+        workspace_root,
+        ArtifactKind::Rule,
+        &origins,
+        &AppraisalConfig::default(),
+    )
+    .into_iter()
+    .find(|(appraisal, _)| appraisal.skill == rule_id)?;
+    matches!(appraisal.verdict, SkillVerdict::Helps { .. })
+        .then_some(ProvenanceGrade::EnvironmentObservation)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/memory/rule_efficacy/tests.rs
+++ b/crates/stella-cli/src/memory/rule_efficacy/tests.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The two pure halves: which records the loop may retract, and what a
+//! demotion reads as. The end-to-end arc is
+//! `memory::learning::rule_lifecycle`.
+
+use stella_learn::skills::appraisal::{DemotionDecision, DemotionReason, KeepSkillReason};
+use stella_records::records::registry;
+use stella_records::records::{Registry, Trust};
+
+use super::{lineages, origins, retraction_reason};
+
+/// One published file holding every record a sweep has to sort out.
+const RECORDS: &str = r#"schema = "context-record/v0.1"
+set_id = "acme"
+
+[[record]]
+lineage_id = "ctx.acme.mined"
+kind = "rule"
+statement = "Regenerate gen/ rather than editing it by hand."
+status = "active"
+origin = "inferred"
+
+[[record]]
+lineage_id = "ctx.acme.hand-written"
+kind = "rule"
+statement = "Retry the billing webhook three times."
+status = "active"
+origin = "user"
+
+[[record]]
+lineage_id = "ctx.acme.already-retracted"
+kind = "rule"
+statement = "Prefer the pnpm lockfile."
+status = "retracted"
+origin = "inferred"
+"#;
+
+fn file(path: &str, contributed_by: Option<String>) -> stella_learn::rules::RuleFile {
+    stella_learn::rules::RuleFile {
+        path: path.to_string(),
+        contents: RECORDS.to_string(),
+        contributed_by,
+    }
+}
+
+fn project_registry() -> Registry {
+    registry::load(
+        &[],
+        &[file(".stella/rules/acme.toml", None)],
+        &stella_records::records::Facts::default(),
+    )
+}
+
+#[test]
+fn only_a_mined_active_project_record_is_the_loops_to_retract() {
+    let registry = project_registry();
+    let origins = origins(&registry);
+
+    assert_eq!(
+        origins.get("mined"),
+        Some(&stella_learn::skills::SkillOrigin::AutoCreated),
+        "the loop wrote this one, so the loop may take it back"
+    );
+    assert!(
+        !origins.contains_key("hand-written"),
+        "a person wrote it; an absent origin is what keeps it"
+    );
+    assert!(
+        !origins.contains_key("already-retracted"),
+        "retracting it again would write one event per sweep, forever"
+    );
+}
+
+#[test]
+fn a_user_tier_record_is_never_the_loops_to_retract() {
+    let registry = registry::load(
+        &[file("~/.stella/rules/acme.toml", None)],
+        &[],
+        &stella_records::records::Facts::default(),
+    );
+    assert!(
+        registry
+            .entries
+            .iter()
+            .any(|entry| entry.record.trust == Trust::User),
+        "the fixture must load as the user tier"
+    );
+    assert!(
+        origins(&registry).is_empty(),
+        "this workspace has no standing to rewrite the user's own rules"
+    );
+}
+
+#[test]
+fn a_plugins_record_is_never_the_loops_to_retract() {
+    let registry = registry::load(
+        &[],
+        &[file(
+            ".stella/plugins/vera/rules/acme.toml",
+            Some("vera".to_string()),
+        )],
+        &stella_records::records::Facts::default(),
+    );
+    assert!(
+        origins(&registry).is_empty(),
+        "`stella plugin remove` is that door, not this sweep"
+    );
+}
+
+#[test]
+fn every_handle_joins_back_to_its_lineage() {
+    let lineages = lineages(&project_registry());
+    assert_eq!(
+        lineages.get("mined").map(String::as_str),
+        Some("ctx.acme.mined"),
+        "the trial ledger names a handle and the retraction door takes a lineage"
+    );
+}
+
+#[test]
+fn a_retraction_reason_names_the_measurement_and_the_way_back() {
+    let harmful = retraction_reason(&DemotionDecision::Demote {
+        reason: DemotionReason::Harmful { lift: -0.25 },
+    })
+    .expect("a demotion earns a reason");
+    assert!(
+        harmful.contains("lift") && harmful.contains("active"),
+        "it must say what measured it and how to put it back: {harmful}"
+    );
+
+    let inert = retraction_reason(&DemotionDecision::Demote {
+        reason: DemotionReason::Inert { trials: 40 },
+    })
+    .expect("a demotion earns a reason");
+    assert!(inert.contains("40"), "the window is the evidence: {inert}");
+
+    assert_eq!(
+        retraction_reason(&DemotionDecision::Keep {
+            reason: KeepSkillReason::HandAuthored,
+        }),
+        None,
+        "a kept record has nothing to explain"
+    );
+}

--- a/crates/stella-cli/src/memory/rules_mining.rs
+++ b/crates/stella-cli/src/memory/rules_mining.rs
@@ -30,10 +30,11 @@
 //!    A rule is a steering directive, and the policy in
 //!    [`stella_protocol::provenance`] prices that at
 //!    `EnvironmentObservation`. Reflection lessons grade `ModelCritique`, so
-//!    a rule mined from them is refused today and stays a proposal. That is
+//!    a rule mined from them is refused and stays a proposal. That is
 //!    the policy noticing something real, not a bug: the loop was publishing
-//!    instructions on a model's opinion about its own run. A holdout
-//!    comparison over recorded turns is the producer that pays the bar.
+//!    instructions on a model's opinion about its own run. The producer that
+//!    pays the bar is the rule's own recorded turns
+//!    ([`super::rule_efficacy::measured_grade`]).
 //! 3. **Auto-activation needs real confidence.** A skill lands as soon as it is
 //!    eligible. A rule additionally needs `confidence >=
 //!    context.promotion.inferred_directive.auto_activate_at_confidence` (85 by
@@ -248,7 +249,8 @@ pub(crate) enum RulePublication {
 /// [`ProvenanceGrade::EnvironmentObservation`]. Reflection lessons grade
 /// [`ProvenanceGrade::ModelCritique`], so a rule mined from them is refused
 /// here and stays a proposal somebody can read. The grade that pays is the
-/// one a measured holdout produces.
+/// one the rule's own recorded turns produce
+/// ([`super::rule_efficacy::measured_grade`]).
 pub(crate) fn write_rule(
     workspace_root: &Path,
     candidate: &RuleCandidate,

--- a/crates/stella-cli/src/proposals_cmd.rs
+++ b/crates/stella-cli/src/proposals_cmd.rs
@@ -584,6 +584,8 @@ pub(crate) fn decide_for_test(
 }
 
 mod retract;
+/// The unprinted half of `stella proposals retract`, for the efficacy sweep.
+pub(crate) use retract::retract_published;
 
 #[cfg(test)]
 mod tests;

--- a/crates/stella-cli/src/proposals_cmd/retract.rs
+++ b/crates/stella-cli/src/proposals_cmd/retract.rs
@@ -72,6 +72,32 @@ impl Published {
 /// `ctx.<set>.<id>` lineage when the short form is ambiguous — the same two
 /// spellings [`super::resolve_proposal`] accepts, for the same reason.
 pub(super) fn retract_rule(workspace_root: &Path, id: &str, reason: &str) -> Result<(), String> {
+    let (lineage_id, path) = retract_published(workspace_root, id, reason)?;
+
+    println!("  {} retracted {}", "✓".green(), lineage_id.bold());
+    println!(
+        "    {} {} keeps the record, marked retracted — the loader stops \
+         selecting it on the next load",
+        "·".dimmed(),
+        path.display()
+    );
+    Ok(())
+}
+
+/// The retraction itself, with nothing printed — the door a caller with no
+/// screen goes through.
+///
+/// Returns the lineage that was retracted and the file it lives in, so a
+/// caller that does have a screen says it in its own words. The efficacy sweep
+/// (`memory::rule_efficacy`) is the other caller: a rule the turns say has
+/// stopped helping must leave selection the same way a person's `stella
+/// proposals retract` does, through one door, and not by a second mechanism
+/// that could disagree with this one about what a retraction is.
+pub(crate) fn retract_published(
+    workspace_root: &Path,
+    id: &str,
+    reason: &str,
+) -> Result<(String, PathBuf), String> {
     if reason.trim().is_empty() {
         return Err("a retraction must carry a reason — a governance decision \
                     with none is not auditable"
@@ -93,15 +119,7 @@ pub(super) fn retract_rule(workspace_root: &Path, id: &str, reason: &str) -> Res
 
     retract_in_place(&mut published)?;
     record_retraction(workspace_root, &lineage_id, reason)?;
-
-    println!("  {} retracted {}", "✓".green(), lineage_id.bold());
-    println!(
-        "    {} {} keeps the record, marked retracted — the loader stops \
-         selecting it on the next load",
-        "·".dimmed(),
-        published.path.display()
-    );
-    Ok(())
+    Ok((lineage_id, published.path))
 }
 
 /// Find the published record `id` names, reading `.stella/rules/` rather than

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -267,28 +267,42 @@ evolution_surfaces! {
     /// Prompts, policies, and the loop's own instructions.
     Framework => "framework",
         EvolutionPosture::Shipped {
-            mechanism: "**this row's evidence column is enforced, and today it refuses \
-                        everything the loop can offer.** All three publication paths \
+            mechanism: "this row's evidence column is enforced. All three publication paths \
                         — auto-activation, `stella proposals keep`, `stella memory promote` \
                         — ask `authorises` before they write, and a refusal names the grade \
                         it needed beside the grade it was offered. A reflection lesson grades \
                         `ModelCritique` and the pool folds by minimum, so nothing mined \
-                        reaches the `EnvironmentObservation` a directive costs: the surface \
-                        is live and its evidence bar is unmet, so a mined rule stays a \
-                        reviewable proposal until a measured producer exists. What \
-                        publishes when the grade pays: the rules miner induces directive \
-                        candidates from reflection observations, and a kept one is written as \
-                        a TOML record under `.stella/rules/`, which `FsRuleSource` loads into \
-                        the system prefix. The system prompt template itself is assembled and \
-                        never self-edited: no path writes AGENTS.md or CLAUDE.md",
-            witness: "a_rule_on_reflection_evidence_is_refused_and_nothing_lands",
+                        reaches the `EnvironmentObservation` a directive costs, and a mined \
+                        rule stays a reviewable proposal — \
+                        `a_rule_on_reflection_evidence_is_refused_and_nothing_lands` still \
+                        pins that. The measured producer that pays the bar is the rule's own \
+                        turns. Each turn records which rules it could show and which \
+                        it showed, into the shared artifact trial ledger. `measured_grade` \
+                        appraises that window, and a rule the turns say confidently helps \
+                        earns `EnvironmentObservation`. The same window runs the other way: a \
+                        mined rule whose turns say withholding it won is retracted through \
+                        the registry's own append-only door — `status = \"retracted\"` in the \
+                        record file plus a `Retired` row in `.stella/rules/promotions.jsonl`. \
+                        A rule a person wrote is kept, whatever the numbers say. What \
+                        publishes when the grade pays is a TOML record under `.stella/rules/`, \
+                        which `FsRuleSource` loads into the system prefix. The system prompt \
+                        template itself is assembled and never self-edited: no path writes \
+                        AGENTS.md or CLAUDE.md",
+            witness: "a_mined_rule_that_stops_helping_is_retracted_and_a_hand_written_one_is_kept",
         },
-        EvolutionTiming::OfflineBatch,
+        // Between turns, not offline: the sweep runs on the post-turn path,
+        // and `memory::records_refresh` digests the rule files at the next
+        // turn boundary, so the next turn in the same session reads the
+        // retracted record's new standing.
+        EvolutionTiming::BetweenTurns,
         ImpactClass::SteeringDirective,
-        "`stella proposals retract <id> --reason <why>`. Nothing is deleted: the record file \
+        "`stella proposals retract <id> --reason <why>`, which the efficacy sweep goes through \
+         too. Nothing is deleted: the record file \
          is rewritten with `status = \"retracted\"` and the retraction is appended to the \
          hash-chained `.stella/rules/promotions.jsonl`, so the registry stops selecting it on \
-         the next load while what Stella believed — and when it stopped — stays readable";
+         the next load while what Stella believed — and when it stopped — stays readable. \
+         Undoing a retraction has no command of its own yet (`#6160`): the statement is still in \
+         the file, and setting its `status` back to `active` puts it back";
 
     /// What Stella remembers between turns.
     Memory => "memory",
@@ -505,11 +519,14 @@ pub const UNWITNESSED_EVOLUTION_BASELINE: usize = 0;
 /// check it asserts the row's own mechanism.** A row is a claim like any other
 /// (CLAUDE.md), and the name of a test is not evidence for it.
 #[cfg(test)]
-fn evolution_sources() -> [&'static str; 14] {
+fn evolution_sources() -> [&'static str; 15] {
     [
         // The Memory row's witness. A window of real turns retires a mined
         // memory, and leaves a hand-written one alone.
         include_str!("../../stella-cli/src/memory/learning/memory_lifecycle.rs"),
+        // The Framework row's witness. The same window retracts a mined rule
+        // and leaves a hand-written one alone.
+        include_str!("../../stella-cli/src/memory/learning/rule_lifecycle.rs"),
         // The Delivery row's witness: what the backlog picks and the
         // ledger row it writes, proven on a fixture tracker.
         include_str!("../../stella-cli/src/self_driving_cmd/ready.rs"),


### PR DESCRIPTION
## What and why

Slice E of #5200. Rules were a **producer** of trial rows and a consumer of
nothing, which cost two of that epic's three definition-of-done boxes:

- `memory/trials.rs` withholds a rule on its turn of the holdout schedule and
  writes the offered→shown join to `artifact_trials.jsonl`. Nothing read those
  rows, so a third of what the schedule costs bought nothing.
- Nothing in the tree produced `ProvenanceGrade::EnvironmentObservation`, which
  is what `ImpactClass::SteeringDirective` costs — so every mined rule was
  refused, correctly, with no path that could ever pay the bar.

Two halves land here.

**The consumer.** `crates/stella-cli/src/memory/rule_efficacy.rs` runs
`appraisals::sweep(root, ArtifactKind::Rule, &origins, &config)` — the same
`appraise` + `decide_demotion` engine the skill and memory sweeps run — from
the post-turn path in `auto_create_skills_typed`, beside
`retire_failing_context`. A `Demote` verdict on a mined rule goes through the
registry's existing append-only door: `status = "retracted"` in the record file
plus a `Retired` row in `.stella/rules/promotions.jsonl`. `decide_demotion`'s
origin check keeps a hand-authored record the way it keeps a hand-written
memory.

`origins` treats a record as the loop's own only when all four of these hold —
`origin = "inferred"`, project tier, no contributing plugin, still active — and
anything else is absent from the map, which `decide_demotion` reads as
hand-authored. That is the same fail-safe direction `retirement::origins` uses,
and the *active* clause is what stops a retracted record earning the same
retraction on every later sweep.

**The grade producer.** `measured_grade` appraises a rule's own rows and
returns `Some(EnvironmentObservation)` on `SkillVerdict::Helps` alone.
`induce_rules` folds that with the mining grade through
`stella_records::context_record::published_grade` — the same `max` over two
derivations against two sources that `stella proposals keep` already uses — and
hands the result to `write_rule`. Reflection prose still folds to
`ModelCritique` and is still refused;
`a_rule_on_reflection_evidence_is_refused_and_nothing_lands` is untouched and
still passes.

The one door is reused rather than mirrored:
`proposals_cmd::retract::retract_rule` is split into a quiet
`retract_published` core (resolve, rewrite, append) with the printing wrapper
left on top, so a person's retraction and the loop's are literally the same two
writes in the same order.

## The #6103 ordering constraint

#6103 is still open, so this PR keys the rule rows so they cannot collide with a
skill of the same id — by writing into neither skill-keyed ledger:

- **No `record_appraisal`.** The rule consumer mirrors the *memory* consumer,
  which reads the sweep's decisions and acts on them without storing a
  `SkillAppraisal`. `APPRAISALS_FILE`'s bare `skill: String` is never handed a
  rule id.
- **No `record_demotion`.** A retraction is filed under the record's own
  `lineage_id`, which is unique across the workspace. The `skill:` lineage
  prefix is never used for a rule.

So #6103 can land before or after this without either changing the other.

## Witness mechanism

`crates/stella-cli/src/memory/learning/rule_lifecycle.rs`, mirroring
`memory_lifecycle.rs` and driving the production seams — no hand-built verdict
(#5198).

`a_mined_rule_that_stops_helping_is_retracted_and_a_hand_written_one_is_kept`
publishes two real records into `.stella/rules/acme.toml`, one
`origin = "inferred"` and one `origin = "user"`, writes **identical** trial rows
for both through `appraisals::record_turn` (shown → failed, withheld → passed),
and then drives `SessionMemory::auto_create_skills`. The mined record's status
is `Retracted` on disk, the hand-written one is `Active`, and the governance
ledger carries the lineage and a reason naming the lift. **It fails on `main` by
construction**: no call site there passes `ArtifactKind::Rule` to a sweep, so no
rule trial is ever read and both records stay active. Only the origin
distinguishes the two records, so a sweep that retracted everything it was
handed fails the second assertion.

Two controls:

- `a_rule_the_turns_cannot_separate_is_left_alone` — every turn passes, shown or
  withheld. `promotions.jsonl` is never created. Matches
  `a_memory_the_turns_cannot_separate_is_left_alone`.
- The first test re-runs the sweep after the retraction and asserts the ledger
  is byte-identical, which pins the *active* clause in `origins`.

`a_measured_rule_earns_the_grade_a_directive_costs` covers the second half: rows
that say the rule helps yield `EnvironmentObservation`, and a rule with no rows
yields `None`. `rule_efficacy/tests.rs` covers the pure halves — a user-tier
record and a plugin-contributed one are never the loop's to retract, and a
`Keep` decision earns no reason.

## Exemplar

`crates/stella-cli/src/memory/retirement.rs` and its witness
`memory_lifecycle.rs`, which are the memory arm of exactly this shape. The
kind-filtered `appraisals::sweep` was already built to be read by a third
consumer; nothing about the engine changed.

## Ledger

`crates/stella-parity/src/evolution.rs`'s `Framework` row drops "the surface is
live and its evidence bar is unmet … until a measured producer exists",
describes the producer that now exists, and names the new witness. Its timing
moves from `OfflineBatch` to `BetweenTurns`: the sweep runs on the post-turn
path, and `memory::records_refresh` digests the rule files at the next turn
boundary, so the next turn in the same session reads the new standing. The
rollback string gains the one gap this opens — undoing a retraction still has no
command of its own (#6160).

## Tests deleted

None.

## Remaining work filed

- #6160 — a retracted rule has no command that puts it back. The loop now
  retracts on its own, so a person who disagrees has only a hand edit.
- #6161 — a rule's measured window is keyed by the render handle, which widens
  when a second lineage ends in the same word. The handle→lineage join here
  keeps that a lost window rather than a retraction of the wrong record.
- #6162 — a mined rule cannot earn its measured grade until something else
  publishes it first. A candidate that has never rendered has no arms, so
  auto-activation cannot start the loop by itself. Said plainly in the module
  prose rather than implied away.

Closes #6143
Refs #5200, #4865, #6103, #5198

## Summary by Sourcery

Consume rule trial evidence between turns to grant measured provenance to effective mined rules and retract mined rules that no longer help.

New Features:
- Read rule trial-ledger outcomes to measure whether mined rules help and grant environment-based provenance when they do.
- Automatically retract mined rules that measured trials show are harmful or inert, while preserving hand-authored, user-tier, plugin-contributed, and already-retracted rules.

Bug Fixes:
- Prevent rule trial rows from being ignored by adding post-turn efficacy evaluation and lifecycle handling.

Enhancements:
- Reuse the published-rule retraction path for both CLI and automated retractions, including append-only governance records and auditable reasons.
- Join trial render handles to rule lineage IDs without writing rule data into skill-keyed appraisal or demotion ledgers.
- Run rule efficacy processing between turns and document the framework surface as witnessed by the new lifecycle test.

Documentation:
- Update the framework evolution ledger to describe measured rule evidence, automated retraction, timing, and rollback limitations.

Tests:
- Add end-to-end lifecycle coverage for retracting harmful mined rules, retaining hand-written rules, avoiding duplicate retractions, and leaving indistinguishable trial windows alone.
- Add coverage for measured environment grades and safe origin filtering for user, plugin, and retracted records.