### PR TITLE
Preregister the two-build pipeline A/B, and make its analysis expressible

### DIFF
--- a/bench/evidence/README.md
+++ b/bench/evidence/README.md
@@ -15,6 +15,8 @@ score_dev_baseline.py     scoring: trials.jsonl -> pass@1 + two 95% intervals
 make_manifest.py          identity: freeze every input that can move the number
 compare_arms.py           two arms of one experiment -> did the change pay?
 witness-ab/               the authored-witness A/B: protocol, plan, decision rule
+pipeline-ab/              the cut built-in path against the plugin path that
+                          replaced it: protocol, plan, decision rule
 tests/                    what keeps the three of them honest
 <run-id>/
   run-manifest.json       the frozen inputs, and why the run is not a claim
@@ -81,6 +83,12 @@ spend per additional task passed. It refuses — non-zero exit, `"verdict":
 one experiment, or when the treatment arm declared a verification tier it never
 exercised. See [`witness-ab/`](witness-ab/) for the experiment it was written
 for and the decision rule it applies.
+
+A declared cross-build mode drops the arm-label check and replaces it with
+stricter ones: each arm must report the commit named for it, the two binary
+hashes must differ, and a per-trial field must show the treatment arm ran the
+path under test. Its report carries a confound line no caller can drop. See
+[`pipeline-ab/`](pipeline-ab/).
 
 ### Reading a descriptive total
 

--- a/bench/evidence/compare_arms.py
+++ b/bench/evidence/compare_arms.py
@@ -46,10 +46,19 @@ Three properties, in the order they can invalidate a conclusion:
    same reward as one that fails and reports success, but only the second one
    lies to a caller who then ships it.
 
+**Two builds, when one build cannot ask the question.** The default above
+holds the binary still and moves one setting. Comparing a deleted path against
+the path that replaced it cannot work that way: it takes one build of each.
+That shape is refused unless the caller declares it, names both commits, and
+names the per-trial field that proves the treatment arm ran the path under
+test. Such a comparison is confounded by every commit between the two builds,
+and its report says so. See ``pipeline-ab/README.md``.
+
 Usage::
 
     python compare_arms.py <control-trials.jsonl> <treatment-trials.jsonl> \\
         --tasks 89 [--markdown out.md]
+        [--cross-sut <control-sha>:<treatment-sha> --treatment-fired f=v]
 
 Exit status is 0 only for a comparison that is allowed to mean something. The
 report is printed either way — a refusal with the numbers withheld is a refusal
@@ -63,6 +72,7 @@ import json
 import math
 import random
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -151,9 +161,87 @@ def _uniform(rows: list[dict[str, Any]], field: str) -> Any:
     return {"DISAGREEMENT": [json.loads(value) for value in seen]}
 
 
+@dataclass(frozen=True)
+class CrossSut:
+    """Two arms that are two binaries, declared before the run.
+
+    The default comparison holds the binary still and moves one setting. Some
+    questions cannot be asked that way. Comparing a path that was deleted
+    against the path that replaced it needs one build of each, so the two arms
+    differ by a commit range rather than by a flag.
+
+    That shape is refused by default, and the refusal is right: an unnoticed
+    SUT split is the most expensive way to get a plausible number. So the
+    caller states the split up front. Every field here is fixed in the
+    preregistration, and each one buys a check the default mode cannot make:
+
+    * ``control_commit`` / ``treatment_commit`` — the commit each arm is built
+      from. The arms must report these two and no others, so a build from the
+      wrong tree is caught rather than averaged in.
+    * ``fired_field`` / ``fired_value`` — the per-trial field and value that
+      prove the treatment arm ran the path under test. A binary that *can* run
+      a path is not a run that *did*. Every treatment trial must carry it and
+      no control trial may, or the two arms are one arm twice.
+
+    A comparison declared this way is confounded, and the report says so. The
+    arms differ by every commit between them, so the claim available is "this
+    arm scored better or worse", never "this change caused it".
+    """
+
+    control_commit: str
+    treatment_commit: str
+    fired_field: str
+    fired_value: str
+
+
+#: What a report may claim once its arms are two binaries. Fixed here rather
+#: than written by each report's author, so no run can soften it.
+CROSS_SUT_CONFOUND = (
+    "the two arms are two builds, so they differ by every commit between them; "
+    "this comparison can say which arm scored better, never which change did it"
+)
+
+
+def parse_cross_sut(commits: str, fired: str) -> CrossSut:
+    """Read the two command-line strings into a declaration, or refuse.
+
+    ``commits`` is ``<control>:<treatment>``, full 40-character hashes. Short
+    hashes are refused because a trial records the full one, and a comparison
+    that has to guess whether two spellings mean one commit is guessing about
+    its own identity.
+
+    ``fired`` is ``field=value``. The value may hold ``=``; the field may not.
+    """
+    parts = commits.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"--cross-sut wants <control>:<treatment>; got {commits!r}")
+    control, treatment = (part.strip() for part in parts)
+    for label, sha in (("control", control), ("treatment", treatment)):
+        if len(sha) != 40 or any(c not in "0123456789abcdef" for c in sha.lower()):
+            raise ValueError(
+                f"--cross-sut {label} commit must be a full 40-character hash; "
+                f"got {sha!r}"
+            )
+    if control.lower() == treatment.lower():
+        raise ValueError(
+            "--cross-sut names one commit twice; two arms on one build is one "
+            "arm run twice"
+        )
+    field, sep, value = fired.partition("=")
+    if not sep or not field.strip() or not value.strip():
+        raise ValueError(f"--treatment-fired wants field=value; got {fired!r}")
+    return CrossSut(
+        control_commit=control.lower(),
+        treatment_commit=treatment.lower(),
+        fired_field=field.strip(),
+        fired_value=value.strip(),
+    )
+
+
 def check_identity(
     control: dict[str, dict[str, Any]],
     treatment: dict[str, dict[str, Any]],
+    cross_sut: CrossSut | None = None,
 ) -> tuple[dict[str, Any], list[str]]:
     """Confirm the two files are the two arms of one experiment.
 
@@ -189,20 +277,81 @@ def check_identity(
                 " trial(s) do not record an assurance arm — pre-#1007 evidence"
                 " cannot be an arm of this experiment"
             )
-        if arms - {None} != {expected}:
+        if cross_sut is None and arms - {None} != {expected}:
             refusals.append(
                 f"{label} arm should be {expected!r}, trials say "
                 f"{sorted(str(a) for a in arms)}"
             )
 
-    # One SUT, or it is two experiments. Recorded per trial by the adapter, so
-    # this reads what ran rather than what the current checkout would produce.
-    for field in ("source_commit", "binary_sha256"):
-        both = _uniform(control_rows + treatment_rows, field)
-        identity[field] = both
-        if isinstance(both, dict) and "DISAGREEMENT" in both:
+    if cross_sut is None:
+        # One SUT, or it is two experiments. Recorded per trial by the adapter,
+        # so this reads what ran rather than what the checkout would produce.
+        for field in ("source_commit", "binary_sha256"):
+            both = _uniform(control_rows + treatment_rows, field)
+            identity[field] = both
+            if isinstance(both, dict) and "DISAGREEMENT" in both:
+                refusals.append(
+                    f"the two arms did not run the same {field}: "
+                    f"{both['DISAGREEMENT']}"
+                )
+    else:
+        identity["cross_sut"] = {
+            "declared_control_commit": cross_sut.control_commit,
+            "declared_treatment_commit": cross_sut.treatment_commit,
+            "treatment_fired": f"{cross_sut.fired_field}={cross_sut.fired_value}",
+            "confounded": True,
+            "confound": CROSS_SUT_CONFOUND,
+        }
+        # The posture is the thing held still here, so both arms must declare
+        # the same one. The arm label says which verification tiers the posture
+        # asks for; it says nothing about which loop the binary ran, which is
+        # why it cannot serve as the arm and is checked as a held setting.
+        posture_arm = _uniform(control_rows + treatment_rows, "assurance_arm")
+        if isinstance(posture_arm, dict) and "DISAGREEMENT" in posture_arm:
             refusals.append(
-                f"the two arms did not run the same {field}: {both['DISAGREEMENT']}"
+                "the two arms declare different assurance arms "
+                f"({posture_arm['DISAGREEMENT']}), so more than the build moved"
+            )
+        # The declared commit is the arm. A build from another tree is a
+        # different experiment wearing this one's name, and the arms' own rows
+        # are the only place that can be caught.
+        for label, rows, declared in (
+            ("control", control_rows, cross_sut.control_commit),
+            ("treatment", treatment_rows, cross_sut.treatment_commit),
+        ):
+            observed = _uniform(rows, "source_commit")
+            identity[f"{label}_source_commit"] = observed
+            if not rows:
+                continue
+            if not isinstance(observed, str) or observed.lower() != declared:
+                refusals.append(
+                    f"the {label} arm was declared on {declared} and its trials "
+                    f"report {observed!r}"
+                )
+        # Two builds, so two binary hashes. Equal hashes mean one binary ran
+        # both arms, whatever the two commits say.
+        control_binary = _uniform(control_rows, "binary_sha256")
+        treatment_binary = _uniform(treatment_rows, "binary_sha256")
+        identity["control_binary_sha256"] = control_binary
+        identity["treatment_binary_sha256"] = treatment_binary
+        for label, value in (
+            ("control", control_binary),
+            ("treatment", treatment_binary),
+        ):
+            if isinstance(value, dict) and "DISAGREEMENT" in value:
+                refusals.append(
+                    f"the {label} arm did not run one binary: "
+                    f"{value['DISAGREEMENT']}"
+                )
+        if (
+            control_rows
+            and treatment_rows
+            and isinstance(control_binary, str)
+            and control_binary == treatment_binary
+        ):
+            refusals.append(
+                "both arms ran binary "
+                f"{control_binary} — two arms on one build is one arm run twice"
             )
 
     if control and treatment:
@@ -253,6 +402,57 @@ def check_tier_fired(treatment: dict[str, dict[str, Any]]) -> tuple[dict[str, An
             "the treatment arm authored no witness on any task: its trials report "
             f"{states} — a run that declares the rung without exercising it "
             "measures the control arm under a treatment-arm digest (#1147)"
+        )
+    return summary, refusals
+
+
+def check_path_fired(
+    control: dict[str, dict[str, Any]],
+    treatment: dict[str, dict[str, Any]],
+    cross_sut: CrossSut,
+) -> tuple[dict[str, Any], list[str]]:
+    """Did the treatment arm run the path under test, on every task?
+
+    The witness A/B learned this the expensive way: a posture that *declares* a
+    tier is not a run that *fired* it. The same trap is wider when the arms are
+    two builds. A binary that can run the path under test can also run without
+    it — a launcher that drops the selector produces a full, plausible arm that
+    ran the control path twice.
+
+    So the field is checked per trial, in both directions. Every treatment
+    trial must carry the declared value, and no control trial may. Missing is
+    a refusal, not a zero: a run whose evidence cannot say which path it took
+    has not answered the question it was paid to answer.
+    """
+    field, wanted = cross_sut.fired_field, cross_sut.fired_value
+    treatment_seen: dict[str, int] = {}
+    for row in treatment.values():
+        seen = row.get(field)
+        key = "<absent>" if seen is None else str(seen)
+        treatment_seen[key] = treatment_seen.get(key, 0) + 1
+    control_carrying = sorted(
+        task for task, row in control.items() if str(row.get(field)) == wanted
+    )
+    fired = treatment_seen.get(wanted, 0)
+    summary = {
+        "field": field,
+        "expected_in_treatment": wanted,
+        "treatment_trials_by_value": treatment_seen,
+        "treatment_trials_on_the_path": fired,
+        "control_trials_on_the_path": control_carrying,
+    }
+    refusals: list[str] = []
+    off_path = sum(treatment_seen.values()) - fired
+    if treatment and off_path:
+        refusals.append(
+            f"{off_path} treatment trial(s) do not report {field}={wanted!r}: "
+            f"{treatment_seen} — an arm that cannot say it ran the path under "
+            "test did not measure it"
+        )
+    if control_carrying:
+        refusals.append(
+            f"{len(control_carrying)} control trial(s) report {field}={wanted!r} "
+            f"({control_carrying[:5]}) — both arms ran the path under test"
         )
     return summary, refusals
 
@@ -468,10 +668,14 @@ def compare(
     control: dict[str, dict[str, Any]],
     treatment: dict[str, dict[str, Any]],
     tasks: int,
+    cross_sut: CrossSut | None = None,
 ) -> dict[str, Any]:
     """The whole comparison, as one JSON-serializable report."""
-    identity, refusals = check_identity(control, treatment)
-    tier, tier_refusals = check_tier_fired(treatment)
+    identity, refusals = check_identity(control, treatment, cross_sut)
+    if cross_sut is None:
+        tier, tier_refusals = check_tier_fired(treatment)
+    else:
+        tier, tier_refusals = check_path_fired(control, treatment, cross_sut)
     refusals = refusals + tier_refusals
 
     universe = sorted(set(control) | set(treatment))
@@ -562,18 +766,31 @@ def compare(
         if refusals
         else decide(primary, verdicts, cost)
     )
-    return {
-        "schema": "stella-witness-ab-comparison-v1",
+    report = {
+        "schema": (
+            "stella-witness-ab-comparison-v1"
+            if cross_sut is None
+            else "stella-cross-sut-ab-comparison-v1"
+        ),
         "comparable": not refusals,
         "refusals": refusals,
         "identity": identity,
-        "witness_tier": tier,
         "primary_outcome": primary,
         "self_verdict": verdicts,
         "cost": cost,
         "decision": decision,
         "per_task": per_task,
     }
+    # One key per question, never one key with two meanings. `witness_tier`
+    # answers "did a second model write the test"; `path_fired` answers "did
+    # the treatment arm run the build's other path". A reader who finds the
+    # wrong one under a familiar name reads a number about something else.
+    if cross_sut is None:
+        report["witness_tier"] = tier
+    else:
+        report["path_fired"] = tier
+        report["confound"] = CROSS_SUT_CONFOUND
+    return report
 
 
 def _mark(value: Any) -> str:
@@ -583,13 +800,17 @@ def _mark(value: Any) -> str:
 def markdown(report: dict[str, Any]) -> str:
     primary, verdicts = report["primary_outcome"], report["self_verdict"]
     cost, decision = report["cost"], report["decision"]
+    cross = report.get("identity", {}).get("cross_sut")
+    arm = "treatment" if cross else "witness"
     lines = [
-        "# Authored witness on vs off — paired comparison",
+        "# Two builds — paired comparison"
+        if cross
+        else "# Authored witness on vs off — paired comparison",
         "",
         f"**{decision['verdict'].upper()}** — " + "; ".join(decision["reasons"] or ["—"]),
         "",
         f"- tasks passed: control {primary['control_passes']}/{primary['tasks_declared']} "
-        f"→ witness {primary['treatment_passes']}/{primary['tasks_declared']} "
+        f"→ {arm} {primary['treatment_passes']}/{primary['tasks_declared']} "
         f"({primary['delta_passes']:+d})",
         f"- paired: gained {primary['gained']}, lost {primary['lost']}, "
         f"both passed {primary['both_pass']}, both failed {primary['both_fail']}"
@@ -599,7 +820,7 @@ def markdown(report: dict[str, Any]) -> str:
             else ", no discordant pairs"
         ),
         f"- wrong \"this passed\" calls: control {verdicts['control']['false_pass']} "
-        f"→ witness {verdicts['treatment']['false_pass']} "
+        f"→ {arm} {verdicts['treatment']['false_pass']} "
         f"({verdicts['false_pass_delta']:+d})",
         f"- spend: ${cost['control']['usd_total']:.2f} → "
         f"${cost['treatment']['usd_total']:.2f}"
@@ -609,14 +830,29 @@ def markdown(report: dict[str, Any]) -> str:
             if cost["usd_per_additional_task_passed"] is not None
             else ""
         ),
-        f"- witness tier fired on {report['witness_tier']['trials_with_an_authored_witness']} "
-        f"treatment trials ({report['witness_tier']['witnesses_authored_total']} witnesses authored)",
-        "",
     ]
+    if cross:
+        fired = report["path_fired"]
+        lines += [
+            f"- arms: control `{cross['declared_control_commit']}` → treatment "
+            f"`{cross['declared_treatment_commit']}`",
+            f"- the path under test ran on {fired['treatment_trials_on_the_path']} "
+            f"treatment trials ({fired['field']}={fired['expected_in_treatment']})",
+            "",
+            f"> **Confounded.** {cross['confound']}.",
+            "",
+        ]
+    else:
+        tier = report["witness_tier"]
+        lines += [
+            f"- witness tier fired on {tier['trials_with_an_authored_witness']} "
+            f"treatment trials ({tier['witnesses_authored_total']} witnesses authored)",
+            "",
+        ]
     if report["refusals"]:
         lines += ["> **Refused.** " + " · ".join(report["refusals"]), ""]
     lines += [
-        "| task | control | witness | control says | witness says | tier |",
+        f"| task | control | {arm} | control says | {arm} says | tier |",
         "|---|---|---|---|---|---|",
     ]
     for row in report["per_task"]:
@@ -632,22 +868,51 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument("control", help="witness-off trials.jsonl")
-    parser.add_argument("treatment", help="witness-on trials.jsonl")
+    parser.add_argument("control", help="control arm trials.jsonl")
+    parser.add_argument("treatment", help="treatment arm trials.jsonl")
     parser.add_argument(
         "--tasks", type=int, required=True, help="preregistered denominator"
     )
     parser.add_argument("--markdown", help="also write the per-task table here")
+    parser.add_argument(
+        "--cross-sut",
+        metavar="CONTROL:TREATMENT",
+        help=(
+            "the two arms are two builds; full commit hash of each, in the "
+            "order the preregistration fixed. Needs --treatment-fired."
+        ),
+    )
+    parser.add_argument(
+        "--treatment-fired",
+        metavar="FIELD=VALUE",
+        help=(
+            "the per-trial field proving the treatment arm ran the path under "
+            "test. Every treatment trial must carry it; no control trial may."
+        ),
+    )
     args = parser.parse_args(argv)
 
+    # Take both flags or neither. A cross-build comparison with no proof the
+    # path under test ran is the one shape this mode exists to refuse, so it
+    # must not be reachable by forgetting a flag.
+    if bool(args.cross_sut) != bool(args.treatment_fired):
+        print(
+            "FATAL: --cross-sut and --treatment-fired are one declaration; "
+            "pass both or neither",
+            file=sys.stderr,
+        )
+        return 2
+    cross_sut = None
     try:
+        if args.cross_sut:
+            cross_sut = parse_cross_sut(args.cross_sut, args.treatment_fired)
         control = load_arm(Path(args.control))
         treatment = load_arm(Path(args.treatment))
     except (OSError, ValueError) as exc:
         print(f"FATAL: {exc}", file=sys.stderr)
         return 1
 
-    report = compare(control, treatment, args.tasks)
+    report = compare(control, treatment, args.tasks, cross_sut)
     print(json.dumps(report, indent=2))
     if args.markdown:
         Path(args.markdown).write_text(markdown(report), encoding="utf-8")

--- a/bench/evidence/pipeline-ab/README.md
+++ b/bench/evidence/pipeline-ab/README.md
@@ -1,0 +1,94 @@
+# The two-build A/B: old path against plugin path
+
+Stella verifies work through an installed plugin. A built-in staged pipeline
+did that job until it was cut from the tree.
+
+One bar was set for the cut, in `doc:pipeline-as-plugins` §7. Run the two paths
+side by side. Show the new one is not worse.
+
+That run has not happened. This directory holds the plan for it.
+
+## The two arms
+
+| arm | build | how it is run | what it is |
+|---|---|---|---|
+| control | `f4c24c12b` | `stella run --pipeline classic` | the built-in staged pipeline |
+| treatment | a build of `main` | `stella run --pipeline witness-v1` | `plugins/stella-witness` over the wrapper socket |
+
+`f4c24c12b` is the parent of `a6d3db4f6`, the commit that deleted the built-in
+path. It is the last tree where that path can be built and run.
+
+**The build is the arm.** A flag can be dropped. A posture can claim a tier it
+never fired. A build cannot be talked into being the other build, and each
+trial records the commit its binary came from.
+
+## What this run can and cannot claim
+
+The two arms are hundreds of commits apart. Everything in that range moved with
+the path under test: the tools, the prompt, the model catalog, the step loop.
+
+So the report may say **this arm scored better or worse than that arm**. It may
+not say **the move to plugins caused it**. `compare_arms.py` stamps that line on
+every two-build report, and there is no way to get a report without it.
+
+## What is fixed before any money is spent
+
+All of it is in `preregistration.json`. The short form:
+
+- 89 tasks, one list file, read by both arms. A task with no trial scores zero
+  and stays in the count.
+- Three replicates. Each one is a fresh pair of arms, one attempt per task.
+  All three get reported. Picking the best is forbidden.
+- No budget cap and no token cap. A cap measures the cap.
+- A stop rule keyed to spend, never to a score. If the first replicate costs
+  more than 600 USD, stop and report that replicate alone.
+- The seed, the draw count and the decision rule, taken from `compare_arms.py`.
+
+## What blocks the run today
+
+1. **The bench adapter cannot pick a path.** `loop_argv` in
+   `bench/harbor_adapter/stella_harbor/loop_mode.py` emits no `--pipeline`
+   flag. Neither arm can be launched as written.
+2. **The evidence cannot say which path ran.** `extract_trial` in
+   `score_dev_baseline.py` drops `stella_loop_mode`, so `trials.jsonl` carries
+   no field that answers it. The analysis below needs that field.
+3. **The control arm has to build.** Its crate is gone from this workspace.
+   The build comes from an old checkout, with its own lock file and toolchain
+   pin. Budget real time for it.
+
+The first two are small and need no rig. They are tracked as `#6178` and
+`#6179`.
+
+## The analysis
+
+`compare_arms.py` refuses two builds by default. That default is right: a split
+nobody declared is the cheapest way to get a number that looks fine and means
+nothing.
+
+Declaring the split turns the refusal into checks:
+
+```bash
+python3 bench/evidence/compare_arms.py \
+  bench/evidence/pipeline-ab-<date>/control/trials.jsonl \
+  bench/evidence/pipeline-ab-<date>/treatment/trials.jsonl \
+  --tasks 89 \
+  --cross-sut <control-sha>:<treatment-sha> \
+  --treatment-fired loop_mode=<the plugin path value> \
+  --markdown bench/evidence/pipeline-ab-<date>/results.md \
+  > bench/evidence/pipeline-ab-<date>/comparison.json
+```
+
+Each arm must report the commit it was declared on. The two binary hashes must
+differ. Every treatment trial must show it ran the plugin path, and no control
+trial may. Any of those fails and the run is refused, with the numbers still
+printed so a reader can check the refusal.
+
+## What counts as done
+
+Three answers close the bar, and all three are real answers:
+
+- the plugin path is at least as good — the bar closes with "not worse";
+- the plugin path is worse — the bar closes with the loss written out;
+- the run cannot tell — the bar closes saying so.
+
+The defect was never a bad result. It was no result.

