### PR TITLE
feat(stella-parity): say what each turn lane binds, seam by seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3469,6 +3469,7 @@ dependencies = [
 name = "stella-parity"
 version = "0.9.352"
 dependencies = [
+ "stella-core",
  "stella-protocol",
  "stella-serve",
 ]

--- a/crates/stella-cli/src/lane_capabilities.rs
+++ b/crates/stella-cli/src/lane_capabilities.rs
@@ -158,6 +158,15 @@ mod tests {
         }
     }
 
+    struct NoRequery;
+
+    #[async_trait::async_trait]
+    impl SteeringRequery for NoRequery {
+        async fn requery(&self, _signal: &stella_core::steering::TurnSignal<'_>) -> Option<String> {
+            None
+        }
+    }
+
     /// **The lane witnesses.** Each of this crate's four lanes says which
     /// lane it is.
     ///
@@ -212,17 +221,39 @@ mod tests {
     /// `Engine::assemble` may not change one of these. An engine that gained
     /// a gate would park where nothing parked before. One that lost its
     /// calibration map would start each turn from a raw estimate.
+    ///
+    /// Both directions, for every seam a caller may or may not hand in: a
+    /// lane must pass on what it is given and must not invent what it is
+    /// not. `stella-parity`'s lane matrix names this test as the witness for
+    /// each of these rows, and a row is only worth its name if the test
+    /// exercises the seam it claims.
     #[test]
     fn each_lane_binds_what_its_call_site_bound_before() {
         let runner = HostHookRunner;
         let calibration = CalibrationMap::default();
         let gate = OpenGate;
         let steering = QuietSteering;
+        let hooks = Hooks::default();
+        let plane = NoRequery;
 
         let deck = lead(None, &runner, &calibration, &gate, &steering, None);
         assert!(deck.calibration.is_some() && deck.gate.is_some() && deck.steering.is_some());
         assert!(deck.requery.is_none(), "no plane was handed in");
         assert!(deck.hooks.is_none(), "no hooks were given");
+        assert_eq!(deck.call_role, ModelCallRole::Worker);
+
+        let deck_with_both = lead(
+            Some(&hooks),
+            &runner,
+            &calibration,
+            &gate,
+            &steering,
+            Some(&plane),
+        );
+        assert!(
+            deck_with_both.hooks.is_some() && deck_with_both.requery.is_some(),
+            "the lead turn must pass on the seams its caller handed it",
+        );
 
         let replayed = resume(None, &runner, &calibration);
         assert!(replayed.calibration.is_some());
@@ -230,15 +261,28 @@ mod tests {
             replayed.gate.is_none() && replayed.steering.is_none(),
             "a replayed turn binds neither, and must not grow one here",
         );
+        assert_eq!(replayed.call_role, ModelCallRole::Worker);
+        assert!(
+            resume(Some(&hooks), &runner, &calibration).hooks.is_some(),
+            "a replayed turn must run the hooks its caller handed it",
+        );
 
         let worker = sub_session(&calibration, &gate, &steering);
         assert!(worker.calibration.is_some() && worker.gate.is_some() && worker.steering.is_some(),);
+        assert_eq!(worker.call_role, ModelCallRole::Worker);
 
         let fleet = fleet_attempt(None, &runner, &calibration, &gate);
         assert!(fleet.calibration.is_some() && fleet.gate.is_some());
         assert!(
             fleet.steering.is_none(),
             "a fleet attempt has no input channel to steer from",
+        );
+        assert_eq!(fleet.call_role, ModelCallRole::Worker);
+        assert!(
+            fleet_attempt(Some(&hooks), &runner, &calibration, &gate)
+                .hooks
+                .is_some(),
+            "a fleet attempt must run the hooks its caller handed it",
         );
     }
 }

--- a/crates/stella-parity/Cargo.toml
+++ b/crates/stella-parity/Cargo.toml
@@ -17,3 +17,9 @@ stella-serve = { path = "../stella-serve" }
 # from (#2782). The matrix reads that policy rather than restating it, which is
 # what keeps the two ledgers from drifting apart.
 stella-protocol = { path = "../stella-protocol" }
+
+[dev-dependencies]
+# The lane matrix reads `TurnCapabilities` in a test. A new slot on that
+# struct must break this build. Nothing is added: `stella-serve` already
+# pulls this crate in.
+stella-core = { path = "../stella-core" }

--- a/crates/stella-parity/README.md
+++ b/crates/stella-parity/README.md
@@ -50,7 +50,7 @@ everywhere at once. The embedding story the matrix serves is
 
 ## Boundary — does this change belong here?
 
-Two ledgers, one discipline. `src/lib.rs` holds the CLI-vs-API capability
+Four tables, one discipline. `src/lib.rs` holds the CLI-vs-API capability
 matrix: the posture types, the matrix rows, and the tests (inline `mod
 tests`) that keep the rows true. `src/evolution.rs` holds the evolution
 ledger (AGENTS.md rule 11): one row per surface Stella changes itself
@@ -58,7 +58,12 @@ through — framework, memory, skill, tool, workflow, model — each declaring a
 posture, timing, impact class, rollback artifact, and, for a live posture,
 the witness test proving the surface can be changed; its rows and the
 `EvolutionSurface` enum come from one macro table, so a surface without a
-row does not compile. A change belongs here when it is a ledger decision — a
+row does not compile. `src/lane.rs` says which builtin lane each
+turn-assembly site stamps, and writes down why nothing stamps the one lane
+nothing does. `src/lane/capability.rs` says what each of those lanes binds:
+one row per lane and seam, with what the lane asked for beside what it got,
+each row read back against the literal its lane writes. A change belongs
+here when it is a ledger decision — a
 new row, a posture change, a witness name, a composition-seam entry,
 lowering `UNWITNESSED_BASELINE` after writing a missing witness. The capability *itself* never lives here: its engine home
 is `stella-core`, its surfaces are `stella-cli` and `stella-serve`, and this
@@ -67,7 +72,10 @@ crate only records how they relate.
 The dependency set is the boundary made concrete: `stella-serve` only, for
 `Route::ALL` — the enumerable API surface the matrix sweeps. The CLI is a
 binary crate, so its surface is checked against source text, the same
-discipline `provider_parity.rs` uses for adapter witnesses. Adding any other
+discipline `provider_parity.rs` uses for adapter witnesses. `stella-core`
+joins that set for tests alone: the lane matrix reads `TurnCapabilities`
+there, so a new slot on that struct breaks this crate's test build until
+every lane row answers it. Adding any other
 dependency here is a design smell: the matrix reads declarations and source
 text, it does not run the stack.
 

