### PR TITLE
docs(adr): the wrapper socket is the plugin SDK, and the canary that keeps it true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,15 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-reserved-paths.sh
 
+      # ADR 0030 says this repository ships no plugin SDK because the plugins
+      # under `plugins/` are the wire contract's canary: a test here spawns
+      # each of them, so a wire change reddens this run instead of a
+      # stranger's install. That only holds while every one of them has such
+      # a test.
+      - name: every first-party plugin is spawned by a test
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-plugin-graded.sh
+
       - name: no library crate returns Result<_, String>
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: python3 ./scripts/check-typed-errors.py

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -183,6 +183,10 @@ jobs:
       - name: The rendering-facts guard can still fail
         run: ./scripts/test-rendering-facts.sh
 
+      - name: plugin-graded guard directions
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-plugin-graded.sh
+
       - name: diagnostic-code registry failure directions
         if: ${{ !cancelled() }}
         run: ./scripts/test-diagnostic-codes.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,9 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + reserved-paths (no Windows device name in a path)
                          #   + rendering-facts (no v2 rendering draws a
                          #     fact SPEC.md retired)
+                         #   + plugin-graded (every plugins/ directory is
+                         #     spawned by an in-tree test, so a wire change
+                         #     reddens this repo rather than an install)
                          #   + wire-schema
                          #   + lockfile-sync (cargo metadata --locked)
                          #   + format-check (fmt --check)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,7 @@ python3 ./scripts/check-deck-paths.py
 python3 ./scripts/check-css-vars.py
 ./scripts/check-reserved-paths.sh
 ./scripts/check-rendering-facts.sh
+./scripts/check-plugin-graded.sh
 ./scripts/check-wire-schema.sh
 ./scripts/check-lockfile-sync.sh
 cargo fmt --check

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     bench-suites wire-paths \
                     tokens hue-separation contrast light-clamp transcript-surfaces prose \
                     line-citations \
-                    deck-fit-all-test deck-paths css-vars reserved-paths rendering-facts
+                    deck-fit-all-test deck-paths css-vars reserved-paths rendering-facts \
+                    plugin-graded
 GATE_GUARDS := $(GATE_GUARDS_FAST) wire-schema
 
 # The cargo steps that resolve or parse but never build. They are not in
@@ -551,6 +552,14 @@ rendering-facts: ## Assert no v2 rendering draws a fact design/tui-v2/SPEC.md re
 .PHONY: rendering-facts-test
 rendering-facts-test: ## Test the rendering-facts guard's directions (hermetic; not part of `gate`)
 	@./scripts/test-rendering-facts.sh
+
+.PHONY: plugin-graded
+plugin-graded: ## Assert every first-party plugin is spawned by an in-tree test (ADR 0030, #6148)
+	@./scripts/check-plugin-graded.sh
+
+.PHONY: plugin-graded-test
+plugin-graded-test: ## Test the plugin-graded guard's directions (hermetic; not part of `gate`)
+	@./scripts/test-plugin-graded.sh
 
 .PHONY: dead-code-allows
 dead-code-allows: ## Assert every #[allow(dead_code)] says why, and that the count only shrinks (#3949)

