### PR TITLE
feat(stella-serve): let a served turn re-ask for context mid-turn

### DIFF
--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -294,11 +294,15 @@ pub static CAPABILITIES: &[Capability] = &[
                         a_fleet_worker_requeries_the_skill_its_opening_prompt_could_not",
             witness: "a_drifted_turn_recalls_the_skill_its_prompt_could_not",
         },
-        api: SurfacePosture::Deferred {
-            waiting_on: "a serve-side SteeringRequery implementor: the engine port exists, but \
-                         the serve stack assembles no requery source, so remote turns still \
-                         select context against the opening prompt alone — #6121 is where \
-                         that is being decided",
+        api: SurfacePosture::Shipped {
+            mechanism: "a turn created with `steering_requery: true` binds stella-serve's \
+                        RemoteRequery, which raises a `requery_request` frame at a drifted \
+                        step boundary and parks on the host's answer to \
+                        POST /v1/turns/{id}/requery-result. Hysteresis and block dedup stay \
+                        server-side, mirroring the CLI's SessionRequery; an unanswered ask \
+                        injects nothing rather than failing the turn. Off by default, because \
+                        a host that has not built the route cannot answer",
+            witness: "a_served_turn_requeries_the_steering_plane_after_its_work_moves_to_a_new_path",
         },
     },
     Capability {

--- a/crates/stella-serve/src/backlog.rs
+++ b/crates/stella-serve/src/backlog.rs
@@ -143,6 +143,8 @@ fn droppable(frame: &ServerFrame) -> bool {
         ServerFrame::Event { .. } => true,
         ServerFrame::ToolRequest { .. }
         | ServerFrame::ProviderRequest { .. }
+        // A dropped re-query parks the step until its deadline.
+        | ServerFrame::RequeryRequest { .. }
         | ServerFrame::TurnHeld { .. }
         | ServerFrame::TurnReleased
         | ServerFrame::TurnComplete { .. } => false,

--- a/crates/stella-serve/src/frame.rs
+++ b/crates/stella-serve/src/frame.rs
@@ -66,6 +66,18 @@ pub enum ServerFrame {
         role: ModelCallRole,
         request: CompletionRequest,
     },
+    /// The engine's work has moved on from the prompt it opened with, and it
+    /// is asking the host for whatever context now fits. The host answers
+    /// with [`RequeryResultIn`] keyed by `request_id`; the engine step that
+    /// raised it is parked until then.
+    ///
+    /// Only ever emitted when the turn asked for it
+    /// (`steering_requery` on `POST /v1/turns`). A host that has not built the
+    /// answering route never sees this frame.
+    RequeryRequest {
+        request_id: String,
+        signal: RequerySignal,
+    },
     /// The turn reached a step boundary and is **holding** there, because
     /// `POST /v1/turns/{id}/pause` asked it to (#932).
     ///
@@ -95,6 +107,54 @@ pub enum ServerFrame {
     TurnReleased,
     /// Terminal frame: the turn ended. No further frames follow for this turn.
     TurnComplete { outcome: TurnOutcomeWire },
+}
+
+/// What the turn has become, as the engine can witness it — the payload of a
+/// [`ServerFrame::RequeryRequest`].
+///
+/// An owned projection of `stella_core::steering::TurnSignal`, which borrows
+/// the turn's own transcript and so cannot cross a frame boundary.
+///
+/// One field of that type is missing here. `active_domains` is a workspace
+/// taxonomy the engine never fills — it passes an empty slice — and a wire
+/// field that is always empty reads as a fact. The host merges its own
+/// domains, and its own file ledger, before it asks its steering plane.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequerySignal {
+    /// The turn's goal, as the operator wrote it. On its own this is what
+    /// every selector had, and it is what goes stale by step 40.
+    pub prompt: String,
+    /// Tools the turn has called, most recent last.
+    pub recent_tool_calls: Vec<String>,
+    /// Workspace paths the turn has touched, read off its tool inputs.
+    pub touched_paths: Vec<String>,
+    /// Error classes the turn has seen. "We are stuck, and this is how" is the
+    /// strongest retrieval cue a turn produces.
+    pub errors_seen: Vec<String>,
+    /// Step index within the turn.
+    pub step: u32,
+    /// Steps since the host last answered with a block.
+    pub since_last_query: u32,
+}
+
+impl RequerySignal {
+    /// Copy out what the engine assembled at the step boundary.
+    #[must_use]
+    pub(crate) fn from_signal(signal: &stella_core::steering::TurnSignal<'_>) -> Self {
+        Self {
+            prompt: signal.prompt.to_string(),
+            recent_tool_calls: signal.recent_tool_calls.to_vec(),
+            touched_paths: signal.touched_paths.to_vec(),
+            errors_seen: signal
+                .errors_seen
+                .iter()
+                .map(|e| (*e).to_string())
+                .collect(),
+            step: signal.step,
+            since_last_query: signal.since_last_query,
+        }
+    }
 }
 
 /// Serializable projection of [`TurnOutcome`] for the wire. `TurnOutcome` lives
@@ -197,6 +257,24 @@ pub enum ProviderDelta {
     Text { text: String },
     /// A fragment of thinking/chain-of-thought content.
     Reasoning { text: String },
+}
+
+/// Host → engine: the answer to a [`ServerFrame::RequeryRequest`].
+///
+/// `context` is the block to put in front of the model, or `null` for "nothing
+/// here is worth the tokens" — the cheap answer, and the expected one for most
+/// boundaries. The engine appends the block to the volatile tail as a user
+/// message and never touches the byte-stable prefix.
+///
+/// The block is injected as sent, so the server prefixes the recall marker
+/// when the host's text does not already carry one: an injected block the
+/// engine read as a real user turn would move the turn window.
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequeryResultIn {
+    pub request_id: String,
+    #[serde(default)]
+    pub context: Option<String>,
 }
 
 /// Serializable mirror of [`ProviderError`]'s taxonomy. The host classifies the
@@ -666,6 +744,40 @@ mod tests {
             panic!("wrong variant");
         };
         assert_eq!(retry_after_ms, None);
+    }
+
+    /// The re-query pair is parsed by hand in another language like every
+    /// other frame here, so its tag and its field names are pinned the same
+    /// way.
+    #[test]
+    fn the_requery_frame_and_its_answer_are_the_wire_contract() {
+        let frame = serde_json::to_value(ServerFrame::RequeryRequest {
+            request_id: "requery-0-1".to_string(),
+            signal: RequerySignal {
+                prompt: "fix the flaky test".to_string(),
+                recent_tool_calls: vec!["read_file".to_string()],
+                touched_paths: vec!["src/adapter.rs".to_string()],
+                errors_seen: vec!["timeout".to_string()],
+                step: 3,
+                since_last_query: 2,
+            },
+        })
+        .unwrap();
+        assert_eq!(frame["type"], "requery_request");
+        assert_eq!(frame["request_id"], "requery-0-1");
+        assert_eq!(frame["signal"]["prompt"], "fix the flaky test");
+        assert_eq!(frame["signal"]["touched_paths"][0], "src/adapter.rs");
+        assert_eq!(frame["signal"]["errors_seen"][0], "timeout");
+        assert_eq!(frame["signal"]["step"], 3);
+        assert_eq!(frame["signal"]["since_last_query"], 2);
+
+        // `context` is optional on the way back: a host with nothing to add
+        // may leave it out entirely rather than spelling `null`.
+        let answer: RequeryResultIn =
+            serde_json::from_value(serde_json::json!({ "request_id": "requery-0-1" }))
+                .expect("an answer with no block still parses");
+        assert_eq!(answer.request_id, "requery-0-1");
+        assert_eq!(answer.context, None);
     }
 
     #[test]

--- a/crates/stella-serve/src/lib.rs
+++ b/crates/stella-serve/src/lib.rs
@@ -27,6 +27,11 @@
 //!   [`ServerFrame::ToolRequest`] — each carry a `request_id`; the host runs the
 //!   effect and answers with [`Session::resolve_provider`] /
 //!   [`Session::resolve_tool`], unblocking the parked engine step.
+//! - A turn that opted in with [`SessionSpec::steering_requery`] also raises
+//!   [`ServerFrame::RequeryRequest`] at its step boundaries once its work has
+//!   moved on from the prompt it opened with, answered by
+//!   [`Session::resolve_requery`]. That one is advisory: an unanswered
+//!   re-query costs the step nothing it started with.
 //! - The terminal frame is [`ServerFrame::TurnComplete`].
 //!
 //! The HTTP/SSE transport that exposes this over a socket is a thin layer on top
@@ -103,7 +108,7 @@ pub use error::ServeError;
 pub use extensions::{Extensions, ServeExtension};
 pub use frame::{
     ProviderDelta, ProviderDeltaIn, ProviderErrorWire, ProviderOutcomeIn, ProviderResultIn,
-    ServerFrame, ToolResultIn, TurnOutcomeWire,
+    RequeryResultIn, RequerySignal, ServerFrame, ToolResultIn, TurnOutcomeWire,
 };
 pub use goal::GoalRun;
 pub use hostguard::HostMode;

