### PR TITLE
feat(stella-autonomy,stella-cli): age a dedup digest out once its issue closes

### DIFF
--- a/crates/stella-autonomy/README.md
+++ b/crates/stella-autonomy/README.md
@@ -87,6 +87,7 @@ the CLI does — so the dashboard and the terminal cannot disagree.
 | [`src/escalation.rs`](src/escalation.rs) | Escalation as a cooldown: `classify` reads an abort message, `retry_after` says how long to wait, `park_after` says when waiting ends. The record is written into the issue body and read back from it. |
 | [`src/gate.rs`](src/gate.rs) | Which checks are allowed to block a merge, and which have stopped earning that right. |
 | [`src/supply.rs`](src/supply.rs) | Where the loop looks when the ranked queue is empty: `WorkSupply`, `SupplyPolicy` (every switch off), the `rearm` rule that re-opens a dry ladder against a moved base, and `novel`, which drops a finding the seen set already holds. |
+| [`src/seen.rs`](src/seen.rs) | The dedup set, and the one thing that ages a line out of it: `Filing` pairs a digest with the issue it became, and `live` drops a line whose every issue closed on a cited change. A line with no filing record never decays. |
 | [`src/regress.rs`](src/regress.rs) | Re-checking the fixes the loop has claimed: `ClosureReceipt`, `check`, and the `sweep` that turns a change gone from the base branch into a fresh defect. |
 | [`src/meta.rs`](src/meta.rs) | The loop read against its own ledger: a raised signal nobody acted on, and a lens that has looked several times and found nothing. |
 | [`src/closure.rs`](src/closure.rs) | How an issue ends, and what has to be true first. |

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -62,6 +62,7 @@ pub mod meta;
 pub mod priority;
 pub mod ready;
 pub mod regress;
+pub mod seen;
 mod stats;
 mod step;
 pub mod supply;

