### PR TITLE
feat(stella-autonomy,stella-cli): let the loop propose a change when it keeps hitting the same wall

### DIFF
--- a/crates/stella-autonomy/src/curate.rs
+++ b/crates/stella-autonomy/src/curate.rs
@@ -9,27 +9,27 @@
 //! and a habit is the only thing here worth asking a person about.
 //!
 //! This module holds the rules that turn those lines into proposals. It reads
-//! nothing and writes nothing — `stella-cli`'s `self_driving_cmd::curate` is
+//! nothing and writes nothing. `stella-cli`'s `self_driving_cmd::curate` is
 //! the half that touches the journal.
 //!
 //! # A proposal is a suggestion, never a change
 //!
 //! [`Proposal`] carries a statement, the surface a person would change, and
-//! the evidence behind it. There is no arm here that applies anything, which
-//! is how the loop proposes an authority it cannot grant itself.
+//! the evidence behind it. No arm here applies anything. That is how the loop
+//! proposes an authority it cannot grant itself.
 //!
 //! # Why the statement is cut back before it is grouped
 //!
 //! Journal lines carry the particulars: an issue key, an error string, a
 //! branch name. Two runs blocked by the same thing say it with different
-//! particulars, so grouping the raw lines finds nothing. The leading clause is
-//! what repeats, so [`shape`] keeps that and drops the rest.
+//! particulars. So grouping the raw lines finds nothing. The leading clause is
+//! what repeats. [`shape`] keeps that and drops the rest.
 //!
 //! # The threshold is the caller's
 //!
 //! [`propose`] takes the recurrence floor rather than declaring one. The
 //! number belongs to the provenance policy, and this crate is a leaf that
-//! cannot read it — a constant here would be a second copy free to drift.
+//! cannot read it. A constant here would be a second copy free to drift.
 //!
 //! `doc:backlog-self-driving` §3.5 is the design.
 
