### PR TITLE
feat(stella-autonomy,stella-cli): give the self-driving loop work when its queue runs dry

### DIFF
--- a/crates/stella-autonomy/README.md
+++ b/crates/stella-autonomy/README.md
@@ -86,6 +86,9 @@ the CLI does — so the dashboard and the terminal cannot disagree.
 | [`src/ready.rs`](src/ready.rs) | `ready_queue`: which backlog issues may be taken next, and in what order. `Blocked by: #N` lines, the `status:ready` override, and the escalation cooldown. |
 | [`src/escalation.rs`](src/escalation.rs) | Escalation as a cooldown: `classify` reads an abort message, `retry_after` says how long to wait, `park_after` says when waiting ends. The record is written into the issue body and read back from it. |
 | [`src/gate.rs`](src/gate.rs) | Which checks are allowed to block a merge, and which have stopped earning that right. |
+| [`src/supply.rs`](src/supply.rs) | Where the loop looks when the ranked queue is empty: `WorkSupply`, `SupplyPolicy` (every switch off), the `rearm` rule that re-opens a dry ladder against a moved base, and `novel`, which drops a finding the seen set already holds. |
+| [`src/regress.rs`](src/regress.rs) | Re-checking the fixes the loop has claimed: `ClosureReceipt`, `check`, and the `sweep` that turns a change gone from the base branch into a fresh defect. |
+| [`src/meta.rs`](src/meta.rs) | The loop read against its own ledger: a raised signal nobody acted on, and a lens that has looked several times and found nothing. |
 | [`src/closure.rs`](src/closure.rs) | How an issue ends, and what has to be true first. |
 | [`src/convention.rs`](src/convention.rs) | How this repository writes issues, learned rather than assumed. |
 | [`src/attribution.rs`](src/attribution.rs) | Attribution lines for filed issues and opened PRs. |

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -58,10 +58,13 @@ mod deliver;
 mod doctrine;
 pub mod escalation;
 pub mod gate;
+pub mod meta;
 pub mod priority;
 pub mod ready;
+pub mod regress;
 mod stats;
 mod step;
+pub mod supply;
 mod surface;
 
 use std::fmt::Write as _;