--- a/crates/stella-autonomy/src/seen.rs
+++ b/crates/stella-autonomy/src/seen.rs
@@ -1,0 +1,191 @@
+//! The dedup set, and the one thing that ages a line out of it.
+//!
+//! `seen.txt` holds one digest per line. A digest in it drops a repeat
+//! before anything is sent. That is what stops the loop filing one defect
+//! twice.
+//!
+//! Nothing ages a line out on its own. So a defect the loop found, filed,
+//! fixed and closed can come back a year later, and the set drops it in
+//! silence. "We know about this" and "we knew about this once, and the cause
+//! is back" are different answers. The second is the one the loop is for.
+//!
+//! What decays a line is the closure of the issue it became. A closure that
+//! cites a change is the loop saying that defect is fixed. Stating the same
+//! finding after that is news, so the line stops suppressing and the finding
+//! is filed again.
+//!
+//! A closure that cites nothing decays nothing. Somebody declined that work,
+//! or it was a copy of another issue, and neither of those is a fix.
+//!
+//! Two rules keep an old set safe:
+//!
+//! - A line with no filing record beside it never decays. Every `seen.txt`
+//!   written before this module existed is such a line, so an upgrade files
+//!   nothing again.
+//! - One closed issue does not decay a line that another issue still holds
+//!   open.
+//!
+//! [`crate::finding_digest`] is untouched here. What a line says is a
+//! byte-for-byte contract with every machine that has run the loop, so the
+//! record that decays a line lives in a second file.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+/// One filing the loop made: which finding, and which issue it became.
+///
+/// One line of `filings.jsonl` in the loop's state directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Filing {
+    /// The dedup digest, spelled as `seen.txt` spells it.
+    pub digest: String,
+    /// The issue key the tracker gave back, with no leading `#`.
+    pub key: String,
+    /// When it was filed, RFC3339. Empty on a record that predates this
+    /// field.
+    #[serde(default)]
+    pub at: String,
+}
+
+impl Filing {
+    /// Record that `digest` was filed as `key` at `at`.
+    #[must_use]
+    pub fn new(digest: &str, key: &str, at: &str) -> Self {
+        Self {
+            digest: digest.trim().to_owned(),
+            key: issue_key(key).to_owned(),
+            at: at.trim().to_owned(),
+        }
+    }
+}
+
+/// An issue key with its decoration removed, so `#412` and ` 412 ` match.
+fn issue_key(raw: &str) -> &str {
+    raw.trim().trim_start_matches('#').trim()
+}
+
+/// The seen lines that still drop a repeat.
+///
+/// `fixed` holds the keys of issues the loop closed on a cited change. Pass
+/// the receipts it wrote as it closed them, and nothing else: a closure that
+/// cited no change is not a claim that anything was fixed.
+///
+/// Order is kept, so the result reads as the file reads.
+#[must_use]
+pub fn live(seen: &[String], filings: &[Filing], fixed: &[String]) -> Vec<String> {
+    let fixed: BTreeSet<&str> = fixed.iter().map(|key| issue_key(key.as_str())).collect();
+    seen.iter()
+        .filter(|line| !decayed(line.trim(), filings, &fixed))
+        .cloned()
+        .collect()
+}
+
+/// Whether one digest has stopped suppressing.
+fn decayed(digest: &str, filings: &[Filing], fixed: &BTreeSet<&str>) -> bool {
+    if digest.is_empty() {
+        return false;
+    }
+    let mut records = filings
+        .iter()
+        .filter(|filing| filing.digest.trim() == digest)
+        .peekable();
+    // No record at all. The line predates the ledger, so its age is unknown,
+    // and an unknown age reads as live. Reading it the other way would file
+    // every finding the loop has ever filed, all at once.
+    if records.peek().is_none() {
+        return false;
+    }
+    records.all(|filing| fixed.contains(issue_key(&filing.key)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::finding_digest;
+
+    fn filed(title: &str, key: &str) -> Filing {
+        Filing::new(&finding_digest(title), key, "2026-09-05T00:00:00Z")
+    }
+
+    const DEFECT: &str = "crates/stella-core/src/driver.rs:812 retry counter never reset";
+    const KEY: &str = "4100";
+
+    /// **The witness.** A defect the loop filed, fixed and closed is offered
+    /// again once its cause comes back.
+    ///
+    /// Before this module, `seen.txt` was the whole answer and held no issue
+    /// key, so nothing could ask whether the issue had closed. The digest
+    /// stayed in the set and the returning defect was dropped in silence.
+    #[test]
+    fn a_defect_whose_fix_was_closed_is_offered_again() {
+        let seen = vec![finding_digest(DEFECT)];
+        let filings = vec![filed(DEFECT, KEY)];
+
+        let kept = live(&seen, &filings, &[format!("#{KEY}")]);
+
+        assert!(
+            kept.is_empty(),
+            "a closed fix must stop suppressing, got {kept:?}"
+        );
+    }
+
+    /// A repeat of a finding whose issue is still open is still dropped.
+    #[test]
+    fn a_repeat_is_dropped_while_its_issue_is_open() {
+        let seen = vec![finding_digest(DEFECT)];
+        let filings = vec![filed(DEFECT, KEY)];
+
+        let kept = live(&seen, &filings, &[]);
+
+        assert_eq!(kept, seen, "an open issue holds its line");
+    }
+
+    /// A `seen.txt` written before `filings.jsonl` existed decays nothing.
+    #[test]
+    fn a_line_with_no_filing_record_never_decays() {
+        let seen = vec![
+            finding_digest(DEFECT),
+            finding_digest("a second defect entirely"),
+        ];
+
+        let kept = live(&seen, &[], &[KEY.to_owned()]);
+
+        assert_eq!(kept, seen, "a legacy set is read whole");
+    }
+
+    /// One closed issue does not decay a line another issue still holds.
+    #[test]
+    fn an_open_filing_beside_a_closed_one_holds_the_line() {
+        let seen = vec![finding_digest(DEFECT)];
+        let filings = vec![filed(DEFECT, KEY), filed(DEFECT, "4200")];
+
+        let kept = live(&seen, &filings, &[KEY.to_owned()]);
+
+        assert_eq!(kept, seen, "the open issue still holds the line");
+    }
+
+    /// A closure that cited nothing is not a fix, so it decays nothing. The
+    /// caller passes only cited closures, and an empty `fixed` list is what
+    /// that looks like here.
+    #[test]
+    fn a_closure_citing_nothing_decays_nothing() {
+        let seen = vec![finding_digest(DEFECT)];
+        let filings = vec![filed(DEFECT, KEY)];
+
+        let kept = live(&seen, &filings, &[]);
+
+        assert_eq!(kept, seen);
+    }
+
+    /// Blank lines and unmatched records leave the set alone.
+    #[test]
+    fn a_blank_line_survives_and_an_unmatched_record_is_ignored() {
+        let seen = vec![String::new(), finding_digest(DEFECT)];
+        let filings = vec![filed("some other finding", KEY)];
+
+        let kept = live(&seen, &filings, &[KEY.to_owned()]);
+
+        assert_eq!(kept, seen);
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -1327,7 +1327,7 @@ fn file_finding(
         .block_on(backlog::file_finding(
             &crate::issue_provider::GhIssueProvider,
             &bound.convention,
-            &st.seen(),
+            &st.live_seen(),
             &draft,
             &attribution.issue,
         ))
@@ -1340,7 +1340,7 @@ fn file_finding(
     st.update_stats(|s| s.record_filing(outcome.canonical()));
 
     if let backlog::Filed::New(key) = &outcome {
-        st.add_seen(&stella_autonomy::finding_digest(title))?;
+        st.record_filing(&stella_autonomy::finding_digest(title), &key.to_string())?;
         // Only for a filing that reached the tracker. A deduplicated finding
         // created no issue, and an event named `IssueCreated` firing for one
         // would make the count a subscriber keeps disagree with the tracker's.

--- a/crates/stella-cli/src/self_driving_cmd/query.rs
+++ b/crates/stella-cli/src/self_driving_cmd/query.rs
@@ -64,7 +64,9 @@ pub(super) fn seen(
     if !digest.is_empty() {
         println!("{}", stella_autonomy::finding_digest(&digest.join(" ")));
     } else if !new.is_empty() {
-        let known = st.seen();
+        // The live set, so this verb answers what the filing paths would do.
+        // A digest whose issue closed on a cited fix reads as new again.
+        let known = st.live_seen();
         for d in new {
             if !known.iter().any(|k| k == d) {
                 println!("{d}");

--- a/crates/stella-cli/src/self_driving_cmd/residue.rs
+++ b/crates/stella-cli/src/self_driving_cmd/residue.rs
@@ -192,7 +192,7 @@ pub(crate) async fn end_of_turn(messages: &[CompletionMessage]) -> Vec<String> {
     let outcomes = file_residue(
         &crate::issue_provider::GhIssueProvider,
         &bound.convention,
-        &st.seen(),
+        &st.live_seen(),
         &cfg.attribution.issue,
         &statements,
     )
@@ -202,7 +202,8 @@ pub(crate) async fn end_of_turn(messages: &[CompletionMessage]) -> Vec<String> {
     for outcome in &outcomes {
         match &outcome.result {
             Ok(Filed::New(key)) => {
-                let _ = st.add_seen(&stella_autonomy::finding_digest(&outcome.title));
+                let digest = stella_autonomy::finding_digest(&outcome.title);
+                let _ = st.record_filing(&digest, &key.to_string());
                 st.update_stats(|s| s.record_filing("new"));
                 notices.push(format!("residue gate filed #{key}: {}", outcome.title));
             }

--- a/crates/stella-cli/src/self_driving_cmd/state.rs
+++ b/crates/stella-cli/src/self_driving_cmd/state.rs
@@ -282,6 +282,9 @@ impl LoopState {
     fn receipts_path(&self) -> PathBuf {
         self.dir.join("receipts.jsonl")
     }
+    fn filings_path(&self) -> PathBuf {
+        self.dir.join("filings.jsonl")
+    }
 
     /// Snapshot the ranked queue as the loop last saw it.
     ///
@@ -441,8 +444,63 @@ impl LoopState {
         self.seen().iter().filter(|l| !l.trim().is_empty()).count()
     }
 
+    /// Append a bare digest, with no filing beside it.
+    ///
+    /// The one caller is `self-driving seen --add`, where a person hands over
+    /// a digest and no issue key exists to pair it with. Such a line can never
+    /// decay, which is what an unknown age is meant to read as. Every path
+    /// that files through the tracker uses [`Self::record_filing`] instead.
     pub fn add_seen(&self, digest: &str) -> Result<(), String> {
         append_line(&self.seen_path(), digest)
+    }
+
+    /// The seen digests that still drop a repeat.
+    ///
+    /// This is what every filing path checks against, and it is smaller than
+    /// [`Self::seen`] by whatever has decayed. A digest decays when every
+    /// issue it was filed as has closed on a cited change — the loop's own
+    /// word that the defect is fixed. See [`stella_autonomy::seen`].
+    ///
+    /// [`Self::seen`] stays the durable set, and `seen_count` still reports
+    /// it: the file is what a move carries and what an operator counts.
+    pub fn live_seen(&self) -> Vec<String> {
+        let fixed: Vec<String> = self
+            .receipts()
+            .into_iter()
+            .filter(|receipt| receipt.by.is_some())
+            .map(|receipt| receipt.key)
+            .collect();
+        stella_autonomy::seen::live(&self.seen(), &self.filings(), &fixed)
+    }
+
+    /// Every filing this loop has made, as a digest and the issue it became.
+    ///
+    /// A line that does not parse is skipped, the same rule the receipts read
+    /// by. A skipped line costs one digest that can never decay, which is the
+    /// old behaviour rather than a new hazard.
+    pub fn filings(&self) -> Vec<stella_autonomy::seen::Filing> {
+        read_jsonl(&self.filings_path())
+            .values
+            .into_iter()
+            .filter_map(|value| serde_json::from_value(value).ok())
+            .collect()
+    }
+
+    /// Write down a filing: the digest into `seen.txt`, and what it became
+    /// beside it.
+    ///
+    /// One call rather than two, because a digest recorded with no filing
+    /// beside it is a line nothing can ever decay. That pairing is the whole
+    /// mechanism, so there is no way in that can skip half of it.
+    ///
+    /// `seen.txt` is written first. Losing the second write costs a line that
+    /// cannot decay; losing the first would re-file a finding the tracker has
+    /// already taken.
+    pub fn record_filing(&self, digest: &str, key: &str) -> Result<(), String> {
+        self.add_seen(digest)?;
+        let filing = stella_autonomy::seen::Filing::new(digest, key, &rfc3339_utc_now());
+        let line = serde_json::to_string(&filing).map_err(|e| e.to_string())?;
+        append_line(&self.filings_path(), &line)
     }
 
     // -- closure receipts ---------------------------------------------------
@@ -1063,5 +1121,132 @@ mod tests {
         assert_eq!(items[2]["rank"], "untriaged");
         assert_eq!(items[2]["number"], "3");
         assert!(doc["at"].as_str().unwrap().ends_with('Z'));
+    }
+
+    /// One closure receipt line, serialized by the type the loop writes, so
+    /// this fixture cannot drift from the shape `receipts()` reads.
+    fn receipt_line(key: &str, by: Option<stella_autonomy::Citation>) -> String {
+        let receipt = stella_autonomy::regress::ClosureReceipt {
+            key: key.to_owned(),
+            closed_at: "2026-09-01T00:00:00Z".to_owned(),
+            by,
+            present_at_close: Some(true),
+        };
+        format!("{}\n", serde_json::to_string(&receipt).unwrap())
+    }
+
+    /// A closure citing the pull request that carried the fix.
+    fn fixed_by(key: &str) -> Option<stella_autonomy::Citation> {
+        Some(stella_autonomy::Citation::PullRequest {
+            key: key.to_owned(),
+        })
+    }
+
+    /// **The witness.** A defect the loop filed, fixed and closed stops
+    /// suppressing, so its return is filed rather than dropped.
+    ///
+    /// Before this change `seen.txt` was the whole answer, `live_seen` did
+    /// not exist, and every filing path read `seen()`. A digest in that file
+    /// dropped the repeat whatever had happened to the issue since.
+    #[test]
+    fn a_closed_fix_lets_its_digest_be_filed_again() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("state");
+        let digest = stella_autonomy::finding_digest("driver.rs:812 retry counter never reset");
+        seed_state(&dir, &format!("{digest}\n"));
+        std::fs::write(
+            dir.join("filings.jsonl"),
+            format!("{{\"digest\":\"{digest}\",\"key\":\"4100\",\"at\":\"\"}}\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("receipts.jsonl"),
+            receipt_line("4100", fixed_by("4101")),
+        )
+        .unwrap();
+
+        let st = LoopState {
+            dir,
+            repo_root: tmp.path().to_path_buf(),
+        };
+
+        assert_eq!(st.seen(), vec![digest.clone()], "the file is unchanged");
+        assert!(
+            st.live_seen().is_empty(),
+            "the closed fix must stop suppressing, got {:?}",
+            st.live_seen()
+        );
+    }
+
+    /// A `seen.txt` written before `filings.jsonl` existed keeps every line,
+    /// so an upgrade re-files nothing.
+    #[test]
+    fn a_legacy_seen_set_is_read_whole() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("state");
+        seed_state(&dir, "aaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbb\n");
+        std::fs::write(
+            dir.join("receipts.jsonl"),
+            receipt_line("4100", fixed_by("4101")),
+        )
+        .unwrap();
+
+        let st = LoopState {
+            dir,
+            repo_root: tmp.path().to_path_buf(),
+        };
+
+        assert_eq!(st.live_seen(), st.seen());
+        assert_eq!(st.seen_count(), 2);
+    }
+
+    /// A filing pairs the digest with the issue it became, in one call, so a
+    /// line that could never decay cannot be written by accident.
+    #[test]
+    fn recording_a_filing_writes_both_halves() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("state");
+        seed_state(&dir, "");
+        let st = LoopState {
+            dir: dir.clone(),
+            repo_root: tmp.path().to_path_buf(),
+        };
+
+        let key = "4100";
+        st.record_filing("d0d0d0d0d0d0d0d0", &format!("#{key}"))
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(dir.join("seen.txt")).unwrap(),
+            "d0d0d0d0d0d0d0d0\n",
+            "seen.txt still holds one bare digest per line"
+        );
+        let filings = st.filings();
+        assert_eq!(filings.len(), 1);
+        assert_eq!(filings[0].digest, "d0d0d0d0d0d0d0d0");
+        assert_eq!(filings[0].key, key, "the leading marker is dropped");
+        assert!(filings[0].at.ends_with('Z'));
+        assert_eq!(st.live_seen(), vec!["d0d0d0d0d0d0d0d0".to_owned()]);
+    }
+
+    /// A closure that cited no change is not a fix, so it decays nothing.
+    #[test]
+    fn a_closure_citing_nothing_keeps_the_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("state");
+        seed_state(&dir, "d0d0d0d0d0d0d0d0\n");
+        std::fs::write(
+            dir.join("filings.jsonl"),
+            "{\"digest\":\"d0d0d0d0d0d0d0d0\",\"key\":\"4100\",\"at\":\"\"}\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("receipts.jsonl"), receipt_line("4100", None)).unwrap();
+
+        let st = LoopState {
+            dir,
+            repo_root: tmp.path().to_path_buf(),
+        };
+
+        assert_eq!(st.live_seen(), st.seen(), "a declined issue is not a fix");
     }
 }

--- a/crates/stella-cli/src/self_driving_cmd/supply.rs
+++ b/crates/stella-cli/src/self_driving_cmd/supply.rs
@@ -131,7 +131,7 @@ pub(super) fn pass(
         findings.extend(found);
     }
 
-    let seen = durable.seen();
+    let seen = durable.live_seen();
     let fresh: Vec<Finding> = stella_autonomy::supply::novel(&findings, &seen)
         .into_iter()
         .cloned()
@@ -314,7 +314,7 @@ fn file(
         .block_on(backlog::file_finding(
             provider,
             &bound.convention,
-            &durable.seen(),
+            &durable.live_seen(),
             &draft,
             &cfg.attribution.issue,
         ))
@@ -323,7 +323,10 @@ fn file(
     durable.update_stats(|stats| stats.record_filing(outcome.canonical()));
 
     if let backlog::Filed::New(key) = &outcome {
-        durable.add_seen(&stella_autonomy::finding_digest(&finding.title))?;
+        durable.record_filing(
+            &stella_autonomy::finding_digest(&finding.title),
+            &key.to_string(),
+        )?;
         audit::record(
             durable,
             Audit::IssueFiled,

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -63,6 +63,7 @@ establishes it. Read the file before believing the row.
 | AIMD ceilings moved only from evidence | `crates/stella-autonomy/src/lib.rs` (`calibrate`) | Done. Additive-increase / multiplicative-decrease, provably convergent. |
 | The aperture ladder — 9 lenses, then `watch` | `crates/stella-autonomy/src/lib.rs` (`LENSES`, `advance`, `WATCH`) | Done. "No defects" is always a statement about a lens. |
 | Finding dedup by content digest | `crates/stella-autonomy/src/lib.rs` (`finding_digest`) | Done. Byte-for-byte contract with existing `seen.txt`. |
+| Dedup decay — a digest stops dropping repeats once its issue closes | `crates/stella-autonomy/src/seen.rs` (`live`), `filings.jsonl` written by `state.rs` (`record_filing`) | Done. Keyed on a closure that cited a change. A line with no filing record never decays, so an existing `seen.txt` is read whole. |
 | Dry-streak oracle advancing the ladder | `crates/stella-autonomy/src/lib.rs` (`dry_streak`) | Done. |
 | Self-diagnosis: `STUCK` / `STARVED` / `NOISY` / `FRAGILE` | `crates/stella-autonomy/src/lib.rs` (`metrics`, `starved`) | Done. Named pathologies, not a health score. |
 | Run liveness resolved by a reader, from heartbeats | `crates/stella-autonomy/src/lib.rs` (`fold_runs`) | Done. |

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -614,6 +614,21 @@ min_steps = 3       # open steps that raise a card
 # takes. Absent means "on"; filing stated follow-up work is the default.
 residue_gate = "on"
 
+# The dedup those checks use is not a setting, and it is what an operator asks
+# about first: why was this finding not filed? The loop keeps every digest it
+# has filed in `seen.txt`, under `~/.stella/self-driving/<repo>/`, and drops a
+# repeat before anything reaches the tracker.
+#
+# A digest stops dropping repeats once every issue it was filed as has closed
+# on a cited change — a pull request or a commit. That closure is the loop
+# saying the defect is fixed, so stating the same finding after it is news,
+# and the finding is filed again. A closure that cited nothing decays nothing:
+# somebody declined that work, or it was a copy of another issue.
+#
+# `filings.jsonl` beside `seen.txt` is what pairs a digest with the issue it
+# became. A line with no such record never decays, which is every `seen.txt`
+# written before this pairing existed, so an upgrade re-files nothing.
+
 # Labels marking a tracking issue — a checklist of other issues, kept open as
 # bookkeeping rather than as work. `drive --backlog` never claims one of
 # these, whatever its `Blocked by:` lines say: an epic reads as ready the


### PR DESCRIPTION
## What and why

A digest in the self-driving loop's `seen.txt` dropped a repeat forever. So a defect the loop found, filed, fixed, closed and then met again a year later was silently not filed the second time. The dedup set could not tell "we already know about this" from "we knew about this once, and the thing that made it true came back", and the second is the case the loop exists to catch.

A digest now stops dropping repeats once **every issue it was filed as has closed on a cited change** — a pull request or a commit. That closure is the loop's own word that the defect is fixed, so stating the same finding after it is news rather than a repeat.

Closure rather than age or base-commit distance, for the reason the issue names: the loop already writes a `ClosureReceipt` as it closes, so the signal is local, dated and free. Any age window would be a number nobody can defend — a defect returning at six months and one returning at eighteen are the same event.

A closure that cited nothing decays nothing. Somebody declined that work, or it was a copy of another issue, and neither is a fix.

## The upgrade path

`finding_digest`'s normalization and the format of `seen.txt` are untouched, because those lines are a byte-for-byte contract with every machine that has ever run the loop. What decays a line lives in a second file: `filings.jsonl`, one JSON object per filing, pairing a digest with the issue key it became.

A `seen.txt` line with no filing record beside it never decays. That is every line written before this change, so an upgrade re-files nothing. Decay also only bites when the finding is *stated again* — a fixed defect is not found by a lens, so a closure on its own files nothing.

`LoopState::record_filing` writes the digest and the filing record in one call, so a line that can never decay cannot be produced by accident. `seen.txt` is written first: losing the second write costs a line that cannot decay, while losing the first would re-file a finding the tracker already took.

## Files

- `crates/stella-autonomy/src/seen.rs` — new, pure, no I/O: `Filing` and `live(seen, filings, fixed)`.
- `crates/stella-cli/src/self_driving_cmd/state.rs` — `filings_path`, `filings()`, `record_filing()`, `live_seen()`.
- `crates/stella-cli/src/self_driving_cmd/{supply,residue}.rs` and `self_driving_cmd.rs` — the three filing paths read `live_seen()` and record through `record_filing`.
- `crates/stella-cli/src/self_driving_cmd/query.rs` — `self-driving seen --new` reads the live set, so the verb answers what the filers would do. `--add` still writes a bare digest, which is the one path with no issue key to pair, and such a line never decays.
- `stella.example.toml`, `docs/spec/backlog-self-driving.md`, `crates/stella-autonomy/README.md` — what the rule keys on, next to `self_driving.residue_gate`.

## Witness mechanism

Three tests, each of which fails on `main` by construction — `live_seen`, `record_filing`, `filings.jsonl` and `stella_autonomy::seen` do not exist there, so the code under test cannot compile against the old tree, and the behaviour it asserts has no other path to it.

- `a_defect_whose_fix_was_closed_is_offered_again` (`crates/stella-autonomy/src/seen.rs`) — the pure rule: one seen digest, one filing record naming issue 4100, 4100 in the fixed set, and the live set comes back empty.
- `a_closed_fix_lets_its_digest_be_filed_again` (`crates/stella-cli/src/self_driving_cmd/state.rs`) — the wiring over a real state directory: `seen()` still returns the file's one line, and `live_seen()` returns nothing. On `main` every filing path read `seen()`, so the repeat was dropped whatever had happened to the issue.
- `a_legacy_seen_set_is_read_whole` (same file) — a `seen.txt` with two digests and no `filings.jsonl`, beside a cited closure, keeps both lines.

Plus `a_closure_citing_nothing_keeps_the_line`, `recording_a_filing_writes_both_halves`, and four more directional cases in `seen.rs` (an open issue holds its line; an open filing beside a closed one holds it; a blank line survives; an unmatched record is ignored).

The receipt fixtures are serialized through `ClosureReceipt` itself rather than hand-written JSON, so they cannot drift from the shape `receipts()` reads — a hand-written copy of that shape was wrong on the first attempt.

## Exemplar

`crates/stella-autonomy/src/regress.rs` — the sibling module that already reads closure receipts back and turns a fact about them into a finding. `seen.rs` copies its shape: pure functions over borrowed data, the I/O left to the caller, one witness test per direction.

## Evidence

CI on this branch. Nothing was compiled locally.

Tests deleted: None.

## Remaining work filed

- #6188 — a digest never ages out when a person closes the issue the loop filed. Decay reads the loop's own closure receipts, and nothing else writes one.
- #6189 — a reverted fix can file two unlinked issues: the regress sweep's report, and the decayed original restated by a lens.

Closes #6149

## Summary by Sourcery

Age self-driving dedup digests out after all associated issues close on cited fixes so recurring defects can be filed again.

New Features:
- Age self-driving dedup digests out of the live set after every associated issue closes on a cited change.
- Track digest-to-issue filing records in `filings.jsonl` while preserving the existing `seen.txt` format and legacy behavior.

Bug Fixes:
- Allow previously fixed findings to be filed again when they reappear, while continuing to suppress findings linked to open or non-fixing closures.

Enhancements:
- Apply the live dedup set consistently across supply, residue, direct filing, and `self-driving seen --new` paths.
- Document the dedup decay behavior and its upgrade-safe handling.

Documentation:
- Document the new dedup decay rule and its state files in the autonomy README, backlog specification, and example configuration.

Tests:
- Add pure-rule and state-level coverage for closed fixes, open filings, non-fixing closures, legacy seen sets, unmatched records, and paired filing writes.