--- a/bench/evidence/pipeline-ab/preregistration.json
+++ b/bench/evidence/pipeline-ab/preregistration.json
@@ -1,0 +1,110 @@
+{
+  "schema": "stella-pipeline-ab-preregistration-v1",
+  "issue": "https://github.com/macanderson/stella/issues/6155",
+  "epic": "https://github.com/macanderson/stella/issues/4029",
+  "status": "plan_fixed_run_not_started",
+  "status_note": "The design, outcomes, seeds and decision rule below are fixed and were written before any data existed. The run has not been executed. It needs a benchmark host, a spend-capable credential, a build of a crate this workspace deleted, and the two adapter preconditions named under `preconditions`. The fields under `to_be_recorded_before_the_first_paid_call` are the run's identity and must be filled in — and this file committed — before the first paid call, not after.",
+  "plan_fixed_at": "2026-09-05",
+  "question": "Is the plugin verification path at least as good as the built-in staged pipeline it replaced?",
+  "why_it_is_owed": "docs/spec/pipeline-as-plugins.md §7 set one bar for deleting the built-in path: a side-by-side benchmark. The deletion shipped ahead of that bar as a recorded maintainer call. This run is the late payment.",
+  "design": "two arms, paired by task, one build each. The SUT commit is the arm: a build cannot be talked into being the other one.",
+  "arms": {
+    "control": {
+      "name": "built-in staged pipeline",
+      "sut_commit": "f4c24c12bde5578818f1141ec4e438291ac4db55",
+      "why_this_commit": "the parent of a6d3db4f6b783ec5d67571b3d08f47051f7eedc0, which deleted crates/stella-pipeline. This is the last commit on main where the built-in path exists and `--pipeline classic` runs it.",
+      "invocation": "stella run --pipeline classic",
+      "plugins_installed": "none",
+      "known_cost_risk": "this path spends several model calls per step (triage, plan, witness author, verify), so its per-trial spend is expected to exceed the raw loop's by an amount nobody here has measured"
+    },
+    "treatment": {
+      "name": "stella-witness plugin over the wrapper socket",
+      "sut_commit": null,
+      "sut_commit_floor": "befa1b3fbd3ce8db3e5e59c710166cfb3041e4ea",
+      "why_this_commit": "the build must carry plugins/stella-witness and the wrapper-plugin driver. The floor above is the main commit this plan was written against; the exact commit built is recorded before the first paid call and must be a descendant of it.",
+      "invocation": "stella run --pipeline witness-v1",
+      "plugins_installed": "plugins/stella-witness, whose [wrapper] id is witness-v1"
+    }
+  },
+  "held_constant": "same task list file read by both arms, same dataset digest, same worker model, same engine posture, same concurrency, attempts fixed per replicate, no budget cap and no token cap, same host, same adapter revision",
+  "confound": {
+    "statement": "the two arms differ by every commit between f4c24c12b and the treatment build, which is hundreds. This is not a clean A/B and no analysis can make it one.",
+    "claim_available": "this arm scored better or worse than that arm",
+    "claim_not_available": "the change from the built-in path to the plugin path caused the difference",
+    "where_it_is_printed": "compare_arms.py stamps it on every cross-build report, and the report cannot be produced without it"
+  },
+  "task_list": {
+    "source": "phaseA + phaseB of the run scratch phases.json, written once to $TB_ROOT/pipeline_ab.tasks and read by both arms",
+    "denominator": 89,
+    "denominator_rule": "fixed here. A task that produced no trial in an arm scores 0 in that arm and stays in the denominator. No task is dropped for any reason, including an operational abort.",
+    "taskset_sha256": null
+  },
+  "repeats": {
+    "shape": "three preregistered replicates, each a fresh pair of arms with attempts=1 per task",
+    "why_not_attempts_greater_than_one": "the analysis keys one row per task per arm and refuses a duplicate, so several attempts inside one job cannot be paired without a fold nobody has written. Three independent pairs also measure run-to-run variance directly, which a majority vote inside one job hides.",
+    "replicates": 3,
+    "reporting": "all three replicates are reported side by side, always. Picking one is an outcome-selected stop and is forbidden.",
+    "spend_stop_rule": "if replicate 1 costs more than 600 USD across both arms, stop and report replicate 1 alone, naming this rule. The trigger is spend and is fixed here; no stop may be triggered by a score."
+  },
+  "outcomes": {
+    "primary": "tasks passed, paired by task over the fixed denominator; reported as gained/lost/both/neither with an exact McNemar test over the discordant pairs and a percentile bootstrap interval on the paired difference",
+    "secondary": "trials whose own verdict claimed the work passed while the external grader scored it zero, overall and restricted to model-opined verdicts (self_verdict_deterministic=false)",
+    "cost": "total spend per arm, the treatment/control ratio, and spend per additional task passed. Wall clock is reported and is not treated as a time measurement while a finished turn's process is killed at the agent timeout."
+  },
+  "analysis": {
+    "tool": "bench/evidence/compare_arms.py",
+    "mode": "--cross-sut <control-sha>:<treatment-sha> --treatment-fired loop_mode=<plugin path value>",
+    "why_a_declared_mode": "the default refuses two builds, and it is right to. The declaration names both commits so a build from the wrong tree is caught, and names the per-trial field proving the treatment arm ran the plugin path so a dropped selector is caught.",
+    "reward_rule": "the external verifier's reward is authoritative; a trial that produced no reward scores 0 and stays in the denominator; a task absent from an arm scores 0 in that arm",
+    "bootstrap_seed": 20260905,
+    "bootstrap_draws": 50000,
+    "significance_alpha": 0.05,
+    "cost_ratio_ceiling": 1.5,
+    "seed_note": "compare_arms.py's BOOTSTRAP_SEED is 20260803 and is fixed for the witness A/B. Running this experiment sets the seed above and records the value the run used in the report."
+  },
+  "decision_rule": {
+    "source": "compare_arms.py's decide(), applied mechanically, with the mapping below fixed before any data exists",
+    "adopt": "the plugin path is at least as good as the built-in path. §7's bar closes with 'not worse'.",
+    "reject": "the plugin path is worse. §7's bar closes with the loss stated in full.",
+    "inconclusive": "no difference this sample can detect. §7's bar closes saying exactly that.",
+    "note": "all three outcomes close the bar. There is no result that leaves it open, because 'we measured and could not tell' is an answer and 'we never measured' was the defect."
+  },
+  "refusals": {
+    "wrong_build": "an arm whose trials report a commit other than the one declared for it",
+    "one_binary": "two arms reporting one binary hash, whatever their commits say",
+    "path_not_exercised": "a treatment trial that cannot report which loop it ran, or a control trial reporting the plugin path",
+    "posture_moved": "the two arms declaring different assurance arms, which means more than the build changed"
+  },
+  "rules": "no reruns, no outcome-selected stops, no task excluded, no threshold moved after data. Operational aborts are named in the report and relaunch under a new job name. A provider 402 or a host failure is not a task failure and is listed separately from the per-task table.",
+  "preconditions": {
+    "adapter_cannot_select_a_pipeline": {
+      "what": "bench/harbor_adapter/stella_harbor/loop_mode.py's loop_argv emits no --pipeline flag at all, so neither arm can be launched by today's adapter",
+      "issue": "https://github.com/macanderson/stella/issues/6178"
+    },
+    "evidence_cannot_say_which_loop_ran": {
+      "what": "score_dev_baseline.py's extract_trial does not carry stella_loop_mode into trials.jsonl, so no committed field answers the question the analysis mode above must ask",
+      "issue": "https://github.com/macanderson/stella/issues/6179"
+    },
+    "control_arm_must_build": {
+      "what": "the control arm's crate is gone from this workspace, so the build is from an old checkout with its own lockfile and toolchain pin. Budget time for getting that binary to exist at all.",
+      "issue": null
+    }
+  },
+  "to_be_recorded_before_the_first_paid_call": {
+    "prereg_url": null,
+    "registered_at": null,
+    "control_sut_commit": "f4c24c12bde5578818f1141ec4e438291ac4db55",
+    "control_binary_sha256": null,
+    "treatment_sut_commit": null,
+    "treatment_binary_sha256": null,
+    "dataset": null,
+    "worker_model": null,
+    "taskset_sha256": null,
+    "denominator": 89,
+    "loop_mode_field_values": {
+      "control": null,
+      "treatment": null
+    },
+    "adapter_revision": null
+  }
+}

