### PR TITLE
docs(spec): name the plugins the plan delivers, and say where vera stands

### DIFF
--- a/docs/spec/pipeline-as-plugins.md
+++ b/docs/spec/pipeline-as-plugins.md
@@ -222,28 +222,45 @@ reference one, and its README says so plainly.
 
 ---
 
-## 3. The nine plugins
+## 3. The plugins
 
 The staged pipeline is not one thing. Splitting it by *what would be installed
 separately* rather than by current module boundaries:
 
 | Plugin | Replaces | Points used | Ships |
 |---|---|---|---|
-| **vera** | witness authoring, flip oracle, verification ladder, reward labelling | `after_turn`, `judge` | Oxagen, private |
+| **stella-witness** | the flip oracle: the artifacts a flip is judged against, and the red→green transition itself | `before_turn`, `after_turn` | first-party, open |
 | **stella-plan** | triage, plan, scope | `before_turn` | first-party, open |
 | **stella-research** | research sub-agents, recall | `before_turn` | first-party, open |
-| **stella-candidates** | worktree candidates, best-of-N fan-out, steering mirror | `before_turn`, `again?` | first-party, open |
+| **stella-candidates** | worktree candidates, best-of-N fan-out, steering mirror | `after_turn`, `again?` | first-party, open |
 | **stella-selfdriving** | the autonomous delivery loop | `again?`, host verbs | first-party, open |
 | **stella-goal** | goal mode, `stella monitor` | `judge`, `again?` | first-party, open |
-| **example-py** | a working Python plugin | `after_turn` | `stella-examples`, public |
-| **example-ts** | a working TypeScript plugin | `after_turn` | `stella-examples`, public |
-| **example-rs** | the reference Rust plugin | all four | `stella-examples`, public |
+| **verify-py** | a working Python plugin | `after_turn` | `stella-examples`, public |
+| **verify-ts** | a working TypeScript plugin | `after_turn` | `stella-examples`, public |
+| **verify-rs** | the reference Rust plugin | all four | `stella-examples`, public |
 
-Two notes on that table. `stella-goal` is included because #3380 already
-observes goal mode and the pipeline are the same shape written twice —
-extracting one and leaving the other rebuilds the drift. And the three examples
-are listed as deliverables, not documentation, because a language is supported
-when a plugin written in it runs in CI, and not before.
+`vera` is not on that list, and `doc:plugin-completion-plan` §4.1 is where it
+came off. Verification ships open, as `stella-witness`: anyone can read it,
+install it and run it, which is what the project's headline claim needs.
+`oxageninc/vera` is the paid superset — verifier independence across a roster,
+tamper hardening past artifact identity, several oracles composed, the durable
+flip record, org policy. It holds a README and nothing else today, and this
+plan does not deliver it. What this repository owes it is the wire contract,
+published as `docs/wire/wrapper.wire.json` and held by `make wire-schema`. §8
+below is the port plan for the nucleus, and `plugins/stella-witness` is where
+that port landed.
+
+`stella-goal` is on the list because #3380 already observes goal mode and the
+pipeline are the same shape written twice — extracting one and leaving the
+other rebuilds the drift.
+
+The three examples are deliverables, not documentation, because a language is
+supported when a plugin written in it runs in CI, and not before.
+
+`stella-candidates` asks for `after_turn` where `doc:plugin-completion-plan`
+§4.2 sketched `before_turn`. Its manifest carries the reason: a plugin is a
+fresh process per point, so a fan-out at `before_turn` exits before there is
+anything to report, and would have to buy every worker turn twice.
 
 ---
 
@@ -833,6 +850,13 @@ still real, open work — deleting the built-in path does not mark it done.
 ---
 
 ## 8. Vera specifically
+
+**Where the port went.** This section planned one private plugin.
+`doc:plugin-completion-plan` §4.1 split it in two and the maintainer took that
+call: the nucleus below ships open, in `plugins/stella-witness`, and Vera is
+the paid superset built on top of it. So read the port list here as the plan
+`stella-witness` executed, and the rest of the section as Vera's remaining
+work.
 
 Vera is a port, not a lift. It takes the verification nucleus and leaves the
 orchestration. **The crate these paths named no longer exists in this

--- a/docs/spec/plugin-completion-plan.md
+++ b/docs/spec/plugin-completion-plan.md
@@ -8,11 +8,21 @@ status: proposed
 
 **Status:** proposed, written 2026-08-19, against `main` at `f9789df17`.
 