--- a/docs/adr/0030-the-wrapper-socket-is-the-plugin-sdk.md
+++ b/docs/adr/0030-the-wrapper-socket-is-the-plugin-sdk.md
@@ -1,0 +1,79 @@
+---
+id: adr/0030-the-wrapper-socket-is-the-plugin-sdk
+title: "ADR 0030: The wrapper socket is the plugin SDK"
+status: implemented
+---
+
+# ADR 0030: The wrapper socket is the plugin SDK
+
+- Status: accepted
+- Date: 2026-09-06
+- Decides: `#6148`
+
+## Context
+
+The plugin plan (`#3246`) had one step left with nothing in the tree: a Python
+SDK. Its closing note put two choices to a maintainer. Ship a Python package,
+so that an author writes handlers and not a JSON dispatcher. Or say that the
+manifest plus the socket is already the whole contract.
+
+Seven plugins under `plugins/` are Python today. Each one reads a JSON request
+on stdin. Each one looks at the point and writes a JSON reply on stdout. They
+share no library.
+
+A Python author is not left with nothing to read.
+`crates/stella-plugin/src/bin/export_wrapper_wire.rs` writes three files, not
+one:
+
+- `docs/wire/wrapper.wire.json` holds every message in its fullest and its
+  emptiest legal form.
+- `docs/wire/wrapper.schema.json` is JSON Schema 2020-12. No language owns it.
+- `docs/wire/wrapper.d.ts` states the same contract in TypeScript.
+
+The gate's `wire-schema` step runs that tool again and diffs all three. A wire
+change that skips them fails the pull request that made it.
+
+## Decision
+
+Ship no SDK from this repository. An author writes against the `plugin.toml`
+manifest, the socket in `doc:wrapper-socket`, and those three files.
+
+**The contract is a wire.** A library over it is a nicety. A first-party one
+in one language starts a queue: Go next, then TypeScript, then Rust. Each one
+is a new place to state the wire wrongly. `macanderson/stella-examples`
+carries `verify-rs`, `verify-py` and `verify-ts`. That is one plugin written
+three times over this socket, with no library in any of them.
+
+**A Python package cannot live here.** `plugins/README.md` gives the reason
+for the plugins themselves. A plugin built and shipped with the binary proves
+the opposite of what it is here to prove. A package would need its own repo,
+its own release train and its own index account. That is the coupling
+`doc:pipeline-as-plugins` exists to remove.
+
+**A wire change has to break something here.** That is the one thing this
+choice leans on, and it is real. Tests in `crates/stella-runtime/tests/`,
+`crates/stella-cli/tests/` and `crates/stella-tui/tests/` spawn these plugins
+through the host's own transport. An SDK would add nothing to that. A missing
+test would take it away.
+
+## Consequences
+
+`plugins/README.md` now states the contract. The next reader does not have to
+ask `#3246`'s question again.
+
+`scripts/check-plugin-graded.sh` (`make plugin-graded`, a gate step) holds the
+canary in place. Every folder under `plugins/` with a `plugin.toml` has to be
+named in some `crates/*/tests/**/*.rs`, on a line that is not a comment. The
+claim sat in `plugins/README.md` and nothing checked it. A new plugin with no
+test would have left that sentence reading true.
+`scripts/test-plugin-graded.sh` (`make plugin-graded-test`) shows the guard
+can still fail.
+
+An author still writes a JSON dispatcher. This record accepts that. It is a
+few lines in any language. The other road is a package this project would
+have to ship for good.
+
+`#5122` is the open question this does not answer. It grades a plugin against
+a replayed wire corpus. What a plugin is graded by and what it is written
+against are two things. If it lands and authors still ask for a library, amend
+this record. Do not add one on the quiet.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -96,6 +96,7 @@ open; nothing before Phase 3 forces it.
 | [0027](0027-a-fleet-worker-gets-its-own-worktree.md) | A Fleet Worker Gets Its Own Worktree | Accepted |
 | [0028](0028-panel-cells-are-glyphs-in-the-contract.md) | A Panel Cell Is a Glyph in the Contract and a Column in the Host | Accepted |
 | [0029](0029-branch-protection-stays-non-strict.md) | Branch Protection Stays Non-Strict | Accepted |
+| [0030](0030-the-wrapper-socket-is-the-plugin-sdk.md) | The Wrapper Socket Is the Plugin SDK | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -155,3 +156,11 @@ up-to-date requirement serialize merges to a handful an hour; the composition
 risk it would have caught is left to `main-canary.yml` and
 `main-red-hold.yml` as an after-the-fact backstop, with the durable close
 tracked at `#4998` rather than a merge queue enabled here.