--- a/bench/evidence/tests/test_compare_arms_cross_sut.py
+++ b/bench/evidence/tests/test_compare_arms_cross_sut.py
@@ -1,0 +1,268 @@
+"""Tests for a comparison whose two arms are two builds.
+
+One build cannot answer every question. To compare a path that was cut against
+the path that took its place, you need a build of each. The default comparison
+refuses that, and it is right to: an unnoticed split between two builds is the
+cheapest way to get a number that looks fine and means nothing.
+
+So the split is declared, and the declaration buys checks the default mode
+cannot make. Each arm must report the commit it was declared on. The two builds
+must differ. And the treatment arm must show, per trial, that it ran the path
+under test. A build that *can* run a path is not a run that *did*.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_EVIDENCE = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _EVIDENCE / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+compare_arms = _load("compare_arms")
+
+OLD = "a" * 40
+NEW = "b" * 40
+PATH_UNDER_TEST = "wrapper:witness-v1"
+
+
+def _cross(**overrides) -> "compare_arms.CrossSut":
+    fields = {
+        "control_commit": OLD,
+        "treatment_commit": NEW,
+        "fired_field": "loop_mode",
+        "fired_value": PATH_UNDER_TEST,
+    }
+    fields.update(overrides)
+    return compare_arms.CrossSut(**fields)
+
+
+def _row(task: str, *, build: str, passed: bool, **extra) -> dict:
+    """One trial row in the shape `score_dev_baseline.py extract` writes."""
+    row = {
+        "task_name": task,
+        "trial_id": f"{task}__aaa",
+        "accuracy": 1.0 if passed else 0.0,
+        "reward": 1.0 if passed else 0.0,
+        # The posture is held still across both builds, so both arms declare
+        # the same assurance arm. It says which tiers the posture asks for. It
+        # does not say which loop the binary ran.
+        "assurance_arm": "witness-off",
+        "source_commit": build,
+        "binary_sha256": build[0] * 64,
+        "engine_posture_sha256": "one-posture",
+        "witness_author_model": None,
+        "witness_authored_state": "unavailable",
+        "witness_authored_count": 0,
+        "self_verdict_passed": passed,
+        "self_verdict_deterministic": False,
+        "usd": 1.0,
+    }
+    row.update(extra)
+    return row
+
+
+def _control(task: str, *, passed: bool = False, **extra) -> dict:
+    extra.setdefault("loop_mode", "staged_pipeline")
+    return _row(task, build=OLD, passed=passed, **extra)
+
+
+def _treatment(task: str, *, passed: bool = True, **extra) -> dict:
+    extra.setdefault("loop_mode", PATH_UNDER_TEST)
+    return _row(task, build=NEW, passed=passed, **extra)
+
+
+def _arms(control_rows: list[dict], treatment_rows: list[dict]):
+    return (
+        {row["task_name"]: row for row in control_rows},
+        {row["task_name"]: row for row in treatment_rows},
+    )
+
+
+def _write(path: Path, rows: list[dict]) -> Path:
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+    return path
+
+
+# --------------------------------------------------------------------------
+# The default mode still refuses a split it was not told about
+# --------------------------------------------------------------------------
+
+
+def test_two_builds_are_refused_when_nobody_declared_them() -> None:
+    control, treatment = _arms([_control("a")], [_treatment("a")])
+
+    report = compare_arms.compare(control, treatment, tasks=1)
+
+    assert report["comparable"] is False
+    assert any("source_commit" in reason for reason in report["refusals"])
+
+
+# --------------------------------------------------------------------------
+# Declared, and therefore checkable
+# --------------------------------------------------------------------------
+
+
+def test_a_declared_two_build_comparison_is_allowed_to_mean_something() -> None:
+    control, treatment = _arms(
+        [_control("a"), _control("b", passed=True)],
+        [_treatment("a"), _treatment("b")],
+    )
+
+    report = compare_arms.compare(control, treatment, tasks=2, cross_sut=_cross())
+
+    assert report["comparable"] is True
+    assert report["refusals"] == []
+    assert report["schema"] == "stella-cross-sut-ab-comparison-v1"
+    assert report["path_fired"]["treatment_trials_on_the_path"] == 2
+    assert "witness_tier" not in report
+
+
+def test_the_report_says_the_two_arms_are_confounded() -> None:
+    """The delta belongs to the arm, never to a change inside the range."""
+    control, treatment = _arms([_control("a")], [_treatment("a")])
+
+    report = compare_arms.compare(control, treatment, tasks=1, cross_sut=_cross())
+    rendered = compare_arms.markdown(report)
+
+    assert report["identity"]["cross_sut"]["confounded"] is True
+    assert report["confound"] == compare_arms.CROSS_SUT_CONFOUND
+    assert "Confounded" in rendered
+
+
+def test_a_build_from_another_tree_is_refused() -> None:
+    other = "c" * 40
+    control, treatment = _arms(
+        [_control("a")], [_row("a", build=other, passed=True, loop_mode=PATH_UNDER_TEST)]
+    )
+
+    report = compare_arms.compare(control, treatment, tasks=1, cross_sut=_cross())
+
+    assert report["comparable"] is False
+    assert any(NEW in reason and other in reason for reason in report["refusals"])
+
+
+def test_one_binary_running_both_arms_is_refused() -> None:
+    """Two commits with one binary hash means one build ran both arms."""
+    control, treatment = _arms(
+        [_control("a", binary_sha256="z" * 64)],
+        [_treatment("a", binary_sha256="z" * 64)],
+    )
+
+    report = compare_arms.compare(control, treatment, tasks=1, cross_sut=_cross())
+
+    assert report["comparable"] is False
+    assert any("one arm run twice" in reason for reason in report["refusals"])
+
+
+def test_a_treatment_trial_that_cannot_say_which_path_it_ran_is_refused() -> None:
+    control, treatment = _arms(
+        [_control("a"), _control("b")],
+        [_treatment("a"), _row("b", build=NEW, passed=True)],
+    )
+
+    report = compare_arms.compare(control, treatment, tasks=2, cross_sut=_cross())
+
+    assert report["comparable"] is False
+    assert any("1 treatment trial(s)" in reason for reason in report["refusals"])
+
+
+def test_a_control_trial_on_the_path_under_test_is_refused() -> None:
+    """Both arms on one path is one arm, whatever the two builds say."""
+    control, treatment = _arms(
+        [_control("a", loop_mode=PATH_UNDER_TEST)], [_treatment("a")]
+    )
+
+    report = compare_arms.compare(control, treatment, tasks=1, cross_sut=_cross())
+
+    assert report["comparable"] is False
+    assert any("both arms ran the path" in reason for reason in report["refusals"])
+
+
+def test_a_posture_that_moved_with_the_build_is_refused() -> None:
+    """Only the build may differ. A second change makes the arms two changes."""
+    control, treatment = _arms(
+        [_control("a")], [_treatment("a", assurance_arm="witness-on")]
+    )
+
+    report = compare_arms.compare(control, treatment, tasks=1, cross_sut=_cross())
+
+    assert report["comparable"] is False
+    assert any("assurance arms" in reason for reason in report["refusals"])
+
+
+# --------------------------------------------------------------------------
+# The declaration itself
+# --------------------------------------------------------------------------
+
+
+def test_a_short_commit_hash_is_refused() -> None:
+    try:
+        compare_arms.parse_cross_sut("a6d3db4f6:" + NEW, "loop_mode=x")
+    except ValueError as exc:
+        assert "40-character" in str(exc)
+    else:  # pragma: no cover - the assertion is the test
+        raise AssertionError("a short hash must not be accepted")
+
+
+def test_one_commit_named_twice_is_refused() -> None:
+    try:
+        compare_arms.parse_cross_sut(f"{OLD}:{OLD}", "loop_mode=x")
+    except ValueError as exc:
+        assert "one arm run twice" in str(exc)
+    else:  # pragma: no cover - the assertion is the test
+        raise AssertionError("one commit cannot be two arms")
+
+
+def test_a_value_holding_an_equals_sign_survives_parsing() -> None:
+    declared = compare_arms.parse_cross_sut(f"{OLD}:{NEW}", "loop_mode=a=b")
+
+    assert declared.fired_field == "loop_mode"
+    assert declared.fired_value == "a=b"
+
+
+def test_the_two_flags_are_one_declaration(tmp_path: Path, capsys) -> None:
+    """Half a declaration would run the mode with no proof of the path."""
+    control = _write(tmp_path / "control.jsonl", [_control("a")])
+    treatment = _write(tmp_path / "treatment.jsonl", [_treatment("a")])
+
+    code = compare_arms.main(
+        [str(control), str(treatment), "--tasks", "1", "--cross-sut", f"{OLD}:{NEW}"]
+    )
+
+    assert code == 2
+    assert "pass both or neither" in capsys.readouterr().err
+
+
+def test_the_cli_runs_a_declared_two_build_comparison(tmp_path: Path, capsys) -> None:
+    control = _write(tmp_path / "control.jsonl", [_control("a"), _control("b")])
+    treatment = _write(tmp_path / "treatment.jsonl", [_treatment("a"), _treatment("b")])
+
+    code = compare_arms.main(
+        [
+            str(control),
+            str(treatment),
+            "--tasks",
+            "2",
+            "--cross-sut",
+            f"{OLD}:{NEW}",
+            "--treatment-fired",
+            f"loop_mode={PATH_UNDER_TEST}",
+        ]
+    )
+    report = json.loads(capsys.readouterr().out)
+
+    assert code == 0
+    assert report["comparable"] is True
+    assert report["identity"]["cross_sut"]["declared_control_commit"] == OLD


### PR DESCRIPTION
## What this is

`doc:pipeline-as-plugins` §7 set one bar for deleting the built-in staged
pipeline: a side-by-side benchmark showing the plugin path that replaced it is
not worse. The deletion shipped ahead of that bar as a recorded maintainer
call, and the measurement has never been run.

The run needs a benchmark rig, real spend, and a build of a crate this
workspace deleted. This PR lands the part that has to exist **before** the
first paid call and cannot be written after it, and reports what reading the
tree turned up.

**This does not close #6155.** Only its first done-item is satisfied here.

## What lands

**`bench/evidence/pipeline-ab/preregistration.json` + `README.md`** — arms,
task list, denominator, seeds, replicates, decision rule and the SUT commit of
each arm, fixed before any data exists.

- control: `f4c24c12bde5578818f1141ec4e438291ac4db55`, the parent of
  `a6d3db4f6` and the last commit where `crates/stella-pipeline` exists.
  Verified: `git show f4c24c12b:crates/stella-pipeline/Cargo.toml` resolves,
  and `--pipeline classic` still selects the staged pipeline in that tree
  (`crates/stella-cli/src/agent/goal.rs` at that commit).
- treatment: a build of `main` running `stella run --pipeline witness-v1` —
  the `[wrapper] id` declared in `plugins/stella-witness/plugin.toml`.
- repeats are three preregistered replicates rather than several attempts per
  task, because the analysis keys one row per task per arm and refuses a
  duplicate; three pairs also measure run-to-run variance instead of hiding it
  inside a majority vote.
- the stop rule is keyed to spend and fixed here. No stop may be triggered by
  a score.

**`bench/evidence/compare_arms.py` gains a declared cross-build mode.** The
issue calls this analysis "already written". It is, for a different experiment:
`check_identity` refuses two arms whose `source_commit` or `binary_sha256`
differ, and demands the arm labels `witness-off`/`witness-on`, which come from
`assurance_tiers_from_posture` and say which verification tiers the posture
asks for — not which loop the binary ran. Both refusals fire on this experiment
by construction.

The new mode is opt-in and **stricter than the default, never looser**:

| default | `--cross-sut A:B --treatment-fired f=v` |
|---|---|
| one `source_commit` across both arms | each arm must report the commit declared for it |
| one `binary_sha256` across both arms | the two hashes must differ |
| arm labels `witness-off`/`witness-on` | both arms must declare the *same* posture arm — only the build may move |
| treatment must have authored a witness | every treatment trial must carry `f=v`, and no control trial may |

`--cross-sut` and `--treatment-fired` are one declaration: passing one alone
exits 2, so the mode cannot be reached by forgetting the proof half. Every
report it produces carries `CROSS_SUT_CONFOUND` in the JSON and a
`> **Confounded.**` line in the markdown, fixed in the module so no run can
soften it.

## Witness mechanism

`bench/evidence/tests/test_compare_arms_cross_sut.py`. It fails on the old code
by construction: `compare()` takes no `cross_sut` argument and the module has
no `CrossSut`, `parse_cross_sut` or `CROSS_SUT_CONFOUND`.

Checked the artisanal way — `git stash push bench/evidence/compare_arms.py` and
re-run:

```
12 failed, 1 passed
AttributeError: module 'compare_arms' has no attribute 'parse_cross_sut'
```

The one that passes on both trees is the contrast case
(`test_two_builds_are_refused_when_nobody_declared_them`), which asserts the
default still refuses an undeclared split. With the change: `79 passed`
across `bench/evidence/tests/`, which `bench.yml`'s required
`harbor_adapter + analyzer pytest` job runs on a `bench/**` diff.

## Exemplar

`bench/evidence/witness-ab/` — this preregistration takes its field shape, its
`to_be_recorded_before_the_first_paid_call` block and its refusal vocabulary
from that directory rather than inventing a second dialect.

## Two blockers found while reading, filed rather than fixed

Both are preconditions on the run, and the preregistration names them:

- **#6178** — `loop_argv` in
  `bench/harbor_adapter/stella_harbor/loop_mode.py` emits no `--pipeline` flag
  in any case, so neither arm can be launched by today's adapter.
- **#6179** — `extract_trial` in `bench/evidence/score_dev_baseline.py` does
  not carry `stella_loop_mode` into `trials.jsonl`, so no committed field says
  which loop a trial ran. That is the field `--treatment-fired` points at.

Fixing either one touches the frozen launcher argv contract or the trial row
shape, which is a separate change with its own tests; folding them into a
preregistration PR would put three unrelated diffs under one review.

## What is deliberately not here

The run itself, and the remaining five done-items of #6155. They need a rig,
a credential and real money, and no amount of reading the tree substitutes.

Tests deleted: None.

Refs #6155

## Summary by Sourcery

Preregister the built-in-versus-plugin pipeline benchmark and make its explicitly confounded two-build analysis enforceable.

New Features:
- Add a preregistered plan for comparing the last built-in pipeline against the replacement plugin pipeline across three paid replicates.
- Support explicitly declared cross-build A/B analysis with commit, binary, posture, and path-execution validation plus mandatory confound reporting.

Enhancements:
- Preserve strict default same-build identity checks while extending comparison reports and markdown output for declared two-build experiments.

Documentation:
- Document the pipeline A/B protocol, decision rules, limitations, and current blockers.

Tests:
- Add coverage for cross-build declarations, identity validation, path execution checks, CLI requirements, refusal cases, and confound reporting.

Chores:
- Record adapter and trial-schema blockers needed before running the benchmark without fixing them in this change.