--- a/crates/stella-parity/src/lane.rs
+++ b/crates/stella-parity/src/lane.rs
@@ -20,8 +20,13 @@
 //! named witness really exists. That is enough to make an author say who
 //! stamps a lane. It is also enough to fail when a site goes back to the
 //! builder path.
+//!
+//! What a lane *binds* is the neighbouring table, [`capability`]. This one
+//! answers who names a lane; that one answers what a lane takes.
 
 use stella_protocol::BuiltinLane;
+
+pub mod capability;
 
 /// Whether a lane has a producer, and what proves it.
 #[derive(Debug)]
@@ -136,52 +141,56 @@ pub fn row(lane: BuiltinLane) -> Option<&'static Lane> {
     LANES.iter().find(|row| row.lane == lane)
 }
 
+/// Every file a row may name as a site or a witness home, as
+/// `(workspace-relative path, source)`.
+///
+/// Source text, not the module tree. `provider_parity` names the trade.
+/// A site or a witness that moves out of this list fails loudly. Extend
+/// the list to fix it. It never fails silently.
+///
+/// Shared with [`capability`], which reads the same files to check what each
+/// lane binds.
+#[cfg(test)]
+pub(crate) fn lane_sources() -> [(&'static str, &'static str); 4] {
+    [
+        // Where four of this workspace's lanes declare what they bind,
+        // and where their shared witness lives.
+        (
+            "crates/stella-cli/src/lane_capabilities.rs",
+            include_str!("../../stella-cli/src/lane_capabilities.rs"),
+        ),
+        // The fork's own assembly.
+        (
+            "crates/stella-core/src/subagent.rs",
+            include_str!("../../stella-core/src/subagent.rs"),
+        ),
+        // The fork's witness lives in a split-out test module, which
+        // `include_str!` of the parent does not pull in.
+        (
+            "crates/stella-core/src/subagent/tests/seams.rs",
+            include_str!("../../stella-core/src/subagent/tests/seams.rs"),
+        ),
+        // The served turn's assembly and its witness, in one file.
+        (
+            "crates/stella-serve/src/session.rs",
+            include_str!("../../stella-serve/src/session.rs"),
+        ),
+    ]
+}
+
+/// The source of one swept file, by its workspace-relative path.
+#[cfg(test)]
+pub(crate) fn source_named(path: &str) -> &'static str {
+    lane_sources()
+        .into_iter()
+        .find(|(name, _)| *name == path)
+        .map(|(_, source)| source)
+        .unwrap_or_else(|| panic!("a lane row names `{path}`, which `lane_sources` does not carry"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Every file a row may name as a site or a witness home, as
-    /// `(workspace-relative path, source)`.
-    ///
-    /// Source text, not the module tree. `provider_parity` names the trade.
-    /// A site or a witness that moves out of this list fails loudly. Extend
-    /// the list to fix it. It never fails silently.
-    fn lane_sources() -> [(&'static str, &'static str); 4] {
-        [
-            // Where four of this workspace's lanes declare what they bind,
-            // and where their shared witness lives.
-            (
-                "crates/stella-cli/src/lane_capabilities.rs",
-                include_str!("../../stella-cli/src/lane_capabilities.rs"),
-            ),
-            // The fork's own assembly.
-            (
-                "crates/stella-core/src/subagent.rs",
-                include_str!("../../stella-core/src/subagent.rs"),
-            ),
-            // The fork's witness lives in a split-out test module, which
-            // `include_str!` of the parent does not pull in.
-            (
-                "crates/stella-core/src/subagent/tests/seams.rs",
-                include_str!("../../stella-core/src/subagent/tests/seams.rs"),
-            ),
-            // The served turn's assembly and its witness, in one file.
-            (
-                "crates/stella-serve/src/session.rs",
-                include_str!("../../stella-serve/src/session.rs"),
-            ),
-        ]
-    }
-
-    fn source_named(path: &str) -> &'static str {
-        lane_sources()
-            .into_iter()
-            .find(|(name, _)| *name == path)
-            .map(|(_, source)| source)
-            .unwrap_or_else(|| {
-                panic!("a lane row names `{path}`, which `lane_sources` does not carry")
-            })
-    }
 
     /// Completeness, from the compiler's side and the table's.
     ///

--- a/crates/stella-parity/src/lane/capability.rs
+++ b/crates/stella-parity/src/lane/capability.rs
@@ -1,0 +1,565 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What each turn lane binds, seam by seam.
+//!
+//! [`super::LANES`] says who stamps a lane name. It stops there. The engine
+//! carries eleven capability slots, and every lane answers all of them in a
+//! struct literal in its own crate. Those literals are right, and the
+//! compiler holds them there. What was missing is one table a reader can
+//! open.
+//!
+//! This is that table. One row per lane and seam.
+//!
+//! Three asks, not two. A seam a lane refuses is a
+//! [`SeamRequest::Declined`], and it carries the reason. A seam nobody has
+//! reached is a [`SeamRequest::Deferred`], and it cites the issue that will
+//! settle it. Before this table both of them read as a bare `None`.
+//!
+//! Two answers, not one. [`SeamRow::requested`] is what the lane asked for.
+//! [`SeamRow::granted`] is what it got. Every lane here gets what it asks,
+//! because it compiles its own literal: the ask and the grant are one edit.
+//! A lane an installed plugin brings will not, and the column is here so the
+//! gate that cuts one down has somewhere to write.
+//!
+//! **What it does not prove.** A witness named here is checked for
+//! existence, never read. A row naming a test that proves something else
+//! still passes, because the name of a test is not evidence for it. So a
+//! seam with no test of its own says
+//! [`Witness::Literal`] rather than borrow a neighbour's, and
+//! [`UNWITNESSED_SEAMS`] counts those.
+
+use stella_protocol::BuiltinLane;
+
+/// Generate the seam enum and its field names from one table.
+///
+/// One place to edit. A slot added to the engine's capability struct needs a
+/// case here, and a case here needs a line in every lane block below.
+macro_rules! seams {
+    ($(
+        $(#[$meta:meta])*
+        $case:ident => $field:literal;
+    )*) => {
+        /// One capability slot on the engine's `TurnCapabilities`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub enum Seam {
+            $($(#[$meta])* $case,)*
+        }
+
+        impl Seam {
+            /// Every seam, in the order the engine declares them.
+            pub const ALL: &'static [Self] = &[$(Self::$case,)*];
+
+            /// The field name this seam stands for.
+            #[must_use]
+            pub const fn field(self) -> &'static str {
+                match self {
+                    $(Self::$case => $field,)*
+                }
+            }
+        }
+    };
+}
+
+/// Generate the matrix from one table, with every seam spelled per lane.
+///
+/// The seam names in the pattern are the totality gate. Adding a seam means
+/// adding a line here, and that line then stops every lane block matching
+/// until each one answers. A lane cannot skip a seam and compile.
+macro_rules! lane_capabilities {
+    ($(
+        $lane:ident => $origin:expr, $site:expr,
+        {
+            hooks: $hooks:expr,
+            hook_approvals: $hook_approvals:expr,
+            calibration: $calibration:expr,
+            gate: $gate:expr,
+            steering: $steering:expr,
+            requery: $requery:expr,
+            bus: $bus:expr,
+            outcomes: $outcomes:expr,
+            fallback: $fallback:expr,
+            call_role: $call_role:expr,
+            lane: $lane_seam:expr,
+        }
+    )*) => {
+        /// Every builtin lane, with every seam answered.
+        ///
+        /// The tests check both directions. Every lane gets one block, every
+        /// block gets one row per seam, and every row is checked against the
+        /// literal its lane compiles.
+        pub static LANE_CAPABILITIES: &[LaneCapabilities] = &[
+            $(LaneCapabilities {
+                lane: BuiltinLane::$lane,
+                origin: $origin,
+                site: $site,
+                seams: &[
+                    SeamRow::new(Seam::Hooks, $hooks),
+                    SeamRow::new(Seam::HookApprovals, $hook_approvals),
+                    SeamRow::new(Seam::Calibration, $calibration),
+                    SeamRow::new(Seam::Gate, $gate),
+                    SeamRow::new(Seam::Steering, $steering),
+                    SeamRow::new(Seam::Requery, $requery),
+                    SeamRow::new(Seam::Bus, $bus),
+                    SeamRow::new(Seam::Outcomes, $outcomes),
+                    SeamRow::new(Seam::Fallback, $fallback),
+                    SeamRow::new(Seam::CallRole, $call_role),
+                    SeamRow::new(Seam::Lane, $lane_seam),
+                ],
+            },)*
+        ];
+    };
+}
+
+seams! {
+    /// Lifecycle hooks and the port that runs them.
+    Hooks => "hooks";
+    /// Where a pre-tool approval decision parks.
+    HookApprovals => "hook_approvals";
+    /// The token-drift map the caller owns across turns.
+    Calibration => "calibration";
+    /// The boundary pause gate.
+    Gate => "gate";
+    /// Step-boundary steering and the soft stop.
+    Steering => "steering";
+    /// Step-boundary context re-query.
+    Requery => "requery";
+    /// The extension hook bus.
+    Bus => "bus";
+    /// Call-outcome feedback for a router's breaker.
+    Outcomes => "outcomes";
+    /// Mid-turn provider fallback.
+    Fallback => "fallback";
+    /// What this engine's model calls are billed to. Always answered.
+    CallRole => "call_role";
+    /// Which lane assembled the engine. Always answered.
+    Lane => "lane";
+}
+
+/// What proves a bound seam arrives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Witness {
+    /// A test with this name. Checked for existence in the swept sources.
+    Test(&'static str),
+    /// No test names this seam yet. The literal is the only evidence, and
+    /// the source check reads it. Counted by [`UNWITNESSED_SEAMS`].
+    Literal,
+}
+
+/// What a lane asks for at one seam.
+#[derive(Debug, Clone, Copy)]
+pub enum SeamRequest {
+    /// The lane binds it.
+    Bound {
+        /// The text the lane's literal writes for this field. Checked
+        /// against the source, so a lane that stops binding fails here.
+        binds: &'static str,
+        /// What proves the seam arrives.
+        witness: Witness,
+    },
+    /// The lane will not bind it, and here is why. A decision somebody made.
+    Declined {
+        /// Why. Prose a reviewer can weigh.
+        reason: &'static str,
+    },
+    /// Nobody has reached it. A gap, said out loud.
+    Deferred {
+        /// The issue that will settle it, cited as `Refs #NNNN`.
+        issue: &'static str,
+        /// What the answer is waiting on.
+        waiting_on: &'static str,
+    },
+}
+
+impl SeamRequest {
+    /// The witness this ask names, when it names one.
+    #[must_use]
+    pub const fn witness(&self) -> Option<Witness> {
+        match self {
+            Self::Bound { witness, .. } => Some(*witness),
+            Self::Declined { .. } | Self::Deferred { .. } => None,
+        }
+    }
+
+    /// Whether the lane binds this seam.
+    #[must_use]
+    pub const fn is_bound(&self) -> bool {
+        matches!(self, Self::Bound { .. })
+    }
+}
+
+/// What the lane got.
+#[derive(Debug, Clone, Copy)]
+pub enum SeamGrant {
+    /// The ask stands as written. Every lane in this table answers so: it
+    /// compiles its own literal, and nothing sits between ask and answer.
+    AsRequested,
+    /// Something cut the ask down, and says who and why. No lane here needs
+    /// it. A lane an installed plugin brings will, and adding the column
+    /// later would be a schema change under a live table.
+    Withheld {
+        /// Who refused, in that gate's own words.
+        authority: &'static str,
+        /// Why.
+        reason: &'static str,
+    },
+}
+
+/// Where a lane comes from, and so what its row is worth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaneOrigin {
+    /// A lane this workspace compiles. The compiler holds its literal, so
+    /// the ask and the grant are one edit.
+    Builtin,
+    /// A lane an installed plugin brings. Its ask arrives at load time and a
+    /// gate answers it, so the two columns can differ.
+    Plugin,
+}
+
+/// A lane's ask and answer at one seam.
+#[derive(Debug, Clone, Copy)]
+pub struct SeamClaim {
+    /// What the lane asked for.
+    pub requested: SeamRequest,
+    /// What it got.
+    pub granted: SeamGrant,
+}
+
+impl SeamClaim {
+    /// The lane binds the seam, and gets it.
+    #[must_use]
+    pub const fn bound(binds: &'static str, witness: Witness) -> Self {
+        Self {
+            requested: SeamRequest::Bound { binds, witness },
+            granted: SeamGrant::AsRequested,
+        }
+    }
+
+    /// The lane will not bind the seam, and says why.
+    #[must_use]
+    pub const fn declined(reason: &'static str) -> Self {
+        Self {
+            requested: SeamRequest::Declined { reason },
+            granted: SeamGrant::AsRequested,
+        }
+    }
+
+    /// Nobody has decided, and the issue that will is named.
+    #[must_use]
+    pub const fn deferred(issue: &'static str, waiting_on: &'static str) -> Self {
+        Self {
+            requested: SeamRequest::Deferred { issue, waiting_on },
+            granted: SeamGrant::AsRequested,
+        }
+    }
+
+    /// The lane asked and a gate refused. Nothing builds one of these yet.
+    /// It is the shape a plugin lane's row takes.
+    #[must_use]
+    pub const fn withheld(
+        requested: SeamRequest,
+        authority: &'static str,
+        reason: &'static str,
+    ) -> Self {
+        Self {
+            requested,
+            granted: SeamGrant::Withheld { authority, reason },
+        }
+    }
+}
+
+/// One row of the matrix: a seam, an ask, and an answer.
+#[derive(Debug, Clone, Copy)]
+pub struct SeamRow {
+    /// Which slot this row is about.
+    pub seam: Seam,
+    /// What the lane asked for.
+    pub requested: SeamRequest,
+    /// What it got.
+    pub granted: SeamGrant,
+}
+
+impl SeamRow {
+    /// One row from a seam and a claim.
+    #[must_use]
+    pub const fn new(seam: Seam, claim: SeamClaim) -> Self {
+        Self {
+            seam,
+            requested: claim.requested,
+            granted: claim.granted,
+        }
+    }
+}
+
+/// Where a lane's capability literal lives.
+#[derive(Debug, Clone, Copy)]
+pub struct LaneSite {
+    /// The workspace-relative file.
+    pub file: &'static str,
+    /// Text just above the literal. The source check starts here, takes the
+    /// next opening of the capability struct, and reads to its close.
+    pub anchor: &'static str,
+}
+
+/// One lane, with every seam answered.
+#[derive(Debug, Clone, Copy)]
+pub struct LaneCapabilities {
+    /// The lane this block is about.
+    pub lane: BuiltinLane,
+    /// Where the lane comes from.
+    pub origin: LaneOrigin,
+    /// The literal to check the rows against. `None` for a lane nothing
+    /// assembles.
+    pub site: Option<LaneSite>,
+    /// One row per seam, in the order the engine declares them.
+    pub seams: &'static [SeamRow],
+}
+
+impl LaneCapabilities {
+    /// This lane's row for `seam`, or `None`.
+    #[must_use]
+    pub fn seam(&self, seam: Seam) -> Option<&SeamRow> {
+        self.seams.iter().find(|row| row.seam == seam)
+    }
+}
+
+/// The block for `lane`, or `None`. The tests make every builtin lane
+/// resolve, so a `None` means the caller named something that is not a lane.
+#[must_use]
+pub fn row(lane: BuiltinLane) -> Option<&'static LaneCapabilities> {
+    LANE_CAPABILITIES.iter().find(|block| block.lane == lane)
+}
+
+/// How many bound seams name no test.
+///
+/// A ratchet that only goes down, checked for exact equality like
+/// [`crate::evolution::UNWITNESSED_EVOLUTION_BASELINE`]. Writing a missing
+/// test lowers this number in the same change. Raising it to turn a red gate
+/// green is the expedient CLAUDE.md forbids.
+///
+/// All five are seams the forked child takes from its parent.
+/// Refs #6163
+pub const UNWITNESSED_SEAMS: usize = 5;
+
+/// The test that pins what each of the CLI's four lanes binds.
+const CLI_SEAMS: Witness = Witness::Test("each_lane_binds_what_its_call_site_bound_before");
+/// The test that pins the lane name each of the CLI's four lanes writes.
+const CLI_LANE: Witness = Witness::Test("every_lane_this_crate_assembles_declares_itself");
+/// The test that pins what a served turn binds.
+const SERVE_SEAMS: Witness = Witness::Test("a_served_turn_binds_what_its_call_site_bound_before");
+
+/// Why none of the CLI's lanes routes an approval to the broker.
+const DECK_APPROVALS: &str = "the deck parks a pre-tool approval on its own responder. The broker \
+                              route is the one-shot door's answer";
+/// Why none of the CLI's lanes takes the bus.
+const DECK_BUS: &str = "the deck's observers ride the event stream, so nothing here reads a bus";
+/// Why none of the CLI's lanes feeds a breaker.
+const DECK_OUTCOMES: &str = "the deck picks its provider once per session, so there is no router \
+                             breaker to feed";
+/// Why none of the CLI's lanes re-routes mid-turn.
+const DECK_FALLBACK: &str = "the deck picks its provider once per session, so there is nothing to \
+                             re-resolve mid-turn";
+/// Why a replayed turn binds no live seam.
+const REPLAY_IS_DEAF: &str = "a replayed turn has no live operator channel. It replays a \
+                              checkpoint to its end and returns";
+/// Why the pipeline-stage lane binds nothing.
+const NO_PIPELINE_PRODUCER: &str = "nothing assembles this lane and nothing will. A verification \
+                                    plugin's stage turn is a plugin lane, so there is no literal \
+                                    here to bind a seam in. Refs #3881";
+/// Why a served turn runs no hooks.
+const SERVE_HOOKS: &str = "the host runs its own hooks on its own side of the wire. This engine \
+                           holds no authority to run a command with";
+/// Why a served turn owns no model-call seam.
+const SERVE_HOST_OWNS_CALLS: &str = "the host owns the model calls, so this is the host's choice \
+                                     rather than this engine's";
+
+lane_capabilities! {
+    // The deck's lead turn. The one lane that binds the re-query plane.
+    Lead => LaneOrigin::Builtin,
+        Some(LaneSite {
+            file: "crates/stella-cli/src/lane_capabilities.rs",
+            anchor: "pub(crate) fn lead<'a>(",
+        }),
+    {
+        hooks: SeamClaim::bound("hooks: hooks.map(", CLI_SEAMS),
+        hook_approvals: SeamClaim::declined(DECK_APPROVALS),
+        calibration: SeamClaim::bound("calibration: Some(calibration)", CLI_SEAMS),
+        gate: SeamClaim::bound("gate: Some(gate)", CLI_SEAMS),
+        steering: SeamClaim::bound("steering: Some(steering)", CLI_SEAMS),
+        requery: SeamClaim::bound("requery,", CLI_SEAMS),
+        bus: SeamClaim::declined(DECK_BUS),
+        outcomes: SeamClaim::declined(DECK_OUTCOMES),
+        fallback: SeamClaim::declined(DECK_FALLBACK),
+        call_role: SeamClaim::bound("call_role: ModelCallRole::Worker", CLI_SEAMS),
+        lane: SeamClaim::bound("lane: Some(TurnLane::Builtin(BuiltinLane::Lead))", CLI_LANE),
+    }
+
+    // A turn replayed from a checkpoint. Nobody is watching it.
+    Resume => LaneOrigin::Builtin,
+        Some(LaneSite {
+            file: "crates/stella-cli/src/lane_capabilities.rs",
+            anchor: "pub(crate) fn resume<'a>(",
+        }),
+    {
+        hooks: SeamClaim::bound("hooks: hooks.map(", CLI_SEAMS),
+        hook_approvals: SeamClaim::declined(DECK_APPROVALS),
+        calibration: SeamClaim::bound("calibration: Some(calibration)", CLI_SEAMS),
+        gate: SeamClaim::declined(REPLAY_IS_DEAF),
+        steering: SeamClaim::declined(REPLAY_IS_DEAF),
+        requery: SeamClaim::declined(REPLAY_IS_DEAF),
+        bus: SeamClaim::declined(DECK_BUS),
+        outcomes: SeamClaim::declined(DECK_OUTCOMES),
+        fallback: SeamClaim::declined(DECK_FALLBACK),
+        call_role: SeamClaim::bound("call_role: ModelCallRole::Worker", CLI_SEAMS),
+        lane: SeamClaim::bound("lane: Some(TurnLane::Builtin(BuiltinLane::Resume))", CLI_LANE),
+    }
+
+    // A deck worker lane. Two of its seams are open questions.
+    SubSession => LaneOrigin::Builtin,
+        Some(LaneSite {
+            file: "crates/stella-cli/src/lane_capabilities.rs",
+            anchor: "pub(crate) fn sub_session<'a>(",
+        }),
+    {
+        hooks: SeamClaim::deferred(
+            "Refs #6157",
+            "a decision on whether a worker lane runs the session's hooks. The lead turn that \
+             spawned it runs them today",
+        ),
+        hook_approvals: SeamClaim::declined(DECK_APPROVALS),
+        calibration: SeamClaim::bound("calibration: Some(calibration)", CLI_SEAMS),
+        gate: SeamClaim::bound("gate: Some(gate)", CLI_SEAMS),
+        steering: SeamClaim::bound("steering: Some(steering)", CLI_SEAMS),
+        requery: SeamClaim::deferred(
+            "Refs #6158",
+            "a decision on whether a worker lane may ask the session's context plane again",
+        ),
+        bus: SeamClaim::declined(DECK_BUS),
+        outcomes: SeamClaim::declined(DECK_OUTCOMES),
+        fallback: SeamClaim::declined(DECK_FALLBACK),
+        call_role: SeamClaim::bound("call_role: ModelCallRole::Worker", CLI_SEAMS),
+        lane: SeamClaim::bound(
+            "lane: Some(TurnLane::Builtin(BuiltinLane::SubSession))",
+            CLI_LANE,
+        ),
+    }
+
+    // The child the delegation tool forks. It takes almost everything the
+    // parent holds, which is why so many rows here read from the parent.
+    SubagentFork => LaneOrigin::Builtin,
+        Some(LaneSite {
+            file: "crates/stella-core/src/subagent.rs",
+            anchor: "pub async fn run_sub_agent_with_sender(",
+        }),
+    {
+        hooks: SeamClaim::bound(
+            "hooks: self.hooks.map(HooksHandle::parts)",
+            Witness::Test("subagent_start_and_stop_hooks_fire_around_a_child_turn"),
+        ),
+        hook_approvals: SeamClaim::bound("hook_approvals: self.hook_approvals", Witness::Literal),
+        calibration: SeamClaim::bound("calibration: self.calibration", Witness::Literal),
+        gate: SeamClaim::bound(
+            "gate: self.gate",
+            Witness::Test("a_child_polls_the_parents_pause_gate"),
+        ),
+        steering: SeamClaim::bound(
+            "steering,",
+            Witness::Test("a_child_honors_the_soft_stop_but_never_eats_the_parents_steering"),
+        ),
+        requery: SeamClaim::declined(
+            "the re-query plane belongs to the session's own turn. A parent-scoped plane would \
+             inject the parent's context into a child's transcript",
+        ),
+        bus: SeamClaim::bound("bus: self.bus", Witness::Literal),
+        outcomes: SeamClaim::bound("outcomes: self.outcomes", Witness::Literal),
+        fallback: SeamClaim::declined(
+            "the child's provider is the spec's own choice, so a mid-turn re-route is not this \
+             fork's call to make",
+        ),
+        call_role: SeamClaim::bound("call_role: spec.role", Witness::Literal),
+        lane: SeamClaim::bound(
+            "lane: Some(TurnLane::Builtin(BuiltinLane::SubagentFork))",
+            Witness::Test("a_forked_child_stamps_the_subagent_fork_lane"),
+        ),
+    }
+
+    // One fleet attempt. Nobody is at a keyboard.
+    FleetWorker => LaneOrigin::Builtin,
+        Some(LaneSite {
+            file: "crates/stella-cli/src/lane_capabilities.rs",
+            anchor: "pub(crate) fn fleet_attempt<'a>(",
+        }),
+    {
+        hooks: SeamClaim::bound("hooks: hooks.map(", CLI_SEAMS),
+        hook_approvals: SeamClaim::declined(DECK_APPROVALS),
+        calibration: SeamClaim::bound("calibration: Some(calibration)", CLI_SEAMS),
+        gate: SeamClaim::bound("gate: Some(gate)", CLI_SEAMS),
+        steering: SeamClaim::declined(
+            "a fleet worker has no input channel. Nobody is at a keyboard to steer it",
+        ),
+        requery: SeamClaim::deferred(
+            "Refs #6158",
+            "a decision on whether a fleet attempt may ask the workspace context plane again",
+        ),
+        bus: SeamClaim::declined(DECK_BUS),
+        outcomes: SeamClaim::declined(DECK_OUTCOMES),
+        fallback: SeamClaim::declined(DECK_FALLBACK),
+        call_role: SeamClaim::bound("call_role: ModelCallRole::Worker", CLI_SEAMS),
+        lane: SeamClaim::bound(
+            "lane: Some(TurnLane::Builtin(BuiltinLane::FleetWorker))",
+            CLI_LANE,
+        ),
+    }
+
+    // The staged pipeline's lane. It has no site, so every seam is refused
+    // for one reason: there is no literal here to bind one in.
+    PipelineStage => LaneOrigin::Builtin, None,
+    {
+        hooks: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+        hook_approvals: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+        calibration: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+        gate: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+        steering: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+        requery: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+        bus: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+        outcomes: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+        fallback: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+        call_role: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+        lane: SeamClaim::declined(NO_PIPELINE_PRODUCER),
+    }
+
+    // A turn a remote host drives over the wire. The host keeps the seams
+    // that need authority this engine does not hold.
+    ServeSession => LaneOrigin::Builtin,
+        Some(LaneSite {
+            file: "crates/stella-serve/src/session.rs",
+            anchor: "fn served_capabilities<'a>(",
+        }),
+    {
+        hooks: SeamClaim::declined(SERVE_HOOKS),
+        hook_approvals: SeamClaim::declined(
+            "this engine runs no hooks, so no approval can be parked",
+        ),
+        calibration: SeamClaim::bound("calibration,", SERVE_SEAMS),
+        gate: SeamClaim::bound("gate: Some(gate)", SERVE_SEAMS),
+        steering: SeamClaim::bound("steering: Some(steering)", SERVE_SEAMS),
+        requery: SeamClaim::deferred(
+            "Refs #6158",
+            "a decision on whether the host supplies a re-query port over the wire",
+        ),
+        bus: SeamClaim::bound("bus,", SERVE_SEAMS),
+        outcomes: SeamClaim::declined(SERVE_HOST_OWNS_CALLS),
+        fallback: SeamClaim::declined(SERVE_HOST_OWNS_CALLS),
+        call_role: SeamClaim::bound(
+            "call_role: stella_protocol::ModelCallRole::Worker",
+            SERVE_SEAMS,
+        ),
+        lane: SeamClaim::bound(
+            "lane: Some(stella_protocol::TurnLane::Builtin(",
+            Witness::Test("a_served_turn_declares_the_serve_session_lane"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-parity/src/lane/capability/tests.rs
+++ b/crates/stella-parity/src/lane/capability/tests.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Both sides of the seam matrix.
+//!
+//! The macro holds the shape. It spells every seam for every lane. The
+//! pattern below breaks when the engine grows a slot.
+//!
+//! These tests hold the rest. Each row is read back against the literal its
+//! lane writes. Each named test has to exist.
+
+use stella_core::TurnCapabilities;
+use stella_protocol::ModelCallRole;
+
+use super::*;
+use crate::lane::{LaneBinding, lane_sources, source_named};
+
+/// The capability literal a lane writes, as source text.
+///
+/// Start at the row's anchor. Take the next open brace of the struct. Read
+/// to the brace that closes it. Each failure names the file and the anchor,
+/// so a moved literal says where to look.
+fn literal(site: &LaneSite) -> &'static str {
+    let source = source_named(site.file);
+    let from_anchor = source.find(site.anchor).map(|at| &source[at..]);
+    let from_anchor = from_anchor.unwrap_or_else(|| {
+        panic!(
+            "{} does not contain `{}`, so its capability literal cannot be found",
+            site.file, site.anchor,
+        )
+    });
+    let body = from_anchor
+        .find("TurnCapabilities {")
+        .map(|at| &from_anchor[at..])
+        .unwrap_or_else(|| {
+            panic!(
+                "{} opens no capability literal after `{}`",
+                site.file, site.anchor,
+            )
+        });
+
+    let mut depth = 0usize;
+    for (index, character) in body.char_indices() {
+        match character {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &body[..=index];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!(
+        "the capability literal after `{}` in {} never closes",
+        site.anchor, site.file,
+    )
+}
+
+/// **The totality witness.** Every slot the engine has is a seam here.
+///
+/// The pattern has no rest arm. A new slot stops this file building. The fix
+/// needs a new [`Seam`] case. That case needs a line in the row macro. That
+/// line stops every lane block until each lane answers.
+#[test]
+fn every_capability_slot_is_a_seam() {
+    let TurnCapabilities {
+        hooks,
+        hook_approvals,
+        calibration,
+        gate,
+        steering,
+        requery,
+        bus,
+        outcomes,
+        fallback,
+        call_role,
+        lane,
+    } = TurnCapabilities::none();
+
+    let slots = [
+        (Seam::Hooks, hooks.is_none()),
+        (Seam::HookApprovals, hook_approvals.is_none()),
+        (Seam::Calibration, calibration.is_none()),
+        (Seam::Gate, gate.is_none()),
+        (Seam::Steering, steering.is_none()),
+        (Seam::Requery, requery.is_none()),
+        (Seam::Bus, bus.is_none()),
+        (Seam::Outcomes, outcomes.is_none()),
+        (Seam::Fallback, fallback.is_none()),
+        (Seam::CallRole, call_role == ModelCallRole::Worker),
+        (Seam::Lane, lane.is_none()),
+    ];
+
+    assert_eq!(
+        slots.len(),
+        Seam::ALL.len(),
+        "the engine's slots and this matrix's seams must be the same list",
+    );
+    for &(seam, bare) in &slots {
+        assert!(
+            bare,
+            "the bare capability set answers `{}` with something",
+            seam.field(),
+        );
+    }
+    for seam in Seam::ALL {
+        assert!(
+            slots.iter().any(|(named, _)| named == seam),
+            "`{}` is a seam no engine slot is mapped to",
+            seam.field(),
+        );
+    }
+}
+
+/// Every lane gets a block, and every block answers every seam once.
+#[test]
+fn every_builtin_lane_answers_every_seam_once() {
+    for builtin in BuiltinLane::ALL {
+        let block = row(builtin)
+            .unwrap_or_else(|| panic!("`{builtin}` has no capability block in this matrix"));
+        assert_eq!(
+            block.seams.len(),
+            Seam::ALL.len(),
+            "`{builtin}` answers {} seams, and the engine has {}",
+            block.seams.len(),
+            Seam::ALL.len(),
+        );
+        for seam in Seam::ALL {
+            let rows = block.seams.iter().filter(|row| row.seam == *seam).count();
+            assert_eq!(
+                rows,
+                1,
+                "`{builtin}` answers `{}` {rows} times",
+                seam.field(),
+            );
+        }
+    }
+    assert_eq!(
+        LANE_CAPABILITIES.len(),
+        BuiltinLane::ALL.len(),
+        "a block names something that is not a builtin lane",
+    );
+}
+
+/// **The matrix witness.** Each claim is read back against the literal its
+/// lane writes.
+///
+/// A `Bound` row names the text its lane writes. That text has to be there.
+/// A row that does not bind makes the other claim. Its field has to be
+/// written as nothing. Flip any row and this fails. So does a lane that
+/// stops binding.
+#[test]
+fn a_seam_claim_agrees_with_its_lane_literal() {
+    for block in LANE_CAPABILITIES {
+        let Some(site) = &block.site else {
+            continue;
+        };
+        let text = literal(site);
+
+        for row in block.seams {
+            let field = row.seam.field();
+            let unbound = format!("{field}: None");
+            match row.requested {
+                SeamRequest::Bound { binds, .. } => {
+                    assert!(
+                        text.contains(binds),
+                        "`{}` claims it binds `{field}` as `{binds}`, and {} writes no such text",
+                        block.lane,
+                        site.file,
+                    );
+                    assert!(
+                        !text.contains(&unbound),
+                        "`{}` claims it binds `{field}`, and {} writes `{unbound}`",
+                        block.lane,
+                        site.file,
+                    );
+                }
+                SeamRequest::Declined { .. } | SeamRequest::Deferred { .. } => {
+                    assert!(
+                        text.contains(&unbound),
+                        "`{}` claims it does not bind `{field}`, and {} does not write \
+                         `{unbound}`",
+                        block.lane,
+                        site.file,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// A block's site must be the one its producer row already named.
+#[test]
+fn a_block_names_the_same_site_as_its_producer_row() {
+    for block in LANE_CAPABILITIES {
+        let producer = crate::lane::row(block.lane)
+            .unwrap_or_else(|| panic!("`{}` has no producer row", block.lane));
+        match (&producer.binding, &block.site) {
+            (LaneBinding::Bound { site, .. }, Some(mine)) => assert_eq!(
+                *site, mine.file,
+                "`{}` is produced at one file and claims its seams at another",
+                block.lane,
+            ),
+            (LaneBinding::NoProducer { .. }, None) => {}
+            _ => panic!(
+                "`{}` disagrees with its producer row about whether anything assembles it",
+                block.lane,
+            ),
+        }
+    }
+}
+
+/// A lane nothing assembles binds nothing. There is no literal to bind in.
+#[test]
+fn a_lane_with_no_site_binds_nothing() {
+    for block in LANE_CAPABILITIES {
+        if block.site.is_some() {
+            continue;
+        }
+        for row in block.seams {
+            assert!(
+                !row.requested.is_bound(),
+                "`{}` binds `{}`, and nothing assembles it",
+                block.lane,
+                row.seam.field(),
+            );
+        }
+    }
+}
+
+/// Every named witness must exist in the swept sources.
+#[test]
+fn every_named_seam_witness_exists() {
+    for block in LANE_CAPABILITIES {
+        for row in block.seams {
+            let Some(Witness::Test(name)) = row.requested.witness() else {
+                continue;
+            };
+            let needle = format!("fn {name}(");
+            assert!(
+                lane_sources()
+                    .iter()
+                    .any(|(_, source)| source.contains(&needle)),
+                "the `{}` lane's `{}` row names `{name}`, which no swept source declares",
+                block.lane,
+                row.seam.field(),
+            );
+        }
+    }
+}
+
+/// The count of seams with no test is exact. It only goes down.
+///
+/// Exact, so writing a test lowers it in the same change. A row that borrows
+/// a neighbour's test would read better and prove less.
+#[test]
+fn the_unwitnessed_seam_count_matches_the_ratchet() {
+    let counted = LANE_CAPABILITIES
+        .iter()
+        .flat_map(|block| block.seams.iter())
+        .filter(|row| matches!(row.requested.witness(), Some(Witness::Literal)))
+        .count();
+    assert_eq!(
+        counted, UNWITNESSED_SEAMS,
+        "{counted} bound seams name no test, and the ratchet says {UNWITNESSED_SEAMS}. Write \
+         the test and lower the number; never raise it",
+    );
+}
+
+/// A deferred seam names the issue that will settle it and what it waits on.
+#[test]
+fn a_deferred_seam_cites_an_issue_and_what_it_waits_on() {
+    let mut deferred = 0;
+    for block in LANE_CAPABILITIES {
+        for row in block.seams {
+            let SeamRequest::Deferred { issue, waiting_on } = row.requested else {
+                continue;
+            };
+            deferred += 1;
+            let number = issue.strip_prefix("Refs #").unwrap_or_default();
+            assert!(
+                !number.is_empty() && number.chars().all(|digit| digit.is_ascii_digit()),
+                "`{}` defers `{}` and cites `{issue}`, which is not an issue citation",
+                block.lane,
+                row.seam.field(),
+            );
+            assert!(
+                waiting_on.split_whitespace().count() >= 6,
+                "`{}` defers `{}` and does not say what the answer waits on",
+                block.lane,
+                row.seam.field(),
+            );
+        }
+    }
+    assert!(
+        deferred > 0,
+        "no row is deferred. If every gap really closed, delete the case rather than keep a \
+         posture nothing uses",
+    );
+}
+
+/// A declined seam says why. A bare refusal reads like the silence this
+/// matrix exists to end.
+#[test]
+fn a_declined_seam_says_why() {
+    for block in LANE_CAPABILITIES {
+        for row in block.seams {
+            let SeamRequest::Declined { reason } = row.requested else {
+                continue;
+            };
+            assert!(
+                reason.split_whitespace().count() >= 6,
+                "`{}` declines `{}` with no reason a reviewer can weigh",
+                block.lane,
+                row.seam.field(),
+            );
+        }
+    }
+}
+
+/// Every lane here is builtin. Each gets what it asks for.
+///
+/// The two columns are for a lane a plugin brings. There a gate stands
+/// between the ask and the answer. No lane here is one. A row that starts to
+/// hold a seam back has to name the gate that did it.
+#[test]
+fn every_row_today_is_granted_as_asked() {
+    for block in LANE_CAPABILITIES {
+        assert_eq!(
+            block.origin,
+            LaneOrigin::Builtin,
+            "`{}` is not a builtin lane, and this matrix only holds those",
+            block.lane,
+        );
+        for row in block.seams {
+            assert!(
+                matches!(row.granted, SeamGrant::AsRequested),
+                "`{}` gets less than it asks for at `{}`, and it compiles its own literal",
+                block.lane,
+                row.seam.field(),
+            );
+        }
+    }
+}

--- a/crates/stella-serve/src/session.rs
+++ b/crates/stella-serve/src/session.rs
@@ -1083,6 +1083,12 @@ mod tests {
             "the host runs its own hooks; this engine has no authority to",
         );
 
+        assert_eq!(
+            host_supplied_nothing.call_role,
+            stella_protocol::ModelCallRole::Worker,
+            "a served turn's own calls are worker calls; its verifier announces its own role",
+        );
+
         let calibration = stella_core::estimator::CalibrationMap::default();
         let bus = stella_core::bus::HookBus::new("serve-lane-test");
         let host_supplied_both =


### PR DESCRIPTION
## What

`crates/stella-parity/src/lane.rs` said who stamps a lane name. It said
nothing about what a lane binds, so the answer stayed spread across three
struct literals in three crates: `stella-cli`'s `lane_capabilities.rs`,
`stella-core`'s `subagent.rs`, and `stella-serve`'s `served_capabilities`.

`crates/stella-parity/src/lane/capability.rs` is the missing table. One row
per lane and seam — all seven builtin lanes against all eleven slots on
`TurnCapabilities`. A row carries three columns the old table had none of:

- **What the lane asked for.** `Bound { binds, witness }`,
  `Declined { reason }`, or `Deferred { issue, waiting_on }`. A seam a lane
  refuses and a seam nobody has reached used to read as the same bare
  `None`.
- **What it got.** `AsRequested` or `Withheld { authority, reason }`. Every
  lane here is `AsRequested`, because it compiles its own literal. A lane an
  installed plugin brings will not be, and the column is there so the gate
  that cuts one down needs no schema change.
- **Where the lane came from.** `LaneOrigin::Builtin` or `Plugin`, so a
  plugin row can say what it is worth.

## Why the rows are trustworthy

Four checks, all in `lane/capability/tests.rs`:

1. **The macro is the totality gate.** `lane_capabilities!` spells all
   eleven seam names in its pattern, so a lane block that skips one does not
   match and does not compile.
2. **`every_capability_slot_is_a_seam` destructures `TurnCapabilities` with
   no rest arm.** A slot added to the engine stops this crate's tests
   building. The repair needs a new `Seam` case, which needs a line in the
   macro pattern, which then stops every lane block matching until each lane
   answers. That chain is what the issue asked for.
3. **`a_seam_claim_agrees_with_its_lane_literal` reads each claim back
   against the source.** It slices the lane's `TurnCapabilities { .. }`
   literal by brace matching from a declared anchor, then asserts a `Bound`
   row's `binds` text is really there and that a `Declined` or `Deferred`
   row's field is really written `<field>: None`.
4. **`every_named_seam_witness_exists`** checks every named test exists in
   the swept sources, as `every_lane_witness_exists` already did for the
   producer rows.

## Witness mechanism

The tests do not exist on `main`, so they fail there by absence. The one
with a real negative control is check 3, and I ran it: flipping
`ServeSession`'s `bus` row from `Bound` to `Declined` and leaving the code
alone gives

```
`ServeSession` claims it does not bind `bus`, and
crates/stella-serve/src/session.rs does not write `bus: None`
```

I verified the whole module by compiling and running it against stubbed
`stella_protocol` / `stella_core` types and the four real swept source files
outside the workspace (`rustc --test`, no cargo build on this machine per
CLAUDE.md). All 14 tests in `lane` and `lane::capability` pass; the flipped
row fails as above. CI is the evidence that counts, and it is running.

## Honest gaps, recorded rather than hidden

`Witness` is `Test(name)` or `Literal`. A row with no test of its own says
`Literal` rather than borrow a neighbour's name, which is the failure #5198
paid for. `UNWITNESSED_SEAMS` is an exact down-only ratchet on those, like
`UNWITNESSED_EVOLUTION_BASELINE` beside it. It stands at 5 — all of them
seams the forked child takes from its parent — and #6163 is the handoff to
zero it.

To keep that number honest rather than convenient, two existing tests were
strengthened so the rows naming them really exercise the seams they claim:
`each_lane_binds_what_its_call_site_bound_before` now also passes hooks and
a re-query plane in and asserts they arrive, and asserts each lane's call
role; `a_served_turn_binds_what_its_call_site_bound_before` now asserts the
served turn's call role. Without those, five more rows would have been
`Literal`.

## Exemplar

`crates/stella-parity/src/evolution.rs`, the ledger beside it: one macro
table generating the rows, a witness named per row and checked for
existence, gaps cited rather than silent, and an exact down-only ratchet on
the unwitnessed ones.

## Dependency

`stella-core` joins `stella-parity` as a **dev-dependency** only, for the
destructure in check 2. It is already in the graph through `stella-serve`,
so it costs no extra build, and the shipped matrix stays a table of strings.

## Tests deleted

None.

## Residue filed

- #6157 — a deck worker lane runs no hooks and nobody decided that. Cited by
  the `SubSession` `hooks` row.
- #6158 — three lanes bind no context re-query plane and none says why.
  Cited by the `SubSession`, `FleetWorker` and `ServeSession` `requery`
  rows.
- #6163 — five seams a forked child takes from its parent have no test. The
  whole of `UNWITNESSED_SEAMS`.

Closes #6150
Refs #3274

## Summary by Sourcery

Document and enforce every builtin lane's capability bindings across all turn-assembly seams.

New Features:
- Add a seam-by-seam capability matrix documenting what each builtin turn lane requests, receives, and where it originates.

Enhancements:
- Make lane capability declarations auditable against their source literals and distinguish declined or deferred seams from bound ones.
- Add compile-time and runtime completeness checks that keep the matrix synchronized with `TurnCapabilities`, builtin lanes, producer sites, witnesses, and documented gaps.
- Track unwitnessed capability seams with an exact down-only ratchet and record unresolved decisions with issue references.

Build:
- Add `stella-core` as a development dependency of `stella-parity` for capability-shape checks.

Documentation:
- Update the parity README and lane documentation to describe the capability matrix and its source-of-truth boundaries.

Tests:
- Strengthen CLI and serve lane tests to verify hook, re-query, call-role, and other capability propagation.