### PR TITLE
docs(prose): repair the prose gate on main

### DIFF
--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -725,11 +725,11 @@ fn attempt_task_boundary(task: &Task) -> String {
 /// loop already runs under — never a failed attempt.
 ///
 /// **What it costs.** One model call per attempt that warrants one, on the same
-/// terms as every other door: gated by `turn_warrants_reflection` so a tool-free
-/// turn spends nothing and by `reflect_routed`'s own friction gate so an
-/// attempt that went straight through spends nothing either, bounded
-/// by this child's remaining headroom, and settled
-/// back into its `BudgetGuard` — so the reflection lands inside the
+/// terms as every other door. It is gated by `turn_warrants_reflection`, so a
+/// tool-free turn spends nothing, and by `reflect_routed`'s own friction gate,
+/// so an attempt that went straight through spends nothing either. It is
+/// bounded by this child's remaining headroom and settled back into its
+/// `BudgetGuard`, so the reflection lands inside the
 /// `--spend-limit` the fleet enforces twice (the child's own cap here, and the
 /// metered total the parent stops new waves on), rather than beside it.
 /// `STELLA_DISABLE_REFLECTION` turns it off, the same switch the one-shot door
@@ -971,8 +971,7 @@ async fn run_task(
     //
     // Assembled after the recall above, not before it: the tool allowance is
     // what the block left of the shared steering allowance, so a stack built
-    // first would settle its array against a spend that had not happened yet
-    // (#6110).
+    // first would settle its array against a spend that had not happened yet.
     let permitted = agent::tool_stack::policy_stack(
         &claims,
         &cfg,

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -1387,12 +1387,12 @@ fn now_unix_secs() -> i64 {
 /// but never a "now" to measure it against (#2901) — a model handed one
 /// endpoint of an interval cannot reason about its width.
 ///
-/// This is why it lives here and not beside the cutoff it completes: the
+/// This is why it lives here and not beside the cutoff it completes. The
 /// cutoff is session-constant (a model card fact, fixed at catalog load) and
-/// rides the byte-stable system prefix, but the date changes once a day —
-/// possibly mid-session — so putting it in the prefix would be a guaranteed
+/// rides the byte-stable system prefix. The date changes once a day, possibly
+/// mid-session, so putting it in the prefix would be a guaranteed
 /// prompt-cache miss at every UTC midnight for every session alive across it
-/// (invariant #7 / L-E8), and `the_assembled_prompt_names_the_session_environment`
+/// (invariant #7 / L-E8). `the_assembled_prompt_names_the_session_environment`
 /// (`crates/stella-cli/src/agent/prompt.rs`) would start failing the moment a
 /// test ran across one. It belongs with the other genuinely volatile facts —
 /// selected skills, per-turn records — that ride this per-turn block instead.

--- a/crates/stella-cli/src/settings/steering.rs
+++ b/crates/stella-cli/src/settings/steering.rs
@@ -2,9 +2,9 @@
 //! the one derivation every caller reads it through.
 //!
 //! The [`SteeringCeiling`] value itself is captured by
-//! [`Settings::merge_captured_scopes`](super::Settings) in `merge.rs`; this
-//! module owns the type and the precedence logic so the two halves of the
-//! answer — "did anyone turn it off?" and "did the org forbid it?" — live
+//! [`Settings::merge_captured_scopes`](super::Settings) in `merge.rs`. This
+//! module owns the type and the precedence logic. That keeps the two halves
+//! of the answer, "did anyone turn it off?" and "did the org forbid it?",
 //! beside each other.
 
 use super::{Settings, truthy_flag};
@@ -26,8 +26,8 @@ impl Default for SteeringCeiling {
 impl Settings {
     /// Whether the steering plane may inject anything this session (#3243).
     ///
-    /// The precedence, which is the house convention plus the one deliberate
-    /// inversion the tool ceiling already uses:
+    /// The precedence. It is the house convention plus the one inversion the
+    /// tool ceiling already uses:
     ///
     /// ```text
     /// built-in default (ON)
@@ -38,11 +38,11 @@ impl Settings {
     ///
     /// Two sentences: **anyone may turn steering off; only the org may
     /// prevent it being turned back on.** That is exactly `apply_tool_ceiling`'s
-    /// shape, so this needs no new concept — and it is why the ceiling is a
+    /// shape, so this needs no new concept. It is also why the ceiling is a
     /// separate field rather than folded into the merged block. Folded in,
-    /// "the project turned it off" and "the org forbade it" would be the same
-    /// value, and the env var could not be allowed to override the first
-    /// without also overriding the second.
+    /// "the project turned it off" and "the org forbade it" would be one
+    /// value. The env var could then not override the first without also
+    /// overriding the second.
     pub fn steering_enabled(&self) -> bool {
         if !self.steering_ceiling.0 {
             return false;

--- a/crates/stella-cli/src/subagent.rs
+++ b/crates/stella-cli/src/subagent.rs
@@ -519,7 +519,7 @@ impl SessionSubAgents {
     /// Because there is no single root that could be correct. A fan-out runs
     /// N candidates concurrently in N disjoint trees, so a registry whose
     /// `root` were re-pointed per dispatch would be re-pointed by every
-    /// sibling underneath the others — and `root` is what every path fence
+    /// sibling underneath the others. `root` is what every path fence
     /// resolves against (`stella_tools::workspace_scope`), so the failure mode
     /// is not a confused tool but a candidate writing into its sibling's tree
     /// while both report isolation. A registry per candidate has one root for

--- a/crates/stella-serve/src/observe/event.rs
+++ b/crates/stella-serve/src/observe/event.rs
@@ -997,11 +997,11 @@ mod tests {
     /// socket first — the read, as EOF, or the next write, as a broken pipe.
     /// Both must keep the turn resumable.
     ///
-    /// This is the rule, not a restatement of the implementation: the two
-    /// are raced by a `tokio::select!` that randomizes which branch it polls,
-    /// so when only `PeerDisconnected` parked the turn, a coin flip inside the
+    /// This is the rule, not a restatement of the implementation. The two
+    /// are raced by a `tokio::select!` that randomizes which branch it polls.
+    /// So when only `PeerDisconnected` parked the turn, a coin flip inside the
     /// runtime decided whether a host that dropped its connection could resume
-    /// the turn it had already paid a model call for — the other side of the
+    /// the turn it had already paid a model call for. The other side of the
     /// flip cancelled it and answered the reconnect `404 unknown turn`.
     #[test]
     fn both_spellings_of_a_hang_up_keep_the_turn_resumable() {

--- a/docs/spec/wrapper-socket.md
+++ b/docs/spec/wrapper-socket.md
@@ -356,8 +356,8 @@ plugin→ { "point": "before_turn", "body": { "context": [ … ] } }     ← end
 
 ### What it must be bounded by
 
-A conversation can hang where a single exchange could not, so the bounds are
-part of the contract rather than an implementation detail:
+A conversation can hang where a single exchange could not. So the bounds are
+part of the contract, not an implementation detail:
 
 - the existing per-point timeout covers the **whole** conversation, not each
   turn of it — a plugin cannot buy time by talking;


### PR DESCRIPTION
`main` is red on `prose`. Two things composed: PR #6168 added one more issue-number citation to `fleet_cmd.rs` than its baseline allows, and the same run of merges pushed six files a hair over their reading-grade ceilings. The gate reports the first failure only, so the grade overruns were hidden behind the citation until it was removed.

This repairs both with prose only, no code change: the citation becomes the fact it stood for, and the single longest sentence in each of the six files (`fleet_cmd.rs`, `memory/recall.rs`, `settings/steering.rs`, `subagent.rs`, `stella-serve/src/observe/event.rs`, `docs/spec/wrapper-socket.md`) is split in two. `python3 scripts/check-prose.py` reports OK on this branch; `make guards-fast` is green. No baseline entry was raised.

No witness test: the `prose` gate is the check that judges this change.

Tests deleted: None

Closes #6196

## Summary by Sourcery

Bug Fixes:
- Repair the prose gate by removing an extraneous issue citation and bringing six files within their reading-grade limits.