+
+ADR 0030 answers the last step of the plugin platform's sequencing plan: this
+repository ships no language SDK. A plugin author writes against the manifest,
+the JSON-over-stdio socket, and the three generated declarations under
+`docs/wire/` — one of which, `wrapper.schema.json`, is language-neutral. The
+decision rests on the plugins under `plugins/` being spawned by tests here, so
+a wire change reddens this repository's CI rather than a stranger's install,
+and `check-plugin-graded.sh` is what holds that in place.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -150,6 +150,11 @@
       "status": "implemented",
       "title": "ADR 0029: Branch protection stays non-strict"
     },
+    "adr/0030-the-wrapper-socket-is-the-plugin-sdk": {
+      "path": "docs/adr/0030-the-wrapper-socket-is-the-plugin-sdk.md",
+      "status": "implemented",
+      "title": "ADR 0030: The wrapper socket is the plugin SDK"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -20,6 +20,29 @@ delivery loop's already-held authority expressible and showable before
 install, not to extract a pipeline stage; see its own README for what it is
 and, as pointedly, what it is not yet.
 
+## What an author writes against
+
+There is no plugin SDK, in Python or any other language, and one is not coming
+from this repository (ADR 0030, `#6148`). The whole author-facing contract is
+the `plugin.toml` manifest and the socket: a JSON request on stdin, a JSON
+response on stdout, the points the manifest declared.
+
+Three generated declarations of that wire are committed under
+[`../docs/wire/`](../docs/wire/), written by
+`crates/stella-plugin/src/bin/export_wrapper_wire.rs` and re-diffed by the
+gate's `wire-schema` step:
+
+| File | What it is |
+| --- | --- |
+| `wrapper.schema.json` | JSON Schema 2020-12 for the request and the response. No language owns it; this is the one to read from Python, Go or anything else. |
+| `wrapper.wire.json` | Every message in its fullest and its emptiest legal form, serialized by the same `Serialize` impls the transport uses. |
+| `wrapper.d.ts` | The same contract as TypeScript declarations. |
+
+`doc:wrapper-socket` is the prose behind them, and
+`macanderson/stella-examples` carries `verify-rs` / `verify-py` / `verify-ts` —
+one plugin written three times over this socket, with no library in any of the
+three.
+
 ## Why these are not workspace members
 
 `Cargo.toml`'s `members` list names twenty-five crates and none of them is
@@ -57,6 +80,16 @@ repository cannot fail the PR that broke it.
 `cargo test --workspace` — the gate's `test` step and `ci.yml`'s required job —
 runs the harnesses in `crates/stella-runtime/tests/`, which spawn these plugins
 through the host's own `SubprocessWrapper` and grade their answers against
-committed vectors. Nothing here is compiled by cargo; the plugins are data and
-a program, and the test is the consumer. A diff that touches only `plugins/**`
-is not a prose path, so it starts the Rust gate like any other change.
+committed vectors. Two live elsewhere for the surface they answer:
+`stella-hello`'s panels in `crates/stella-tui/tests/`, and `stella-selfdriving`'s
+consent text in `crates/stella-cli/tests/`. Nothing here is compiled by cargo;
+the plugins are data and a program, and the test is the consumer. A diff that
+touches only `plugins/**` is not a prose path, so it starts the Rust gate like
+any other change.
+
+That every one of them has such a test is checked rather than claimed:
+`scripts/check-plugin-graded.sh` (`make plugin-graded`, a gate step) fails when
+a directory here holds a `plugin.toml` and no `crates/*/tests/**/*.rs` names it
+outside a comment. It is what keeps ADR 0030's argument true — a wire change
+reddens this repository's CI rather than a stranger's install — as plugins are
+added.

--- a/scripts/check-plugin-graded.sh
+++ b/scripts/check-plugin-graded.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Every first-party plugin is spawned by an in-tree test.
+#
+# ADR 0030 says this repository ships no SDK for plugin authors. The manifest
+# plus the socket is the whole contract. That choice leans on one thing. The
+# plugins under `plugins/` speak the same wire a stranger's plugin speaks. A
+# test here spawns each of them through the host's own transport. So a wire
+# change reddens this repository's CI, not an install somewhere else.
+#
+# `plugins/README.md` said that and nothing checked it. Add a plugin with no
+# test and the claim stays true of the rest. That is the quiet way to break
+# it: the sentence still reads right.
+#
+# The rule. Every folder under `plugins/` with a `plugin.toml` is named on a
+# line of some `crates/*/tests/**/*.rs` that is not a comment. A `//` mention
+# is a pointer, not a run. `driver_socket.rs` names `stella-selfdriving` in a
+# doc comment and spawns it nowhere.
+#
+# This cannot see whether a test spawns the plugin or just reads its manifest.
+# It does not try. A path written into test code is a claim a reviewer can
+# check. `check-consumer-sites.sh` holds a `site:` string to the same bar.
+#
+# Two overrides exist for `scripts/test-plugin-graded.sh` alone. It needs
+# fixture trees to show this guard can still fail. The real tree is green by
+# design.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+plugin_root="${PLUGIN_ROOT:-plugins}"
+crates_root="${CRATES_ROOT:-crates}"
+
+fail=0
+report=""
+note() { report="${report}$1"$'\n'; }
+
+if [ ! -d "$plugin_root" ]; then
+  echo "check-plugin-graded: FAILED — no $plugin_root/ directory to check." >&2
+  exit 1
+fi
+
+# Every test source that could name a plugin, gathered once. `find` rather
+# than a glob so the depth under tests/ is unbounded (tests/common/mod.rs is
+# one level down and names a plugin).
+sources="$(mktemp "${TMPDIR:-/tmp}/stella-plugin-graded.XXXXXX")"
+trap 'rm -f "$sources"' EXIT INT TERM
+if [ -d "$crates_root" ]; then
+  find "$crates_root" -mindepth 3 -path '*/tests/*' -name '*.rs' -type f >"$sources"
+fi
+
+checked=0
+for manifest in "$plugin_root"/*/plugin.toml; do
+  [ -f "$manifest" ] || continue
+  dir="$(dirname "$manifest")"
+  name="$(basename "$dir")"
+  checked=$((checked + 1))
+
+  # A line naming the plugin's directory, with `//` comment lines dropped
+  # first so a doc comment cannot pass for a spawn.
+  graders=""
+  while IFS= read -r src; do
+    [ -n "$src" ] || continue
+    if sed 's|^[[:space:]]*//.*$||' "$src" | grep -qF "plugins/$name"; then
+      graders="${graders}${src}"$'\n'
+    fi
+  done <"$sources"
+
+  if [ -z "$graders" ]; then
+    fail=1
+    note "  $dir is graded by no test."
+  fi
+done
+
+if [ "$checked" -eq 0 ]; then
+  echo "check-plugin-graded: FAILED — no $plugin_root/*/plugin.toml found." >&2
+  echo >&2
+  echo "Nothing to check is a defect, not a pass: this guard exists because" >&2
+  echo "the plugins here are the wire contract's canary." >&2
+  exit 1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "check-plugin-graded: FAILED" >&2
+  echo >&2
+  printf '%s' "$report" >&2
+  echo >&2
+  echo "Each of these is a program written against the wrapper socket, and" >&2
+  echo "nothing in $crates_root/*/tests/ spawns it. A change to the wire would" >&2
+  echo "break it silently, which is what ADR 0030 says cannot happen to a" >&2
+  echo "first-party plugin." >&2
+  echo >&2
+  echo "Add a test that runs it — crates/stella-runtime/tests/ holds the" >&2
+  echo "wrapper harnesses, crates/stella-tui/tests/ the panel ones — and name" >&2
+  echo "its directory in the test's code, not only in a comment." >&2
+  exit 1
+fi
+
+echo "check-plugin-graded: OK — $checked first-party plugin(s), each named by a test."

--- a/scripts/check-plugin-graded.sh
+++ b/scripts/check-plugin-graded.sh
@@ -57,12 +57,20 @@ for manifest in "$plugin_root"/*/plugin.toml; do
 
   # A line naming the plugin's directory, with `//` comment lines dropped
   # first so a doc comment cannot pass for a spawn.
+  #
+  # The strip and the search do not share a pipe. Under `pipefail` a `grep -q`
+  # that matches early exits while `sed` is still writing, `sed` takes SIGPIPE
+  # and reports 141, and the pipeline reads as no-match. Which files lost that
+  # race varied run to run: five runs of the piped form over this repository
+  # reported stella-witness four times, stella-candidates twice, and once
+  # reported nothing at all.
   graders=""
   while IFS= read -r src; do
     [ -n "$src" ] || continue
-    if sed 's|^[[:space:]]*//.*$||' "$src" | grep -qF "plugins/$name"; then
-      graders="${graders}${src}"$'\n'
-    fi
+    stripped="$(sed 's|^[[:space:]]*//.*$||' "$src")"
+    case "$stripped" in
+      *"plugins/$name"*) graders="${graders}${src}"$'\n' ;;
+    esac
   done <"$sources"
 
   if [ -z "$graders" ]; then