@@ -43,7 +43,7 @@ pub struct Sighting {
     /// What the loop said it could not do.
     pub statement: String,
     /// The run it happened in. The recurrence count is over distinct values
-    /// of this, so a run that hits one wall thirty times still counts once.
+    /// of this. A run that hits one wall thirty times still counts once.
     pub run: String,
     /// Where a reader finds the line — a timestamp, an issue key.
     pub evidence: String,
@@ -53,10 +53,9 @@ pub struct Sighting {
 
 /// The three things this repository steers itself with.
 ///
-/// A proposal names one. What each costs — the evidence grade and the
-/// authority that may publish it — is not declared here: it is derived from
-/// the evolution matrix's own impact class by the caller, so this crate holds
-/// no copy of a policy it cannot read.
+/// A proposal names one. What each costs is not declared here. The caller
+/// derives the grade and the authority from the evolution matrix's own impact
+/// class. So this crate holds no copy of a policy it cannot read.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Target {
@@ -101,17 +100,17 @@ pub struct Proposal {
 
 /// Longest leading clause a statement is grouped by, in characters.
 ///
-/// Long enough to tell two walls apart, short enough that a sentence which
+/// Long enough to tell two walls apart. Short enough that a sentence which
 /// keeps going cannot split one wall into several.
 const SHAPE_CHARS: usize = 80;
 
 /// The part of a statement that repeats across runs.
 ///
 /// Everything from the first particular onwards is dropped: a parenthesis, a
-/// colon, a dash, a backtick. Each of those opens the detail — an error
-/// string, an issue key, a branch — that makes two sightings of one wall look
-/// like two walls. What is left is lowercased and its whitespace collapsed,
-/// so a message reflowed by an editor still groups with its earlier self.
+/// colon, a dash, a backtick. Each of those opens a detail — an error string,
+/// an issue key, a branch. Those details make two sightings of one wall look
+/// like two walls. What is left is lowercased and its whitespace collapsed. So
+/// a message reflowed by an editor still groups with its earlier self.
 ///
 /// An empty result means the line was nothing but particulars, and it is not
 /// evidence of anything.
@@ -135,10 +134,9 @@ pub fn shape(statement: &str) -> String {
 /// The walls that recur, with the evidence behind each.
 ///
 /// A group is kept when it was met in at least `min_distinct_runs` separate
-/// runs. Repetition inside one run counts once, because a loop that retried
-/// the same command forty times in one afternoon has one observation and not
-/// forty — the same distinct-task rule the provenance policy applies to
-/// mined evidence.
+/// runs. Repetition inside one run counts once. A loop that retried the same
+/// command forty times in one afternoon has one observation, not forty. That
+/// is the distinct-task rule the provenance policy applies to mined evidence.
 ///
 /// Output is ordered by target and then by shape, so two passes over one
 /// journal propose the same things in the same order.

--- a/crates/stella-autonomy/src/curate.rs
+++ b/crates/stella-autonomy/src/curate.rs
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Turning a wall the loop keeps hitting into a proposal somebody can accept.
+//!
+//! The loop writes down every step it could not take: a check that failed, a
+//! rule it waived, an issue it handed back, a command it retried. One such
+//! line is an accident. The same line in several separate runs is a habit,
+//! and a habit is the only thing here worth asking a person about.
+//!
+//! This module holds the rules that turn those lines into proposals. It reads
+//! nothing and writes nothing — `stella-cli`'s `self_driving_cmd::curate` is
+//! the half that touches the journal.
+//!
+//! # A proposal is a suggestion, never a change
+//!
+//! [`Proposal`] carries a statement, the surface a person would change, and
+//! the evidence behind it. There is no arm here that applies anything, which
+//! is how the loop proposes an authority it cannot grant itself.
+//!
+//! # Why the statement is cut back before it is grouped
+//!
+//! Journal lines carry the particulars: an issue key, an error string, a
+//! branch name. Two runs blocked by the same thing say it with different
+//! particulars, so grouping the raw lines finds nothing. The leading clause is
+//! what repeats, so [`shape`] keeps that and drops the rest.
+//!
+//! # The threshold is the caller's
+//!
+//! [`propose`] takes the recurrence floor rather than declaring one. The
+//! number belongs to the provenance policy, and this crate is a leaf that
+//! cannot read it — a constant here would be a second copy free to drift.
+//!
+//! `doc:backlog-self-driving` §3.5 is the design.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// One line of the loop's journal, as evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Sighting {
+    /// What the loop said it could not do.
+    pub statement: String,
+    /// The run it happened in. The recurrence count is over distinct values
+    /// of this, so a run that hits one wall thirty times still counts once.
+    pub run: String,
+    /// Where a reader finds the line — a timestamp, an issue key.
+    pub evidence: String,
+    /// Which surface a person would change to answer it.
+    pub target: Target,
+}
+
+/// The three things this repository steers itself with.
+///
+/// A proposal names one. What each costs — the evidence grade and the
+/// authority that may publish it — is not declared here: it is derived from
+/// the evolution matrix's own impact class by the caller, so this crate holds
+/// no copy of a policy it cannot read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Target {
+    /// A procedure the agent can follow next time.
+    Skill,
+    /// A directive that steers the agent away from the wall.
+    Rule,
+    /// Executable capability the agent does not have.
+    Tool,
+}
+
+impl Target {
+    /// Every target, in the order a reader meets them above.
+    pub const ALL: &[Self] = &[Self::Skill, Self::Rule, Self::Tool];
+
+    /// The canonical `snake_case` tag.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Skill => "skill",
+            Self::Rule => "rule",
+            Self::Tool => "tool",
+        }
+    }
+}
+
+/// A wall the loop keeps hitting, with the evidence that says so.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Proposal {
+    /// Which surface a person would change.
+    pub target: Target,
+    /// The wall, in the loop's own words — the first sighting's full line.
+    pub statement: String,
+    /// The shape the sightings were grouped by. Stable across runs, so it is
+    /// what a dedup digest is taken from.
+    pub shape: String,
+    /// Where each supporting line is, oldest first.
+    pub evidence: Vec<String>,
+    /// The distinct runs that met it, in the order they were seen.
+    pub runs: Vec<String>,
+}
+
+/// Longest leading clause a statement is grouped by, in characters.
+///
+/// Long enough to tell two walls apart, short enough that a sentence which
+/// keeps going cannot split one wall into several.
+const SHAPE_CHARS: usize = 80;
+
+/// The part of a statement that repeats across runs.
+///
+/// Everything from the first particular onwards is dropped: a parenthesis, a
+/// colon, a dash, a backtick. Each of those opens the detail — an error
+/// string, an issue key, a branch — that makes two sightings of one wall look
+/// like two walls. What is left is lowercased and its whitespace collapsed,
+/// so a message reflowed by an editor still groups with its earlier self.
+///
+/// An empty result means the line was nothing but particulars, and it is not
+/// evidence of anything.
+#[must_use]
+pub fn shape(statement: &str) -> String {
+    let head: String = statement
+        .chars()
+        .take_while(|&c| !matches!(c, '(' | ':' | '`' | '—' | '[' | ';'))
+        .take(SHAPE_CHARS)
+        .collect();
+    let mut out = String::with_capacity(head.len());
+    for word in head.split_whitespace() {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(&word.to_lowercase());
+    }
+    out
+}
+
+/// The walls that recur, with the evidence behind each.
+///
+/// A group is kept when it was met in at least `min_distinct_runs` separate
+/// runs. Repetition inside one run counts once, because a loop that retried
+/// the same command forty times in one afternoon has one observation and not
+/// forty — the same distinct-task rule the provenance policy applies to
+/// mined evidence.
+///
+/// Output is ordered by target and then by shape, so two passes over one
+/// journal propose the same things in the same order.
+#[must_use]
+pub fn propose(sightings: &[Sighting], min_distinct_runs: usize) -> Vec<Proposal> {
+    // At least one, so a caller that passes zero cannot turn every single
+    // sighting into a proposal.
+    let floor = min_distinct_runs.max(1);
+
+    // Keyed by target as well as shape: the same words reached through a
+    // waiver and through a failed check are two different asks, and merging
+    // them would attribute one proposal's evidence to the other's surface.
+    let mut groups: BTreeMap<(Target, String), Proposal> = BTreeMap::new();
+    for sighting in sightings {
+        let shape = shape(&sighting.statement);
+        if shape.is_empty() || sighting.run.trim().is_empty() {
+            continue;
+        }
+        let entry = groups
+            .entry((sighting.target, shape.clone()))
+            .or_insert_with(|| Proposal {
+                target: sighting.target,
+                statement: sighting.statement.trim().to_owned(),
+                shape,
+                evidence: Vec::new(),
+                runs: Vec::new(),
+            });
+        if !entry.evidence.contains(&sighting.evidence) {
+            entry.evidence.push(sighting.evidence.clone());
+        }
+        if !entry.runs.contains(&sighting.run) {
+            entry.runs.push(sighting.run.clone());
+        }
+    }
+
+    groups
+        .into_values()
+        .filter(|proposal| proposal.runs.len() >= floor)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sighting(statement: &str, run: &str, evidence: &str, target: Target) -> Sighting {
+        Sighting {
+            statement: statement.to_owned(),
+            run: run.to_owned(),
+            evidence: evidence.to_owned(),
+            target,
+        }
+    }
+
+    /// **The witness.** A wall met in three separate runs becomes one
+    /// proposal, and the proposal names every run behind it.
+    #[test]
+    fn a_wall_met_in_three_runs_becomes_a_proposal_naming_its_evidence() {
+        let seen = vec![
+            sighting("could not file `a`: 502", "r1", "at:1", Target::Tool),
+            sighting("could not file `b`: 500", "r2", "at:2", Target::Tool),
+            sighting("could not file `c`: timeout", "r3", "at:3", Target::Tool),
+        ];
+
+        let made = propose(&seen, 3);
+
+        assert_eq!(made.len(), 1, "got {made:?}");
+        assert_eq!(made[0].target, Target::Tool);
+        assert_eq!(made[0].runs, vec!["r1", "r2", "r3"]);
+        assert_eq!(made[0].evidence, vec!["at:1", "at:2", "at:3"]);
+        assert_eq!(made[0].shape, "could not file");
+    }
+
+    /// Two runs is not a habit when the floor is three.
+    #[test]
+    fn two_runs_do_not_reach_a_floor_of_three() {
+        let seen = vec![
+            sighting("could not file `a`: 502", "r1", "at:1", Target::Tool),
+            sighting("could not file `b`: 500", "r2", "at:2", Target::Tool),
+        ];
+
+        assert!(propose(&seen, 3).is_empty());
+    }
+
+    /// Thirty repetitions inside one run are one observation, not thirty.
+    /// This is the anti-poisoning rule the provenance policy states, applied
+    /// to the loop's own journal.
+    #[test]
+    fn repetition_inside_one_run_never_reaches_the_floor() {
+        let seen: Vec<Sighting> = (0..30)
+            .map(|n| {
+                sighting(
+                    "could not file `x`: 502",
+                    "r1",
+                    &format!("at:{n}"),
+                    Target::Tool,
+                )
+            })
+            .collect();
+
+        assert!(propose(&seen, 3).is_empty());
+    }
+
+    /// One wall reached through two different surfaces is two asks.
+    #[test]
+    fn the_same_words_under_two_targets_stay_two_proposals() {
+        let seen = vec![
+            sighting("the gate is red", "r1", "at:1", Target::Rule),
+            sighting("the gate is red", "r2", "at:2", Target::Rule),
+            sighting("the gate is red", "r3", "at:3", Target::Rule),
+            sighting("the gate is red", "r1", "at:4", Target::Skill),
+            sighting("the gate is red", "r2", "at:5", Target::Skill),
+            sighting("the gate is red", "r3", "at:6", Target::Skill),
+        ];
+
+        let made = propose(&seen, 3);
+
+        assert_eq!(made.len(), 2, "got {made:?}");
+        assert_eq!(made[0].target, Target::Skill);
+        assert_eq!(made[1].target, Target::Rule);
+    }
+
+    /// A floor of zero still needs one sighting, so a caller cannot turn the
+    /// whole journal into proposals by passing nothing.
+    #[test]
+    fn a_zero_floor_is_read_as_one() {
+        let seen = vec![sighting(
+            "could not file `a`: 502",
+            "r1",
+            "at:1",
+            Target::Tool,
+        )];
+
+        assert_eq!(propose(&seen, 0).len(), 1);
+    }
+
+    /// A line with no run behind it is not evidence of a habit.
+    #[test]
+    fn a_sighting_with_no_run_is_dropped() {
+        let seen = vec![
+            sighting("could not file `a`: 502", "  ", "at:1", Target::Tool),
+            sighting("could not file `b`: 500", "", "at:2", Target::Tool),
+            sighting("could not file `c`: 500", "", "at:3", Target::Tool),
+        ];
+
+        assert!(propose(&seen, 1).is_empty());
+    }
+
+    /// The particulars are what differ between two sightings of one wall, so
+    /// the shape stops at the first of them.
+    #[test]
+    fn the_shape_stops_at_the_first_particular() {
+        assert_eq!(
+            shape("could not triage (network); ranking"),
+            "could not triage"
+        );
+        assert_eq!(
+            shape("the baseline is already red (cargo) — advisory"),
+            "the baseline is already red"
+        );
+        assert_eq!(shape("Could   not   file `x`: 502"), "could not file");
+        assert_eq!(shape("(nothing but particulars)"), "");
+    }
+
+    /// Every target answers to a tag, and no two share one.
+    #[test]
+    fn every_target_has_its_own_tag() {
+        let tags: Vec<&str> = Target::ALL.iter().map(|t| t.as_str()).collect();
+        let mut unique = tags.clone();
+        unique.sort_unstable();
+        unique.dedup();
+
+        assert_eq!(tags.len(), unique.len(), "got {tags:?}");
+    }
+}

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -54,6 +54,7 @@
 mod attribution;
 mod closure;
 mod convention;
+pub mod curate;
 mod deliver;
 mod doctrine;
 pub mod escalation;

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -31,6 +31,7 @@ pub(crate) mod config;
 // Only `branches_naming` is widened inside; the rest stays `pub(super)`.
 pub(crate) mod contention;
 mod convention;
+mod curate;
 mod deliver;
 mod drive;
 pub(crate) mod governor;

--- a/crates/stella-cli/src/self_driving_cmd/curate.rs
+++ b/crates/stella-cli/src/self_driving_cmd/curate.rs
@@ -11,29 +11,28 @@
 //!
 //! No path in this module writes a skill file, a record under
 //! `.stella/rules/`, or a line of `.stella/rules/promotions.jsonl`. That is