--- a/crates/stella-autonomy/src/meta.rs
+++ b/crates/stella-autonomy/src/meta.rs
@@ -1,0 +1,243 @@
+//! What the loop keeps getting wrong, read from its own ledger.
+//!
+//! Every cycle appends a row. The rows say how much was fixed, how much was
+//! filed, whether the gate was red, and which lens was open. Read together
+//! they show habits that no single cycle shows.
+//!
+//! This module turns those habits into defects the loop files against itself.
+//! Two kinds:
+//!
+//! - A named signal the fold already raises — `STUCK`, `NOISY`, `FRAGILE`,
+//!   `STARVED`. Each of these is reported and acted on by nobody, which is
+//!   what a signal with no reader always becomes.
+//! - A lens that has looked several times and found nothing at all. Its
+//!   backing is probably not running.
+//!
+//! Each finding has a fixed title, so the dedup key holds. A habit is filed
+//! once, not once per cycle.
+//!
+//! `doc:backlog-self-driving` §4.1 is the design.
+
+use std::collections::BTreeMap;
+
+use crate::supply::Finding;
+use crate::{Calibration, CycleRecord, Metrics, Signal, metrics, starved};
+
+/// The label a finding about the loop carries.
+///
+/// The loop wasting its own cycles is a defect, and the type axis of a backlog
+/// convention spells that `bug`.
+pub const DEFECT_LABEL: &str = "bug";
+
+/// How many cycles a lens must have run before its silence counts.
+///
+/// Three, matching the dry-streak the ladder already uses. One quiet cycle is
+/// a clean tree; three in a row on one lens is a tool that is not looking.
+pub const BARREN_CYCLES: u64 = 3;
+
+/// The defects the ledger shows about the loop itself.
+#[must_use]
+pub fn sweep(rows: &[CycleRecord], cal: &Calibration) -> Vec<Finding> {
+    let folded = metrics(rows);
+    let controller = starved(cal);
+
+    let mut out: Vec<Finding> = folded
+        .signals
+        .iter()
+        .chain(controller.iter())
+        .map(|signal| signal_finding(signal, &folded))
+        .collect();
+
+    for lens in barren_lenses(rows) {
+        out.push(barren_finding(&lens));
+    }
+    out
+}
+
+/// One defect for one raised signal.
+fn signal_finding(signal: &Signal, folded: &Metrics) -> Finding {
+    let Signal { code, text } = signal;
+    let Metrics {
+        cycles,
+        fixed,
+        filed,
+        new_findings,
+        zero_fix_cycles,
+        red_gate_cycles,
+        ..
+    } = folded;
+    Finding {
+        title: format!("the self-driving loop raises {code} against its own ledger"),
+        body: format!(
+            "The loop's ledger raises `{code}`: {text}.\n\n\
+             Over {cycles} cycle(s) it fixed {fixed}, filed {filed}, and found \
+             {new_findings} new defect(s). {zero_fix_cycles} cycle(s) fixed nothing and \
+             {red_gate_cycles} ended on a red gate.\n\n\
+             A signal nobody acts on trains people to skip signals, so this one is filed \
+             as work rather than printed again.\n\n\
+             ## How to check\n\n\
+             1. Read `ledger.jsonl` in this repository's self-driving state directory.\n\
+             2. Find which cycles raise `{code}` and what they have in common.\n\
+             3. Fix the cause, or change the rule that raises it.\n\n\
+             ## Definition of done\n\n\
+             - [ ] The cause of `{code}` is named, with the ledger rows that show it.\n\
+             - [ ] Either the loop stops meeting it, or the rule that raises it changes.\n"
+        ),
+        labels: vec![DEFECT_LABEL.to_owned()],
+    }
+}
+
+/// One defect for one lens that never finds anything.
+fn barren_finding(lens: &str) -> Finding {
+    Finding {
+        title: format!("the `{lens}` lens has looked several times and found nothing"),
+        body: format!(
+            "The `{lens}` rung of the aperture ladder has run at least {BARREN_CYCLES} \
+             cycles and has never produced a new finding.\n\n\
+             That is one of two things. Either the tree is clean on this question, or the \
+             backing the lens declares is not running. The second is far more likely, and \
+             it is silent: a lens whose tool fails reports the same nothing as a lens whose \
+             answer is nothing.\n\n\
+             ## How to check\n\n\
+             1. Read the backing `{lens}` declares in the aperture list \
+             (`stella self-driving aperture --list`).\n\
+             2. Run that tool by hand against a clean tree.\n\
+             3. If it runs and finds nothing, say so on this issue and close it. If it \
+             fails, fix the tool or the declaration.\n\n\
+             ## Definition of done\n\n\
+             - [ ] The `{lens}` backing has been run by hand and its output read.\n\
+             - [ ] Either the tool is fixed, or this issue records that the silence is \
+             real.\n"
+        ),
+        labels: vec![DEFECT_LABEL.to_owned()],
+    }
+}
+
+/// Lenses that have run enough cycles to be judged and found nothing at all.
+fn barren_lenses(rows: &[CycleRecord]) -> Vec<String> {
+    let mut tally: BTreeMap<&str, (u64, u64)> = BTreeMap::new();
+    for row in rows {
+        let name = row.aperture.trim();
+        if name.is_empty() || name == crate::WATCH {
+            continue;
+        }
+        let entry = tally.entry(name).or_insert((0, 0));
+        entry.0 += 1;
+        entry.1 += row.new_findings;
+    }
+    tally
+        .into_iter()
+        .filter(|(_, (cycles, found))| *cycles >= BARREN_CYCLES && *found == 0)
+        .map(|(name, _)| name.to_owned())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AimdLimits;
+
+    fn row(aperture: &str, fixed: u64, filed: u64, found: u64, gate: &str) -> CycleRecord {
+        CycleRecord {
+            cycle: 1,
+            run_id: "r".to_owned(),
+            ended_at: String::new(),
+            ended_at_unix: 0,
+            fixed,
+            filed,
+            new_findings: found,
+            bench: String::new(),
+            gate: gate.to_owned(),
+            prs: Vec::new(),
+            tier: String::new(),
+            aperture: aperture.to_owned(),
+            lens_tool: None,
+            outcome: String::new(),
+            minutes: 0,
+            dry: found == 0,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    fn seeded() -> Calibration {
+        Calibration::seeded(&AimdLimits::default())
+    }
+
+    /// **The witness.** A lens that has looked three times and found nothing
+    /// becomes a defect about the lens.
+    #[test]
+    fn a_lens_that_never_finds_anything_becomes_a_finding() {
+        let rows = vec![
+            row("properties", 1, 0, 0, "green"),
+            row("properties", 1, 0, 0, "green"),
+            row("properties", 1, 0, 0, "green"),
+        ];
+
+        let found = sweep(&rows, &seeded());
+
+        assert_eq!(found.len(), 1, "got {found:?}");
+        assert!(found[0].title.contains("properties"));
+        assert_eq!(found[0].labels, vec![DEFECT_LABEL.to_owned()]);
+    }
+
+    /// Two cycles is not enough to judge a lens.
+    #[test]
+    fn two_quiet_cycles_are_not_enough() {
+        let rows = vec![
+            row("properties", 1, 0, 0, "green"),
+            row("properties", 1, 0, 0, "green"),
+        ];
+
+        assert!(sweep(&rows, &seeded()).is_empty());
+    }
+
+    /// A lens that found something is not barren, however many cycles it ran.
+    #[test]
+    fn a_lens_that_found_something_is_not_barren() {
+        let rows = vec![
+            row("rubric", 1, 0, 0, "green"),
+            row("rubric", 1, 0, 2, "green"),
+            row("rubric", 1, 0, 0, "green"),
+            row("rubric", 1, 0, 0, "green"),
+        ];
+
+        assert!(sweep(&rows, &seeded()).is_empty());
+    }
+
+    /// `watch` is a mode and not a lens, so its silence says nothing.
+    #[test]
+    fn watch_is_never_reported_as_barren() {
+        let rows = vec![
+            row(crate::WATCH, 1, 0, 0, "green"),
+            row(crate::WATCH, 1, 0, 0, "green"),
+            row(crate::WATCH, 1, 0, 0, "green"),
+        ];
+
+        assert!(sweep(&rows, &seeded()).is_empty());
+    }
+
+    /// A raised signal becomes a defect, so it reaches the queue instead of
+    /// being printed to nobody.
+    #[test]
+    fn a_raised_signal_becomes_a_finding() {
+        let rows = vec![
+            row("rubric", 0, 0, 1, "green"),
+            row("rubric", 0, 0, 1, "green"),
+            row("rubric", 0, 0, 1, "green"),
+        ];
+
+        let found = sweep(&rows, &seeded());
+
+        assert!(
+            found.iter().any(|f| f.title.contains("STUCK")),
+            "got {:?}",
+            found.iter().map(|f| &f.title).collect::<Vec<_>>()
+        );
+    }
+
+    /// An empty ledger says nothing about anything.
+    #[test]
+    fn an_empty_ledger_yields_nothing() {
+        assert!(sweep(&[], &seeded()).is_empty());
+    }
+}

--- a/crates/stella-autonomy/src/regress.rs
+++ b/crates/stella-autonomy/src/regress.rs
@@ -1,0 +1,309 @@
+//! Re-checking the fixes this loop has already claimed.
+//!
+//! A closed issue is a claim with a date on it. The change that fixed it was
+//! on the base branch when the loop closed the issue. Any merge after that can
+//! take it away again: a revert, a force push, a rebase that drops it.
+//!
+//! So the loop writes down a [`ClosureReceipt`] as it closes. The receipt says
+//! what the closure cited, and whether that change was on the base at the
+//! time. This module reads the receipts back and asks the same question again.
+//!
+//! A change that was there and is gone is a fact, not a claim, and it is filed
+//! as a fresh defect. That is what makes this supply worth its cost: an audit
+//! finding needs triage, and this one does not.
+//!
+//! A receipt that cited no change cannot be re-checked. Those are counted and
+//! reported. The count says how often *done* was a claim rather than a proof,
+//! and it is meant to be read.
+//!
+//! `doc:backlog-self-driving` §4.3 is the design.
+
+use serde::{Deserialize, Serialize};
+
+use crate::closure::Citation;
+use crate::supply::Finding;
+
+/// The label a returning defect carries.
+///
+/// A fix that came back out is a defect, and the type axis of a backlog
+/// convention spells that `bug`. A convention with no such member refuses the
+/// draft, and the refusal stands. Nothing here invents a word.
+pub const DEFECT_LABEL: &str = "bug";
+
+/// What the loop wrote down when it closed an issue.
+///
+/// One line of `receipts.jsonl` in the loop's own state directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClosureReceipt {
+    /// The issue key, as the tracker spells it, with no leading `#`.
+    pub key: String,
+    /// When it closed, RFC3339.
+    #[serde(default)]
+    pub closed_at: String,
+    /// What the closure cited. `None` when it cited no change at all — a
+    /// duplicate, or work somebody declined.
+    #[serde(default)]
+    pub by: Option<Citation>,
+    /// Whether the cited change was on the base branch at the time.
+    ///
+    /// `None` when git could not answer, and on any receipt written before
+    /// this field existed. An unknown reads as unsweepable, never as gone:
+    /// telling *gone* from *never seen* is the whole job here.
+    #[serde(default)]
+    pub present_at_close: Option<bool>,
+}
+
+/// What re-checking one receipt found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Check {
+    /// The change is still on the base.
+    Holds,
+    /// It was there, and it is gone.
+    Regressed,
+    /// It cannot be re-checked.
+    Skipped(Skip),
+}
+
+/// Why a receipt cannot be re-checked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Skip {
+    /// The closure cited no change at all.
+    NoChangeCited,
+    /// Git could not say whether the change was on the base at close time.
+    UnknownAtClose,
+    /// The change was already absent when the issue closed.
+    AbsentAtClose,
+}
+
+impl Skip {
+    /// A short word for a report.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NoChangeCited => "no change cited",
+            Self::UnknownAtClose => "unknown at close",
+            Self::AbsentAtClose => "absent at close",
+        }
+    }
+}
+
+/// Re-check one receipt against what the base holds now.
+///
+/// Only a change that was there and is gone counts. A change nobody could see
+/// at close time is skipped, because *gone* and *never seen* would then look
+/// the same, and filing the wrong one of those costs a person a wasted hour.
+#[must_use]
+pub fn check(receipt: &ClosureReceipt, present_now: bool) -> Check {
+    if receipt.by.is_none() {
+        return Check::Skipped(Skip::NoChangeCited);
+    }
+    match receipt.present_at_close {
+        None => Check::Skipped(Skip::UnknownAtClose),
+        Some(false) => Check::Skipped(Skip::AbsentAtClose),
+        Some(true) if present_now => Check::Holds,
+        Some(true) => Check::Regressed,
+    }
+}
+
+/// The defect a returning bug is filed as.
+#[must_use]
+pub fn finding(receipt: &ClosureReceipt) -> Finding {
+    let key = receipt.key.trim().trim_start_matches('#');
+    let cited = receipt
+        .by
+        .as_ref()
+        .map_or_else(|| "nothing".to_owned(), Citation::render);
+    Finding {
+        title: format!("the fix for #{key} has left the base branch"),
+        body: format!(
+            "This loop closed #{key} as done and cited {cited}. That change was on the base \
+             branch then. It is not there now.\n\n\
+             Something took it back out: a revert, a force push, or a rebase that dropped \
+             it. Until it returns, the defect #{key} described is back.\n\n\
+             ## How to check\n\n\
+             1. Read #{key} for what the defect was.\n\
+             2. Ask git what happened to {cited} — `git log` over the paths it touched.\n\
+             3. Land the fix again, with a test that fails without it.\n\n\
+             ## Definition of done\n\n\
+             - [ ] The fix {cited} carried is back on the base branch, or a fresh change \
+             carries the same fix.\n\
+             - [ ] A test fails without that change and passes with it.\n"
+        ),
+        labels: vec![DEFECT_LABEL.to_owned()],
+    }
+}
+
+/// What one pass over the receipts found.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Report {
+    /// Receipts that could be re-checked.
+    pub checked: u64,
+    /// Receipts that could not be, one entry each.
+    pub skipped: Vec<Skip>,
+    /// The defects to file.
+    pub findings: Vec<Finding>,
+}
+
+/// Re-check every receipt.
+///
+/// `present_now` answers whether one cited change is on the base branch right
+/// now. It is a parameter because asking git is work this crate does not do.
+/// It is called only for a receipt that could regress, so a long ledger costs
+/// one git call per fix the loop has claimed and none for the rest.
+pub fn sweep(
+    receipts: &[ClosureReceipt],
+    mut present_now: impl FnMut(&Citation) -> bool,
+) -> Report {
+    let mut report = Report::default();
+    for receipt in receipts {
+        let present = match (&receipt.by, receipt.present_at_close) {
+            (Some(cite), Some(true)) => present_now(cite),
+            _ => false,
+        };
+        match check(receipt, present) {
+            Check::Holds => report.checked += 1,
+            Check::Regressed => {
+                report.checked += 1;
+                report.findings.push(finding(receipt));
+            }
+            Check::Skipped(skip) => report.skipped.push(skip),
+        }
+    }
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn receipt(key: &str, by: Option<Citation>, present: Option<bool>) -> ClosureReceipt {
+        ClosureReceipt {
+            key: key.to_owned(),
+            closed_at: "2026-09-01T00:00:00Z".to_owned(),
+            by,
+            present_at_close: present,
+        }
+    }
+
+    fn pr(key: &str) -> Option<Citation> {
+        Some(Citation::PullRequest {
+            key: key.to_owned(),
+        })
+    }
+
+    /// **The witness.** A fix that was on the base and has left it is filed
+    /// again.
+    #[test]
+    fn a_fix_that_has_left_the_base_is_filed_again() {
+        let rows = vec![receipt("4100", pr("4101"), Some(true))];
+
+        let report = sweep(&rows, |_| false);
+
+        assert_eq!(report.checked, 1);
+        assert!(report.skipped.is_empty());
+        assert_eq!(report.findings.len(), 1);
+        assert!(
+            report.findings[0].title.contains("4100"),
+            "the finding must name the issue: {}",
+            report.findings[0].title
+        );
+        assert!(report.findings[0].body.contains("4101"));
+    }
+
+    /// A fix still on the base files nothing.
+    #[test]
+    fn a_fix_still_on_the_base_files_nothing() {
+        let rows = vec![receipt("4100", pr("4101"), Some(true))];
+
+        let report = sweep(&rows, |_| true);
+
+        assert_eq!(report.checked, 1);
+        assert!(report.findings.is_empty());
+    }
+
+    /// A closure that cited no change cannot be re-checked, and the count of
+    /// those is reported rather than hidden.
+    #[test]
+    fn a_closure_with_no_change_cited_is_counted_not_filed() {
+        let rows = vec![receipt("4100", None, None)];
+
+        let report = sweep(&rows, |_| false);
+
+        assert_eq!(report.checked, 0);
+        assert_eq!(report.skipped, vec![Skip::NoChangeCited]);
+        assert!(report.findings.is_empty());
+    }
+
+    /// A change nobody could see at close time is skipped. Filing it would
+    /// report *gone* for something that was never there.
+    #[test]
+    fn a_change_unseen_at_close_is_never_reported_as_gone() {
+        let unknown = receipt("1", pr("2"), None);
+        let absent = receipt("3", pr("4"), Some(false));
+
+        let report = sweep(&[unknown, absent], |_| false);
+
+        assert_eq!(report.checked, 0);
+        assert_eq!(
+            report.skipped,
+            vec![Skip::UnknownAtClose, Skip::AbsentAtClose]
+        );
+        assert!(report.findings.is_empty());
+    }
+
+    /// A commit citation is checked the same way a pull request is.
+    #[test]
+    fn a_commit_citation_is_checked_too() {
+        let rows = vec![receipt(
+            "77",
+            Some(Citation::Commit {
+                sha: "f8935f2".to_owned(),
+            }),
+            Some(true),
+        )];
+
+        let report = sweep(&rows, |_| false);
+
+        assert_eq!(report.findings.len(), 1);
+        assert!(report.findings[0].body.contains("commit f8935f2"));
+    }
+
+    /// A receipt round-trips, so a line written by one build is read by the
+    /// next.
+    #[test]
+    fn a_receipt_round_trips() {
+        let row = receipt("12", pr("13"), Some(true));
+
+        let text = serde_json::to_string(&row).expect("serialize");
+        let back: ClosureReceipt = serde_json::from_str(&text).expect("parse");
+
+        assert_eq!(back, row);
+    }
+
+    /// An older line, written before the fields below `key` existed, still
+    /// parses. It reads as unsweepable, which is the safe answer.
+    #[test]
+    fn an_older_receipt_line_still_parses() {
+        let back: ClosureReceipt =
+            serde_json::from_str(r#"{"key":"12"}"#).expect("parse the older shape");
+
+        assert_eq!(back.by, None);
+        assert_eq!(check(&back, false), Check::Skipped(Skip::NoChangeCited));
+    }
+
+    /// Two returning defects file under two keys, because the digest keeps
+    /// the issue number.
+    #[test]
+    fn two_returning_fixes_are_two_findings() {
+        let rows = vec![
+            receipt("100", pr("101"), Some(true)),
+            receipt("200", pr("201"), Some(true)),
+        ];
+
+        let report = sweep(&rows, |_| false);
+
+        let first = crate::finding_digest(&report.findings[0].title);
+        let second = crate::finding_digest(&report.findings[1].title);
+        assert_ne!(first, second);
+    }
+}

--- a/crates/stella-autonomy/src/supply.rs
+++ b/crates/stella-autonomy/src/supply.rs
@@ -370,7 +370,10 @@ mod tests {
         let fresh = finding("the writer forgets the closing brace");
         let seen = vec![crate::finding_digest(&old.title)];
 
-        let out = novel(&[old.clone(), fresh.clone()], &seen);
+        // Bound rather than passed inline: `novel` borrows from the slice, so
+        // a temporary array would be dropped before the assertion reads it.
+        let offered = [old.clone(), fresh.clone()];
+        let out = novel(&offered, &seen);
 
         assert_eq!(out, vec![&fresh]);
     }

--- a/crates/stella-autonomy/src/supply.rs
+++ b/crates/stella-autonomy/src/supply.rs
@@ -1,0 +1,388 @@
+//! Where the loop looks for work once the ranked queue is empty.
+//!
+//! The queue drains. Three other supplies do not, and this module holds the
+//! rules that say which of them is open:
+//!
+//! - `rearm` re-opens the lens ladder once the base branch has moved.
+//! - `regress` re-checks the fixes the loop has already claimed.
+//! - `meta` reads the loop's own ledger for habits.
+//!
+//! Each one has its own switch, and each switch starts off. A loop that
+//! upgrades keeps drawing from the queue alone. An endless supply of work is
+//! not an endless supply of *useful* work, so opening one is a choice a
+//! person makes.
+//!
+//! Re-passing a lens is cheap because of [`novel`]. The dedup set is keyed by
+//! digest across the whole repository, so a finding the loop has filed before
+//! is dropped before it reaches the tracker. A re-pass yields the new code and
+//! nothing else.
+//!
+//! [`WorkSupply`] names the three. The crate root's `Supply` is a different
+//! thing: what the machine has to spend, in cores and disk and memory.
+//!
+//! `doc:backlog-self-driving` §4 is the design.
+
+use serde::{Deserialize, Serialize};
+
+/// One thing to file, before it becomes a tracker draft.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Finding {
+    /// One line. The dedup key is taken from this.
+    pub title: String,
+    /// The handoff. Assume the reader was not there.
+    pub body: String,
+    /// The labels the draft carries.
+    pub labels: Vec<String>,
+}
+
+/// A supply the loop draws from when the queue is empty.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkSupply {
+    /// Re-open the lens ladder against a base that has moved.
+    Rearm,
+    /// Re-check the fixes this loop has claimed.
+    Regress,
+    /// Read the loop's own ledger.
+    Meta,
+}
+
+impl WorkSupply {
+    /// Every supply, in the order a sweep draws from them.
+    pub const ALL: &[Self] = &[Self::Rearm, Self::Regress, Self::Meta];
+
+    /// The word an operator writes in `stella.toml`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rearm => "rearm",
+            Self::Regress => "regress",
+            Self::Meta => "meta",
+        }
+    }
+}
+
+/// How many commits the base must gain before a dry ladder re-opens.
+///
+/// Fifty is about a week of merges on a busy tree. It is a choice and not a
+/// measurement: small enough that a busy tree gets a fresh look, large enough
+/// that a quiet one is left alone.
+pub const DEFAULT_REARM_COMMITS: u64 = 50;
+
+/// How many days may pass instead, when the commit count stays low.
+///
+/// A tree that gains ten commits a month still drifts. Thirty days is the
+/// other way in.
+pub const DEFAULT_REARM_DAYS: u64 = 30;
+
+/// Which supplies are open, and how far the base must move to re-arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SupplyPolicy {
+    /// Whether a dry ladder may re-open.
+    pub rearm: bool,
+    /// Whether closed work is re-checked.
+    pub regress: bool,
+    /// Whether the ledger is read for habits.
+    pub meta: bool,
+    /// Commits the base must gain first.
+    pub rearm_commits: u64,
+    /// Days that may pass instead.
+    pub rearm_days: u64,
+}
+
+impl Default for SupplyPolicy {
+    /// Draw from the queue and nothing else.
+    fn default() -> Self {
+        Self {
+            rearm: false,
+            regress: false,
+            meta: false,
+            rearm_commits: DEFAULT_REARM_COMMITS,
+            rearm_days: DEFAULT_REARM_DAYS,
+        }
+    }
+}
+
+impl SupplyPolicy {
+    /// Whether this policy opens any supply at all.
+    #[must_use]
+    pub fn any_open(&self) -> bool {
+        self.rearm || self.regress || self.meta
+    }
+
+    /// Whether one named supply is open.
+    #[must_use]
+    pub fn opens(&self, supply: WorkSupply) -> bool {
+        match supply {
+            WorkSupply::Rearm => self.rearm,
+            WorkSupply::Regress => self.regress,
+            WorkSupply::Meta => self.meta,
+        }
+    }
+}
+
+/// What the loop can see about the base since the ladder went dry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Baseline {
+    /// Commits the base has gained since the clean sweep. `None` when git
+    /// could not be asked.
+    pub commits: Option<u64>,
+    /// Days since that sweep. `None` when nothing wrote the date down.
+    pub days: Option<u64>,
+    /// Whether the loop is filing far more than it finds.
+    pub noisy: bool,
+}
+
+/// Whether a dry ladder re-opens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rearm {
+    /// Re-open the ladder at this rung.
+    Reopen {
+        /// The first lens.
+        lens: &'static str,
+    },
+    /// Leave it shut.
+    Hold {
+        /// What holds it shut.
+        reason: Hold,
+    },
+}
+
+/// Why a dry ladder stays shut.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Hold {
+    /// The switch is off. This is the default.
+    SwitchOff,
+    /// A lens is still open, so there is nothing to re-arm.
+    LadderOpen,
+    /// The base has not moved far enough yet.
+    Unmoved,
+    /// Nothing says where the last clean sweep was.
+    NoBaseline,
+    /// The loop files far more than it finds. Widening would add noise.
+    Noisy,
+}
+
+/// Whether the ladder re-opens against a base that has moved.
+///
+/// `aperture` is the rung the loop has open. Anything but [`crate::WATCH`]
+/// means the ladder still has a question to ask, so there is nothing to
+/// re-arm.
+///
+/// A `NOISY` loop is held shut. That signal fires when the loop files far more
+/// than it finds, and the answer to that is to narrow rather than to open one
+/// more lens.
+///
+/// # Examples
+///
+/// ```
+/// # use stella_autonomy::supply::{Baseline, Hold, Rearm, SupplyPolicy, rearm};
+/// let mut policy = SupplyPolicy::default();
+/// let moved = Baseline { commits: Some(500), days: None, noisy: false };
+///
+/// // Off by default, whatever the base did.
+/// assert_eq!(rearm("watch", &moved, &policy), Rearm::Hold { reason: Hold::SwitchOff });
+///
+/// policy.rearm = true;
+/// assert_eq!(rearm("watch", &moved, &policy), Rearm::Reopen { lens: "rubric" });
+/// ```
+#[must_use]
+pub fn rearm(aperture: &str, base: &Baseline, policy: &SupplyPolicy) -> Rearm {
+    let hold = |reason| Rearm::Hold { reason };
+    if !policy.rearm {
+        return hold(Hold::SwitchOff);
+    }
+    if aperture.trim() != crate::WATCH {
+        return hold(Hold::LadderOpen);
+    }
+    if base.noisy {
+        return hold(Hold::Noisy);
+    }
+    if base.commits.is_none() && base.days.is_none() {
+        return hold(Hold::NoBaseline);
+    }
+    let moved = base.commits.is_some_and(|n| n >= policy.rearm_commits)
+        || base.days.is_some_and(|n| n >= policy.rearm_days);
+    if moved {
+        Rearm::Reopen {
+            lens: crate::LENSES.first().map_or(crate::WATCH, |l| l.name),
+        }
+    } else {
+        hold(Hold::Unmoved)
+    }
+}
+
+/// The findings whose digest is absent from the seen set.
+///
+/// The key is [`crate::finding_digest`] over the title, which is the key the
+/// filing path uses. This is what makes a re-pass safe: a repeat finding is
+/// dropped before anything is sent.
+#[must_use]
+pub fn novel<'a>(findings: &'a [Finding], seen: &[String]) -> Vec<&'a Finding> {
+    findings
+        .iter()
+        .filter(|finding| {
+            let digest = crate::finding_digest(&finding.title);
+            !seen.iter().any(|line| line.trim() == digest)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finding(title: &str) -> Finding {
+        Finding {
+            title: title.to_owned(),
+            body: "body".to_owned(),
+            labels: vec!["bug".to_owned()],
+        }
+    }
+
+    /// **The witness.** Every supply is shut on a fresh policy, so a build
+    /// that gains them changes no running loop.
+    #[test]
+    fn every_supply_is_shut_by_default() {
+        let policy = SupplyPolicy::default();
+        assert!(!policy.any_open());
+        for supply in WorkSupply::ALL {
+            assert!(
+                !policy.opens(*supply),
+                "{} is open by default",
+                supply.as_str()
+            );
+        }
+    }
+
+    /// **The witness for the re-arm rule.** A ladder that went dry at one
+    /// commit re-opens once the base has gained enough of them, and not
+    /// before.
+    #[test]
+    fn a_dry_ladder_reopens_once_the_base_has_moved_far_enough() {
+        let policy = SupplyPolicy {
+            rearm: true,
+            ..SupplyPolicy::default()
+        };
+
+        let just_short = Baseline {
+            commits: Some(DEFAULT_REARM_COMMITS - 1),
+            days: Some(0),
+            noisy: false,
+        };
+        assert_eq!(
+            rearm(crate::WATCH, &just_short, &policy),
+            Rearm::Hold {
+                reason: Hold::Unmoved
+            }
+        );
+
+        let far_enough = Baseline {
+            commits: Some(DEFAULT_REARM_COMMITS),
+            days: Some(0),
+            noisy: false,
+        };
+        assert_eq!(
+            rearm(crate::WATCH, &far_enough, &policy),
+            Rearm::Reopen { lens: "rubric" }
+        );
+    }
+
+    /// Days are the other way in, for a tree that merges rarely.
+    #[test]
+    fn enough_days_reopen_the_ladder_on_their_own() {
+        let policy = SupplyPolicy {
+            rearm: true,
+            ..SupplyPolicy::default()
+        };
+        let slow = Baseline {
+            commits: Some(1),
+            days: Some(DEFAULT_REARM_DAYS),
+            noisy: false,
+        };
+        assert_eq!(
+            rearm(crate::WATCH, &slow, &policy),
+            Rearm::Reopen { lens: "rubric" }
+        );
+    }
+
+    /// An open lens has a question left, so there is nothing to re-arm.
+    #[test]
+    fn an_open_lens_is_not_rearmed() {
+        let policy = SupplyPolicy {
+            rearm: true,
+            ..SupplyPolicy::default()
+        };
+        let moved = Baseline {
+            commits: Some(10_000),
+            days: Some(10_000),
+            noisy: false,
+        };
+        assert_eq!(
+            rearm("rubric", &moved, &policy),
+            Rearm::Hold {
+                reason: Hold::LadderOpen
+            }
+        );
+    }
+
+    /// A loop that files far more than it finds is narrowed, not widened.
+    #[test]
+    fn a_noisy_loop_does_not_widen() {
+        let policy = SupplyPolicy {
+            rearm: true,
+            ..SupplyPolicy::default()
+        };
+        let moved = Baseline {
+            commits: Some(10_000),
+            days: Some(10_000),
+            noisy: true,
+        };
+        assert_eq!(
+            rearm(crate::WATCH, &moved, &policy),
+            Rearm::Hold {
+                reason: Hold::Noisy
+            }
+        );
+    }
+
+    /// With nothing recorded, the loop cannot say the base moved, so it does
+    /// not act as though it had.
+    #[test]
+    fn an_unknown_baseline_holds_the_ladder_shut() {
+        let policy = SupplyPolicy {
+            rearm: true,
+            ..SupplyPolicy::default()
+        };
+        assert_eq!(
+            rearm(crate::WATCH, &Baseline::default(), &policy),
+            Rearm::Hold {
+                reason: Hold::NoBaseline
+            }
+        );
+    }
+
+    /// **The witness for the sweep's yield.** A re-opened lens offers only
+    /// what the seen set does not already hold.
+    #[test]
+    fn a_reopened_sweep_yields_only_digests_absent_from_the_seen_set() {
+        let old = finding("the parser drops a trailing comma");
+        let fresh = finding("the writer forgets the closing brace");
+        let seen = vec![crate::finding_digest(&old.title)];
+
+        let out = novel(&[old.clone(), fresh.clone()], &seen);
+
+        assert_eq!(out, vec![&fresh]);
+    }
+
+    /// The same defect with a shifted line number is one finding, because the
+    /// digest normalizes it. That is what keeps a re-pass cheap.
+    #[test]
+    fn a_shifted_line_number_is_the_same_finding() {
+        let first = finding("parser.rs:120 drops a trailing comma");
+        let again = finding("parser.rs:481 drops a trailing comma");
+        let seen = vec![crate::finding_digest(&first.title)];
+
+        assert!(novel(&[again], &seen).is_empty());
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -47,6 +47,7 @@ pub(crate) mod residue;
 pub(crate) mod state;
 mod stats;
 mod stop;
+mod supply;
 mod surface;
 mod triage;
 pub(crate) mod turn_flags;
@@ -1051,6 +1052,12 @@ fn cycle_end(
         let mut cal = st.calibration();
         cal.extra
             .insert("last_clean_head".to_string(), Value::String(head));
+        // And when. A tree that merges rarely still drifts, so the re-arm rule
+        // reads the date as well as the commit count.
+        cal.extra.insert(
+            "last_clean_at".to_string(),
+            Value::from(crate::timefmt::now_unix()),
+        );
         st.write_calibration(&cal)?;
     }
     Ok(())

--- a/crates/stella-cli/src/self_driving_cmd/audit.rs
+++ b/crates/stella-cli/src/self_driving_cmd/audit.rs
@@ -86,6 +86,8 @@ pub(super) enum Action {
     PrMerged,
     /// A pull request was handed to a human.
     PrEscalated,
+    /// A supply that does not drain was drawn from.
+    Swept,
     /// An issue was filed.
     IssueFiled,
     /// An issue was closed.
@@ -121,6 +123,7 @@ impl Action {
             Self::PrObserved => "pr observed",
             Self::PrMerged => "pr merged",
             Self::PrEscalated => "pr escalated",
+            Self::Swept => "swept",
             Self::IssueFiled => "filed",
             Self::IssueClosed => "closed",
             Self::Waited => "waiting",

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -72,6 +72,9 @@ pub(crate) struct LoopConfig {
     /// Whether the drive loop also watches the release workflow's latest run
     /// and files on red. On unless `stella.toml` says `deploy_watch = "off"`.
     pub deploy_watch: bool,
+    /// Where the loop looks for work once the ranked queue is empty. Every
+    /// supply is shut unless `[self_driving.supply]` opens one.
+    pub supply: stella_autonomy::supply::SupplyPolicy,
     /// Which coding agent performs issue work.
     pub worker: crate::settings::toml_config::WorkerSection,
 }
@@ -90,6 +93,7 @@ impl Default for LoopConfig {
             verify_timeout_secs: 1800,
             residue_gate: true,
             deploy_watch: true,
+            supply: stella_autonomy::supply::SupplyPolicy::default(),
             worker: crate::settings::toml_config::WorkerSection::default(),
         }
     }
@@ -123,6 +127,7 @@ pub(crate) fn load(root: &Path) -> LoopConfig {
         verify_timeout_secs: parsed.self_driving.verify.timeout_secs.unwrap_or(1800),
         residue_gate: parsed.self_driving.residue_gate.enabled(),
         deploy_watch: parsed.self_driving.deploy_watch.enabled(),
+        supply: parsed.self_driving.supply.policy(),
         worker: parsed.self_driving.worker,
     }
 }

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -52,10 +52,11 @@
 //! # What this slice performs, and what it only reports
 //!
 //! It drives `claim → work → deliver`, the path that produces pull requests.
-//! `Sweep` and `Curate` are returned by the machine and **reported rather than
-//! performed** — B4 and B6 build them. Each says out loud that it is not built
-//! and stops, rather than spinning on a step it cannot take: a driver that did
-//! nothing for a step it was handed would look healthy forever.
+//! When an operator opens one of the extra supplies it sweeps as well: it
+//! re-checks the fixes it has claimed, and reads its own ledger for habits.
+//! `Curate` is the one step left that the machine can ask for and this build
+//! cannot take, so it says so and stops. A driver that did nothing for a step
+//! it was handed would look healthy forever.
 
 use std::collections::HashMap;
 
@@ -283,6 +284,9 @@ pub(super) fn drive(
     let mut state = LoopState {
         planned: true,
         batch: max_issues,
+        // Where the loop looks once the queue is dry. `None` unless an
+        // operator opened a supply, which is what keeps an upgrade quiet.
+        lens: super::supply::open_lens(durable, &cfg, &root),
         ..LoopState::default()
     };
     // Best effort: a tracker that refuses the label costs the loop its record
@@ -989,16 +993,12 @@ pub(super) fn drive(
             },
 
             LoopStep::Sweep { lens } => {
-                audit::record(
-                    durable,
-                    Audit::SessionStopped,
-                    None,
-                    &format!(
-                        "the machine asked to sweep `{lens}` and this build cannot — B4 builds \
-                         it (#3599). Stopping rather than spinning on a step it cannot take."
-                    ),
-                );
-                return report(durable, &tally, &budget);
+                // A sweep that files nothing shuts the supply for the rest of
+                // this run, so the loop falls through to watch instead of
+                // asking for the same step again.
+                if !super::supply::pass(durable, &provider, &cfg, &root, &lens) {
+                    state.lens = None;
+                }
             }
 
             LoopStep::Curate => {

--- a/crates/stella-cli/src/self_driving_cmd/lifecycle.rs
+++ b/crates/stella-cli/src/self_driving_cmd/lifecycle.rs
@@ -271,11 +271,20 @@ fn apply_closure(
     // Counted by canonical resolution through `record_closure`, so the three
     // kinds cannot drift from the total — the balance a dashboard shows beside
     // them is true by construction rather than by every call site remembering.
+    //
+    // The receipt is written here too. It says what the closure cited, so a
+    // later sweep can ask whether that change is still on the base branch.
     match durable {
-        Some(state) => state.update_stats(|s| s.record_closure(canonical)),
-        None => state::LoopState::open()
-            .map(|st| st.update_stats(|s| s.record_closure(canonical)))
-            .unwrap_or_default(),
+        Some(state) => {
+            state.update_stats(|s| s.record_closure(canonical));
+            super::supply::record_receipt(state, key, closure);
+        }
+        None => {
+            if let Ok(state) = state::LoopState::open() {
+                state.update_stats(|s| s.record_closure(canonical));
+                super::supply::record_receipt(&state, key, closure);
+            }
+        }
     }
 
     // After the tracker has taken it, so a subscriber woken by this event

--- a/crates/stella-cli/src/self_driving_cmd/state.rs
+++ b/crates/stella-cli/src/self_driving_cmd/state.rs
@@ -88,6 +88,20 @@ pub(crate) fn floors() -> Floors {
 // Resolution
 // ---------------------------------------------------------------------------
 
+/// Whether a git command succeeded, ignoring what it printed.
+///
+/// [`git`] answers with output, so a command that succeeds silently reads as a
+/// failure there. `merge-base --is-ancestor` is exactly that shape: it prints
+/// nothing and says yes or no in its exit code.
+pub(crate) fn git_ok(root: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
 pub(crate) fn git(root: &Path, args: &[&str]) -> Option<String> {
     let out = Command::new("git")
         .arg("-C")
@@ -265,6 +279,9 @@ impl LoopState {
     fn queue_path(&self) -> PathBuf {
         self.dir.join("queue.json")
     }
+    fn receipts_path(&self) -> PathBuf {
+        self.dir.join("receipts.jsonl")
+    }
 
     /// Snapshot the ranked queue as the loop last saw it.
     ///
@@ -426,6 +443,33 @@ impl LoopState {
 
     pub fn add_seen(&self, digest: &str) -> Result<(), String> {
         append_line(&self.seen_path(), digest)
+    }
+
+    // -- closure receipts ---------------------------------------------------
+
+    /// Every closure this loop has written down.
+    ///
+    /// A line that does not parse is skipped, the same rule the ledger reads
+    /// by: one bad line must not hide the rest.
+    pub fn receipts(&self) -> Vec<stella_autonomy::regress::ClosureReceipt> {
+        read_jsonl(&self.receipts_path())
+            .values
+            .into_iter()
+            .filter_map(|value| serde_json::from_value(value).ok())
+            .collect()
+    }
+
+    /// Write down what a closure cited, so it can be re-checked later.
+    ///
+    /// Append-only, like the ledger beside it. The file is the whole basis of
+    /// the regression sweep: a closure nobody wrote down is a claim nothing
+    /// can ever falsify.
+    pub fn append_receipt(
+        &self,
+        receipt: &stella_autonomy::regress::ClosureReceipt,
+    ) -> Result<(), String> {
+        let line = serde_json::to_string(receipt).map_err(|e| e.to_string())?;
+        append_line(&self.receipts_path(), &line)
     }
 
     // -- the run lifecycle ---------------------------------------------------

--- a/crates/stella-cli/src/self_driving_cmd/supply.rs
+++ b/crates/stella-cli/src/self_driving_cmd/supply.rs
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Drawing work from the supplies that do not drain.
+//!
+//! The ranked queue runs out. Three other supplies do not.
+//! `stella_autonomy::supply` holds the rules for them. This module is the half
+//! that touches the world. It asks git how far the base has moved, reads the
+//! loop's own files, and files what the rules hand back.
+//!
+//! Each supply is shut until an operator opens it in `stella.toml`. A build
+//! that gains this code changes no running loop.
+//!
+//! # What one pass does
+//!
+//! [`pass`] draws from each open supply in turn. What the seen set already
+//! holds is dropped first, so a re-pass yields the new code and nothing else.
+//! The rest is filed through `backlog::file_finding`, the one door: it checks
+//! the digest and the workspace rules before the tracker is reached.
+//!
+//! A pass that files nothing returns `false`. The driver then shuts the supply
+//! for the rest of the run, so the loop cannot ask for the same step again and
+//! again.
+//!
+//! `doc:backlog-self-driving` §4 is the design.
+
+use std::path::Path;
+
+use stella_autonomy::regress::ClosureReceipt;
+use stella_autonomy::supply::{Baseline, Finding, Rearm};
+use stella_autonomy::{Citation, Closure};
+use stella_protocol::issue::{IssueDraft, IssueLabel, IssueProvider};
+
+use super::audit::{self, Action as Audit};
+use super::config::LoopConfig;
+use super::state::LoopState as Durable;
+use super::{backlog, convention, state};
+
+/// The lens the loop has open, or `None` when no supply is.
+///
+/// Read once per run, before the first step. Anything but `None` makes the
+/// machine ask for a sweep when the queue is dry.
+///
+/// When the ladder is spent the re-arm rule says whether it opens again. That
+/// write lands on disk, so the rung the loop picks up survives the run.
+pub(super) fn open_lens(durable: &Durable, cfg: &LoopConfig, root: &Path) -> Option<String> {
+    if !cfg.supply.any_open() {
+        return None;
+    }
+    let aperture = durable.aperture();
+    if aperture != stella_autonomy::WATCH {
+        return Some(aperture);
+    }
+
+    let base = baseline(durable, root);
+    // Decided before the match, so the borrow of `aperture` ends here and the
+    // hold arm below can hand the name back.
+    let decision = stella_autonomy::supply::rearm(&aperture, &base, &cfg.supply);
+    match decision {
+        Rearm::Reopen { lens } => match durable.set_aperture(lens) {
+            Ok(()) => {
+                audit::record(
+                    durable,
+                    Audit::Swept,
+                    None,
+                    &format!(
+                        "the base has moved since the last clean sweep, so the ladder \
+                         re-opens at `{lens}`"
+                    ),
+                );
+                Some(lens.to_owned())
+            }
+            Err(error) => {
+                audit::record(
+                    durable,
+                    Audit::Transient,
+                    None,
+                    &format!("could not re-open the ladder at `{lens}`: {error}"),
+                );
+                None
+            }
+        },
+        // Still a supply to draw from: `regress` and `meta` do not need a
+        // lens. The name is what the machine reports, not what it draws from.
+        Rearm::Hold { .. } => Some(aperture),
+    }
+}
+
+/// Draw from every open supply once. `true` when something reached the
+/// tracker.
+pub(super) fn pass(
+    durable: &Durable,
+    provider: &dyn IssueProvider,
+    cfg: &LoopConfig,
+    root: &Path,
+    lens: &str,
+) -> bool {
+    let mut findings: Vec<Finding> = Vec::new();
+
+    if cfg.supply.regress {
+        let receipts = durable.receipts();
+        let report = stella_autonomy::regress::sweep(&receipts, |cite| present_on_base(root, cite));
+        audit::record(
+            durable,
+            Audit::Swept,
+            None,
+            &format!(
+                "regress: {} of {} receipt(s) re-checked, {} could not be, {} fix(es) gone",
+                report.checked,
+                receipts.len(),
+                report.skipped.len(),
+                report.findings.len()
+            ),
+        );
+        findings.extend(report.findings);
+    }
+
+    if cfg.supply.meta {
+        let rows = durable.cycles().rows;
+        let found = stella_autonomy::meta::sweep(&rows, &durable.calibration());
+        audit::record(
+            durable,
+            Audit::Swept,
+            None,
+            &format!(
+                "meta: {} finding(s) over {} cycle(s)",
+                found.len(),
+                rows.len()
+            ),
+        );
+        findings.extend(found);
+    }
+
+    let seen = durable.seen();
+    let fresh: Vec<Finding> = stella_autonomy::supply::novel(&findings, &seen)
+        .into_iter()
+        .cloned()
+        .collect();
+    if fresh.is_empty() {
+        audit::record(
+            durable,
+            Audit::Swept,
+            None,
+            &format!(
+                "the `{lens}` sweep found nothing the seen set does not already hold \
+                 ({} finding(s) offered)",
+                findings.len()
+            ),
+        );
+        return false;
+    }
+
+    let mut filed = 0_u32;
+    for finding in &fresh {
+        match file(durable, provider, cfg, root, finding) {
+            Ok(true) => filed += 1,
+            Ok(false) => {}
+            Err(error) => audit::record(
+                durable,
+                Audit::Transient,
+                None,
+                &format!("could not file `{}`: {error}", finding.title),
+            ),
+        }
+    }
+    filed > 0
+}
+
+/// Write down what a closure cited, and whether that change was on the base.
+///
+/// Called as an issue closes. Both closing paths funnel through one place, so
+/// both write a receipt. The check runs now rather than later so a sweep can
+/// tell *gone* from *never seen*.
+pub(super) fn record_receipt(durable: &Durable, key: &str, closure: &Closure) {
+    let root = durable.repo_root.as_path();
+    let by = match closure {
+        Closure::Fixed { by } | Closure::Partial { by, .. } => Some(by.clone()),
+        Closure::NotPlanned { .. } | Closure::Duplicate { .. } => None,
+    };
+    let present_at_close = by.as_ref().map(|cite| {
+        // The merge that carried the fix may be newer than this clone's copy
+        // of the base. Fetch first, or every fix reads as absent and the
+        // sweep has nothing it can ever check.
+        let _ = state::git(root, &["fetch", "--quiet", "origin"]);
+        present_on_base(root, cite)
+    });
+
+    let receipt = ClosureReceipt {
+        key: key.trim().trim_start_matches('#').to_owned(),
+        closed_at: crate::timefmt::rfc3339_utc_now(),
+        by,
+        present_at_close,
+    };
+    if let Err(error) = durable.append_receipt(&receipt) {
+        audit::record(
+            durable,
+            Audit::Transient,
+            None,
+            &format!("could not write the receipt for #{key}: {error}"),
+        );
+    }
+}
+
+/// Whether the change a citation names is on the base branch now.
+///
+/// A commit is asked about by sha. A pull request is looked for by the `(#N)`
+/// a squash merge leaves in the subject line. Anything else answers `false`.
+/// A document names a choice, and a choice cannot leave a branch.
+fn present_on_base(root: &Path, cite: &Citation) -> bool {
+    match cite {
+        Citation::Commit { sha } => {
+            let sha = sha.trim();
+            if sha.is_empty() {
+                return false;
+            }
+            let base = super::work::base_ref(root);
+            state::git_ok(root, &["merge-base", "--is-ancestor", sha, base.as_str()])
+        }
+        Citation::PullRequest { key } => {
+            let key = key.trim().trim_start_matches('#');
+            if key.is_empty() {
+                return false;
+            }
+            let base = super::work::base_ref(root);
+            let needle = format!("--grep=(#{key})");
+            state::git(
+                root,
+                &[
+                    "log",
+                    "-n",
+                    "1",
+                    "--format=%H",
+                    "--fixed-strings",
+                    needle.as_str(),
+                    base.as_str(),
+                ],
+            )
+            .is_some()
+        }
+        Citation::Document { .. } | Citation::ContextRecord { .. } => false,
+    }
+}
+
+/// How far the base has moved since the last clean sweep.
+fn baseline(durable: &Durable, root: &Path) -> Baseline {
+    let cal = durable.calibration();
+    let head = cal
+        .extra
+        .get("last_clean_head")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .filter(|head| !head.is_empty() && head.as_str() != "none");
+    let at = cal
+        .extra
+        .get("last_clean_at")
+        .and_then(serde_json::Value::as_i64);
+
+    let base = super::work::base_ref(root);
+    let commits = head
+        .and_then(|head| {
+            let range = format!("{head}..{base}");
+            state::git(root, &["rev-list", "--count", range.as_str()])
+        })
+        .and_then(|count| count.trim().parse::<u64>().ok());
+    let days = at.map(|then| {
+        let elapsed = crate::timefmt::now_unix().saturating_sub(then).max(0);
+        elapsed as u64 / 86_400
+    });
+
+    Baseline {
+        commits,
+        days,
+        noisy: noisy(durable),
+    }
+}
+
+/// Whether the loop files far more than it finds.
+fn noisy(durable: &Durable) -> bool {
+    stella_autonomy::metrics(&durable.cycles().rows)
+        .signals
+        .iter()
+        .any(|signal| signal.code == "NOISY")
+}
+
+/// File one finding through the door every filing goes through.
+///
+/// `Ok(true)` means the tracker took it. A repeat and a refusal are both
+/// `Ok(false)`. Neither is an error, and both are counted already.
+fn file(
+    durable: &Durable,
+    provider: &dyn IssueProvider,
+    cfg: &LoopConfig,
+    root: &Path,
+    finding: &Finding,
+) -> Result<bool, String> {
+    let bound = convention::load(root);
+    let draft = IssueDraft {
+        title: finding.title.clone(),
+        body: finding.body.clone(),
+        labels: finding
+            .labels
+            .iter()
+            .map(|name| IssueLabel { name: name.clone() })
+            .collect(),
+        parent: None,
+        assignee: None,
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start a runtime for the issue provider: {error}"))?;
+    let outcome = runtime
+        .block_on(backlog::file_finding(
+            provider,
+            &bound.convention,
+            &durable.seen(),
+            &draft,
+            &cfg.attribution.issue,
+        ))
+        .map_err(|error| error.to_string())?;
+
+    durable.update_stats(|stats| stats.record_filing(outcome.canonical()));
+
+    if let backlog::Filed::New(key) = &outcome {
+        durable.add_seen(&stella_autonomy::finding_digest(&finding.title))?;
+        audit::record(
+            durable,
+            Audit::IssueFiled,
+            Some(&key.to_string()),
+            &finding.title,
+        );
+        return Ok(true);
+    }
+
+    audit::record(
+        durable,
+        Audit::Swept,
+        None,
+        &format!("not filed ({}): {}", outcome.canonical(), finding.title),
+    );
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **The witness.** A workspace that says nothing about supplies opens
+    /// none, so a build that gains this code changes no running loop.
+    #[test]
+    fn a_default_workspace_opens_no_supply() {
+        let cfg = LoopConfig::default();
+
+        assert!(!cfg.supply.any_open());
+        assert!(!cfg.supply.rearm);
+        assert!(!cfg.supply.regress);
+        assert!(!cfg.supply.meta);
+    }
+
+    /// The document's own switches reach the policy the loop reads.
+    #[test]
+    fn the_document_switches_reach_the_policy() {
+        use crate::settings::toml_config::{SupplySection, SupplySwitch};
+
+        let section = SupplySection {
+            rearm: SupplySwitch::On,
+            regress: SupplySwitch::Off,
+            meta: SupplySwitch::On,
+            rearm_commits: Some(7),
+            rearm_days: None,
+        };
+        let policy = section.policy();
+
+        assert!(policy.rearm);
+        assert!(!policy.regress);
+        assert!(policy.meta);
+        assert_eq!(policy.rearm_commits, 7);
+        assert_eq!(
+            policy.rearm_days,
+            stella_autonomy::supply::DEFAULT_REARM_DAYS
+        );
+    }
+
+    /// A decision cannot leave a branch, so a document citation is never
+    /// reported as a fix that went missing.
+    #[test]
+    fn an_authority_citation_is_never_present_on_a_branch() {
+        let cite = Citation::Document {
+            doc_id: "doc:backlog-self-driving".to_owned(),
+        };
+
+        assert!(!present_on_base(Path::new("."), &cite));
+    }
+}

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -429,6 +429,10 @@ pub struct SelfDrivingSection {
     /// find it to turn the gate on.
     #[serde(default)]
     pub residue_gate: ResidueGateSwitch,
+    /// `[self_driving.supply]` — where the loop looks for work once the
+    /// ranked queue is empty.
+    #[serde(default)]
+    pub supply: SupplySection,
     /// `deploy_watch = "on" | "off"` — whether the drive loop also watches
     /// the release workflow's latest run and files on red. On unless an
     /// operator stands it down: a watch that must be asked for is a watch
@@ -442,6 +446,69 @@ pub struct SelfDrivingSection {
     /// same rule `[self_driving.triage]`'s lists follow.
     #[serde(default)]
     pub container_labels: Vec<String>,
+}
+
+/// `[self_driving.supply]` — where the loop looks for work when the ranked
+/// queue is empty.
+///
+/// Every switch here starts off. The queue is the only supply that drains,
+/// and it is the only one a fresh install draws from. An operator turns one on
+/// when they want the loop to keep going without them. An endless supply of
+/// work is not an endless supply of *useful* work, so each one is a choice
+/// somebody makes rather than a default they inherit.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SupplySection {
+    /// `rearm = "on" | "off"` — re-open the lens ladder once the base branch
+    /// has moved. A lens that found nothing at one commit says nothing about
+    /// the tree two hundred commits later.
+    pub rearm: SupplySwitch,
+    /// `regress = "on" | "off"` — re-check the fixes this loop has claimed. A
+    /// fix that has left the base branch is a defect again.
+    pub regress: SupplySwitch,
+    /// `meta = "on" | "off"` — read the loop's own ledger for habits it should
+    /// file against itself.
+    pub meta: SupplySwitch,
+    /// `rearm_commits = <n>` — how many commits the base must gain before a
+    /// dry ladder re-opens. Absent means the built-in number.
+    pub rearm_commits: Option<u64>,
+    /// `rearm_days = <n>` — how many days may pass instead, for a tree that
+    /// merges rarely. Absent means the built-in number.
+    pub rearm_days: Option<u64>,
+}
+
+impl SupplySection {
+    /// The policy the loop reads.
+    #[must_use]
+    pub fn policy(self) -> stella_autonomy::supply::SupplyPolicy {
+        let built_in = stella_autonomy::supply::SupplyPolicy::default();
+        stella_autonomy::supply::SupplyPolicy {
+            rearm: self.rearm.enabled(),
+            regress: self.regress.enabled(),
+            meta: self.meta.enabled(),
+            rearm_commits: self.rearm_commits.unwrap_or(built_in.rearm_commits),
+            rearm_days: self.rearm_days.unwrap_or(built_in.rearm_days),
+        }
+    }
+}
+
+/// One supply switch. Off unless an operator turns it on.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SupplySwitch {
+    /// Draw from this supply.
+    On,
+    /// Do not. The default.
+    #[default]
+    Off,
+}
+
+impl SupplySwitch {
+    /// Whether the supply is open.
+    #[must_use]
+    pub fn enabled(self) -> bool {
+        matches!(self, Self::On)
+    }
 }
 
 /// The end-of-turn residue gate's switch (`doc:backlog-self-driving` B5).

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -622,6 +622,28 @@ residue_gate = "on"
 # it, the same rule `self_driving.triage`'s lists follow.
 container_labels = ["epic"]
 
+[self_driving.supply]
+# Where the loop looks for work once the ranked queue is empty. Every switch
+# here is OFF, and that is the shipped default: the queue is the only supply
+# that drains, so it is the only one a fresh install draws from. An endless
+# supply of work is not an endless supply of USEFUL work, which is why each of
+# these is a choice somebody makes rather than one they inherit.
+#
+# rearm  — re-open the lens ladder once the base branch has moved. A lens that
+#          found nothing at one commit says nothing about the tree two hundred
+#          commits later.
+# regress— re-check the fixes this loop has already claimed. A fix that has
+#          left the base branch is a defect again, and that is a fact rather
+#          than a claim needing triage.
+# meta   — read the loop's own ledger for habits it should file against itself.
+rearm = "off"
+regress = "off"
+meta = "off"
+# How far the base must move before a dry ladder re-opens. Either bound alone
+# is enough: a busy tree trips the commit count, a quiet one trips the days.
+rearm_commits = 50
+rearm_days = 30
+
 [self_driving.attribution]
 # What the loop appends to what it writes. Source-tracked so it travels with the
 # repository, and rewritable by an installed plugin — a downstream distribution

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -619,6 +619,44 @@ machine is a weaker signal than a clean CI run and a far stronger one than nothi
   </OptionCard>
 </CardGrid>
 
+#### `[self_driving.supply]`
+
+Where the loop looks for work once the ranked queue is empty. Every switch here is off,
+and that is the shipped default. The queue is the only supply that drains, so it is the
+only one a fresh install draws from. An endless supply of work is not an endless supply
+of *useful* work, so each of these is a choice somebody makes rather than one they
+inherit.
+
+Nothing a sweep finds can be filed twice. Every filing goes through the same dedup set,
+keyed by a digest of the finding's own words, so re-passing a lens yields what the new
+code introduced and nothing else.
+
+<CardGrid size="sm">
+  <OptionCard name="self_driving.supply.rearm" defaultValue="off">
+    Re-open the lens ladder once the base branch has moved. A lens that found nothing at
+    one commit says nothing about the tree two hundred commits later. Held shut while the
+    loop's own ledger reports `NOISY`: a loop filing far more than it finds should narrow
+    rather than open one more lens.
+  </OptionCard>
+  <OptionCard name="self_driving.supply.regress" defaultValue="off">
+    Re-check the fixes this loop has already claimed. As it closes an issue the loop
+    writes down what the closure cited and whether that change was on the base branch at
+    the time. A change that was there and is gone is a fact rather than a claim needing
+    triage, and it is filed as a fresh defect.
+  </OptionCard>
+  <OptionCard name="self_driving.supply.meta" defaultValue="off">
+    Read the loop's own ledger for habits it should file against itself — a raised signal
+    nobody has acted on, or a lens that has looked several times and found nothing at all.
+  </OptionCard>
+  <OptionCard name="self_driving.supply.rearm_commits" defaultValue="50">
+    How many commits the base must gain before a dry ladder re-opens.
+  </OptionCard>
+  <OptionCard name="self_driving.supply.rearm_days" defaultValue="30">
+    How many days may pass instead, for a tree that merges rarely. Either bound alone is
+    enough.
+  </OptionCard>
+</CardGrid>
+
 #### `[self_driving.doctrine]`
 
 How the loop decides things where two operators would decide differently. These are


### PR DESCRIPTION
## What and why

`stella_autonomy::step` already returns `LoopStep::Sweep { lens }` when the
ranked queue is empty and a lens is still open. Nothing performed it. `drive.rs`
recorded that this build could not sweep and returned — and `state.lens` was
never set from anything, so the step was unreachable in the driver at all.

This builds the three supplies `doc:backlog-self-driving` §4 names, each behind
its own switch, and every switch off by default (`[self_driving.supply]`).

**`rearm`** (§4.2) — a dry ladder re-opens at `rubric` once the base branch has
moved past a declared distance since the sweep that exhausted it: 50 commits or
30 days, either bound alone. The distance is read from `last_clean_head` (already
written) plus a new `last_clean_at` beside it. Held shut while the loop's own
ledger raises `NOISY`, which is §4.4's "narrow rather than widen" made real
rather than reported.

**`regress`** (§4.3) — as an issue closes, `apply_closure` writes a
`ClosureReceipt` to `receipts.jsonl`: what the closure cited, and whether that
change was on the base branch at the time (a commit by `merge-base
--is-ancestor`, a pull request by the `(#N)` a squash merge leaves in the
subject). The sweep asks the same question again. **Only a green→red counts**:
a change that was there and is gone is a fact and is filed; a change nobody
could see at close time is counted as unsweepable and reported, never filed.
That is what stops the sweep reporting *gone* for something that was never
there — the one false positive class this design could have had.

**`meta`** (§4.1) — the ledger read against the loop itself: one defect per
raised signal (`STUCK`/`NOISY`/`FRAGILE`/`STARVED`, which today are printed to
nobody), and one per lens that has run at least three cycles and never produced
a finding, because a lens whose tool fails reports the same nothing as a lens
whose answer is nothing.

Everything files through `backlog::file_finding`, so the digest dedup and the
workspace convention check both hold. **`finding_digest` is byte-for-byte
untouched** — every existing `seen.txt` keeps deduplicating, and the existing
`the_seen_set_survives_the_move_byte_for_byte` test is unchanged.

A sweep that files nothing shuts the supply for the rest of the run, so the
driver falls through to `Watch` instead of asking for the same step forever.

## Witness mechanism

Every witness below **fails on `main` by construction**: the modules, the
config section and the receipt file do not exist there, so the tests do not
compile against the old tree.

| Witness | What it pins |
|---|---|
| `supply::tests::every_supply_is_shut_by_default` | an upgrade changes no running loop |
| `supply::tests::a_dry_ladder_reopens_once_the_base_has_moved_far_enough` | what "moved enough" means, at the boundary (49 holds, 50 re-opens) |
| `supply::tests::enough_days_reopen_the_ladder_on_their_own` | the second bound |
| `supply::tests::an_open_lens_is_not_rearmed` / `a_noisy_loop_does_not_widen` / `an_unknown_baseline_holds_the_ladder_shut` | the three holds |
| `supply::tests::a_reopened_sweep_yields_only_digests_absent_from_the_seen_set` | **the yield witness this phase names** |
| `supply::tests::a_shifted_line_number_is_the_same_finding` | the digest normalization the re-pass rests on |
| `regress::tests::a_fix_that_has_left_the_base_is_filed_again` | the regression finding |
| `regress::tests::a_change_unseen_at_close_is_never_reported_as_gone` | the false-positive class is closed |
| `regress::tests::a_closure_with_no_change_cited_is_counted_not_filed` | the unsweepable count is published |
| `regress::tests::an_older_receipt_line_still_parses` | a line from an older build reads as unsweepable, not as gone |
| `meta::tests::a_lens_that_never_finds_anything_becomes_a_finding` / `a_raised_signal_becomes_a_finding` | the meta supply |
| `self_driving_cmd::supply::tests::a_default_workspace_opens_no_supply` | the shipped default, read through `LoopConfig` |
| `self_driving_cmd::supply::tests::the_document_switches_reach_the_policy` | `[self_driving.supply]` reaches the machine |

## Exemplar

`stella-autonomy`'s own `closure.rs` / `deliver.rs` shape: a closed set of
outcomes plus a pure decision function, with the I/O as a caller-supplied
parameter (`sweep`'s `present_now`) rather than a dependency — the same seam
`stella-core`'s ports use.

## Scope

The driver channel's `DriverCall::SweepAudit` / `SweepRegress` / `SweepMeta`
still answer `Unsupported`. Serving these three over the wire needs the argument
and result shapes #6118 describes; this issue is the behaviour, that one is the
wire.

Tests deleted: None

## Residue filed

- #6182 — the driver never runs the lens it re-armed. The aperture is durable
  and the audit phase does run it; doing it inside one `drive` run needs a model
  seat for each lens's `interpret` step, which is bigger than this change.
- #6183 — `SweepAudit` / `SweepRegress` / `SweepMeta` on the driver channel still
  answer `Unsupported`.
- #6184 — no hand-run `stella self-driving sweep` verb, so a supply cannot be
  tried before its switch is turned on.

Closes #6146

## Summary by Sourcery

Enable the self-driving loop to draw useful work from configurable non-draining supplies when its ranked queue is empty.

New Features:
- Add configurable work supplies for re-arming dry lens sweeps, detecting regressions in previously closed fixes, and identifying issues in the loop's own ledger.
- Allow self-driving sweeps to execute when the ranked queue is empty and file novel findings through the existing backlog workflow.

Bug Fixes:
- Prevent repeated empty sweep steps from causing the driver to loop indefinitely by disabling the supply for the remainder of the run when no new finding is filed.
- Ensure regression checks only report changes that were present at closure and are now absent, avoiding false positives for changes that were never observed.

Enhancements:
- Persist closure receipts and clean-sweep timestamps to support later regression and re-arm decisions.
- Keep all new supplies disabled by default while supporting independent configuration of their switches and re-arm thresholds.

Documentation:
- Document the new self-driving supply configuration and its re-arm thresholds.
- Describe the new autonomy modules and supply behavior in the autonomy README.

Tests:
- Add coverage for supply defaults, re-arm thresholds and safeguards, regression classification, receipt compatibility, meta findings, deduplication, and configuration propagation.