--- a/scripts/test-plugin-graded.sh
+++ b/scripts/test-plugin-graded.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Tests for `check-plugin-graded.sh`. It still fails on a plugin no test runs.
+#
+#   ./scripts/test-plugin-graded.sh
+#
+# Not a `make gate` step. It builds throwaway fixture trees, the same posture
+# as `test-consumer-sites.sh`. Run it when you touch the guard.
+#
+# The guard's own tree is green by design, since it is a gate step. So a fixture
+# is what shows it can still fail: a plugin that no test names. Each case below
+# builds the shape it is about. It then points the guard at that tree with the
+# two overrides, `PLUGIN_ROOT` and `CRATES_ROOT`.
+#
+# Runs on bash 3.2.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/check-plugin-graded.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+pass=0
+fail=0
+
+# `want <name> <expect-pass|expect-fail> <plugin-root> <crates-root> [sub]`
+want() {
+  local name="$1" expect="$2" plugins="$3" crates="$4" sub="${5:-}" out rc
+  out="$(PLUGIN_ROOT="$plugins" CRATES_ROOT="$crates" "$SCRIPT" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ]; then
+    if [ "$rc" -eq 0 ]; then
+      pass=$((pass + 1)); echo "ok   $name"
+    else
+      fail=$((fail + 1)); echo "FAIL $name — expected OK, got:"; echo "$out"
+    fi
+    return
+  fi
+  if [ "$rc" -eq 0 ]; then
+    fail=$((fail + 1)); echo "FAIL $name — the guard passed an ungraded plugin:"; echo "$out"
+    return
+  fi
+  case "$out" in
+  *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+  *) fail=$((fail + 1)); echo "FAIL $name — failed for the wrong reason (wanted '$sub'):"; echo "$out" ;;
+  esac
+}
+
+# One fixture. It holds one plugin with a manifest, and one crate with tests.
+new_case() { # <name>
+  local dir="$TMP/$1"
+  mkdir -p "$dir/plugins/demo-plugin" "$dir/crates/mycrate/tests"
+  printf '[plugin]\nid = "demo-plugin"\n' >"$dir/plugins/demo-plugin/plugin.toml"
+  echo "$dir"
+}
+
+# ── N: the shapes that must pass ─────────────────────────────────────────────
+d="$(new_case graded)"
+printf 'let dir = root.join("plugins/demo-plugin");\n' >"$d/crates/mycrate/tests/spawn.rs"
+want "N1 a plugin named in a test's code passes" \
+  expect-pass "$d/plugins" "$d/crates"
+
+d="$(new_case shared_helper)"
+mkdir -p "$d/crates/mycrate/tests/common"
+printf 'pub fn dir() -> &str { "plugins/demo-plugin" }\n' \
+  >"$d/crates/mycrate/tests/common/mod.rs"
+want "N2 a shared helper one level under tests/ counts" \
+  expect-pass "$d/plugins" "$d/crates"
+
+d="$(new_case no_manifest)"
+mkdir -p "$d/plugins/notes"
+printf 'let dir = root.join("plugins/demo-plugin");\n' >"$d/crates/mycrate/tests/spawn.rs"
+want "N3 a directory with no plugin.toml is not a plugin and is skipped" \
+  expect-pass "$d/plugins" "$d/crates"
+
+# ── O: the defect — a plugin nothing runs ────────────────────────────────────
+d="$(new_case ungraded)"
+printf 'let dir = root.join("plugins/other-plugin");\n' >"$d/crates/mycrate/tests/spawn.rs"
+want "O1 a plugin no test names fails, naming it" \
+  expect-fail "$d/plugins" "$d/crates" "demo-plugin is graded by no test"
+
+d="$(new_case comment_only)"
+printf '//! Drives plugins/demo-plugin one day.\n// plugins/demo-plugin\n' \
+  >"$d/crates/mycrate/tests/spawn.rs"
+want "O2 a plugin named only in a comment fails — a mention is not a run" \
+  expect-fail "$d/plugins" "$d/crates" "demo-plugin is graded by no test"
+
+d="$(new_case src_only)"
+mkdir -p "$d/crates/mycrate/src"
+printf 'const DIR: &str = "plugins/demo-plugin";\n' >"$d/crates/mycrate/src/lib.rs"
+printf 'let dir = root.join("plugins/other-plugin");\n' >"$d/crates/mycrate/tests/spawn.rs"
+want "O3 a plugin named in src/ but by no test fails" \
+  expect-fail "$d/plugins" "$d/crates" "demo-plugin is graded by no test"
+
+# ── E: edges ─────────────────────────────────────────────────────────────────
+d="$TMP/empty"
+mkdir -p "$d/plugins" "$d/crates"
+want "E1 a plugin root with no manifests fails (nothing to check is a bug)" \
+  expect-fail "$d/plugins" "$d/crates" "no"
+
+d="$(new_case no_crates)"
+want "E2 a tree with no test sources at all fails rather than passing vacuously" \
+  expect-fail "$d/plugins" "$d/nowhere" "demo-plugin is graded by no test"
+
+want "E3 a plugin root that does not exist fails" \
+  expect-fail "$TMP/absent" "$TMP" "no"
+
+# ── R: the real workspace ────────────────────────────────────────────────────
+want "R1 this repository's own plugins are each graded" \
+  expect-pass "plugins" "crates"
+
+echo
+echo "passed ${pass}, failed ${fail}"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What and why