-`doc:pipeline-as-plugins` §3 names **nine plugins** that replace one staged
+**Update.** §4.1's recommendation is the maintainer's decision now: verification
+ships open as `plugins/stella-witness`, and `vera` is the paid superset rather
+than a deliverable of this plan. §1's audit stands as what the tree looked like
+on the day it was read; §5 and §7 below are written to the decision. Every
+plugin `doc:pipeline-as-plugins` §3 lists is in the tree today and is graded by
+a check that runs on a pull request — the six first-party ones by a harness in
+`crates/stella-runtime/tests/` or `crates/stella-cli/src/driver_plugin/tests.rs`,
+the three `verify-*` examples by `example_plugins_smoke.rs` against the commit
+`scripts/stella-examples-pin.txt` pins.
+
+`doc:pipeline-as-plugins` §3 lists the plugins that replace one staged
 pipeline and one built-in autonomous loop. §7 states the bar plainly: *"a
 side-by-side benchmark holds before the built-in path is deleted."* The
 built-in path was deleted on 2026-08-19 (#3865). This document answers the
-question that deletion makes urgent — **which of the nine actually exist** —
+question that deletion makes urgent — **which of them actually exist** —
 and specifies the work for the ones that do not.
 
 Everything asserted about today's tree was read out of it and is cited so it
@@ -21,18 +31,22 @@ says so.
 
 ---
 
-## 0. The one-sentence answer
+## 0. The one-sentence answer, on the day this was written
 
-**Four of the nine are built and graded, one of those four cannot do its job on
-any host running today, three more exist but are ungated from this repository,
-and the single most important plugin in the plan — the one carrying the
-project's headline claim — is an empty repository with a README in it.**
+**`stella-plan` and `stella-research` are built and graded, `stella-goal` is
+built and cannot do its job on any host running today, the three `verify-*`
+examples exist but are ungated from this repository, `stella-candidates` and
+`stella-selfdriving` are missing, and the plugin carrying the project's
+headline claim is an empty repository with a README in it.**
+
+Every one of those is closed now, and the last one closed by moving: §4.1 gave
+the headline claim to `plugins/stella-witness`, which ships in this repository.
 
 ---
 
 ## 1. The audit
 
-| # | Plugin (§3) | Where it should be | State | Evidence |
+| # | Plugin (§3, as it read then) | Where it should be | State | Evidence |
 |---|---|---|---|---|
 | 1 | **vera** | `oxageninc/vera`, private | **NOT BUILT** | `gh api repos/oxageninc/vera/contents` returns exactly one entry, `README.md`; repo size 3 KB; last push 2026-08-17 |
 | 2 | **stella-plan** | this repo, `plugins/` | **BUILT, graded** | `plugins/stella-plan/{plugin.toml,main.py}`; `crates/stella-runtime/tests/plan_plugin_{conformance,dispatch,hostcall}.rs` |
@@ -170,6 +184,17 @@ precondition on distribution rather than a nice-to-have.
 
 ### 4.1 Verification: split it in two — `stella-witness` (open) and `vera` (commercial)
 
+**Decided, and this is the record of it.** The recommendation below was put to
+the maintainer as a call to make, and the answer was to split. Verification
+ships open: `plugins/stella-witness` is in the tree, its manifest and README
+state the split as the decision, and
+`crates/stella-runtime/tests/witness_plugin_conformance.rs` grades it on every
+pull request. `oxageninc/vera` keeps the commercial superset and stops being a
+deliverable of this plan; what this repository owes it is the published wire
+corpus, and nothing else. `doc:pipeline-as-plugins` §3 and §8 are written to
+that answer. The rest of this section is the argument that produced it, kept
+because a decision without its reasons gets relitigated.
+
 **Recommendation, and it is the one substantive departure from
 `doc:pipeline-as-plugins` §8 in this document.** §8 plans a single private
 plugin. I recommend two:
@@ -215,10 +240,11 @@ defend — *verification is open; verification at organisational scale is paid* 
 which is the same line every successful open-core infrastructure project draws,
 and the only one compatible with §2.1 above.
 
-**This is a maintainer's call, per `CLAUDE.md`'s "now vs. right" rule, and I am
-naming it rather than deciding it.** If the answer is one private plugin, then
-§2.1 needs a corresponding correction in `README.md` and `AGENTS.md`: the open
-product does not verify, and should stop implying it does.
+**This was a maintainer's call, per `CLAUDE.md`'s "now vs. right" rule, and it
+was made: split.** Had the answer been one private plugin, §2.1 would have
+needed a matching correction in `README.md` and `AGENTS.md` — the open product
+does not verify, and should stop implying it does. It went the other way, so
+those two stand as written.
 
 **Manifest sketch for `stella-witness`:**
 
@@ -376,7 +402,7 @@ third-party-usable must **not** live here, or it proves nothing.
 | **`stella-witness`** | **`macanderson/stella` — `plugins/`** | §4.1: the open referent for the project's central claim; also the heaviest consumer of the wire contract, so it must break the PR that breaks it |
 | **`stella-candidates`** | **`macanderson/stella` — `plugins/`** | consumes `candidate_fanout`, a capability that lives here and is still moving |
 | **`stella-selfdriving`** | **`macanderson/stella` — `plugins/`** (unchanged) | consumes `DriverCall`, which is still growing verb by verb through #3599 |
-| **`vera`** | **`oxageninc/vera`, private** | commercial superset; depends on the published wire contract, not on this tree's internals |
+| **`vera`** | **`oxageninc/vera`, private** | commercial superset, and **not a deliverable of this plan** (§4.1); holds a README and nothing else today. It depends on the published wire contract, never on this tree's internals, which is the whole of what this repository owes it |
 | `verify-rs`, `verify-py`, `verify-ts` | **`macanderson/stella-examples` — `plugins/`** (unchanged) | third-party-shaped by design; pinned by SHA from this repo's CI (§4.5b) |
 
 **The one rule that keeps this from rotting:** a plugin in this repository is
@@ -478,9 +504,11 @@ Everything downstream of it is a plugin; it is the last piece of *platform*.
 
 ## 7. Definition of done for this document
 
-- All nine of §3's plugins exist, and each is graded by something that runs on
-  a PR — in-tree harness for the six that ship here, pinned-SHA smoke check for
-  the three that ship in `stella-examples`, published wire corpus for Vera.
+- Every plugin `doc:pipeline-as-plugins` §3 lists exists, and each is graded by
+  something that runs on a PR — an in-tree harness for the six that ship here,
+  a pinned-SHA smoke check for the three that ship in `stella-examples`. Vera
+  is not on that list and is graded by nothing here; the published wire corpus
+  is what it is owed and what it is held to.
 - One `--pipeline` selection can bind grounding, planning and verification
   together, so the plugin path is not strictly less capable than the path it
   replaced.


### PR DESCRIPTION
## What and why

`doc:pipeline-as-plugins` §3 named nine plugins. `vera` was one of them and
`stella-witness` was not — yet `plugins/stella-witness` is in the tree, is the
open referent `AGENTS.md`'s headline claim needs, and is graded on every pull
request by `crates/stella-runtime/tests/witness_plugin_conformance.rs`.
`oxageninc/vera` holds a README and nothing else (`gh api
repos/oxageninc/vera/contents` returns `.github` and `README.md`). So the
tree's own statement of what this plan delivers disagreed with what shipped,
in both directions at once.

Documentation only. Nothing under `crates/` changes.

### `docs/spec/pipeline-as-plugins.md`

- §3 lists `stella-witness` and drops `vera`, with a paragraph saying where
  `vera` stands: the paid superset, not a deliverable of this plan, owed the
  published wire corpus and nothing else.
- The three example rows take the names the tree uses — `verify-rs`,
  `verify-py`, `verify-ts` — matching §9's own table,
  `scripts/stella-examples-pin.txt` and `example_plugins_smoke.rs`.
- `stella-candidates` takes the point its shipped manifest declares
  (`after_turn`, not `before_turn`), with the manifest's own reason beside it.
- The heading loses its count, so a later change to the set cannot leave a
  stale number behind.
- §8 opens by saying where the port went: the nucleus it plans shipped in
  `plugins/stella-witness`, and the rest of the section is Vera's remaining
  work.

### `docs/spec/plugin-completion-plan.md`

- §4.1 records the split as the maintainer's decision rather than a
  recommendation awaiting one. Until now that decision lived only in
  `plugins/stella-witness/README.md`.
- §0 and §1 are dated to the audit that produced them, so a reader does not
  take a 2026-08-19 snapshot for today's tree.
- §5's homes table says `vera` is not a deliverable of this plan.
- §7's statement of done names the set instead of counting it, and stops
  claiming Vera is graded here.

## Witness

Documentation only — no witness test, per `AGENTS.md` § "The definition of
done: witness tests" ("Pure refactors, docs, and CI changes don't need a
witness"). What was checked instead, and it is checkable by anyone:

- `python3 scripts/check-prose.py` — neither edited file appears in the
  output. Both reading grades fell: `pipeline-as-plugins.md` 12.93 → 12.75,
  `plugin-completion-plan.md` 12.39 → 12.30, against
  `scripts/prose-grade-baseline.txt`. No baseline entry added or raised.
- `make doc-links` — OK, 1187 citations resolve.
- `make line-citations` — OK, none added.
- `make guards-fast` — the only failure is `prose` on
  `crates/stella-cli/src/fleet_cmd.rs`, which fails identically on
  `origin/main` (checked by running the guard against a clean checkout of
  `origin/main` in this worktree). That is #6196, and a peer session holds the
  repair claim on it; `./scripts/main-red-claim.sh check` stood this session
  down, so the repair is not folded in here.

## Tests deleted

None.

## Remaining work filed

See the issue list at the end of this PR's thread.

Closes #6156

## Summary by Sourcery

Update the plugin planning specifications to match the shipped open verification plugin and distinguish it from Vera's remaining commercial scope.

Enhancements:
- Align the plugin planning documentation with the shipped plugin set, naming `stella-witness` and the `verify-*` examples while documenting `vera` as a separate paid superset.
- Record the completed decision to split open verification from Vera and clarify the status, audit context, ownership, and completion criteria for the plugin plan.
- Correct the documented lifecycle point for `stella-candidates` and explain where the verification port landed.

Documentation:
- Update the pipeline and plugin completion specifications to reflect the current repository state and the published wire contract owed to Vera.