### PR TITLE
fix(stella-parity,stella-serve): the ServeSession lane binds the re-query seam

### DIFF
--- a/crates/stella-parity/src/lane/capability.rs
+++ b/crates/stella-parity/src/lane/capability.rs
@@ -379,7 +379,7 @@ const SERVE_HOST_OWNS_CALLS: &str = "the host owns the model calls, so this is t
                                      rather than this engine's";
 
 lane_capabilities! {
-    // The deck's lead turn. The one lane that binds the re-query plane.
+    // The deck's lead turn. The CLI lane that binds the re-query plane.
     Lead => LaneOrigin::Builtin,
         Some(LaneSite {
             file: "crates/stella-cli/src/lane_capabilities.rs",
@@ -548,10 +548,7 @@ lane_capabilities! {
         calibration: SeamClaim::bound("calibration,", SERVE_SEAMS),
         gate: SeamClaim::bound("gate: Some(gate)", SERVE_SEAMS),
         steering: SeamClaim::bound("steering: Some(steering)", SERVE_SEAMS),
-        requery: SeamClaim::deferred(
-            "Refs #6158",
-            "a decision on whether the host supplies a re-query port over the wire",
-        ),
+        requery: SeamClaim::bound("requery,", SERVE_SEAMS),
         bus: SeamClaim::bound("bus,", SERVE_SEAMS),
         outcomes: SeamClaim::declined(SERVE_HOST_OWNS_CALLS),
         fallback: SeamClaim::declined(SERVE_HOST_OWNS_CALLS),

--- a/crates/stella-serve/src/observe/event.rs
+++ b/crates/stella-serve/src/observe/event.rs
@@ -85,9 +85,9 @@ impl LevelFilter {
 
 /// Which endpoint a request reached, as a **template**.
 ///
-/// The raw path is never recorded, because every `{id}` template above
-/// carries a turn or session id in it. Serde renames each case to its template
-/// so a record reads like an access log without any rendering step.
+/// The raw path is never kept. Every `{id}` template holds a turn or a
+/// session id. Serde names each case for its template, so a record reads
+/// like an access log with no work done to it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Route {
     #[serde(rename = "/healthz")]
@@ -114,8 +114,8 @@ pub enum Route {
     /// for an in-flight `provider_request`, ahead of its `provider-result`.
     #[serde(rename = "/v1/turns/{id}/provider-delta")]
     TurnProviderDelta,
-    /// The answer to a `requery_request`: the context block the host's
-    /// steering plane chose for a turn whose work has moved, or nothing.
+    /// The answer to a `requery_request`. It carries the block the host
+    /// chose for a turn whose work has moved, or nothing.
     #[serde(rename = "/v1/turns/{id}/requery-result")]
     TurnRequeryResult,
     #[serde(rename = "/v1/turns/{id}/cancel")]
@@ -468,9 +468,9 @@ impl StreamEndReason {
 pub enum ReverseKind {
     Provider,
     Tool,
-    /// A step-boundary context re-query. Distinct from the other two because
-    /// it is the one reverse request a turn survives unanswered: the step
-    /// proceeds with no extra context rather than failing.
+    /// A step-boundary context re-query. It is the one reverse request a
+    /// turn lives through unanswered. The step runs on with no extra
+    /// context, and does not fail.
     Requery,
 }
 


### PR DESCRIPTION
Two branches composed into a red `main`, exactly the shared-cell shape
AGENTS.md describes: both were green against their own bases and neither
CI run could see the other.

#6172 made `served_capabilities` write `requery,` — field shorthand — so
the `ServeSession` lane really does bind the seam now. #6171 landed the
lane-capability table with that row still `deferred`, which the literal
check reads as "and the site must write `requery: None`".
`a_seam_claim_agrees_with_its_lane_literal` fails on the composed tree.

The row moves to `bound("requery,", SERVE_SEAMS)`. `SERVE_SEAMS` is honest
for it: `a_served_turn_binds_what_its_call_site_bound_before` already
asserts `requery` in both directions — absent when the host supplied none,
present when it supplied one — so the row does not fall back to
`Witness::Literal` and `UNWITNESSED_SEAMS` is unchanged.

The `Lead` block's comment claimed it was the one lane that binds the
plane. Two do now.

Also lowers `crates/stella-serve/src/observe/event.rs` back under its
reading-grade ceiling. #6172 nudged it from 8.62 to 8.63, which is my own
regression and is repaired here rather than filed.

## Witness mechanism

The witness is the existing `a_seam_claim_agrees_with_its_lane_literal`
(`crates/stella-parity/src/lane/capability/tests.rs`). It fails on `main`'s
tip today, on the composed tree, and passes with this one-line change —
fail→pass without a new test, because the assertion that catches this
already exists and is what turned red.

Tests deleted: None

Closes #6193


## A red this PR does not fix

`docs/spec/wrapper-socket.md` sits at reading grade 12.20 against a 12.16
ceiling, so `check-prose` — and with it the `guard self-tests` job — is red on
`main` and on every open pull request. That drift arrived with `d625382fa`
(#6178) and is not this change's to repair; AGENTS.md asks for a ratchet you
did not cause to land on its own from a fresh `main`. Filed as #6199. `guard self-tests` is not a required check.

## Residue filed

- #6199 — `docs/spec/wrapper-socket.md` is over its reading-grade ceiling.

## Summary by Sourcery

Align ServeSession's capability contract with its re-query behavior and tighten related documentation.

Bug Fixes:
- Mark the ServeSession re-query capability as bound so parity checks correctly reflect the lane's existing behavior.

Enhancements:
- Update lane documentation to reflect that both the CLI and ServeSession lanes bind the re-query plane.
- Simplify route and reverse-request documentation while restoring the event module's reading-grade threshold.