Epic #3246's last sequencing step asked for a Python SDK, and its closing
comment put two options to a maintainer that nobody answered. SCR-002 says an
architecture decision is chosen and recorded, not asked, so this takes the
second option and writes it down:

**This repository ships no language SDK.** The author-facing contract is the
`plugin.toml` manifest, the JSON-over-stdio socket (`doc:wrapper-socket`), and
the three generated declarations under `docs/wire/`.

The premise the epic's step rested on was wrong.
`crates/stella-plugin/src/bin/export_wrapper_wire.rs` writes three committed
artifacts, not one: `wrapper.wire.json` (a byte corpus), `wrapper.schema.json`
(JSON Schema 2020-12, which no language owns) and `wrapper.d.ts`. The gate's
`wire-schema` step regenerates and diffs all three, so a Python author already
has a machine-readable declaration and a wire change that skips it fails the
PR that made it.

`macanderson/stella-examples` carries `verify-rs` / `verify-py` / `verify-ts` —
one plugin written three times over this socket, with no library in any of the
three.

## The mechanism the decision leans on, now checked

The argument for shipping no SDK is that a wire change breaks something *here*
rather than at a stranger's install, because every first-party plugin under
`plugins/` is spawned by an in-tree test. `plugins/README.md` claimed exactly
that and nothing checked it — add a plugin with no harness and the sentence
still reads true of the others.