--- a/crates/stella-serve/src/observe/event.rs
+++ b/crates/stella-serve/src/observe/event.rs
@@ -85,9 +85,9 @@ impl LevelFilter {
 
 /// Which endpoint a request reached, as a **template**.
 ///
-/// The raw path is never recorded, because for seven of these it contains
-/// the turn id (and two more carry a session id). Serde renames each case to its template so a record reads like
-/// an access log without any rendering step.
+/// The raw path is never recorded, because every `{id}` template above
+/// carries a turn or session id in it. Serde renames each case to its template
+/// so a record reads like an access log without any rendering step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Route {
     #[serde(rename = "/healthz")]
@@ -114,6 +114,10 @@ pub enum Route {
     /// for an in-flight `provider_request`, ahead of its `provider-result`.
     #[serde(rename = "/v1/turns/{id}/provider-delta")]
     TurnProviderDelta,
+    /// The answer to a `requery_request`: the context block the host's
+    /// steering plane chose for a turn whose work has moved, or nothing.
+    #[serde(rename = "/v1/turns/{id}/requery-result")]
+    TurnRequeryResult,
     #[serde(rename = "/v1/turns/{id}/cancel")]
     TurnCancel,
     #[serde(rename = "/v1/turns/{id}/steer")]
@@ -157,6 +161,7 @@ impl Route {
             Self::TurnToolResult => "/v1/turns/{id}/tool-result",
             Self::TurnProviderResult => "/v1/turns/{id}/provider-result",
             Self::TurnProviderDelta => "/v1/turns/{id}/provider-delta",
+            Self::TurnRequeryResult => "/v1/turns/{id}/requery-result",
             Self::TurnCancel => "/v1/turns/{id}/cancel",
             Self::TurnSteer => "/v1/turns/{id}/steer",
             Self::TurnPause => "/v1/turns/{id}/pause",
@@ -181,7 +186,7 @@ impl Route {
     /// method's exhaustive match until the author classifies it, and the
     /// tests assert `ALL` contains exactly the `is_real` cases it names —
     /// so the array cannot silently lag the enum.
-    pub const ALL: [Route; 18] = [
+    pub const ALL: [Route; 19] = [
         Route::Healthz,
         Route::Readyz,
         Route::Metrics,
@@ -191,6 +196,7 @@ impl Route {
         Route::TurnToolResult,
         Route::TurnProviderResult,
         Route::TurnProviderDelta,
+        Route::TurnRequeryResult,
         Route::TurnCancel,
         Route::TurnSteer,
         Route::TurnPause,
@@ -219,6 +225,7 @@ impl Route {
             | Route::TurnToolResult
             | Route::TurnProviderResult
             | Route::TurnProviderDelta
+            | Route::TurnRequeryResult
             | Route::TurnCancel
             | Route::TurnSteer
             | Route::TurnPause
@@ -461,6 +468,10 @@ impl StreamEndReason {
 pub enum ReverseKind {
     Provider,
     Tool,
+    /// A step-boundary context re-query. Distinct from the other two because
+    /// it is the one reverse request a turn survives unanswered: the step
+    /// proceeds with no extra context rather than failing.
+    Requery,
 }
 
 /// Which half of the checkpoint sink failed.

--- a/crates/stella-serve/src/observe/metrics.rs
+++ b/crates/stella-serve/src/observe/metrics.rs
@@ -92,6 +92,7 @@ pub struct Metrics {
 
     reverse_dispatched_provider_total: AtomicU64,
     reverse_dispatched_tool_total: AtomicU64,
+    reverse_dispatched_requery_total: AtomicU64,
     reverse_answered_total: AtomicU64,
     reverse_wait_ms_total: AtomicU64,
     reverse_timed_out_total: AtomicU64,
@@ -157,6 +158,7 @@ pub struct Snapshot {
 
     pub reverse_dispatched_provider_total: u64,
     pub reverse_dispatched_tool_total: u64,
+    pub reverse_dispatched_requery_total: u64,
     pub reverse_answered_total: u64,
     pub reverse_wait_ms_total: u64,
     pub reverse_timed_out_total: u64,
@@ -231,6 +233,7 @@ impl Metrics {
 
             reverse_dispatched_provider_total: self.reverse_dispatched_provider_total.load(ORDER),
             reverse_dispatched_tool_total: self.reverse_dispatched_tool_total.load(ORDER),
+            reverse_dispatched_requery_total: self.reverse_dispatched_requery_total.load(ORDER),
             reverse_answered_total: self.reverse_answered_total.load(ORDER),
             reverse_wait_ms_total: self.reverse_wait_ms_total.load(ORDER),
             reverse_timed_out_total: self.reverse_timed_out_total.load(ORDER),
@@ -361,6 +364,7 @@ impl Observer for Metrics {
                 match kind {
                     ReverseKind::Provider => &self.reverse_dispatched_provider_total,
                     ReverseKind::Tool => &self.reverse_dispatched_tool_total,
+                    ReverseKind::Requery => &self.reverse_dispatched_requery_total,
                 }
                 .fetch_add(1, ORDER);
                 self.reverse_in_flight.fetch_add(1, ORDER);

--- a/crates/stella-serve/src/pending.rs
+++ b/crates/stella-serve/src/pending.rs
@@ -38,6 +38,9 @@ type ProviderDeltaFeed = mpsc::UnboundedSender<ProviderDelta>;
 /// A registered reply channel, discriminated by the kind of request it answers.
 enum PendingReply {
     Tool(oneshot::Sender<ToolOutput>),
+    /// The host's answer to a step-boundary context re-query: a block to put
+    /// in front of the model, or `None` for "nothing worth the tokens".
+    Requery(oneshot::Sender<Option<String>>),
     Provider {
         reply: ProviderReply,
         /// Stays in the map (looked up, never taken) so any number of delta
@@ -106,6 +109,22 @@ impl Pending {
         true
     }
 
+    /// Register a re-query reply channel under `id`. Same contract — and the
+    /// same locked cancellation check — as [`Pending::register_tool`].
+    #[must_use]
+    pub(crate) fn register_requery(
+        &self,
+        id: String,
+        reply: oneshot::Sender<Option<String>>,
+    ) -> bool {
+        let mut map = self.lock();
+        if self.is_cancelled() {
+            return false;
+        }
+        map.insert(id, PendingReply::Requery(reply));
+        true
+    }
+
     /// Register a provider reply channel under `id`, together with the feed
     /// any streamed fragments for that request are delivered on. Same
     /// contract — and the same locked cancellation check — as
@@ -131,6 +150,15 @@ impl Pending {
         // A receive-side drop (the engine step was cancelled) is not an error to
         // the host: the request is simply gone.
         let _ = self.report_misroute(id, self.take_tool(id))?.send(output);
+        Ok(())
+    }
+
+    /// Resolve a re-query request with the host-supplied block. Errors if `id`
+    /// is unknown or names another kind of request.
+    pub fn resolve_requery(&self, id: &str, context: Option<String>) -> Result<(), ServeError> {
+        let _ = self
+            .report_misroute(id, self.take_requery(id))?
+            .send(context);
         Ok(())
     }
 
@@ -171,7 +199,7 @@ impl Pending {
                     }
                     Ok(())
                 }
-                Some(PendingReply::Tool(_)) => {
+                Some(PendingReply::Tool(_) | PendingReply::Requery(_)) => {
                     Err(ServeError::RequestKindMismatch(id.to_string(), "provider"))
                 }
                 None => Err(ServeError::UnknownRequest(id.to_string())),
@@ -289,6 +317,21 @@ impl Pending {
             Some(other) => {
                 map.insert(id.to_string(), other);
                 Err(ServeError::RequestKindMismatch(id.to_string(), "tool"))
+            }
+            None => Err(ServeError::UnknownRequest(id.to_string())),
+        }
+    }
+
+    /// Take the re-query reply channel registered under `id`, leaving a
+    /// wrong-kinded entry untouched. Same single-lock discipline as
+    /// [`Pending::take_tool`], for the same reason.
+    fn take_requery(&self, id: &str) -> Result<oneshot::Sender<Option<String>>, ServeError> {
+        let mut map = self.lock();
+        match map.remove(id) {
+            Some(PendingReply::Requery(tx)) => Ok(tx),
+            Some(other) => {
+                map.insert(id.to_string(), other);
+                Err(ServeError::RequestKindMismatch(id.to_string(), "requery"))
             }
             None => Err(ServeError::UnknownRequest(id.to_string())),
         }

--- a/crates/stella-serve/src/remote.rs
+++ b/crates/stella-serve/src/remote.rs
@@ -31,6 +31,8 @@ use crate::frame::{ProviderDelta, ServerFrame};
 use crate::observe::event::{RequestId, ReverseKind, ServeEvent, millis};
 use crate::pending::Pending;
 
+pub(crate) mod requery;
+
 /// Record that a reverse request reached the host, and start its clock.
 ///
 /// Emitted *after* the frame is sent, never before: a request the host never

--- a/crates/stella-serve/src/remote/requery.rs
+++ b/crates/stella-serve/src/remote/requery.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The step-boundary context re-query, remoted.
+//!
+//! A re-query fans out over recall, and that costs the host money. This server
+//! is also allowed no rights of its own: it opens no store and reads no
+//! `.stella/`. So the ask travels the way a model call and a tool call do. A
+//! [`ServerFrame::RequeryRequest`] goes out, a
+//! `POST /v1/turns/{id}/requery-result` comes back, and the engine step waits
+//! in between.
+//!
+//! # What stays on this side of the wire
+//!
+//! The port owns two jobs, and both are here. Both exist to stop the host
+//! being asked for nothing.
+//!
+//! - **When to ask.** A changed signal buys an ask; a counter never does. The
+//!   fingerprint is the paths the turn has touched and the errors it has seen.
+//!   Tool names are left out, since they change every step whether the work
+//!   moved or not. [`MIN_STEPS_BETWEEN`] then spaces the asks out, so two
+//!   changes one step apart cannot bill twice. The CLI's
+//!   `stella_cli::memory::steering::SessionRequery` does the same thing on the
+//!   other surface.
+//! - **What not to send twice.** The engine puts this block in front of the
+//!   model as it is, so a block that matches one in the turn already has to
+//!   die here. The set starts from the recall blocks the turn opened with.
+//!
+//! There is a finer dedup than that: "the turn already showed that frame".
+//! It stays on the CLI side. A frame handle names a thing in a workspace, and
+//! this server never sees one. The host knows what it sent.
+//!
+//! # An ask nobody answers is not a failed turn
+//!
+//! A quiet host fails the turn on the provider port, and hands the model an
+//! error on the tool port. Here it answers `None`, and the step runs with what
+//! it had. More context is a bonus, so losing it costs the turn nothing.
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use stella_core::steering::TurnSignal;
+use tokio::sync::oneshot;
+
+use crate::frame::{RequerySignal, ServerFrame};
+use crate::observe::event::ReverseKind;
+use crate::pending::Pending;
+
+use super::{answered, dispatched, timed_out};
+
+/// How many steps a fresh answer waits after the last one. This spaces the
+/// asks out; the fingerprint is what starts one. The CLI's `SessionRequery`
+/// uses the same number, since a served turn drifts at the rate a local one
+/// does.
+const MIN_STEPS_BETWEEN: u32 = 2;
+
+/// Hands out [`RemoteRequery`] tags, on the terms the provider and tool ports
+/// use. A request id only has to be one of a kind inside one turn's
+/// [`Pending`] map. A counter shared by the whole process does that, and no
+/// call site has to be handed one.
+static REQUERY_INSTANCES: AtomicU64 = AtomicU64::new(0);
+
+/// What this turn has shown the model so far, and the last signal it
+/// answered.
+struct RequeryState {
+    /// Blocks already in history, by exact bytes.
+    produced: HashSet<String>,
+    /// The last signal the plane answered. It starts empty, so a turn that
+    /// never drifts never asks.
+    answered_fingerprint: u64,
+}
+
+/// `stella_core::ports::SteeringRequery`, asked over the wire.
+pub(crate) struct RemoteRequery {
+    instance: u64,
+    frames: crate::backlog::FrameSink,
+    pending: Pending,
+    counter: AtomicU64,
+    timeout: Duration,
+    state: Mutex<RequeryState>,
+}
+
+impl RemoteRequery {
+    /// One of these per turn. It starts from the recall blocks `messages`
+    /// holds, so none of them can go in twice.
+    pub(crate) fn new(
+        messages: &[stella_protocol::CompletionMessage],
+        frames: crate::backlog::FrameSink,
+        pending: Pending,
+        timeout: Duration,
+    ) -> Self {
+        let produced = messages
+            .iter()
+            .filter(|m| {
+                m.role == stella_protocol::MessageRole::User
+                    && m.content.starts_with(stella_core::receipts::RECALL_MARKER)
+            })
+            .map(|m| m.content.clone())
+            .collect();
+        Self {
+            instance: REQUERY_INSTANCES.fetch_add(1, Ordering::Relaxed),
+            frames,
+            pending,
+            counter: AtomicU64::new(0),
+            timeout,
+            state: Mutex::new(RequeryState {
+                produced,
+                answered_fingerprint: fingerprint(&[], &[]),
+            }),
+        }
+    }
+
+    /// Ask the host, and wait for its answer up to this turn's deadline.
+    /// Every way the ask can fail gives `None`. The module header says why
+    /// that is safe here and nowhere else.
+    async fn ask(&self, signal: &TurnSignal<'_>) -> Option<String> {
+        let request_id = format!(
+            "requery-{}-{}",
+            self.instance,
+            self.counter.fetch_add(1, Ordering::Relaxed)
+        );
+        let (tx, rx) = oneshot::channel();
+        // Add the entry before the frame goes out, so it is there by the time
+        // the host can answer. A refused add means the turn was cancelled.
+        if !self.pending.register_requery(request_id.clone(), tx) {
+            return None;
+        }
+        if self
+            .frames
+            .send(ServerFrame::RequeryRequest {
+                request_id: request_id.clone(),
+                signal: RequerySignal::from_signal(signal),
+            })
+            .is_err()
+        {
+            self.pending.abandon(&request_id);
+            return None;
+        }
+        let started = dispatched(&self.pending, &request_id, ReverseKind::Requery);
+        match tokio::time::timeout(self.timeout, rx).await {
+            Ok(Ok(context)) => {
+                answered(&self.pending, &request_id, ReverseKind::Requery, started);
+                context
+            }
+            // The sender went away: a cancel, or the turn shutting down.
+            // `Pending` reports the dropped work itself.
+            Ok(Err(_)) => None,
+            Err(_) => {
+                self.pending.abandon(&request_id);
+                timed_out(&self.pending, &request_id, ReverseKind::Requery, started);
+                None
+            }
+        }
+    }
+}
+
+/// A digest of the drift marks that ignores their order. `BTreeSet` is what
+/// makes two signals with the same facts agree.
+fn fingerprint(paths: &[String], errors: &[&str]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::hash::DefaultHasher::new();
+    let paths: std::collections::BTreeSet<&str> = paths.iter().map(String::as_str).collect();
+    let errors: std::collections::BTreeSet<&str> = errors.iter().copied().collect();
+    (paths, errors).hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Give the host's block the mark the engine's turn-window rule reads.
+///
+/// The block goes in as a user message, word for word.
+/// `driver::loop_evidence::turn_start_index` tells added context from a real
+/// user turn by this prefix alone. A host that left it off would move the turn
+/// window, so the server adds it.
+fn marked(block: String) -> String {
+    if block.starts_with(stella_core::receipts::RECALL_MARKER) {
+        return block;
+    }
+    format!("{}\n{block}", stella_core::receipts::RECALL_MARKER)
+}
+
+#[async_trait::async_trait]
+impl stella_core::ports::SteeringRequery for RemoteRequery {
+    async fn requery(&self, signal: &TurnSignal<'_>) -> Option<String> {
+        if signal.since_last_query < MIN_STEPS_BETWEEN {
+            return None;
+        }
+        // Never park a cancelled turn. `Pending::cancel` has woken everyone
+        // already, so a park now would wait out the whole deadline with
+        // nobody left to answer it.
+        if self.pending.is_cancelled() {
+            return None;
+        }
+        let current = fingerprint(signal.touched_paths, signal.errors_seen);
+        // The guard is a `std::sync::Mutex`, so it is never held over the
+        // await below. That is what keeps this future `Send`.
+        if self
+            .state
+            .lock()
+            .expect("requery state")
+            .answered_fingerprint
+            == current
+        {
+            return None;
+        }
+        let context = self.ask(signal).await;
+        let mut state = self.state.lock().expect("requery state");
+        // The signal counts as answered either way. A drift the host had
+        // nothing for must not be asked again on every later step.
+        state.answered_fingerprint = current;
+        let block = marked(context?);
+        state.produced.insert(block.clone()).then_some(block)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A changed signal is what starts an ask. Two boundaries that saw the
+    /// same paths and errors in a different order agree, and buy no second
+    /// ask.
+    #[test]
+    fn the_fingerprint_ignores_the_order_facts_arrived_in() {
+        let a = vec!["src/b.rs".to_string(), "src/a.rs".to_string()];
+        let b = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
+        assert_eq!(fingerprint(&a, &["timeout"]), fingerprint(&b, &["timeout"]));
+        assert_ne!(fingerprint(&a, &["timeout"]), fingerprint(&a, &[]));
+        assert_ne!(fingerprint(&a, &[]), fingerprint(&[], &[]));
+    }
+
+    /// A host that sends plain text gets the mark added. One that wrote the
+    /// mark keeps its own bytes, so no block is marked twice.
+    #[test]
+    fn a_block_without_the_recall_marker_is_given_one() {
+        let marker = stella_core::receipts::RECALL_MARKER;
+        let added = marked("see src/adapter.rs".to_string());
+        assert!(added.starts_with(marker), "{added}");
+        assert!(added.ends_with("see src/adapter.rs"), "{added}");
+
+        let already = format!("{marker}\nsee src/adapter.rs");
+        assert_eq!(marked(already.clone()), already);
+    }
+}

--- a/crates/stella-serve/src/router.rs
+++ b/crates/stella-serve/src/router.rs
@@ -20,6 +20,7 @@ pub(crate) fn route_addresses_a_turn(route: Route) -> bool {
             | Route::TurnToolResult
             | Route::TurnProviderResult
             | Route::TurnProviderDelta
+            | Route::TurnRequeryResult
             | Route::TurnCancel
             | Route::TurnSteer
             | Route::TurnPause
@@ -45,6 +46,7 @@ pub(crate) fn classify<'a>(segs: &[&'a str]) -> (Route, Option<&'a str>) {
         ["v1", "turns", id, "tool-result"] => (Route::TurnToolResult, Some(id)),
         ["v1", "turns", id, "provider-result"] => (Route::TurnProviderResult, Some(id)),
         ["v1", "turns", id, "provider-delta"] => (Route::TurnProviderDelta, Some(id)),
+        ["v1", "turns", id, "requery-result"] => (Route::TurnRequeryResult, Some(id)),
         ["v1", "turns", id, "cancel"] => (Route::TurnCancel, Some(id)),
         ["v1", "turns", id, "steer"] => (Route::TurnSteer, Some(id)),
         ["v1", "turns", id, "pause"] => (Route::TurnPause, Some(id)),
@@ -103,6 +105,7 @@ pub(crate) fn allowed(route: Route) -> &'static str {
         | Route::TurnToolResult
         | Route::TurnProviderResult
         | Route::TurnProviderDelta
+        | Route::TurnRequeryResult
         | Route::TurnCancel
         | Route::TurnSteer
         | Route::TurnPause

--- a/crates/stella-serve/src/routes.rs
+++ b/crates/stella-serve/src/routes.rs
@@ -33,6 +33,7 @@ use crate::observe::record::{RequestRecord, Responder};
 use crate::session::{Session, SessionSpec};
 use crate::state::ServerState;
 
+pub(crate) mod requery;
 mod sessions;
 
 // Re-exported rather than moved-and-renamed: `server.rs` dispatches every route
@@ -68,6 +69,12 @@ struct TurnRequest {
     /// Omitted — or an empty object — reproduces today's behavior exactly.
     #[serde(default)]
     engine: Option<EngineOverrides>,
+    /// Let this turn re-ask the host for context at its step boundaries.
+    /// Off by default, because a host that has not built
+    /// `POST /v1/turns/{id}/requery-result` cannot answer, and an unanswered
+    /// request parks the step for the whole reverse-request deadline.
+    #[serde(default)]
+    steering_requery: bool,
     /// Run this turn as a judged multi-round goal run (#1297). Omitted is a
     /// single turn, exactly as before.
     #[serde(default)]
@@ -470,6 +477,7 @@ pub(crate) async fn handle_create(
                 turn.budget.session_limit_usd,
             ),
             reverse_request_timeout,
+            steering_requery: turn.steering_requery,
             turn: TurnRef::new(turn_id),
             observer,
             on_settled: None,

--- a/crates/stella-serve/src/routes/requery.rs
+++ b/crates/stella-serve/src/routes/requery.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `POST /v1/turns/{id}/requery-result` — the host's answer to a
+//! `requery_request`.
+//!
+//! Its own file, not one more handler in `routes.rs`. That file is the closest
+//! one in this crate to the 1500-line cap
+//! (`scripts/check-file-size.sh`). It moved its session handlers out the same
+//! way.
+
+use std::sync::Arc;
+
+use crate::frame::RequeryResultIn;
+use crate::observe::record::Responder;
+use crate::routes::error_body;
+use crate::state::ServerState;
+
+/// Answer the parked step with the block the host chose, or with nothing.
+///
+/// An id nothing waits on gets a `409`, just as the two result routes give
+/// one. A re-query the port gave up on is out of the map. Saying so tells the
+/// host its answer was late; silence would not.
+pub(crate) async fn handle_requery_result(
+    res: &mut Responder<'_>,
+    state: &Arc<ServerState>,
+    id: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let Some(entry) = state.lookup(id) else {
+        return res.json("404 Not Found", &error_body("unknown turn")).await;
+    };
+    let posted: RequeryResultIn = match serde_json::from_slice(body) {
+        Ok(posted) => posted,
+        Err(err) => {
+            return res
+                .json(
+                    "400 Bad Request",
+                    &error_body(&format!("invalid requery result: {err}")),
+                )
+                .await;
+        }
+    };
+    match entry
+        .pending
+        .resolve_requery(&posted.request_id, posted.context)
+    {
+        Ok(()) => res.json("200 OK", br#"{"status":"ok"}"#).await,
+        Err(err) => {
+            res.json("409 Conflict", &error_body(&err.to_string()))
+                .await
+        }
+    }
+}

--- a/crates/stella-serve/src/routes/sessions.rs
+++ b/crates/stella-serve/src/routes/sessions.rs
@@ -77,6 +77,11 @@ struct SessionTurnRequest {
     /// the stateless route.
     #[serde(default)]
     sub_agents: Option<SubAgentsSpec>,
+    /// Mid-turn context re-query, same block and same default-off reading as
+    /// the stateless route. It appends to the volatile tail only,
+    /// so the session's byte-stable prefix is untouched.
+    #[serde(default)]
+    steering_requery: bool,
 }
 
 /// Response to `POST /v1/sessions/{id}/turns`. The turn is an ordinary member
@@ -266,6 +271,7 @@ pub(crate) async fn handle_session_turn(
     // `None` when the registry's bounds refuse this id — see
     // `crate::calibration` for why a host-supplied key gets a bounded map.
     let calibration = state.calibration().for_provider(&request.provider_id);
+    let steering_requery = request.steering_requery;
     let registered = state.register_turn(move |turn_id| {
         Session::start(SessionSpec {
             provider_id: request.provider_id,
@@ -276,6 +282,7 @@ pub(crate) async fn handle_session_turn(
             config,
             budget,
             reverse_request_timeout,
+            steering_requery,
             turn: TurnRef::new(turn_id),
             observer,
             on_settled: Some(hook_sess.settle_hook(token)),

--- a/crates/stella-serve/src/schema_export.rs
+++ b/crates/stella-serve/src/schema_export.rs
@@ -62,7 +62,7 @@ use stella_protocol::schema_export::{
 };
 
 use crate::engine_overrides::EngineOverrides;
-use crate::frame::{ProviderDeltaIn, ProviderResultIn, ServerFrame, ToolResultIn};
+use crate::frame::{ProviderDeltaIn, ProviderResultIn, RequeryResultIn, ServerFrame, ToolResultIn};
 
 /// Why the transport's wire contract could not be published.
 ///
@@ -111,6 +111,12 @@ pub fn provider_delta_schema() -> Value {
     schemars::schema_for!(ProviderDeltaIn).to_value()
 }
 
+/// The JSON Schema for the requery-result body a host POSTs back.
+#[must_use]
+pub fn requery_result_schema() -> Value {
+    schemars::schema_for!(RequeryResultIn).to_value()
+}
+
 /// The JSON Schema for the optional `engine` object on `POST /v1/turns` and
 /// `POST /v1/sessions/{id}/turns` (#1167).
 #[must_use]
@@ -151,6 +157,11 @@ static INBOUND_BODIES: &[InboundBody] = &[
         name: "ProviderDeltaIn",
         schema: provider_delta_schema,
         banner: DELTA_HEADER,
+    },
+    InboundBody {
+        name: "RequeryResultIn",
+        schema: requery_result_schema,
+        banner: REQUERY_HEADER,
     },
     InboundBody {
         name: "EngineOverrides",
@@ -203,7 +214,9 @@ pub fn inbound_schema() -> Result<Value, ServeSchemaError> {
              answers POST /v1/turns/{id}/tool-result; ProviderResultIn answers \
              POST /v1/turns/{id}/provider-result; ProviderDeltaIn optionally \
              streams fragments of an in-flight provider answer to \
-             POST /v1/turns/{id}/provider-delta ahead of its ProviderResultIn. \
+             POST /v1/turns/{id}/provider-delta ahead of its ProviderResultIn; \
+             RequeryResultIn answers POST /v1/turns/{id}/requery-result with \
+             the context block a drifted turn should also see, or with null. \
              Each is keyed by the request_id carried on the frame it answers. \
              EngineOverrides is not a reverse-request answer at all: it is the \
              optional `engine` object on POST /v1/turns and \
@@ -265,8 +278,8 @@ pub fn artifacts() -> Result<Vec<(&'static str, String)>, ServeSchemaError> {
     let outbound = server_frame_schema();
 
     // One definition set across every root the `.d.ts` prints. Each root
-    // carries its own copy of every payload type it reaches, so printing five
-    // of them back to back declared ten identifiers twice — `TS2300` (#4583).
+    // carries its own copy of every payload type it reaches, so printing them
+    // back to back declared ten identifiers twice — `TS2300` (#4583).
     let mut defs = Map::new();
     let mut frame = hoist("ServerFrame", outbound.clone(), &mut defs)?;
     let mut sections = Vec::with_capacity(INBOUND_BODIES.len());
@@ -275,7 +288,7 @@ pub fn artifacts() -> Result<Vec<(&'static str, String)>, ServeSchemaError> {
     }
 
     // The whole definition set rides with the first document printed, and the
-    // four that follow declare only their own root. Nothing is lost by that:
+    // inbound roots that follow declare only their own. Nothing is lost by that:
     // TypeScript declarations are order-independent within a file, so an
     // interface referring to one printed above it resolves exactly as it did
     // when every root carried its own copy.
@@ -389,6 +402,22 @@ const DELTA_HEADER: &str = "
 // simply never uses this route.
 ";
 
+/// Rides above `RequeryResultIn`: the answer is optional in a way the schema
+/// cannot say — `null` is the ordinary reply, and no answer at all is safe.
+const REQUERY_HEADER: &str = "
+// ── inbound, optional: answering a context re-query ─────────────────────────
+//
+// A turn created with `steering_requery: true` raises a `requery_request`
+// frame at a step boundary once its work has moved on from the prompt it
+// opened with. POST the block your own context plane chose to
+// `POST /v1/turns/{id}/requery-result`, keyed by the frame's request_id, or
+// post `context: null` — the ordinary answer — for nothing worth the tokens.
+// The block is appended to the turn's volatile tail and never touches the
+// byte-stable prefix. Leaving the request unanswered is safe: the step
+// proceeds with the context it already had once the reverse-request deadline
+// expires.
+";
+
 const ENGINE_HEADER: &str = "
 // ── request-side: the optional `engine` object on POST /v1/turns ────────────
 //
@@ -435,9 +464,9 @@ mod tests {
     /// The exact half is asserted on [`INBOUND_BODIES`] and the reaches-the-
     /// document half on the generated `$defs`, because since #4583 that map
     /// also carries every payload type the bodies reference. Asserting the
-    /// whole map exactly would pin the payload graph of four Rust types, which
-    /// changes for reasons that have nothing to do with an endpoint gaining a
-    /// body.
+    /// whole map exactly would pin the payload graph of every body's Rust
+    /// type, which changes for reasons that have nothing to do with an
+    /// endpoint gaining a body.
     #[test]
     fn every_inbound_body_is_published_in_the_contract() {
         let published: Vec<&str> = INBOUND_BODIES.iter().map(|body| body.name).collect();
@@ -447,6 +476,7 @@ mod tests {
                 "ToolResultIn",
                 "ProviderResultIn",
                 "ProviderDeltaIn",
+                "RequeryResultIn",
                 "EngineOverrides"
             ],
             "the published inbound bodies drifted from the ones a host can POST"

--- a/crates/stella-serve/src/server.rs
+++ b/crates/stella-serve/src/server.rs
@@ -16,6 +16,7 @@
 //! | `POST /v1/turns/{id}/tool-result` | answer a `tool_request` (`ToolResultIn`) |
 //! | `POST /v1/turns/{id}/provider-result` | answer a `provider_request` (`ProviderResultIn`) |
 //! | `POST /v1/turns/{id}/provider-delta` | stream fragments of an in-flight `provider_request`, ahead of its result (#1165) |
+//! | `POST /v1/turns/{id}/requery-result` | answer a `requery_request` |
 //! | `POST /v1/turns/{id}/cancel` | end an in-flight turn → `{ "status": "cancelled" }` |
 //! | `POST /v1/turns/{id}/steer` | inject a mid-turn user message (#932) |
 //! | `POST /v1/turns/{id}/pause` | hold the turn at its next step boundary; optional `{"reason"}` (#932) |
@@ -32,9 +33,9 @@
 //! the turn registry they act on in `src/state.rs`; this module is the
 //! transport — listener, connection fold, auth, route classification.
 //!
-//! The SSE stream is the engine → host direction; the two result POSTs are the
-//! host → engine direction. Together they are the reverse tool-call protocol —
-//! the engine never runs a model or tool call itself.
+//! The SSE stream runs engine → host. The result POSTs run host → engine.
+//! Together they are the reverse tool-call protocol. The engine never runs a
+//! model or a tool call itself.
 //!
 //! # Every connection produces exactly one record
 //!
@@ -763,6 +764,7 @@ async fn route(
             | Route::TurnToolResult
             | Route::TurnProviderResult
             | Route::TurnProviderDelta
+            | Route::TurnRequeryResult
             | Route::TurnSteer
             // Body-bearing but not body-*requiring*: an empty pause is the
             // shape the route shipped with and stays valid (#932).
@@ -799,6 +801,9 @@ async fn route(
             routes::handle_provider_result(res, state, id, &req.body).await
         }
         Route::TurnProviderDelta => routes::handle_provider_delta(res, state, id, &req.body).await,
+        Route::TurnRequeryResult => {
+            routes::requery::handle_requery_result(res, state, id, &req.body).await
+        }
         Route::TurnSteer => routes::handle_steer(res, state, id, &req.body).await,
         Route::TurnPause => routes::handle_pause(res, state, id, &req.body).await,
         Route::SessionsCreate => routes::handle_session_create(res, state, &req.body).await,

--- a/crates/stella-serve/src/session.rs
+++ b/crates/stella-serve/src/session.rs
@@ -1086,6 +1086,18 @@ mod tests {
         }
     }
 
+    /// Stands in for a host that built the re-query route. What it answers
+    /// does not matter here — these tests ask which seams a served turn
+    /// binds, not what a bound seam returns.
+    struct SilentRequery;
+
+    #[async_trait]
+    impl stella_core::ports::SteeringRequery for SilentRequery {
+        async fn requery(&self, _signal: &stella_core::steering::TurnSignal<'_>) -> Option<String> {
+            None
+        }
+    }
+
     /// **The lane witness.** A served turn declares the `ServeSession` lane,
     /// so a host grouping turns by lane sees this one as its own bucket
     /// rather than as an unattributed `null`.
@@ -1122,8 +1134,10 @@ mod tests {
         let host_supplied_nothing = served_capabilities(None, &gate, &steering, None, None);
         assert!(host_supplied_nothing.gate.is_some() && host_supplied_nothing.steering.is_some());
         assert!(
-            host_supplied_nothing.calibration.is_none() && host_supplied_nothing.bus.is_none(),
-            "a host that supplied neither must not be given one",
+            host_supplied_nothing.calibration.is_none()
+                && host_supplied_nothing.bus.is_none()
+                && host_supplied_nothing.requery.is_none(),
+            "a host that supplied none of them must not be given one",
         );
         assert!(
             host_supplied_nothing.hooks.is_none(),
@@ -1132,8 +1146,19 @@ mod tests {
 
         let calibration = stella_core::estimator::CalibrationMap::default();
         let bus = stella_core::bus::HookBus::new("serve-lane-test");
-        let host_supplied_both =
-            served_capabilities(Some(&calibration), &gate, &steering, None, Some(&bus));
-        assert!(host_supplied_both.calibration.is_some() && host_supplied_both.bus.is_some());
+        let requery = SilentRequery;
+        let host_supplied_all = served_capabilities(
+            Some(&calibration),
+            &gate,
+            &steering,
+            Some(&requery),
+            Some(&bus),
+        );
+        assert!(
+            host_supplied_all.calibration.is_some()
+                && host_supplied_all.bus.is_some()
+                && host_supplied_all.requery.is_some(),
+            "every seam the host supplied must reach the turn",
+        );
     }
 }

--- a/crates/stella-serve/src/session.rs
+++ b/crates/stella-serve/src/session.rs
@@ -164,6 +164,15 @@ pub struct SessionSpec {
     /// pre-#1298 behavior — the turn estimates uncorrected and contributes no
     /// samples.
     pub calibration: Option<Arc<stella_core::estimator::CalibrationMap>>,
+    /// Let this turn re-ask the host for context at its step boundaries.
+    /// `false` — the default — attaches no re-query source at all: the turn
+    /// picks its context from the opening prompt and never looks again.
+    ///
+    /// Opt-in rather than always-on because only the host can answer. A host
+    /// that has not built `POST /v1/turns/{id}/requery-result` would leave
+    /// every request unanswered, and each one parks the step for the whole
+    /// [`SessionSpec::reverse_request_timeout`].
+    pub steering_requery: bool,
 }
 
 /// The settlement callback a session owner installs on a turn — see
@@ -400,6 +409,21 @@ impl Session {
         deltas: Vec<crate::frame::ProviderDelta>,
     ) -> Result<(), ServeError> {
         self.pending.resolve_provider_delta(request_id, deltas)
+    }
+
+    /// Answer a [`ServerFrame::RequeryRequest`] with the block the host's
+    /// steering plane chose, or `None` when nothing is worth the tokens.
+    ///
+    /// The block is appended to the turn's volatile tail as a user message;
+    /// the byte-stable prefix is never touched. The server prefixes the recall
+    /// marker when the block does not already carry one, so the engine reads
+    /// it as injected context rather than as a user turn.
+    pub fn resolve_requery(
+        &self,
+        request_id: &str,
+        context: Option<String>,
+    ) -> Result<(), ServeError> {
+        self.pending.resolve_requery(request_id, context)
     }
 
     /// Answer a [`ServerFrame::ProviderRequest`] with a classified failure.
@@ -736,7 +760,20 @@ fn run_session(
         // Every attachment below is by reference for the engine's lifetime, so
         // the owners have to outlive it — hence the bindings above rather than
         // temporaries here.
-        //
+
+        // The step-boundary context re-query, when the host asked for it. It
+        // starts from the opening transcript, so a block the turn already
+        // holds cannot go in twice — which is why it is built here, before
+        // `spec.messages` moves into the turn below.
+        let requery = spec.steering_requery.then(|| {
+            crate::remote::requery::RemoteRequery::new(
+                &spec.messages,
+                frame_tx.clone(),
+                pending.clone(),
+                spec.reverse_request_timeout,
+            )
+        });
+
         // Assembled rather than built up by optional builders: this turn is
         // the `ServeSession` lane and says so, and `served_capabilities`
         // answers every seam rather than only the ones a chain attached.
@@ -745,7 +782,15 @@ fn run_session(
             tool_view,
             spec.config.clone(),
             &sleeper,
-            served_capabilities(spec.calibration.as_deref(), &gate, &*steering, bus.as_ref()),
+            served_capabilities(
+                spec.calibration.as_deref(),
+                &gate,
+                &*steering,
+                requery
+                    .as_ref()
+                    .map(|r| r as &dyn stella_core::ports::SteeringRequery),
+                bus.as_ref(),
+            ),
         );
 
         // Two mutually exclusive modes: plain turn, judged goal run (#1297).
@@ -841,13 +886,15 @@ fn run_session(
 /// stops this function compiling until somebody decides what a served turn
 /// does with it — the whole reason that type has no `Default`.
 ///
-/// `calibration` and `bus` are `Option`s because the host supplies them or
-/// does not: a map is only useful across turns, and the bus exists only when
-/// the deployment installed an extension.
+/// `calibration`, `requery` and `bus` are `Option`s because the host supplies
+/// them or does not: a map is only useful across turns, the bus exists only
+/// when the deployment installed an extension, and a re-query source exists
+/// only when the turn asked for one.
 fn served_capabilities<'a>(
     calibration: Option<&'a stella_core::estimator::CalibrationMap>,
     gate: &'a dyn stella_engine::TurnGate,
     steering: &'a dyn stella_engine::TurnSteering,
+    requery: Option<&'a dyn stella_core::ports::SteeringRequery>,
     bus: Option<&'a stella_core::bus::HookBus>,
 ) -> TurnCapabilities<'a> {
     TurnCapabilities {
@@ -858,7 +905,7 @@ fn served_capabilities<'a>(
         calibration,
         gate: Some(gate),
         steering: Some(steering),
-        requery: None,
+        requery,
         bus,
         outcomes: None,
         // The host owns the model calls, so re-resolving a provider mid-turn

--- a/crates/stella-serve/src/session.rs
+++ b/crates/stella-serve/src/session.rs
@@ -1100,7 +1100,7 @@ mod tests {
         let gate = OpenGate;
         let steering = QuietSteering;
 
-        let seams = served_capabilities(None, &gate, &steering, None);
+        let seams = served_capabilities(None, &gate, &steering, None, None);
 
         assert_eq!(
             seams.lane,
@@ -1119,7 +1119,7 @@ mod tests {
         let gate = OpenGate;
         let steering = QuietSteering;
 
-        let host_supplied_nothing = served_capabilities(None, &gate, &steering, None);
+        let host_supplied_nothing = served_capabilities(None, &gate, &steering, None, None);
         assert!(host_supplied_nothing.gate.is_some() && host_supplied_nothing.steering.is_some());
         assert!(
             host_supplied_nothing.calibration.is_none() && host_supplied_nothing.bus.is_none(),
@@ -1133,7 +1133,7 @@ mod tests {
         let calibration = stella_core::estimator::CalibrationMap::default();
         let bus = stella_core::bus::HookBus::new("serve-lane-test");
         let host_supplied_both =
-            served_capabilities(Some(&calibration), &gate, &steering, Some(&bus));
+            served_capabilities(Some(&calibration), &gate, &steering, None, Some(&bus));
         assert!(host_supplied_both.calibration.is_some() && host_supplied_both.bus.is_some());
     }
 }

--- a/crates/stella-serve/src/state.rs
+++ b/crates/stella-serve/src/state.rs
@@ -618,6 +618,7 @@ mod tests {
             checkpoint: None,
             extensions: crate::extensions::Extensions::new(),
             calibration: None,
+            steering_requery: false,
         }
     }
 

--- a/crates/stella-serve/tests/bridge.rs
+++ b/crates/stella-serve/tests/bridge.rs
@@ -3,13 +3,14 @@
 //! reverse-RPC requests, exactly as the real host (Oxagen) will over HTTP. If
 //! this holds, wrapping a socket around it is transport plumbing.
 
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde_json::json;
 use stella_core::{BudgetGuard, EngineConfig, TurnOutcome};
 use stella_protocol::{
-    BudgetMode, CompletionMessage, CompletionResult, CompletionUsage, ToolCall, ToolOutput,
-    ToolSchema,
+    BudgetMode, CompletionMessage, CompletionResult, CompletionUsage, MessageRole, ToolCall,
+    ToolOutput, ToolSchema,
 };
 use stella_serve::observe::TurnRef;
 use stella_serve::{ProviderDelta, ServerFrame, Session, SessionSpec, TurnOutcomeWire};
@@ -79,6 +80,7 @@ fn spec_for(prompt: &str) -> SessionSpec {
         sub_agents: None,
         extensions: stella_serve::Extensions::new(),
         calibration: None,
+        steering_requery: false,
     }
 }
 
@@ -157,6 +159,9 @@ async fn tool_round_trip_completes_the_turn() {
                     .unwrap();
             }
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             // An unpaused turn crosses every step boundary freely, so the
             // pause gate must stay silent — a hold nobody asked for would
             // be a frame every host has to learn to ignore.
@@ -199,6 +204,9 @@ async fn immediate_completion_needs_no_tools() {
             }
             ServerFrame::ToolRequest { .. } => tool_calls += 1,
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             // An unpaused turn crosses every step boundary freely, so the
             // pause gate must stay silent — a hold nobody asked for would
             // be a frame every host has to learn to ignore.
@@ -235,6 +243,9 @@ async fn an_unanswered_provider_request_fails_on_the_deadline() {
         match frame {
             ServerFrame::ProviderRequest { .. } => provider_requests += 1,
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             // An unpaused turn crosses every step boundary freely, so the
             // pause gate must stay silent — a hold nobody asked for would
             // be a frame every host has to learn to ignore.
@@ -293,6 +304,9 @@ async fn an_unanswered_tool_request_times_out_into_a_tool_error() {
             // Never answered — the port's deadline must resolve it instead.
             ServerFrame::ToolRequest { .. } => tool_requests += 1,
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             // An unpaused turn crosses every step boundary freely, so the
             // pause gate must stay silent — a hold nobody asked for would
             // be a frame every host has to learn to ignore.
@@ -332,6 +346,9 @@ async fn cancelling_a_parked_turn_unwinds_it_promptly() {
             // Cancel instead of answering, while the step is parked on us.
             ServerFrame::ProviderRequest { .. } => session.cancel(),
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             // An unpaused turn crosses every step boundary freely, so the
             // pause gate must stay silent — a hold nobody asked for would
             // be a frame every host has to learn to ignore.
@@ -439,6 +456,9 @@ async fn streamed_provider_deltas_surface_as_events_before_the_completion() {
                 _ => {}
             },
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             // An unpaused turn crosses every step boundary freely, so the
             // pause gate must stay silent — a hold nobody asked for would
             // be a frame every host has to learn to ignore.
@@ -491,6 +511,9 @@ async fn a_host_that_never_streams_is_unchanged() {
                 event: stella_protocol::AgentEvent::TextDelta { .. },
             } => text_deltas += 1,
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             // An unpaused turn crosses every step boundary freely, so the
             // pause gate must stay silent — a hold nobody asked for would
             // be a frame every host has to learn to ignore.
@@ -557,6 +580,9 @@ async fn a_streaming_host_resets_the_reverse_request_deadline() {
                     .unwrap();
             }
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             // An unpaused turn crosses every step boundary freely, so the
             // pause gate must stay silent — a hold nobody asked for would
             // be a frame every host has to learn to ignore.
@@ -596,6 +622,9 @@ async fn provider_error_aborts_cleanly() {
                     .unwrap();
             }
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             // An unpaused turn crosses every step boundary freely, so the
             // pause gate must stay silent — a hold nobody asked for would
             // be a frame every host has to learn to ignore.
@@ -610,4 +639,208 @@ async fn provider_error_aborts_cleanly() {
         Some(TurnOutcomeWire::Aborted { .. }) => {}
         other => panic!("expected a clean abort, got {other:?}"),
     }
+}
+
+// ── the mid-turn context re-query ───────────────────────────────────────────
+
+/// The system message a re-query must not disturb: the byte-stable prefix a
+/// turn's prompt cache depends on (AGENTS.md rule 7).
+const STABLE_PREFIX: &str = "you are a careful engineer";
+
+/// The block a scripted host returns whenever the server asks for context.
+const CONTEXT_BLOCK: &str = "the provider adapters share one SSE parser";
+
+/// What one scripted re-query turn produced, for the tests that read it.
+struct RequeryRun {
+    outcome: Option<TurnOutcomeWire>,
+    /// The transcript as the engine left it.
+    messages: Vec<CompletionMessage>,
+    /// How many times the server asked the host for context.
+    asks: usize,
+    /// The touched paths carried on the first ask.
+    signal_paths: Vec<String>,
+    /// Whether a model call made after the ask saw the block.
+    block_reached_the_model: bool,
+}
+
+/// Run a three-step turn whose first two steps each touch `src/adapter.rs`, so
+/// the third boundary has both a drifted signal and the spacing the port
+/// requires, and answer whatever it asks for with `context`.
+async fn scripted_requery_turn(context: Option<&str>) -> RequeryRun {
+    let settled: Arc<Mutex<Vec<CompletionMessage>>> = Arc::new(Mutex::new(Vec::new()));
+    let write_back = Arc::clone(&settled);
+    let mut session = Session::start(SessionSpec {
+        messages: vec![
+            CompletionMessage::system(STABLE_PREFIX),
+            CompletionMessage::user("fix the flaky test"),
+        ],
+        steering_requery: true,
+        on_settled: Some(Box::new(move |settlement| {
+            *write_back.lock().expect("settled transcript") = settlement.messages;
+        })),
+        ..spec_for("unused — the messages above are this turn's transcript")
+    });
+
+    let mut run = RequeryRun {
+        outcome: None,
+        messages: Vec::new(),
+        asks: 0,
+        signal_paths: Vec::new(),
+        block_reached_the_model: false,
+    };
+    let mut provider_calls = 0usize;
+
+    while let Some(frame) = session.next_frame().await {
+        match frame {
+            ServerFrame::ProviderRequest {
+                request_id,
+                request,
+                ..
+            } => {
+                provider_calls += 1;
+                if request
+                    .messages
+                    .iter()
+                    .any(|message| message.content.contains(CONTEXT_BLOCK))
+                {
+                    run.block_reached_the_model = true;
+                }
+                let result = if provider_calls <= 2 {
+                    wants_tool(
+                        &format!("call-{provider_calls}"),
+                        "echo",
+                        json!({ "path": "src/adapter.rs" }),
+                    )
+                } else {
+                    final_answer("done")
+                };
+                session.resolve_provider(&request_id, result).unwrap();
+            }
+            ServerFrame::ToolRequest { request_id, .. } => {
+                session
+                    .resolve_tool(
+                        &request_id,
+                        ToolOutput::Ok {
+                            content: "read it".to_string(),
+                            data: None,
+                        },
+                    )
+                    .unwrap();
+            }
+            ServerFrame::RequeryRequest { request_id, signal } => {
+                if run.asks == 0 {
+                    run.signal_paths = signal.touched_paths.clone();
+                }
+                run.asks += 1;
+                session
+                    .resolve_requery(&request_id, context.map(str::to_string))
+                    .unwrap();
+            }
+            ServerFrame::TurnComplete { outcome: done } => run.outcome = Some(done),
+            ServerFrame::Event { .. } => {}
+            ServerFrame::TurnHeld { .. } | ServerFrame::TurnReleased => {
+                panic!("an unpaused turn must not announce a hold")
+            }
+        }
+    }
+    run.messages = settled.lock().expect("settled transcript").clone();
+    run
+}
+
+/// **The witness for `turn.steering_requery` on the API surface.**
+///
+/// A served turn whose work moves onto a path its opening prompt never named
+/// asks the host for context at a step boundary, and what the host answers
+/// reaches the next model call.
+///
+/// It fails on `main` by construction, twice over: `stella-serve` assembles
+/// no re-query source there (`served_capabilities` passes `requery: None`),
+/// and there is no `requery_request` frame for a host to answer even if it
+/// did.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_served_turn_requeries_the_steering_plane_after_its_work_moves_to_a_new_path() {
+    let run = scripted_requery_turn(Some(CONTEXT_BLOCK)).await;
+
+    assert_eq!(run.asks, 1, "the drifted boundary asked exactly once");
+    assert_eq!(
+        run.signal_paths,
+        vec!["src/adapter.rs".to_string()],
+        "the host is told what the turn has touched, not just its prompt"
+    );
+    assert!(
+        run.block_reached_the_model,
+        "the host's block must reach the model call after it, or the re-query bought nothing"
+    );
+    assert_eq!(
+        run.outcome,
+        Some(TurnOutcomeWire::Completed {
+            text: "done".to_string(),
+            cost_usd: 0.0,
+        }),
+    );
+}
+
+/// The re-query appends and nothing else: the system message is byte-identical
+/// after it, and the block rides the volatile tail as a marked user message
+/// (AGENTS.md rule 7).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_served_requery_leaves_the_byte_stable_prefix_untouched() {
+    let run = scripted_requery_turn(Some(CONTEXT_BLOCK)).await;
+
+    let prefix = run.messages.first().expect("the turn settled a transcript");
+    assert_eq!(prefix.role, MessageRole::System);
+    assert_eq!(
+        prefix.content, STABLE_PREFIX,
+        "a re-query must not move one byte of the cached prefix"
+    );
+
+    let injected: Vec<&CompletionMessage> = run
+        .messages
+        .iter()
+        .filter(|message| message.content.contains(CONTEXT_BLOCK))
+        .collect();
+    assert_eq!(
+        injected.len(),
+        1,
+        "the block is injected once, not per step"
+    );
+    let block = injected[0];
+    assert_eq!(block.role, MessageRole::User);
+    assert!(
+        block
+            .content
+            .starts_with(stella_core::receipts::RECALL_MARKER),
+        "an injected block must carry the recall marker or the engine reads it \
+         as a user turn: {:?}",
+        block.content
+    );
+}
+
+/// The cheap answer. A host with nothing worth the tokens answers `null`, and
+/// the turn runs on with the context it already had.
+///
+/// The control for the witness above: both turns ask, and only the answered
+/// one grows a message.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_host_that_declines_a_requery_injects_nothing() {
+    let run = scripted_requery_turn(None).await;
+
+    assert_eq!(run.asks, 1, "the boundary still drifted, so it still asked");
+    assert!(
+        !run.block_reached_the_model,
+        "a declined re-query must put nothing in front of the model"
+    );
+    assert!(
+        run.messages.iter().all(|message| !message
+            .content
+            .starts_with(stella_core::receipts::RECALL_MARKER)),
+        "a declined re-query must leave no injected block behind"
+    );
+    assert_eq!(
+        run.outcome,
+        Some(TurnOutcomeWire::Completed {
+            text: "done".to_string(),
+            cost_usd: 0.0,
+        }),
+    );
 }

--- a/crates/stella-serve/tests/goal_and_subagents.rs
+++ b/crates/stella-serve/tests/goal_and_subagents.rs
@@ -83,6 +83,7 @@ fn base_spec(prompt: &str) -> SessionSpec {
         // shipping binary's own posture — see `hooks.rs` for the plane itself.
         extensions: Default::default(),
         calibration: None,
+        steering_requery: false,
     }
 }
 
@@ -169,6 +170,9 @@ async fn a_goal_run_is_requestable_over_the_wire_and_streams_its_rounds() {
                     .unwrap();
             }
             ServerFrame::TurnComplete { outcome: done } => outcome = Some(done),
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             ServerFrame::TurnHeld { .. } | ServerFrame::TurnReleased => {}
         }
     }

--- a/crates/stella-serve/tests/hooks.rs
+++ b/crates/stella-serve/tests/hooks.rs
@@ -77,6 +77,7 @@ fn spec_with(extensions: Vec<Arc<dyn ServeExtension>>) -> SessionSpec {
         checkpoint: None,
         extensions,
         calibration: None,
+        steering_requery: false,
         // Neither is the subject here: these scenarios drive a single turn and
         // assert on what the hook plane saw, so the goal loop and sub-agents
         // stay off — their own acceptance lives in `goal_and_subagents.rs`.
@@ -180,6 +181,9 @@ async fn run_turn(session: &mut Session) -> Vec<(String, serde_json::Value)> {
                     .unwrap();
             }
             ServerFrame::TurnComplete { .. } => break,
+            ServerFrame::RequeryRequest { .. } => {
+                panic!("a turn that did not opt in must not ask for context")
+            }
             // Nothing here pauses, so the control frames are inert; matched
             // rather than wildcarded so a new frame kind lands as a compile
             // error in a test that reads the stream.

--- a/docs/spec/serve-surface.md
+++ b/docs/spec/serve-surface.md
@@ -64,11 +64,12 @@ not in this table is a 404.
 | `GET` | `/healthz` | Unauthenticated. Liveness — is the process alive. `{"status":"ok"}` |
 | `GET` | `/readyz` | Unauthenticated. Readiness — is it safe to send new work. `200 {"state":"ready"}`, or `503` with `"starting"` / `"draining"` (#1131) |
 | `GET` | `/v1/metrics` | Counters as a flat JSON object of integers. Authenticated like every other route, and **pull-only** — see [serve-observability.md](./serve-observability.md) |
-| `POST` | `/v1/turns` | Body is `TurnRequest`; returns `{"turn_id":"turn-<32 hex>"}`. Optional `goal` and `sub_agents` objects (#1297) — see below. Optional `engine` object (#1167) carries per-turn caller-policy knobs (`max_output_tokens`, `temperature`, `effort`, `reasoning`, `params`, `compaction_budget_tokens`, `summarize_overflow`, `summarize_keep_recent`) lowered onto the defaults — omitted/empty is a no-op; unusable values are 400s naming the knob; values past an operator ceiling are clamped and reported in the response's `clamped` array (`{knob, requested, effective}`, absent when nothing was lowered). `retry_policy`/`loop_detection` are operator policy and not settable |
+| `POST` | `/v1/turns` | Body is `TurnRequest`; returns `{"turn_id":"turn-<32 hex>"}`. Optional `goal` and `sub_agents` objects (#1297) — see below. Optional `engine` object (#1167) carries per-turn caller-policy knobs (`max_output_tokens`, `temperature`, `effort`, `reasoning`, `params`, `compaction_budget_tokens`, `summarize_overflow`, `summarize_keep_recent`) lowered onto the defaults — omitted/empty is a no-op; unusable values are 400s naming the knob; values past an operator ceiling are clamped and reported in the response's `clamped` array (`{knob, requested, effective}`, absent when nothing was lowered). `retry_policy`/`loop_detection` are operator policy and not settable. Optional `steering_requery: true` lets the turn raise `requery_request` frames at its step boundaries; omitted is `false` and raises none |
 | `GET` | `/v1/turns/{id}/events` | SSE `id: <seq>` + `data: <ServerFrame>`. Resumable via `?after=<seq>` or `Last-Event-ID`. One concurrent subscriber; a second gets 409 |
 | `POST` | `/v1/turns/{id}/provider-result` | Answers a `provider_request` |
 | `POST` | `/v1/turns/{id}/provider-delta` | Optional (#1165): a batch of streamed fragments (`{"request_id", "deltas": [{"kind":"text"\|"reasoning","text":"…"}]}`) for an in-flight `provider_request`, ahead of its `provider-result`. Fragments surface on `/events` as `text_delta` / `reasoning` frames and each batch resets the reverse-request deadline. Empty batches are refused (400); fragments after the result get a 409 |
 | `POST` | `/v1/turns/{id}/tool-result` | Answers a `tool_request` |
+| `POST` | `/v1/turns/{id}/requery-result` | Answers a `requery_request`: `{"request_id", "context": "…"\|null}`. The block is appended to the turn's volatile tail as a marked user message and never touches the byte-stable prefix; `null` — the ordinary answer — injects nothing. Only a turn created with `steering_requery: true` ever raises the frame, and leaving one unanswered costs the step nothing it started with |
 | `POST` | `/v1/turns/{id}/cancel` | Step-boundary stop (#1129): the turn unwinds at its next step, keeping completed steps, and still emits `turn_complete`. Deregistered immediately, so a second cancel is a 404. There is no `DELETE` |
 | `POST` | `/v1/turns/{id}/steer` | `{"message": "…"}` — injected at the next step boundary, echoed as a `steered` event (#932) |
 | `POST` | `/v1/turns/{id}/pause` | Hold at the next step boundary. Idempotent; never mid-tool (#932). Body optional: `{"reason": "…"}` rides onto the `turn_held` frame. An empty body holds without a reason; a non-empty body that is not JSON is a 400 |
@@ -76,7 +77,7 @@ not in this table is a 404.
 | `GET` | `/v1/calibration` | Token-drift report (#1298): `{"models":[{provider_id, model, samples, estimated_input_tokens, actual_input_tokens, drift_ratio, applied_factor}], "untracked_turns": 0}` — what the engine estimated against what the provider billed. Read-only and authenticated, same reasoning as `/v1/metrics`. Empty `models` before any turn has committed a step. State is process memory keyed by `(provider_id, model)`; nothing is persisted, so a redeployed sidecar re-converges — which is why every row carries `samples`. `provider_id` is host-supplied, so the registry tracks a bounded number of them (64) with a bounded key length (128); a turn refused a map by either bound runs uncalibrated and is counted in `untracked_turns`, so a non-zero value means the rows are an incomplete picture |
 | `POST` | `/v1/sessions` | `{"system_prompt": "…", "budget": …}` → `{"session_id":"session-<32 hex>"}` (#931) |
 | `GET` | `/v1/sessions/{id}` | History, cost to date, live turn id, and `held` — whether that live turn has been asked to hold (#932). Always answers from the last settled state |
-| `POST` | `/v1/sessions/{id}/turns` | `TurnRequest` minus `messages`/`budget`, plus `input` (this turn's new messages). Accepts the same optional `engine` object as `/v1/turns` (safe for the prompt-cache contract: no engine knob touches the transcript). Returns `{"turn_id", "session_id"}` plus the same `clamped` reporting; the turn is then an ordinary `/v1/turns/{id}` member. One live turn per session (else 409) |
+| `POST` | `/v1/sessions/{id}/turns` | `TurnRequest` minus `messages`/`budget`, plus `input` (this turn's new messages). Accepts `steering_requery` on the same terms as `/v1/turns` — the block rides the volatile tail, so the session's byte-stable prefix is untouched. Accepts the same optional `engine` object as `/v1/turns` (safe for the prompt-cache contract: no engine knob touches the transcript). Returns `{"turn_id", "session_id"}` plus the same `clamped` reporting; the turn is then an ordinary `/v1/turns/{id}` member. One live turn per session (else 409) |
 | `DELETE` | `/v1/sessions/{id}` | Ends the session and cancels its live turn. Also drops its resume point |
 | `GET` | `/v1/sessions/{id}/checkpoint` | The session's resume point, verbatim (a `stella_core::step::Checkpoint`). Read from the **store**, not the session registry — so a session this process never created still answers `200` if its bytes are there. `404` when there is none, when the id is not a legal key, or when no store is configured (#1198) |
 | `DELETE` | `/v1/sessions/{id}/checkpoint` | Reclaim a resume point the host has finished recovering. Idempotent |
@@ -104,7 +105,8 @@ destination, and which a client written from it gets wrong:
   exist and is authenticated.
 - **Reverse RPC is keyed by `request_id` on its own frame types**, not by a
   `call_id` on a `tool_start` / `scope_review` `AgentEvent`. The
-  engine emits dedicated `tool_request` / `provider_request` `ServerFrame`
+  engine emits dedicated `tool_request` / `provider_request` /
+  `requery_request` `ServerFrame`
   variants whose ids are `<port>-<instance>-<counter>` (`prov-1-3`, `tool-0-0`,
   …) and are opaque to the host — echo them back, never parse them. This is the
   single most dangerous drift in this document for anyone mirroring it in
@@ -583,7 +585,8 @@ per-step checkpoint and crash-resume. This is ADR-033 §6 item 1 and §4.3.
   registry. The id is **opaque to the host** — echo it back, never parse it);
   the host runs the
   governed work and POSTs the result back to
-  `/v1/turns/{id}/{tool-result,provider-result}` with that `request_id`. The
+  `/v1/turns/{id}/{tool-result,provider-result,requery-result}` with that
+  `request_id`. The
   engine's `RemoteToolExecutor::execute` awaits a per-`request_id` oneshot.
   **Not the same thing as** the `call_id` on a `tool_start` `AgentEvent`: that
   id is the model's, addresses the tool call inside the transcript, and is not

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -2241,6 +2241,47 @@ export interface ProviderShare {
 export type ReasoningEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 /**
+ * What the turn has become, as the engine can witness it — the payload of a
+ * [`ServerFrame::RequeryRequest`].
+ *
+ * An owned projection of `stella_core::steering::TurnSignal`, which borrows
+ * the turn's own transcript and so cannot cross a frame boundary.
+ *
+ * One field of that type is missing here. `active_domains` is a workspace
+ * taxonomy the engine never fills — it passes an empty slice — and a wire
+ * field that is always empty reads as a fact. The host merges its own
+ * domains, and its own file ledger, before it asks its steering plane.
+ */
+export interface RequerySignal {
+  /**
+   * Error classes the turn has seen. "We are stuck, and this is how" is the
+   * strongest retrieval cue a turn produces.
+   */
+  errors_seen: string[];
+  /**
+   * The turn's goal, as the operator wrote it. On its own this is what
+   * every selector had, and it is what goes stale by step 40.
+   */
+  prompt: string;
+  /**
+   * Tools the turn has called, most recent last.
+   */
+  recent_tool_calls: string[];
+  /**
+   * Steps since the host last answered with a block.
+   */
+  since_last_query: number;
+  /**
+   * Step index within the turn.
+   */
+  step: number;
+  /**
+   * Workspace paths the turn has touched, read off its tool inputs.
+   */
+  touched_paths: string[];
+}
+
+/**
  * What a `ScopeReview` gate presents for approval before a large plan
  * executes (L-E5).
  *
@@ -2857,6 +2898,10 @@ export type ServerFrame = {
   role: ModelCallRole;
   type: "provider_request";
 } | {
+  request_id: string;
+  signal: RequerySignal;
+  type: "requery_request";
+} | {
   reason?: string | null;
   type: "turn_held";
 } | {
@@ -2874,6 +2919,7 @@ export type KnownTypeTag =
   | "event"
   | "tool_request"
   | "provider_request"
+  | "requery_request"
   | "turn_held"
   | "turn_released"
   | "turn_complete";
@@ -2991,6 +3037,36 @@ export interface ProviderDeltaIn {
    * carries no information and is refused at the route.
    */
   deltas: ProviderDelta[];
+  request_id: string;
+}}
+
+// ── inbound, optional: answering a context re-query ─────────────────────────
+//
+// A turn created with `steering_requery: true` raises a `requery_request`
+// frame at a step boundary once its work has moved on from the prompt it
+// opened with. POST the block your own context plane chose to
+// `POST /v1/turns/{id}/requery-result`, keyed by the frame's request_id, or
+// post `context: null` — the ordinary answer — for nothing worth the tokens.
+// The block is appended to the turn's volatile tail and never touches the
+// byte-stable prefix. Leaving the request unanswered is safe: the step
+// proceeds with the context it already had once the reverse-request deadline
+// expires.
+
+/**
+ * Host → engine: the answer to a [`ServerFrame::RequeryRequest`].
+ *
+ * `context` is the block to put in front of the model, or `null` for "nothing
+ * here is worth the tokens" — the cheap answer, and the expected one for most
+ * boundaries. The engine appends the block to the volatile tail as a user
+ * message and never touches the byte-stable prefix.
+ *
+ * The block is injected as sent, so the server prefixes the recall marker
+ * when the host's text does not already carry one: an injected block the
+ * engine read as a real user turn would move the turn window.
+ */
+export interface RequeryResultIn {
+{
+  context?: string | null;
   request_id: string;
 }}
 

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -3785,6 +3785,57 @@
         }
       ]
     },
+    "RequerySignal": {
+      "description": "What the turn has become, as the engine can witness it — the payload of a\n[`ServerFrame::RequeryRequest`].\n\nAn owned projection of `stella_core::steering::TurnSignal`, which borrows\nthe turn's own transcript and so cannot cross a frame boundary.\n\nOne field of that type is missing here. `active_domains` is a workspace\ntaxonomy the engine never fills — it passes an empty slice — and a wire\nfield that is always empty reads as a fact. The host merges its own\ndomains, and its own file ledger, before it asks its steering plane.",
+      "properties": {
+        "errors_seen": {
+          "description": "Error classes the turn has seen. \"We are stuck, and this is how\" is the\nstrongest retrieval cue a turn produces.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "prompt": {
+          "description": "The turn's goal, as the operator wrote it. On its own this is what\nevery selector had, and it is what goes stale by step 40.",
+          "type": "string"
+        },
+        "recent_tool_calls": {
+          "description": "Tools the turn has called, most recent last.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "since_last_query": {
+          "description": "Steps since the host last answered with a block.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "step": {
+          "description": "Step index within the turn.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "touched_paths": {
+          "description": "Workspace paths the turn has touched, read off its tool inputs.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "prompt",
+        "recent_tool_calls",
+        "touched_paths",
+        "errors_seen",
+        "step",
+        "since_last_query"
+      ],
+      "type": "object"
+    },
     "ScopeProposal": {
       "description": "What a `ScopeReview` gate presents for approval before a large plan\nexecutes (L-E5).\n\nEverything after `estimated_cost_usd` is additive (`serde(default)`), so\nstreams recorded before those fields existed parse with every one absent,\nand a proposal that names none serializes exactly as it always has:\n`repo`/`branch`, the read and write globs and the shell policy are the\nscope-card grid's facts, and `revision` is the plan breadcrumb's.",
       "properties": {
@@ -4662,6 +4713,27 @@
         "provider_id",
         "role",
         "request"
+      ],
+      "type": "object"
+    },
+    {
+      "description": "The engine's work has moved on from the prompt it opened with, and it\nis asking the host for whatever context now fits. The host answers\nwith [`RequeryResultIn`] keyed by `request_id`; the engine step that\nraised it is parked until then.\n\nOnly ever emitted when the turn asked for it\n(`steering_requery` on `POST /v1/turns`). A host that has not built the\nanswering route never sees this frame.",
+      "properties": {
+        "request_id": {
+          "type": "string"
+        },
+        "signal": {
+          "$ref": "#/$defs/RequerySignal"
+        },
+        "type": {
+          "const": "requery_request",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "request_id",
+        "signal"
       ],
       "type": "object"
     },

--- a/docs/wire/serveinbound.schema.json
+++ b/docs/wire/serveinbound.schema.json
@@ -733,6 +733,26 @@
         }
       ]
     },
+    "RequeryResultIn": {
+      "description": "Host → engine: the answer to a [`ServerFrame::RequeryRequest`].\n\n`context` is the block to put in front of the model, or `null` for \"nothing\nhere is worth the tokens\" — the cheap answer, and the expected one for most\nboundaries. The engine appends the block to the volatile tail as a user\nmessage and never touches the byte-stable prefix.\n\nThe block is injected as sent, so the server prefixes the recall marker\nwhen the host's text does not already carry one: an injected block the\nengine read as a real user turn would move the turn window.",
+      "properties": {
+        "context": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "request_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "request_id"
+      ],
+      "title": "RequeryResultIn",
+      "type": "object"
+    },
     "ServiceTier": {
       "description": "Provider service tier: `Priority` routes to faster paid-tier capacity,\n`Flex` to cheaper capacity with slower response times. Only applied by\nproviders that support tiered service; others use their default tier.",
       "oneOf": [
@@ -882,6 +902,6 @@
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Bodies a host POSTs back to answer a reverse request. ToolResultIn answers POST /v1/turns/{id}/tool-result; ProviderResultIn answers POST /v1/turns/{id}/provider-result; ProviderDeltaIn optionally streams fragments of an in-flight provider answer to POST /v1/turns/{id}/provider-delta ahead of its ProviderResultIn. Each is keyed by the request_id carried on the frame it answers. EngineOverrides is not a reverse-request answer at all: it is the optional `engine` object on POST /v1/turns and POST /v1/sessions/{id}/turns, published here because it is wire contract. This document is a definitions container, not a union: the bodies are not interchangeable and carry no discriminant. Every payload type they reference is defined here beside them, once each.",
+  "description": "Bodies a host POSTs back to answer a reverse request. ToolResultIn answers POST /v1/turns/{id}/tool-result; ProviderResultIn answers POST /v1/turns/{id}/provider-result; ProviderDeltaIn optionally streams fragments of an in-flight provider answer to POST /v1/turns/{id}/provider-delta ahead of its ProviderResultIn; RequeryResultIn answers POST /v1/turns/{id}/requery-result with the context block a drifted turn should also see, or with null. Each is keyed by the request_id carried on the frame it answers. EngineOverrides is not a reverse-request answer at all: it is the optional `engine` object on POST /v1/turns and POST /v1/sessions/{id}/turns, published here because it is wire contract. This document is a definitions container, not a union: the bodies are not interchangeable and carry no discriminant. Every payload type they reference is defined here beside them, once each.",
   "title": "StellaServeInbound"
 }


### PR DESCRIPTION
## What and why

Mid-turn context re-query worked on `stella run`, the deck and a fleet
worker, and not over the wire. A served turn picked its context from its
opening prompt and never looked again, so a long turn that drifted onto
new files kept working from what the first sentence asked for.
`stella-serve` assembled no re-query source at all — `served_capabilities`
passed `requery: None`.

**A fourth reverse request.** A re-query fans out over recall and costs the
host money, and this server holds no rights of its own, so the ask travels
the way the model call and the tool call already do.

- `ServerFrame::RequeryRequest { request_id, signal }` joins the outbound
  union. `signal` is `RequerySignal`, an owned copy of what the engine
  assembled at the boundary.
- `RequeryResultIn { request_id, context }` answers it, over
  `POST /v1/turns/{id}/requery-result`. `null` is the ordinary answer.
- `crates/stella-serve/src/remote/requery.rs` is new: `RemoteRequery`
  implements `stella_core::ports::SteeringRequery` and is bound in
  `served_capabilities`. The route handler is
  `crates/stella-serve/src/routes/requery.rs`, its own file because
  `routes.rs` is the closest file in this crate to the 1500-line cap.

**Off by default.** `SessionSpec::steering_requery`, on the wire as
`steering_requery` on `POST /v1/turns` and `POST /v1/sessions/{id}/turns`.
A host that has not built the answering route cannot answer, and an
unanswered ask would park the step for the whole reverse-request deadline
at every boundary. A turn that does not opt in emits no such frame and
behaves exactly as before.

**Hysteresis and dedup stay server-side**, mirroring the CLI's
`SessionRequery` (`crates/stella-cli/src/memory/steering.rs`, the exemplar
this follows): a fingerprint over touched paths and error classes, a
two-step minimum spacing, and a produced-block set seeded from the recall
blocks the turn opened with. Per-handle dedup stays on the CLI side, since
a handle names something in a workspace this server never sees.

**An unanswered ask is not a failed turn.** A timeout, a dropped host or a
closed frame sink all answer `None`, and the step runs on with the context
it had.

**The marker is added here.** The engine injects the block as sent, and
`turn_start_index` tells injected context from a user turn by
`RECALL_MARKER` alone, so `RemoteRequery` prefixes it when the host's text
does not carry one.

## Witness mechanism

`a_served_turn_requeries_the_steering_plane_after_its_work_moves_to_a_new_path`
(`crates/stella-serve/tests/bridge.rs`) drives a three-step turn whose first
two steps touch `src/adapter.rs`. At the third boundary the signal has
drifted and the spacing is met, the server emits `requery_request`, the mock
host answers with a block, and the test asserts the block reached the next
model call's messages. It fails on `main` by construction, twice: the frame
type does not exist there and `served_capabilities` passes `requery: None`.

Two more pin the rest: `a_served_requery_leaves_the_byte_stable_prefix_untouched`
asserts the system message is byte-identical and the block rides the
volatile tail as a marked user message, and
`a_host_that_declines_a_requery_injects_nothing` is the negative control —
the same turn asks and injects nothing when the host answers `null`.

`crates/stella-parity/src/lib.rs`'s `turn.steering_requery` row moves its
`api` posture from `Deferred` to `Shipped`, naming that witness and the new
route.

## Wire contract

`docs/wire/serveframe.schema.json`, `serveinbound.schema.json` and
`serveframe.d.ts` carry the new frame arm, `RequerySignal` and
`RequeryResultIn`. `docs/spec/serve-surface.md` gains the route row.

Tests deleted: None

Closes #6121

## Summary by Sourcery

Enable opted-in served turns to request fresh context from their host when mid-turn work drifts, without failing turns when no context is returned.

New Features:
- Add opt-in mid-turn context re-query support for served turns through outbound `requery_request` frames and the `requery-result` response endpoint.
- Allow stateless and session turns to enable steering re-querying while preserving existing default behavior.

Bug Fixes:
- Allow served turns to refresh context when their work drifts beyond the opening prompt instead of relying on stale initial context.

Enhancements:
- Keep re-query throttling, drift detection, deduplication, cancellation, timeout, and graceful no-context handling within the serving layer.
- Preserve byte-stable prompt prefixes while injecting returned context into the volatile conversation tail.

Documentation:
- Publish the re-query wire types, JSON schemas, TypeScript declarations, and serving-surface documentation.

Tests:
- Add bridge coverage for successful context re-query, prefix stability, and declined re-queries.
- Promote served steering re-query parity coverage from deferred to shipped.

Chores:
- Extend reverse-request routing, pending reply handling, observability, and metrics for re-query requests.