-//! the rule the loop is held to: it may propose any authority, and it may
-//! grant itself none. Acceptance stays where it already lives — a person
-//! reads the proposal and goes through `stella context keep` and `stella
-//! context promote`, which append to the hash-chained ledger under a real
-//! approver.
+//! the rule the loop is held to. It may propose any authority. It may grant
+//! itself none. Acceptance stays where it already lives. A person reads the
+//! proposal and goes through `stella context keep` and `stella context
+//! promote`, which append to the hash-chained ledger under a real approver.
 //!
 //! # What the evidence is
 //!
 //! Every step the loop could not take is already a line in `audit.jsonl`: a
 //! check that failed, a rule it waived, an issue it handed back, a command it
 //! retried. [`WALLS`] names the actions that count and the surface each one
-//! points at. A line's session is the run it happened in, and the recurrence
-//! count is over distinct runs, so an afternoon spent retrying one command is
-//! one observation rather than forty.
+//! points at. A line's session is the run it happened in. The recurrence
+//! count is over distinct runs. So an afternoon spent retrying one command is
+//! one observation, not forty.
 //!
 //! # What a proposal costs
 //!
 //! Nothing here restates what the evidence has to be worth. The surface's
-//! impact class comes from `stella-parity`'s evolution matrix — the map in
+//! impact class comes from `stella-parity`'s evolution matrix. The map in
 //! [`impact_of`] is pinned against those rows by
-//! `the_loop_proposes_at_the_impact_its_evolution_row_declares` — and the
-//! grade and authority that impact requires come from
-//! `stella_protocol::provenance`, the one place that policy lives.
+//! `the_loop_proposes_at_the_impact_its_evolution_row_declares`. The grade and
+//! authority that impact requires come from `stella_protocol::provenance`,
+//! the one place that policy lives.
 //!
 //! `doc:backlog-self-driving` §3.5 is the design.
 
@@ -53,10 +52,10 @@ use super::state::LoopState as Durable;
 ///
 /// Not a number chosen here. `EvidencePool::from_observations` lifts a pool to
 /// `ProvenanceGrade::TrajectoryAbstraction` only once its evidence spans
-/// `TRAJECTORY_ABSTRACTION_MIN_DISTINCT_TASKS` distinct tasks, and that is the
+/// `TRAJECTORY_ABSTRACTION_MIN_DISTINCT_TASKS` distinct tasks. That is the
 /// weakest grade any of the three surfaces below accepts. Under the floor a
-/// proposal could not be published however a person decided, so making one
-/// would be noise with somebody's attention as its cost.
+/// proposal could not be published however a person decided. Making one would
+/// be noise, with somebody's attention as its cost.
 const RECURRENCE_THRESHOLD: usize = TRAJECTORY_ABSTRACTION_MIN_DISTINCT_TASKS as usize;
 
 /// The most proposals one pass may make.
@@ -85,7 +84,7 @@ const JOURNAL_READ_LIMIT: usize = 5_000;
 ///   command is a tool's job, so the ask is a tool.
 ///
 /// The grouping is also what makes [`grade_of`] answerable per target rather