`scripts/check-plugin-graded.sh` (`make plugin-graded`, a new gate step in
`GATE_GUARDS_FAST` — it compiles nothing) asserts that every directory under
`plugins/` holding a `plugin.toml` is named on a **non-comment** line of some
`crates/*/tests/**/*.rs`. The comment exclusion is not decoration:
`crates/stella-runtime/tests/driver_socket.rs` discusses
`plugins/stella-selfdriving` in a `///` line and spawns it nowhere, while
`crates/stella-cli/tests/self_driving_consent.rs` is what actually runs it.

## Witness mechanism

`scripts/test-plugin-graded.sh` (`make plugin-graded-test`, run by
`guard-self-tests.yml`) builds fixture trees and pins both directions, because
the real tree is green by construction:

- N1-N3: a plugin named in a test's code passes; a shared helper one level
  under `tests/` counts; a directory with no `plugin.toml` is skipped.
- O1: a plugin no test names **fails**, naming it.
- O2: a plugin named only in a `//` comment fails — a mention is not a run.
- O3: a plugin named in `src/` but by no test fails.
- E1-E3: an empty plugin root, a tree with no test sources, and an absent
  plugin root all fail rather than passing vacuously.
- R1: this repository's own seven plugins are each graded.

Every case fails on `main`, where neither script exists. Locally:
`./scripts/test-plugin-graded.sh` -> `passed 10, failed 0`, and
`./scripts/check-plugin-graded.sh` -> `OK — 7 first-party plugin(s), each
named by a test.`

