### PR TITLE
refactor(stella-core): retire the plugin event namespace nothing can fill

### DIFF
--- a/crates/stella-core/src/bus/names.rs
+++ b/crates/stella-core/src/bus/names.rs
@@ -262,209 +262,70 @@ pub fn is_blocking(name: &str) -> bool {
     BLOCKING.contains(&name)
 }
 
-// ---- plugin namespace (A9, docs/spec/pipeline-as-plugins.md §4) ----
-//
-// `plugin.<id>.*` was not contemplated when this module's opening comment
-// was written — the string "plugin" appears nowhere above this line. What
-// the opening comment's "extensions may emit custom names" already granted
-// is the *permission*; this section is what makes that permission a
-// reserved, collision-free namespace instead of a convention a plugin could
-// accidentally (or adversarially) step outside of. Every name here lands in
-// the journal as [`stella_protocol::AgentEvent::Unknown`] — see
-// `stella-cli/src/trace.rs`'s fold arm — never as a new `AgentEvent`
-// case, so it carries no row in the signal-consumer ledger
-// (`stella-protocol/src/event/consumers.rs`) and needs none: `Unknown` is
-// the vocabulary's designed extension point, not a gap in it.
-
-/// Prefix reserving the whole namespace for plugin-authored event names. No
-/// name in [`ALL`] may start with it (`plugin_names_never_collide_with_the_host_catalog`
-/// below enforces that on every host name this build declares), and the only
-/// sanctioned way to build a name that *does* start with it is
-/// [`plugin_event_name`], which validates the id and local segment first.
-pub const PLUGIN_NAMESPACE_PREFIX: &str = "plugin.";
-
-/// Why a candidate plugin id, or the local segment of a plugin event name,
-/// was rejected.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum PluginNamespaceError {
-    /// A plugin id must name something.
-    #[error("plugin id must not be empty")]
-    EmptyId,
-    /// Ids are restricted to `[a-z0-9_-]` specifically so one cannot smuggle
-    /// an extra `.` (which would let `"a.b"` masquerade as owning the
-    /// sub-namespace `plugin.a.b.*` rather than the single segment
-    /// `plugin.a.b`) or a `*` (which would let an id collide with a
-    /// namespace-wildcard subscription like `plugin.a.*`).
-    #[error(
-        "plugin id {id:?} contains {ch:?} at byte {at}, which is not allowed — ids are \
-         restricted to lowercase ascii letters, digits, '-' and '_' so an id can never \
-         smuggle a namespace boundary ('.') or a wildcard ('*')"
-    )]
-    InvalidIdChar { id: String, ch: char, at: usize },
-    /// The segment after `plugin.<id>.` must name something too.
-    #[error("plugin event local name must not be empty")]
-    EmptyLocalName,
-    /// `*` is rejected in the local segment for the same reason as the id:
-    /// a fact name is not a subscription pattern.
-    #[error(
-        "plugin event local name {local:?} contains '*' at byte {at}, which is not allowed — \
-         a wildcard cannot appear in a concrete event name"
-    )]
-    WildcardInLocalName { local: String, at: usize },
-}
-
-fn is_valid_plugin_id_char(c: char) -> bool {
-    c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_'
-}
-
-/// Validate a plugin id on its own — the check [`plugin_event_name`] runs
-/// before it will build a name from the id, and the check anything wanting
-/// to confirm ownership without building a name (e.g. a lookup keyed by id)
-/// should run first.
-pub fn validate_plugin_id(id: &str) -> Result<(), PluginNamespaceError> {
-    if id.is_empty() {
-        return Err(PluginNamespaceError::EmptyId);
-    }
-    match id
-        .char_indices()
-        .find(|(_, c)| !is_valid_plugin_id_char(*c))
-    {
-        Some((at, ch)) => Err(PluginNamespaceError::InvalidIdChar {
-            id: id.to_string(),
-            ch,
-            at,
-        }),
-        None => Ok(()),
-    }
-}
-
-/// Build the one name a plugin owns for a fact of its own: `plugin.<id>.<local>`.
-/// The sole constructor for a name in this namespace — go through it and the
-/// two collisions this namespace exists to prevent (an id smuggling a `.` or
-/// `*`, or an empty segment) cannot be represented in the string it returns.
-pub fn plugin_event_name(plugin_id: &str, local: &str) -> Result<String, PluginNamespaceError> {
-    validate_plugin_id(plugin_id)?;
-    if local.is_empty() {
-        return Err(PluginNamespaceError::EmptyLocalName);
-    }
-    if let Some(at) = local.find('*') {
-        return Err(PluginNamespaceError::WildcardInLocalName {
-            local: local.to_string(),
-            at,
-        });
-    }
-    Ok(format!("{PLUGIN_NAMESPACE_PREFIX}{plugin_id}.{local}"))
-}
-
-/// Whether `name` is owned by `plugin_id` — i.e. starts with exactly
-/// `plugin.<plugin_id>.`. Rejects a name owned by a *different* plugin whose
-/// id happens to share a prefix (`plugin_id` `"foo"` never matches
-/// `"plugin.foobar.x"`): the boundary check requires the character right
-/// after the id to be the separating dot, not just a shared prefix.
-pub fn is_plugin_owned(name: &str, plugin_id: &str) -> bool {
-    if validate_plugin_id(plugin_id).is_err() {
-        return false;
-    }
-    name.strip_prefix(PLUGIN_NAMESPACE_PREFIX)
-        .and_then(|rest| rest.strip_prefix(plugin_id))
-        .is_some_and(|rest| rest.starts_with('.'))
-}
-
-/// The plugin id owning `name`, when `name` is a well-formed
-/// `plugin.<id>.<local>` name. `None` for anything outside the namespace,
-/// and also for a malformed member of it (`"plugin."`, `"plugin..x"`, an id
-/// with an invalid character) — a fold reading the journal must not
-/// misattribute a malformed name to a guessed id.
-pub fn plugin_id_of(name: &str) -> Option<&str> {
-    let rest = name.strip_prefix(PLUGIN_NAMESPACE_PREFIX)?;
-    let (id, local) = rest.split_once('.')?;
-    if local.is_empty() {
-        return None;
-    }
-    validate_plugin_id(id).ok()?;
-    Some(id)
-}
-
 #[cfg(test)]