-/// than per line: every action pointing at one surface is the same kind of
+/// than per line. Every action pointing at one surface is the same kind of
 /// claim.
 const WALLS: &[(Audit, Target)] = &[
     (Audit::WorkFailed, Target::Skill),
@@ -99,17 +98,17 @@ const WALLS: &[(Audit, Target)] = &[
 /// What the loop's evidence for one target is worth.
 ///
 /// A failed turn, a failed check and a retried command are the environment
-/// answering — an exit status, a tracker's refusal — which is
+/// answering — an exit status, a tracker's refusal. That is
 /// [`ProvenanceGrade::EnvironmentObservation`] exactly. A waiver, a deferral
-/// or an escalation is the loop's own judgement about a run, which is
-/// [`ProvenanceGrade::ModelCritique`]; it grades down for the reason the
-/// provenance policy grades down, that under-grading parks a proposal until
-/// somebody re-derives it while over-grading publishes on evidence that was
-/// never there.
+/// or an escalation is the loop's own judgement about a run. That is
+/// [`ProvenanceGrade::ModelCritique`], and it grades down for the reason the
+/// provenance policy grades down. Under-grading parks a proposal until
+/// somebody re-derives it. Over-grading publishes on evidence that was never
+/// there.
 ///
-/// Recurrence moves neither answer. Aggregation never promotes evidence, so
-/// ten runs agreeing that the loop waived the same rule is still one class of
-/// claim — which is why a rule proposal from this journal can never reach the
+/// Recurrence moves neither answer. Aggregation never promotes evidence. Ten
+/// runs agreeing that the loop waived the same rule is still one class of
+/// claim. So a rule proposal from this journal can never reach the
 /// `EnvironmentObservation` a steering directive costs.
 fn grade_of(target: Target) -> ProvenanceGrade {
     match target {
@@ -120,15 +119,15 @@ fn grade_of(target: Target) -> ProvenanceGrade {
 
 /// What a wrong change to the surface a target names can break.
 ///
-/// One line per row of `stella-parity`'s evolution matrix: a skill is that
-/// matrix's `Skill` row (`ImpactClass::AdvisoryRecord`), a rule is its
-/// `Framework` row (`ImpactClass::SteeringDirective`), a custom tool is its
-/// `Tool` row (`ImpactClass::ExecutableTool`). The matrix is the declaration
-/// and this is a reader of it, held to it by
+/// One line per row of `stella-parity`'s evolution matrix. A skill is that
+/// matrix's `Skill` row (`ImpactClass::AdvisoryRecord`). A rule is its
+/// `Framework` row (`ImpactClass::SteeringDirective`). A custom tool is its
+/// `Tool` row (`ImpactClass::ExecutableTool`). The matrix declares; this
+/// reads. It is held to those rows by
 /// `the_loop_proposes_at_the_impact_its_evolution_row_declares` in
 /// `crates/stella-parity/src/evolution/tests.rs`, which reads this source.
 ///
-/// The grade and the authority an impact costs are not written here at all:
+/// The grade and the authority an impact costs are not written here at all.
 /// `ImpactClass::required_grade` and `ImpactClass::required_authority` answer
 /// those, out of the one policy that holds them.
 fn impact_of(target: Target) -> ImpactClass {
@@ -141,8 +140,8 @@ fn impact_of(target: Target) -> ImpactClass {
 
 /// One proposal, as the loop writes it down.
 ///
-/// Every field is something the loop observed or read out of the policy. No
-/// field says the proposal was applied, because no path here applies one.
+/// Every field is something the loop saw, or read out of the policy. No field
+/// says the proposal was applied. No path here applies one.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) struct ProposalRow {
     /// The dedup key, taken from the grouped shape rather than the whole line,
@@ -175,10 +174,10 @@ pub(super) struct ProposalRow {
 
 /// The recurring walls this journal shows that are not written down yet.
 ///
-/// The journal is read twice per run: once to count, because the machine's
-/// ladder consults the count before it asks for a curate step, and once to
-/// write, when it does ask. Both go through here, so the two can never
-/// disagree about what a pass would produce.
+/// The journal is read twice per run. Once to count, because the machine's
+/// ladder reads the count before it asks for a curate step. Once to write,
+/// when it does ask. Both go through here, so the two can never disagree
+/// about what a pass would produce.
 pub(super) fn fresh(durable: &Durable) -> Vec<Proposal> {
     let walls = sightings(&durable.audit_path());
     let already: Vec<String> = durable
@@ -195,9 +194,9 @@ pub(super) fn fresh(durable: &Durable) -> Vec<Proposal> {
 
 /// How many proposals a pass would make right now.
 ///
-/// What the machine reads before it decides whether to spend an idle step on
-/// curating. Zero for a loop that has never hit the same wall in three runs,
-/// which is the ordinary case and the one that must cost nothing.
+/// What the machine reads before it spends an idle step on curating. Zero for
+/// a loop that has never hit the same wall in three runs. That is the usual
+/// case, and the one that must cost nothing.
 pub(super) fn pending(durable: &Durable) -> u32 {
     u32::try_from(fresh(durable).len()).unwrap_or(u32::MAX)
 }
@@ -205,15 +204,15 @@ pub(super) fn pending(durable: &Durable) -> u32 {
 /// Write down every recurring wall this journal shows. `true` when anything
 /// reached the file.
 ///
-/// Best-effort per proposal: a row that cannot be appended is reported and the
-/// rest are still written, on the rule the audit trail itself follows — a
-/// failure to write the paperwork must not cost the work.
+/// Best-effort per proposal. A row that cannot be appended is reported, and
+/// the rest are still written. That is the rule the audit trail itself
+/// follows: failing to write the paperwork must not cost the work.
 pub(super) fn pass(durable: &Durable, root: &Path) -> bool {
     let governance = match crate::context_records::read_governance(root) {
         Ok(governance) => governance.mode.as_str().to_owned(),
-        // A governance file that will not parse fails closed everywhere else,
-        // and it does here too: the loop records what it could not establish
-        // rather than writing down the permissive default as a fact.
+        // A governance file that will not parse fails closed everywhere
+        // else, and it does here too. The loop records what it could not
+        // settle, rather than writing the permissive default down as a fact.
         Err(error) => {
             audit::record(
                 durable,

--- a/crates/stella-cli/src/self_driving_cmd/curate.rs
+++ b/crates/stella-cli/src/self_driving_cmd/curate.rs
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Saying out loud that the loop keeps hitting the same wall.
+//!
+//! `stella_autonomy::curate` holds the rules. This is the half that touches
+//! the world: it reads the loop's own journal, groups what recurs, and writes
+//! each recurring wall down as a proposal beside the loop's other evidence.
+//!
+//! # A proposal is a suggestion, and nothing here can apply one
+//!
+//! No path in this module writes a skill file, a record under
+//! `.stella/rules/`, or a line of `.stella/rules/promotions.jsonl`. That is
+//! the rule the loop is held to: it may propose any authority, and it may
+//! grant itself none. Acceptance stays where it already lives — a person
+//! reads the proposal and goes through `stella context keep` and `stella
+//! context promote`, which append to the hash-chained ledger under a real
+//! approver.
+//!
+//! # What the evidence is
+//!
+//! Every step the loop could not take is already a line in `audit.jsonl`: a
+//! check that failed, a rule it waived, an issue it handed back, a command it
+//! retried. [`WALLS`] names the actions that count and the surface each one
+//! points at. A line's session is the run it happened in, and the recurrence
+//! count is over distinct runs, so an afternoon spent retrying one command is
+//! one observation rather than forty.
+//!
+//! # What a proposal costs
+//!
+//! Nothing here restates what the evidence has to be worth. The surface's
+//! impact class comes from `stella-parity`'s evolution matrix — the map in
+//! [`impact_of`] is pinned against those rows by
+//! `the_loop_proposes_at_the_impact_its_evolution_row_declares` — and the
+//! grade and authority that impact requires come from
+//! `stella_protocol::provenance`, the one place that policy lives.
+//!
+//! `doc:backlog-self-driving` §3.5 is the design.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use stella_autonomy::curate::{Proposal, Sighting, Target};
+use stella_protocol::provenance::{
+    ImpactClass, PromotionRefusal, ProvenanceGrade, PublicationAuthority, authorises,
+};
+use stella_records::context_record::TRAJECTORY_ABSTRACTION_MIN_DISTINCT_TASKS;
+
+use super::audit::{self, Action as Audit, AuditEntry};
+use super::state::LoopState as Durable;
+
+/// How many separate runs must meet a wall before it becomes a proposal.
+///
+/// Not a number chosen here. `EvidencePool::from_observations` lifts a pool to
+/// `ProvenanceGrade::TrajectoryAbstraction` only once its evidence spans
+/// `TRAJECTORY_ABSTRACTION_MIN_DISTINCT_TASKS` distinct tasks, and that is the
+/// weakest grade any of the three surfaces below accepts. Under the floor a
+/// proposal could not be published however a person decided, so making one
+/// would be noise with somebody's attention as its cost.
+const RECURRENCE_THRESHOLD: usize = TRAJECTORY_ABSTRACTION_MIN_DISTINCT_TASKS as usize;
+
+/// The most proposals one pass may make.
+///
+/// A journal full of one-off failures that happen to share a leading clause is
+/// a detector misfiring, not twenty habits. The cap turns that into bounded
+/// noise.
+const MAX_PROPOSALS_PER_PASS: usize = 8;
+
+/// How far back through the journal one pass reads, in lines.
+///
+/// The newest window, because a wall the loop stopped hitting a year ago is
+/// not a wall. Wide enough to hold several runs of an ordinary loop.
+const JOURNAL_READ_LIMIT: usize = 5_000;
+
+/// The journal actions that record a wall, and what each one points at.
+///
+/// A wall is a step the loop could not take. Which surface answers it depends
+/// on what kind of step it was:
+///
+/// - A turn or a check that failed is a piece of work the loop did not know
+///   how to do. A procedure is what it lacked, so the ask is a skill.
+/// - A waiver, a deferral or an escalation is a judgement the loop made and
+///   kept making. A directive settles a judgement once, so the ask is a rule.
+/// - A command retried as transient is the environment refusing. Wrapping a
+///   command is a tool's job, so the ask is a tool.
+///
+/// The grouping is also what makes [`grade_of`] answerable per target rather
+/// than per line: every action pointing at one surface is the same kind of
+/// claim.
+const WALLS: &[(Audit, Target)] = &[
+    (Audit::WorkFailed, Target::Skill),
+    (Audit::VerifyFailed, Target::Skill),
+    (Audit::Waived, Target::Rule),
+    (Audit::Deferred, Target::Rule),
+    (Audit::Escalated, Target::Rule),
+    (Audit::Transient, Target::Tool),
+];
+
+/// What the loop's evidence for one target is worth.
+///
+/// A failed turn, a failed check and a retried command are the environment
+/// answering — an exit status, a tracker's refusal — which is
+/// [`ProvenanceGrade::EnvironmentObservation`] exactly. A waiver, a deferral
+/// or an escalation is the loop's own judgement about a run, which is
+/// [`ProvenanceGrade::ModelCritique`]; it grades down for the reason the
+/// provenance policy grades down, that under-grading parks a proposal until
+/// somebody re-derives it while over-grading publishes on evidence that was
+/// never there.
+///
+/// Recurrence moves neither answer. Aggregation never promotes evidence, so
+/// ten runs agreeing that the loop waived the same rule is still one class of
+/// claim — which is why a rule proposal from this journal can never reach the
+/// `EnvironmentObservation` a steering directive costs.
+fn grade_of(target: Target) -> ProvenanceGrade {
+    match target {
+        Target::Skill | Target::Tool => ProvenanceGrade::EnvironmentObservation,
+        Target::Rule => ProvenanceGrade::ModelCritique,
+    }
+}
+
+/// What a wrong change to the surface a target names can break.
+///
+/// One line per row of `stella-parity`'s evolution matrix: a skill is that
+/// matrix's `Skill` row (`ImpactClass::AdvisoryRecord`), a rule is its
+/// `Framework` row (`ImpactClass::SteeringDirective`), a custom tool is its
+/// `Tool` row (`ImpactClass::ExecutableTool`). The matrix is the declaration
+/// and this is a reader of it, held to it by
+/// `the_loop_proposes_at_the_impact_its_evolution_row_declares` in
+/// `crates/stella-parity/src/evolution/tests.rs`, which reads this source.
+///
+/// The grade and the authority an impact costs are not written here at all:
+/// `ImpactClass::required_grade` and `ImpactClass::required_authority` answer
+/// those, out of the one policy that holds them.
+fn impact_of(target: Target) -> ImpactClass {
+    match target {
+        Target::Skill => ImpactClass::AdvisoryRecord,
+        Target::Rule => ImpactClass::SteeringDirective,
+        Target::Tool => ImpactClass::ExecutableTool,
+    }
+}
+
+/// One proposal, as the loop writes it down.
+///
+/// Every field is something the loop observed or read out of the policy. No
+/// field says the proposal was applied, because no path here applies one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct ProposalRow {
+    /// The dedup key, taken from the grouped shape rather than the whole line,
+    /// so tomorrow's sighting of one wall does not read as a second wall.
+    pub digest: String,
+    /// When the loop wrote it down, RFC3339 UTC.
+    pub at: String,
+    /// Which surface a person would change — `skill`, `rule` or `tool`.
+    pub surface: String,
+    /// The wall, in the loop's own words.
+    pub statement: String,
+    /// The journal lines behind it, oldest first.
+    pub evidence: Vec<String>,
+    /// The distinct runs that met it.
+    pub runs: Vec<String>,
+    /// What the loop's evidence for this is worth.
+    pub grade: String,
+    /// What this surface's impact class requires, read from the policy.
+    pub required_grade: String,
+    /// Who may publish that impact class, read from the same policy.
+    pub required_authority: String,
+    /// The governance mode in force when it was written.
+    pub governance: String,
+    /// Why the loop could not have published this on its own, when it could
+    /// not. Absent means its evidence and authority reach the bar — and it
+    /// still publishes nothing, because a proposal is all it makes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refusal: Option<PromotionRefusal>,
+}
+
+/// The recurring walls this journal shows that are not written down yet.
+///
+/// The journal is read twice per run: once to count, because the machine's
+/// ladder consults the count before it asks for a curate step, and once to
+/// write, when it does ask. Both go through here, so the two can never
+/// disagree about what a pass would produce.
+pub(super) fn fresh(durable: &Durable) -> Vec<Proposal> {
+    let walls = sightings(&durable.audit_path());
+    let already: Vec<String> = durable
+        .proposals()
+        .into_iter()
+        .map(|row| row.digest)
+        .collect();
+    stella_autonomy::curate::propose(&walls, RECURRENCE_THRESHOLD)
+        .into_iter()
+        .filter(|proposal| !already.contains(&stella_autonomy::finding_digest(&proposal.shape)))
+        .take(MAX_PROPOSALS_PER_PASS)
+        .collect()
+}
+
+/// How many proposals a pass would make right now.
+///
+/// What the machine reads before it decides whether to spend an idle step on
+/// curating. Zero for a loop that has never hit the same wall in three runs,
+/// which is the ordinary case and the one that must cost nothing.
+pub(super) fn pending(durable: &Durable) -> u32 {
+    u32::try_from(fresh(durable).len()).unwrap_or(u32::MAX)
+}
+
+/// Write down every recurring wall this journal shows. `true` when anything
+/// reached the file.
+///
+/// Best-effort per proposal: a row that cannot be appended is reported and the
+/// rest are still written, on the rule the audit trail itself follows — a
+/// failure to write the paperwork must not cost the work.
+pub(super) fn pass(durable: &Durable, root: &Path) -> bool {
+    let governance = match crate::context_records::read_governance(root) {
+        Ok(governance) => governance.mode.as_str().to_owned(),
+        // A governance file that will not parse fails closed everywhere else,
+        // and it does here too: the loop records what it could not establish
+        // rather than writing down the permissive default as a fact.
+        Err(error) => {
+            audit::record(
+                durable,
+                Audit::Transient,
+                None,
+                &format!("could not read the governance mode: {error}"),
+            );
+            "unknown".to_owned()
+        }
+    };
+
+    let proposals = fresh(durable);
+    if proposals.is_empty() {
+        audit::record(
+            durable,
+            Audit::Swept,
+            None,
+            "no wall in the journal has been met in enough separate runs to propose anything",
+        );
+        return false;
+    }
+
+    let mut written = 0_u32;
+    for proposal in &proposals {
+        let row = row_for(proposal, &governance);
+        let standing = match &row.refusal {
+            None => format!(
+                "its {} evidence reaches the {} this surface needs, and a person still decides",
+                row.grade, row.required_grade
+            ),
+            Some(refusal) => format!("the loop could not publish it in any case: {refusal:?}"),
+        };
+        match durable.append_proposal(&row) {
+            Ok(()) => {
+                written += 1;
+                audit::record(
+                    durable,
+                    Audit::Swept,
+                    None,
+                    &format!(
+                        "proposing a {} after {} run(s) met the same wall — {standing}. Nothing \
+                         is applied; accept it with `stella context keep`, then `stella context \
+                         promote`",
+                        row.surface,
+                        row.runs.len(),
+                    ),
+                );
+            }
+            Err(error) => audit::record(
+                durable,
+                Audit::Transient,
+                None,
+                &format!(
+                    "could not write the proposal for this wall: {error} — {}",
+                    proposal.statement
+                ),
+            ),
+        }
+    }
+    written > 0
+}
+
+/// One proposal as a row, with everything the policy says about it filled in.
+fn row_for(proposal: &Proposal, governance: &str) -> ProposalRow {
+    let impact = impact_of(proposal.target);
+    let grade = grade_of(proposal.target);
+
+    ProposalRow {
+        digest: stella_autonomy::finding_digest(&proposal.shape),
+        at: crate::timefmt::rfc3339_utc_now(),
+        surface: proposal.target.as_str().to_owned(),
+        statement: proposal.statement.clone(),
+        evidence: proposal.evidence.clone(),
+        runs: proposal.runs.clone(),
+        grade: grade.as_str().to_owned(),
+        required_grade: impact.required_grade().as_str().to_owned(),
+        required_authority: impact.required_authority().as_str().to_owned(),
+        governance: governance.to_owned(),
+        // The loop acts as itself, which is the weakest authority there is.
+        refusal: authorises(Some(grade), PublicationAuthority::Agent, impact).err(),
+    }
+}
+
+/// The walls the journal's newest window shows, oldest first.
+fn sightings(journal: &Path) -> Vec<Sighting> {
+    let Ok(text) = std::fs::read_to_string(journal) else {
+        return Vec::new();
+    };
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines.len().saturating_sub(JOURNAL_READ_LIMIT);
+
+    let mut out = Vec::new();
+    for line in &lines[start..] {
+        let Ok(entry) = serde_json::from_str::<AuditEntry>(line) else {
+            continue;
+        };
+        let Some((_, target)) = WALLS.iter().find(|(action, _)| *action == entry.action) else {
+            continue;
+        };
+        out.push(Sighting {
+            statement: entry.outcome.clone(),
+            // The drive session, because that is one launch of the loop. A
+            // one-shot verb writes no session and folds into the cycle run
+            // around it, which is the next-best boundary and never worse:
+            // reading a cycle as a run can only under-count recurrence.
+            run: entry
+                .session_id
+                .clone()
+                .unwrap_or_else(|| entry.run_id.clone()),
+            evidence: entry.at.clone(),
+            target: *target,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/self_driving_cmd/curate/tests.rs
+++ b/crates/stella-cli/src/self_driving_cmd/curate/tests.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! What the curate pass reads, what it writes, and what it must never touch.
+//! What the curate pass reads. What it writes. What it must not touch.
 
 use std::path::Path;
 
 use super::*;
 
-/// A state directory on a tempdir. Both fields are `pub`, so a test can build
-/// one without `LoopState::open`'s home resolution and migration.
+/// A state directory on a tempdir. Both fields are `pub`. So a test can build
+/// one without `LoopState::open`'s home lookup and migration.
 fn loop_state(dir: &tempfile::TempDir) -> Durable {
     Durable {
         dir: dir.path().to_path_buf(),
@@ -32,15 +32,15 @@ fn journal(durable: &Durable, run: &str, at: &str, action: Audit, outcome: &str)
     std::fs::write(durable.audit_path(), text).unwrap();
 }
 
-/// A workspace whose governance is the one this repository runs under.
+/// A workspace set to the mode this repo runs under.
 fn regulated(root: &Path) {
     let rules = root.join(".stella").join("rules");
     std::fs::create_dir_all(&rules).unwrap();
     std::fs::write(rules.join("governance.toml"), "mode = \"regulated\"\n").unwrap();
 }
 
-/// What the published-record directory holds, in a stable order — `read_dir`
-/// promises none, so an unsorted comparison would flake rather than fail.
+/// What the published-record dir holds, in a fixed order. `read_dir` promises
+/// no order. An unsorted compare would flake rather than fail.
 fn published(root: &Path) -> Vec<std::path::PathBuf> {
     let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(root.join(".stella/rules"))
         .into_iter()
@@ -52,9 +52,9 @@ fn published(root: &Path) -> Vec<std::path::PathBuf> {
 }
 
 /// **The witness.** A wall met in three separate runs becomes one written
-/// proposal that names every run behind it — and under `regulated` governance
-/// the pass publishes nothing: no skill, no record under `.stella/rules/`, and
-/// no line of the hash-chained promotion ledger.
+/// proposal. That proposal names every run behind it. Under `regulated` mode
+/// the pass writes nothing. No skill. No record under `.stella/rules/`. No
+/// line of the hash-chained ledger.
 #[test]
 fn a_recurring_wall_becomes_a_proposal_and_nothing_is_applied() {
     let dir = tempfile::tempdir().unwrap();
@@ -101,16 +101,16 @@ fn a_recurring_wall_becomes_a_proposal_and_nothing_is_applied() {
     );
     assert_eq!(rows[0].governance, "regulated");
 
-    // Nothing was applied. The published-record directory is as it was, and
-    // neither the promotion ledger nor a skill exists.
+    // Nothing was applied. The published-record directory is as it was.
+    // Neither the promotion ledger nor a skill exists.
     assert_eq!(published(dir.path()), before);
     assert!(!dir.path().join(".stella/rules/promotions.jsonl").exists());
     assert!(!dir.path().join(".stella/skills").exists());
 }
 
-/// A second pass over the same journal proposes nothing: the digest of a wall
-/// already written down is what keeps a standing proposal from being made
-/// again on every run.
+/// A second pass over the same journal proposes nothing. The digest of a wall
+/// already written down is what stops a standing proposal being made again on
+/// every run.
 #[test]
 fn a_wall_already_written_down_is_not_proposed_again() {
     let dir = tempfile::tempdir().unwrap();
@@ -133,8 +133,8 @@ fn a_wall_already_written_down_is_not_proposed_again() {
     assert_eq!(durable.proposals().len(), 1);
 }
 
-/// A loop that has never repeated itself proposes nothing, so a build that
-/// gains this code changes nothing for a workspace with an ordinary journal.
+/// A loop that has never repeated itself proposes nothing. So a build that
+/// gains this code changes nothing for a workspace with a plain journal.
 #[test]
 fn a_journal_with_no_repetition_proposes_nothing() {
     let dir = tempfile::tempdir().unwrap();
@@ -161,8 +161,8 @@ fn a_journal_with_no_repetition_proposes_nothing() {
     assert!(durable.proposals().is_empty());
 }
 
-/// A journal nothing has written yet is read as no walls rather than as an
-/// error, so the first poll of a fresh loop costs nothing.
+/// A journal nothing has written yet reads as no walls, not as an error. So
+/// the first poll of a fresh loop costs nothing.
 #[test]
 fn a_missing_journal_is_read_as_no_walls() {
     let dir = tempfile::tempdir().unwrap();
@@ -172,11 +172,11 @@ fn a_missing_journal_is_read_as_no_walls() {
     assert_eq!(pending(&durable), 0);
 }
 
-/// A rule proposal rests on the loop's own judgement, and judgement is a
+/// A rule proposal rests on the loop's own judgement. Judgement is a
 /// `ModelCritique` however many runs agree. A steering directive costs an
-/// `EnvironmentObservation`, so the loop can never publish one of these on its
-/// own evidence — which is the line "propose any authority, grant itself
-/// none" is drawn at, checked against the policy rather than asserted.
+/// `EnvironmentObservation`. So the loop can never publish one on its own
+/// evidence. That is where "propose any authority, grant itself none" is
+/// drawn. It is checked against the policy, not asserted.
 #[test]
 fn a_rule_on_the_loops_own_judgement_could_never_be_published_by_the_loop() {
     let refused = authorises(
@@ -195,8 +195,8 @@ fn a_rule_on_the_loops_own_judgement_could_never_be_published_by_the_loop() {
     ));
 }
 
-/// A custom tool costs a deterministic proof and a person. The loop has
-/// neither, and the row it writes says so instead of implying it could.
+/// A custom tool costs a firm proof and a person. The loop has neither. The
+/// row it writes says so, rather than implying it could.
 #[test]
 fn a_tool_proposal_records_why_the_loop_could_not_publish_it() {
     let proposal = Proposal {
@@ -217,8 +217,8 @@ fn a_tool_proposal_records_why_the_loop_could_not_publish_it() {
     ));
 }
 
-/// Every wall the journal can record points at a surface, and every surface
-/// answers to an impact class — so no action reaches the ledger without the
+/// Every wall the journal can record points at a surface. Every surface
+/// answers to an impact class. So no action reaches the ledger without the
 /// policy having something to say about it.
 #[test]
 fn every_wall_names_a_surface_with_an_impact_class() {

--- a/crates/stella-cli/src/self_driving_cmd/curate/tests.rs
+++ b/crates/stella-cli/src/self_driving_cmd/curate/tests.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What the curate pass reads, what it writes, and what it must never touch.
+
+use std::path::Path;
+
+use super::*;
+
+/// A state directory on a tempdir. Both fields are `pub`, so a test can build
+/// one without `LoopState::open`'s home resolution and migration.
+fn loop_state(dir: &tempfile::TempDir) -> Durable {
+    Durable {
+        dir: dir.path().to_path_buf(),
+        repo_root: dir.path().to_path_buf(),
+    }
+}
+
+/// Write one journal line, as `audit::record` would have.
+fn journal(durable: &Durable, run: &str, at: &str, action: Audit, outcome: &str) {
+    let line = serde_json::json!({
+        "at": at,
+        "run_id": "cycle-1",
+        "action": action,
+        "subject": serde_json::Value::Null,
+        "outcome": outcome,
+        "session_id": run,
+    });
+    let mut text = std::fs::read_to_string(durable.audit_path()).unwrap_or_default();
+    text.push_str(&serde_json::to_string(&line).unwrap());
+    text.push('\n');
+    std::fs::write(durable.audit_path(), text).unwrap();
+}
+
+/// A workspace whose governance is the one this repository runs under.
+fn regulated(root: &Path) {
+    let rules = root.join(".stella").join("rules");
+    std::fs::create_dir_all(&rules).unwrap();
+    std::fs::write(rules.join("governance.toml"), "mode = \"regulated\"\n").unwrap();
+}
+
+/// What the published-record directory holds, in a stable order — `read_dir`
+/// promises none, so an unsorted comparison would flake rather than fail.
+fn published(root: &Path) -> Vec<std::path::PathBuf> {
+    let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(root.join(".stella/rules"))
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// **The witness.** A wall met in three separate runs becomes one written
+/// proposal that names every run behind it — and under `regulated` governance
+/// the pass publishes nothing: no skill, no record under `.stella/rules/`, and
+/// no line of the hash-chained promotion ledger.
+#[test]
+fn a_recurring_wall_becomes_a_proposal_and_nothing_is_applied() {
+    let dir = tempfile::tempdir().unwrap();
+    let durable = loop_state(&dir);
+    regulated(dir.path());
+    let before = published(dir.path());
+
+    journal(
+        &durable,
+        "sd-1",
+        "2026-09-01T00:00:00Z",
+        Audit::Transient,
+        "could not file `a`: 502",
+    );
+    journal(
+        &durable,
+        "sd-2",
+        "2026-09-02T00:00:00Z",
+        Audit::Transient,
+        "could not file `b`: 500",
+    );
+    journal(
+        &durable,
+        "sd-3",
+        "2026-09-03T00:00:00Z",
+        Audit::Transient,
+        "could not file `c`: timed out",
+    );
+
+    assert_eq!(pending(&durable), 1);
+    assert!(pass(&durable, dir.path()));
+
+    let rows = durable.proposals();
+    assert_eq!(rows.len(), 1, "got {rows:?}");
+    assert_eq!(rows[0].surface, "tool");
+    assert_eq!(rows[0].runs, vec!["sd-1", "sd-2", "sd-3"]);
+    assert_eq!(
+        rows[0].evidence,
+        vec![
+            "2026-09-01T00:00:00Z",
+            "2026-09-02T00:00:00Z",
+            "2026-09-03T00:00:00Z"
+        ]
+    );
+    assert_eq!(rows[0].governance, "regulated");
+
+    // Nothing was applied. The published-record directory is as it was, and
+    // neither the promotion ledger nor a skill exists.
+    assert_eq!(published(dir.path()), before);
+    assert!(!dir.path().join(".stella/rules/promotions.jsonl").exists());
+    assert!(!dir.path().join(".stella/skills").exists());
+}
+
+/// A second pass over the same journal proposes nothing: the digest of a wall
+/// already written down is what keeps a standing proposal from being made
+/// again on every run.
+#[test]
+fn a_wall_already_written_down_is_not_proposed_again() {
+    let dir = tempfile::tempdir().unwrap();
+    let durable = loop_state(&dir);
+    regulated(dir.path());
+
+    for (n, run) in ["sd-1", "sd-2", "sd-3"].iter().enumerate() {
+        journal(
+            &durable,
+            run,
+            &format!("2026-09-0{}T00:00:00Z", n + 1),
+            Audit::WorkFailed,
+            &format!("the turn did not finish: exit {n}"),
+        );
+    }
+
+    assert!(pass(&durable, dir.path()));
+    assert_eq!(pending(&durable), 0);
+    assert!(!pass(&durable, dir.path()));
+    assert_eq!(durable.proposals().len(), 1);
+}
+
+/// A loop that has never repeated itself proposes nothing, so a build that
+/// gains this code changes nothing for a workspace with an ordinary journal.
+#[test]
+fn a_journal_with_no_repetition_proposes_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let durable = loop_state(&dir);
+    regulated(dir.path());
+
+    journal(
+        &durable,
+        "sd-1",
+        "2026-09-01T00:00:00Z",
+        Audit::Transient,
+        "could not file `a`: 502",
+    );
+    journal(
+        &durable,
+        "sd-2",
+        "2026-09-02T00:00:00Z",
+        Audit::Waived,
+        "the baseline is already red (cargo) — advisory",
+    );
+
+    assert_eq!(pending(&durable), 0);
+    assert!(!pass(&durable, dir.path()));
+    assert!(durable.proposals().is_empty());
+}
+
+/// A journal nothing has written yet is read as no walls rather than as an
+/// error, so the first poll of a fresh loop costs nothing.
+#[test]
+fn a_missing_journal_is_read_as_no_walls() {
+    let dir = tempfile::tempdir().unwrap();
+    let durable = loop_state(&dir);
+
+    assert!(sightings(&durable.audit_path()).is_empty());
+    assert_eq!(pending(&durable), 0);
+}
+
+/// A rule proposal rests on the loop's own judgement, and judgement is a
+/// `ModelCritique` however many runs agree. A steering directive costs an
+/// `EnvironmentObservation`, so the loop can never publish one of these on its
+/// own evidence — which is the line "propose any authority, grant itself
+/// none" is drawn at, checked against the policy rather than asserted.
+#[test]
+fn a_rule_on_the_loops_own_judgement_could_never_be_published_by_the_loop() {
+    let refused = authorises(
+        Some(grade_of(Target::Rule)),
+        PublicationAuthority::Agent,
+        impact_of(Target::Rule),
+    );
+
+    assert!(matches!(
+        refused,
+        Err(PromotionRefusal::EvidenceTooWeak {
+            required: ProvenanceGrade::EnvironmentObservation,
+            actual: ProvenanceGrade::ModelCritique,
+            ..
+        })
+    ));
+}
+
+/// A custom tool costs a deterministic proof and a person. The loop has
+/// neither, and the row it writes says so instead of implying it could.
+#[test]
+fn a_tool_proposal_records_why_the_loop_could_not_publish_it() {
+    let proposal = Proposal {
+        target: Target::Tool,
+        statement: "could not file `a`: 502".to_owned(),
+        shape: "could not file".to_owned(),
+        evidence: vec!["2026-09-01T00:00:00Z".to_owned()],
+        runs: vec!["sd-1".to_owned(), "sd-2".to_owned(), "sd-3".to_owned()],
+    };
+
+    let row = row_for(&proposal, "regulated");
+
+    assert_eq!(row.required_grade, "deterministic_proof");
+    assert_eq!(row.required_authority, "local_human");
+    assert!(matches!(
+        row.refusal,
+        Some(PromotionRefusal::EvidenceTooWeak { .. })
+    ));
+}
+
+/// Every wall the journal can record points at a surface, and every surface
+/// answers to an impact class — so no action reaches the ledger without the
+/// policy having something to say about it.
+#[test]
+fn every_wall_names_a_surface_with_an_impact_class() {
+    for (_, target) in WALLS {
+        let impact = impact_of(*target);
+
+        assert!(ImpactClass::ALL.contains(&impact), "{target:?}");
+        assert!(
+            ProvenanceGrade::ALL.contains(&grade_of(*target)),
+            "{target:?}"
+        );
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -54,9 +54,9 @@
 //! It drives `claim → work → deliver`, the path that produces pull requests.
 //! When an operator opens one of the extra supplies it sweeps as well: it
 //! re-checks the fixes it has claimed, and reads its own ledger for habits.
-//! `Curate` is the one step left that the machine can ask for and this build
-//! cannot take, so it says so and stops. A driver that did nothing for a step
-//! it was handed would look healthy forever.
+//! On an idle step it curates: [`super::curate`] reads the loop's own journal
+//! for a wall it keeps hitting and writes that down as a proposal a person can
+//! accept. Every step the machine can ask for is now one this build takes.
 
 use std::collections::HashMap;
 
@@ -287,6 +287,8 @@ pub(super) fn drive(
         // Where the loop looks once the queue is dry. `None` unless an
         // operator opened a supply, which is what keeps an upgrade quiet.
         lens: super::supply::open_lens(durable, &cfg, &root),
+        // Walls the journal already shows and nobody has been told about.
+        pending_proposals: super::curate::pending(durable),
         ..LoopState::default()
     };
     // Best effort: a tracker that refuses the label costs the loop its record
@@ -1002,13 +1004,11 @@ pub(super) fn drive(
             }
 
             LoopStep::Curate => {
-                audit::record(
-                    durable,
-                    Audit::SessionStopped,
-                    None,
-                    "the machine asked to curate and this build cannot — B6 builds it (#3599).",
-                );
-                return report(durable, &tally, &budget);
+                // One pass writes down every wall it can see, so the count is
+                // cleared either way and the loop falls through to watch —
+                // the shape the sweep arm uses for a supply it has drained.
+                super::curate::pass(durable, &root);
+                state.pending_proposals = 0;
             }
 
             LoopStep::Watch { until } => {

--- a/crates/stella-cli/src/self_driving_cmd/state.rs
+++ b/crates/stella-cli/src/self_driving_cmd/state.rs
@@ -285,6 +285,9 @@ impl LoopState {
     fn filings_path(&self) -> PathBuf {
         self.dir.join("filings.jsonl")
     }
+    fn proposals_path(&self) -> PathBuf {
+        self.dir.join("proposals.jsonl")
+    }
 
     /// Snapshot the ranked queue as the loop last saw it.
     ///
@@ -528,6 +531,31 @@ impl LoopState {
     ) -> Result<(), String> {
         let line = serde_json::to_string(receipt).map_err(|e| e.to_string())?;
         append_line(&self.receipts_path(), &line)
+    }
+
+    // -- curation proposals -------------------------------------------------
+
+    /// Every proposal the loop has written down, oldest first.
+    ///
+    /// A line that does not parse is skipped, the same rule the receipts
+    /// beside it read by: one bad line must not hide the rest.
+    pub(super) fn proposals(&self) -> Vec<super::curate::ProposalRow> {
+        read_jsonl(&self.proposals_path())
+            .values
+            .into_iter()
+            .filter_map(|value| serde_json::from_value(value).ok())
+            .collect()
+    }
+
+    /// Write down one proposal.
+    ///
+    /// Append-only, like the receipts. A proposal is a suggestion with its
+    /// evidence attached, so a later pass adds to the record rather than
+    /// rewriting what the loop said before — and nothing loads this file into
+    /// a session, which is what keeps a proposal from being a change.
+    pub(super) fn append_proposal(&self, row: &super::curate::ProposalRow) -> Result<(), String> {
+        let line = serde_json::to_string(row).map_err(|e| e.to_string())?;
+        append_line(&self.proposals_path(), &line)
     }
 
     // -- the run lifecycle ---------------------------------------------------

--- a/crates/stella-parity/src/evolution/tests.rs
+++ b/crates/stella-parity/src/evolution/tests.rs
@@ -249,3 +249,32 @@ fn liveness_and_witnesses_agree() {
         }
     }
 }
+
+/// **The self-driving loop proposes at the impact its row declares.**
+///
+/// `stella-cli`'s `self_driving_cmd::curate` writes a proposal for one of
+/// three surfaces and reads what that surface costs out of the provenance
+/// policy. Which impact class each of its targets carries is a second reading
+/// of this matrix, and nothing in `stella-cli` can see the matrix — that crate
+/// does not link this one, because this one links `stella-serve`, which the
+/// shipping binary must not. So the pin runs from this side, over the source
+/// text, the way every witness above is checked.
+#[test]
+fn the_loop_proposes_at_the_impact_its_evolution_row_declares() {
+    let curate = include_str!("../../../stella-cli/src/self_driving_cmd/curate.rs");
+
+    for (target, surface) in [
+        ("Target::Skill", EvolutionSurface::Skill),
+        ("Target::Rule", EvolutionSurface::Framework),
+        ("Target::Tool", EvolutionSurface::Tool),
+    ] {
+        let arm = format!("{target} => ImpactClass::{:?},", surface.row().impact);
+        assert!(
+            curate.contains(&arm),
+            "the {} row declares {:?}, so curate.rs's `impact_of` should read \
+             `{arm}` — the two have drifted",
+            surface.as_str(),
+            surface.row().impact,
+        );
+    }
+}

--- a/crates/stella-parity/src/evolution/tests.rs
+++ b/crates/stella-parity/src/evolution/tests.rs
@@ -5,17 +5,15 @@
 //!
 //! Totality is the compiler's job here — [`EvolutionSurface`] and
 //! [`EVOLUTION_SURFACES`] come out of one macro, so a surface with no row is
-//! not a case these tests have to catch. What they catch is everything the
-//! generator cannot: a witness that has been renamed away, a gap citing
-//! nothing, a declared grade drifting from the policy that defines it, and the
-//! unwitnessed debt creeping upward.
+//! not a case these tests have to catch. They catch what the generator
+//! cannot. A witness renamed away. A gap citing nothing. A declared grade
+//! drifting from the policy that defines it. Unwitnessed debt creeping up.
 
 use super::*;
 
-/// A witness exists if the swept sources declare a function by that name —
-/// the same substring check [`crate`]'s matrix and `provider_parity` use, and
-/// not an AST walk: a moved witness should fail loudly rather than be quietly
-/// re-resolved.
+/// A witness exists if the swept sources declare a function by that name.
+/// This is the substring check [`crate`]'s matrix and `provider_parity` use,
+/// not an AST walk. A moved witness should fail loudly, not be re-resolved.
 fn witness_exists(sources: &[&str], witness: &str) -> bool {
     let needle = format!("fn {witness}(");
     sources.iter().any(|source| source.contains(&needle))
@@ -141,9 +139,9 @@ fn every_prohibited_row_cites_a_design_document_by_id() {
     }
 }
 
-/// Unwitnessed debt is a down-only ratchet, checked for exact equality so that
-/// raising it is an edit a reviewer sees rather than a threshold quietly
-/// absorbing a new row.
+/// Unwitnessed debt is a down-only ratchet. It is checked for exact equality,
+/// so raising it is an edit a reviewer sees. A threshold that merely bounded
+/// it would absorb a new row in silence.
 #[test]
 fn unwitnessed_rows_match_the_declared_baseline_exactly() {
     let count = EVOLUTION_SURFACES


### PR DESCRIPTION
## What

`LoopStep::Curate` had no performer. `crates/stella-cli/src/self_driving_cmd/drive.rs` recorded that the machine had asked for a step this build could not take, and returned. `state.pending_proposals` was never set either, so nothing could reach that arm in the first place.

The loop now proposes.

## Why this evidence

The wall the loop keeps hitting is already written down. Every step it could not take is one line of `audit.jsonl` under `~/.stella/self-driving/<repo>/`: a turn that failed, a check that failed, a rule it waived, an issue it handed back, a command it retried. Those lines carry the run they happened in, which is the distinct-task boundary the recurrence count needs.

## The two halves

**`crates/stella-autonomy/src/curate.rs`** (new module, one `pub mod` line in `lib.rs` — nothing added to the crate root's logic). Pure: `Sighting`, `Target` (`Skill` / `Rule` / `Tool`), `Proposal`, and `propose(sightings, min_distinct_runs)`. It groups by `shape`, the leading clause of a statement, because journal lines differ in their particulars — an issue key, an error string — and grouping the raw lines finds nothing. Repetition inside one run counts once. The recurrence floor is a parameter, not a constant here: the number belongs to the provenance policy, and this crate is a leaf that cannot read it.

**`crates/stella-cli/src/self_driving_cmd/curate.rs`** (new sibling; `self_driving_cmd.rs` gains only its `mod` line). Reads the journal, calls `propose`, and appends each recurring wall to `proposals.jsonl` beside the loop's other evidence.

`drive.rs` seeds `state.pending_proposals` from `curate::pending`, and the `Curate` arm runs `curate::pass` and zeroes the count — the shape the `Sweep` arm uses for a supply it has drained.

## The rule this does not break

**The loop may propose any authority and grant itself none.** No path in the new module writes a skill file, a record under `.stella/rules/`, or a line of `.stella/rules/promotions.jsonl`. `plugins/stella-selfdriving/plugin.toml` and `crates/stella-cli/tests/self_driving_consent.rs` are untouched, so `curate_accept` is still absent from the shipped consent text.

The policy is consulted rather than restated:

- `RECURRENCE_THRESHOLD` is `stella_records::…::TRAJECTORY_ABSTRACTION_MIN_DISTINCT_TASKS`. Below that floor `EvidencePool` never lifts a pool to `TrajectoryAbstraction`, the weakest grade any of the three surfaces accepts, so a proposal under it could not be published however a person decided.
- Each row's required grade and authority come from `ImpactClass::required_grade()` / `required_authority()` in `crates/stella-protocol/src/provenance.rs`.
- The `Target -> ImpactClass` map is a second reading of `crates/stella-parity/src/evolution.rs`'s rows, and `the_loop_proposes_at_the_impact_its_evolution_row_declares` pins it against them. It runs from the parity side, over the source text with `include_str!`, because `stella-cli` does not link `stella-parity` — that crate links `stella-serve`, which the shipping binary must not. The idiom is the one `evolution_sources()` already uses for every named witness.
- Aggregation does not promote: a rule proposal rests on the loop's own judgement and grades `ModelCritique` however many runs agree, so a steering directive is out of its reach. `a_rule_on_the_loops_own_judgement_could_never_be_published_by_the_loop` asks `authorises` rather than asserting it.

## Witness

`a_recurring_wall_becomes_a_proposal_and_nothing_is_applied` (`crates/stella-cli/src/self_driving_cmd/curate/tests.rs`). Three separate runs hit the same wall in a `regulated` workspace; one proposal row appears naming all three runs and all three journal lines; `.stella/rules/` is byte-for-byte as it was, `promotions.jsonl` does not exist, and no skill directory was created.

It fails on `main` by construction: `self_driving_cmd::curate` does not exist there, and the `Curate` arm returns from the driver instead of performing.

Beside it: `a_wall_already_written_down_is_not_proposed_again` (the dedup digest), `a_journal_with_no_repetition_proposes_nothing` (a build that gains this changes nothing for an ordinary journal), `a_missing_journal_is_read_as_no_walls`, and `a_tool_proposal_records_why_the_loop_could_not_publish_it`. `crates/stella-autonomy/src/curate.rs` carries seven more over the grouping rules, including `repetition_inside_one_run_never_reaches_the_floor`.

## Exemplar

`crates/stella-cli/src/self_driving_cmd/supply.rs` and `crates/stella-autonomy/src/meta.rs` — the same split of a pure rule module from the half that touches the world, the same `pass` returning whether anything landed, and the same journal-shaped audit lines.

## Where this stops short of the issue, said out loud

The issue's constraints ask that acceptance go through `stella context keep` / `promote` and the hash-chained ledger. It does — a person runs those, and nothing here writes a record. What this does **not** do is put the loop's proposals into the context ledger as `ProposalRecord`s so `stella proposals keep <id>` can take one by id. That needs an `ObservationSource` for the loop's own journal, and adding the loop's evidence under the existing `ToolOutcome` source would raise the grade of the pool `rules_mining` reads and weaken the `Framework` row's stated safety. Filed as #6211 with the full argument.

## Tests deleted

None.

## Residue filed

- #6209 — `curate_propose` / `curate_list` still refuse every caller on the driver channel.
- #6211 — a proposed wall cannot be accepted with a command, only by hand.
- #6212 — `make prose` is red on `main` (`fleet_cmd.rs`, 54 hits against a baseline of 53, from #6168). Pre-existing and untouched here; repairing it belongs in its own PR from a fresh `main`.

Closes #6152

## Summary by Sourcery

Enable the self-driving loop to turn repeatedly encountered journaled obstacles into reviewable, provenance-aware proposals without applying any changes automatically.

New Features:
- Detect recurring obstacles in self-driving loop audit journals and record them as proposals for skills, rules, or tools.
- Execute curation during idle loop steps and persist proposal evidence, provenance requirements, governance context, and publication refusals.

Bug Fixes:
- Replace the previously unhandled curation step, which stopped the driver without producing output, with an active curation pass.

Enhancements:
- Group journal sightings by normalized statement shape across distinct runs, deduplicate existing proposals, and prevent repeated sightings within one run from meeting the recurrence threshold.
- Keep proposal generation advisory-only so the loop cannot modify skills, rules, or promotion ledgers itself.

Tests:
- Add coverage for recurrence grouping, thresholds, deduplication, missing journals, target separation, provenance refusals, and ensuring proposals are not applied.
- Pin curation target impact mappings to the evolution matrix.