## Exemplar

`scripts/check-consumer-sites.sh` and its `scripts/test-consumer-sites.sh`
self-test — same shape, same standard for what a path written into code
claims, same fixture-tree posture for proving the guard can still fail.

## Not done here

No SDK, and no port of a plugin onto one. That is what the decision refuses.
A conformance kit for third-party authors (#5122) is a different thing — it
grades a plugin, where this is about what a plugin is written against — and
ADR 0030 says to amend the record rather than add a library quietly if that
lands and authors still ask.

## Base

Branched from `main` at `9136a2092`, which is red on `prose` for reasons this
diff did not cause (#6196, repaired by #6203). This branch's own files are
clean: `scripts/check-plugin-graded.sh` grades 4.37,
`scripts/test-plugin-graded.sh` 2.91, the ADR 4.84 — all under the 6.00
ceiling a new file is held to — and `plugins/README.md` and `docs/adr/README.md`
both came **down** from their ratchets. `make guards-fast` is otherwise green,
including `gate-parity` (56 steps, named in AGENTS.md and CONTRIBUTING.md,
each run by a workflow) and `shellcheck` on both new scripts.

Tests deleted: None.

Residue filed: none new — #5122 already tracks the conformance kit, and ADR
0030 names it as the open question it does not answer.

Closes #6148

## Summary by Sourcery

Record that the wrapper socket is the plugin SDK and enforce that every first-party plugin remains covered by an in-tree test.

New Features:
- Document ADR 0030 establishing the manifest, JSON-over-stdio wrapper socket, and generated wire declarations as the complete plugin authoring contract instead of a language-specific SDK.

Enhancements:
- Add a guard that ensures every first-party plugin is referenced by an in-tree Rust test, preserving the repository's plugin-based wire compatibility canary.

Build:
- Expose plugin grading and its hermetic self-test through the Makefile and fast guard workflow.

CI:
- Run the first-party plugin grading check in CI and validate its failure cases in the guard self-test workflow.

Documentation:
- Add and register ADR 0030, and update plugin documentation to describe the no-SDK decision and the generated wire contract.

Tests:
- Add fixture-based coverage for valid, invalid, comment-only, source-only, empty, and repository plugin grading scenarios.