-mod plugin_namespace_tests {
+mod catalog_tests {
     use super::*;
 
+    /// Every name this module declares is a name the host emits.
+    ///
+    /// The catalog is the contract for what the host emits, so a constant
+    /// here that [`ALL`] does not list is a promise instead — which is why
+    /// `agent.step.started` waited for its emitters before it was written
+    /// down. `plugin.` was the exception: a prefix held for events no
+    /// plugin could send, pointing at a trace fold that is gone from the
+    /// tree. This test reads the module's own source, so the next reserved
+    /// name has to arrive with the code that emits it.
     #[test]
-    fn plugin_names_never_collide_with_the_host_catalog() {
-        for name in ALL {
+    fn every_declared_name_is_one_the_host_emits() {
+        let lines: Vec<&str> = include_str!("names.rs").lines().collect();
+        let mut declared = 0usize;
+        let mut at = 0usize;
+        while at < lines.len() {
+            let line = lines[at];
+            at += 1;
+            let Some(rest) = line.strip_prefix("pub const ") else {
+                continue;
+            };
+            // A declaration may wrap across lines, so read on to its
+            // semicolon and check it rather than skip it.
+            let mut decl = rest.to_string();
+            while !decl.contains(';') && at < lines.len() {
+                decl.push(' ');
+                decl.push_str(lines[at].trim());
+                at += 1;
+            }
+            let Some((head, value)) = decl.split_once(" = ") else {
+                continue;
+            };
+            let Some((name, ty)) = head.split_once(": ") else {
+                continue;
+            };
+            if ty.trim() != "&str" {
+                continue;
+            }
+            let emitted = value.trim().trim_end_matches(';').trim().trim_matches('"');
             assert!(
-                !name.starts_with(PLUGIN_NAMESPACE_PREFIX),
-                "host-emitted name {name:?} must never start with {PLUGIN_NAMESPACE_PREFIX:?} — \
-                 the namespace is reserved for plugins"
+                ALL.contains(&emitted),
+                "{name} declares {emitted:?}, which ALL does not list — a name \
+                 nothing emits is a promise, so ship the emitter or drop the \
+                 constant"
             );
+            declared += 1;
         }
+        assert_eq!(
+            declared,
+            ALL.len(),
+            "the scan read {declared} declarations against {} entries in ALL — \
+             every catalog name is one constant, so the two counts move together",
+            ALL.len()
+        );
+    }
+
+    /// Nothing can block on a name the catalog does not carry.
+    #[test]
+    fn blocking_is_a_subset_of_the_catalog() {
         for name in BLOCKING {
-            assert!(!name.starts_with(PLUGIN_NAMESPACE_PREFIX));
+            assert!(is_known(name), "{name} blocks but ALL does not list it");
         }
-    }
-
-    #[test]
-    fn builds_and_recovers_a_well_formed_name() {
-        let name = plugin_event_name("demo-reviewer_2", "finding.raised").unwrap();
-        assert_eq!(name, "plugin.demo-reviewer_2.finding.raised");
-        assert_eq!(plugin_id_of(&name), Some("demo-reviewer_2"));
-        assert!(is_plugin_owned(&name, "demo-reviewer_2"));
-    }
-
-    #[test]
-    fn rejects_a_dot_smuggled_into_the_id() {
-        let err = plugin_event_name("a.b", "fact").unwrap_err();
-        assert!(matches!(
-            err,
-            PluginNamespaceError::InvalidIdChar { ch: '.', .. }
-        ));
-    }
-
-    #[test]
-    fn rejects_a_wildcard_smuggled_into_the_id() {
-        let err = plugin_event_name("a*", "fact").unwrap_err();
-        assert!(matches!(
-            err,
-            PluginNamespaceError::InvalidIdChar { ch: '*', .. }
-        ));
-    }
-
-    #[test]
-    fn rejects_a_wildcard_in_the_local_segment() {
-        let err = plugin_event_name("demo", "fact.*").unwrap_err();
-        assert!(matches!(
-            err,
-            PluginNamespaceError::WildcardInLocalName { .. }
-        ));
-    }
-
-    #[test]
-    fn rejects_empty_id_and_empty_local() {
-        assert_eq!(
-            plugin_event_name("", "fact").unwrap_err(),
-            PluginNamespaceError::EmptyId
-        );
-        assert_eq!(
-            plugin_event_name("demo", "").unwrap_err(),
-            PluginNamespaceError::EmptyLocalName
-        );
-    }
-
-    /// A name outside a plugin's own namespace is rejected: neither
-    /// ownership nor id recovery may be fooled by a shared string prefix
-    /// that is not a shared namespace segment.
-    #[test]
-    fn a_name_outside_a_plugins_own_namespace_is_rejected() {
-        let mine = plugin_event_name("foo", "fact").unwrap();
-        assert!(is_plugin_owned(&mine, "foo"));
-        assert!(!is_plugin_owned(&mine, "other"));
-        // "foobar" is not the owner of a name in "foo"'s namespace, even
-        // though the id string shares a prefix.
-        assert!(!is_plugin_owned("plugin.foobar.fact", "foo"));
-        assert_eq!(plugin_id_of("plugin.foobar.fact"), Some("foobar"));
-        assert_eq!(plugin_id_of("not.a.plugin.name"), None);
-        assert_eq!(plugin_id_of("plugin."), None);
-        assert_eq!(plugin_id_of("plugin.."), None);
-        assert_eq!(plugin_id_of("plugin.a.b"), Some("a"));
     }
 }

--- a/docs/spec/pipeline-as-plugins.md
+++ b/docs/spec/pipeline-as-plugins.md
@@ -494,26 +494,35 @@ rule this item was written to protect.
 
 ### A9. Plugin events and the trace fold
 
-**LANDED (ed18283).** `PLUGIN_NAMESPACE_PREFIX = "plugin."` is reserved in the
-bus catalog (`crates/stella-core/src/bus/names.rs:284`, with
-`plugin_event_name`/`plugin_id_of` validating and parsing it), and
-`crates/stella-cli/src/trace.rs` gained the fold arm: `TraceRecord::plugin_facts:
-Vec<PluginFact>` (`trace.rs:130-136`, `:195-207`), folded from `plugin.<id>.*`
-journal events (`trace.rs:351-354`) — present and empty, never omitted, when
-no plugin ran. Everything this item asked for exists.
+**RETIRED.** Neither half is in the tree, and neither had work left to do.
 
-(Correction, 2026-08-17: an earlier draft said this namespace was "already
-contemplated at `crates/stella-core/src/bus/names.rs:3-4`". It is not — the
-string `plugin` does not appear in that file at all. What lines 3-4 actually
-say is the weaker, general "Extensions may emit custom names — the catalog is
-the contract for what the host emits, not a closed set", which permits the
-namespace without contemplating it. The namespace is entirely net-new.)
+The fold went first. `trace_capture` is gone, so
+`crates/stella-cli/src/trace.rs` is absent and `TRACE_SCHEMA_VERSION` has no
+hits anywhere. `crates/stella-cli/src/settings/unknown.rs` records the
+retirement and its reason: `store.db` already holds every step, tool call and
+cost the trace wrote.
 
-**Plugins do not write traces.** They emit journal events; the trace is a fold
-(`crates/stella-cli/src/trace.rs:8-18`). Contributed facts then inherit
-replayability, `TRACE_SCHEMA_VERSION` skip-on-unknown, redaction, and the
-guarantee that nothing reaches `store.db`. A plugin writing `traces.jsonl`
-directly routes around all four.
+The namespace followed. `PLUGIN_NAMESPACE_PREFIX = "plugin."` and its four
+helpers held names for events a plugin could never send: no manifest key
+declares one, no field on the wrapper wire carries one, and the only stated
+destination was the fold above. `crates/stella-core/src/bus/names.rs` says of
+`agent.step.started` that a name nothing emits is a promise rather than a
+contract, and this was the exception to that. The module's own test,
+`every_declared_name_is_one_the_host_emits`, now holds the rule by reading its
+source, so the next reserved name arrives with the code that emits it.
+
+**Where a plugin's facts go instead.** They reach the journal as typed events
+that name their consumers — `AgentEvent::Proof`, `AgentEvent::Verdict` and
+`AgentEvent::GateBoard` in `crates/stella-protocol/src/event/kind.rs`, each
+carrying a row generated from `crates/stella-protocol/src/event/tags.rs` — and
+`store.db` is the durable store. A free-form channel would still owe a manifest
+key, a wire field, a consent line, a destination, and an answer to AGENTS.md's
+rule that every emitted signal names what reads it. Build it when a plugin
+needs it; the name validation is a page of code.
+
+**Plugins still do not write traces**, and now nothing does. A plugin writing a
+journal of its own would route around redaction and around the consumer ledger
+at once, which is why the evidence channel is the one it gets.
 
 ### A10. A worktree handle that crosses a process
 

--- a/docs/spec/wrapper-socket.md
+++ b/docs/spec/wrapper-socket.md
@@ -486,12 +486,14 @@ not create.
 
 ## 7. What this design does not do
 
-- **It does not let a plugin emit a trace.** Plugins emit journal events in
-  the `plugin.<id>.*` namespace; the trace is a fold
-  (`crates/stella-cli/src/trace.rs`). Contributed facts then inherit
-  replayability, `TRACE_SCHEMA_VERSION` skip-on-unknown, redaction, and the
-  guarantee that nothing reaches `store.db`. A plugin writing `traces.jsonl`
-  directly routes around all four.
+- **It does not let a plugin emit a trace, or an event of its own.** A
+  plugin's facts cross as evidence, and the host turns them into typed journal
+  events that name their consumers — `AgentEvent::Proof`,
+  `AgentEvent::Verdict`, `AgentEvent::GateBoard`. There is no free-form event
+  channel: the `plugin.<id>.*` namespace was retired with the trace fold it
+  pointed at, because nothing could send a name in it
+  (`doc:pipeline-as-plugins` A9). A plugin writing its own journal would route
+  around redaction and around the consumer ledger.
 - **It does not give a plugin an `Engine`, a provider, or a credential.** A
   wrapper names a role *intent*; the host resolves it against the user's BYOK
   providers, carves the budget, attaches gate/steering/hooks, runs the turn and


### PR DESCRIPTION
## What

Retires the `plugin.<id>.*` event namespace from
`crates/stella-core/src/bus/names.rs`, and corrects the two specs that record
it as shipped.

Gone: `PLUGIN_NAMESPACE_PREFIX`, `PluginNamespaceError`, `validate_plugin_id`,
`plugin_event_name`, `is_plugin_owned`, `plugin_id_of`, and the
`plugin_namespace_tests` module. Nothing outside that module called any of
them:

```
rg 'plugin_event_name|is_plugin_owned|plugin_id_of' crates/ | rg -v 'bus/names.rs'
   -> no hits
```

## Why

The issue asks a maintainer to pick option 1 (build a free-form plugin event
channel) or option 2 (delete the namespace). SCR-002 says pick the durable one
rather than ask, so this is option 2, and the reasoning is on the issue as a
comment before any code was written.

The namespace reserved names for events a plugin could never send. No manifest
key declares one, no field on the wrapper wire carries one, and the only stated
destination was `crates/stella-cli/src/trace.rs`'s fold arm, which #3894
deleted along with `trace_capture`. So the comment that opened the section
cited a file that is not in the tree, and it was the only statement anywhere of
where a plugin event would end up.

The module already carries the rule this broke. On `agent.step.started`:

> Added with the emitters (#1133) rather than pre-declared, because the catalog
> is the contract for what the host emits and a name nothing emits is a
> promise, not a contract.

A reserved prefix with no producer is also the shape AGENTS.md invariant 10
refuses, and the shape #4417 and #3521 already paid for — vocabulary that reads
as a shipped feature and routes nowhere.

The requirement #3246 §1 was serving is met by a channel that does have
consumers: a plugin's proof reaches the journal as `AgentEvent::Proof`,
`AgentEvent::Verdict` and `AgentEvent::GateBoard`, each with a row generated
from `crates/stella-protocol/src/event/tags.rs`, and `store.db` is the durable
store the trace fold stood in for. Rebuilding the namespace the day a producer
exists costs a page of name validation; leaving it standing costs every reader
who believes it works.

## Witness

`every_declared_name_is_one_the_host_emits`, in `names.rs`'s new
`catalog_tests`. It reads the module's own source with `include_str!` and
asserts that every `pub const … : &str` the module declares is a member of
`ALL`, then that the two counts match.

It fails on the old code by construction: `PLUGIN_NAMESPACE_PREFIX` is exactly
such a constant, holds `"plugin."`, and `ALL` does not list it — so the scan
finds 96 declarations against 95 entries and the membership assertion fires on
the prefix. After the deletion it reads 95 against 95 and passes. Checked by
running the same scan over `origin/main`'s copy of the file and over this one.

It is also the guard the section needed in the first place: the next reserved
name has to arrive with the code that puts it in `ALL`.

`blocking_is_a_subset_of_the_catalog` keeps the half of the deleted collision
test that was about the host catalog rather than about the plugin prefix.

## Docs

- `docs/spec/pipeline-as-plugins.md` A9 said **LANDED** and cited
  `trace.rs:130-136`. It now records the retirement, names where a plugin's
  facts go, and pins no line numbers.
- `docs/spec/wrapper-socket.md` §7 carried the same claim in one line, and now
  says there is no free-form event channel.

## Exemplar

None borrowed — this is a deletion plus a self-checking catalog test in the
module that already stated the rule.

## Tests deleted

All of them in the removed `plugin_namespace_tests` module, all covering the
deleted helpers: `plugin_names_never_collide_with_the_host_catalog`,
`builds_and_recovers_a_well_formed_name`, `rejects_a_dot_smuggled_into_the_id`,
`rejects_a_wildcard_smuggled_into_the_id`,
`rejects_a_wildcard_in_the_local_segment`, `rejects_empty_id_and_empty_local`,
`a_name_outside_a_plugins_own_namespace_is_rejected`. The first one's surviving
half — no blocking name is outside the catalog — is kept as
`blocking_is_a_subset_of_the_catalog`.

## Remaining work filed

#6177 — no gate reads a Rust comment that cites a deleted source file, which is
how the stale `trace.rs` citation survived long enough to be the only statement
of where a plugin event went.

#3246 §1's "fire its own events" is answered in writing on that epic, with a
link to this change.

Closes #6151
