### PR TITLE
fix(bench-evidence): carry which loop a trial ran into trials.jsonl

### DIFF
--- a/bench/evidence/README.md
+++ b/bench/evidence/README.md
@@ -55,11 +55,12 @@ committed. `trials.jsonl` is extracted from it and carries every field the score
 depends on; `run-manifest.json` records the digest of each committed artifact so
 a reader can tell whether what they have is what was published.
 
-Each row also carries the posture digest, assurance arm, binary SHA, source
-commit and Harbor version **the trial itself recorded**, so the manifest states
-the run's identity by collapsing 89 independent observations of it rather than by
-recomputing it from whatever checkout the manifest happened to be built in. Those
-are the same thing only while the run is still warm.
+Each row also carries the posture digest, assurance arm, loop mode, binary
+SHA, source commit and Harbor version **the trial itself recorded**, so the
+manifest states the run's identity by collapsing 89 independent observations
+of it rather than by recomputing it from whatever checkout the manifest
+happened to be built in. Those are the same thing only while the run is still
+warm.
 
 Since #1284 a row also carries what the trial's own verification ladder did:
 which witness state it reached, and whether Stella itself claimed the work

--- a/bench/evidence/score_dev_baseline.py
+++ b/bench/evidence/score_dev_baseline.py
@@ -172,14 +172,13 @@ def extract_trial(result_path: Path) -> dict[str, Any]:
         "binary_sha256": metadata.get("stella_binary_sha256"),
         "source_commit": metadata.get("stella_source_commit"),
         "harbor_version": metadata.get("stella_harbor_version"),
-        # Which loop the binary actually ran. `assurance_arm` above answers
-        # which verification tiers the posture asks for, not which loop ran —
-        # a launcher that drops the plugin selector produces a full,
-        # plausible arm that ran the control path, and only this field can
-        # tell the two apart. Missing lands as `None`, never guessed:
-        # `compare_arms.py --treatment-fired` refuses a run whose evidence
-        # cannot say which path it took, and a defaulted value would silently
-        # forge the answer it refuses on.
+        # Which loop the binary ran. `assurance_arm` above says which
+        # verification tiers the posture wants, not which loop ran. A
+        # launcher that drops the plugin selector can still make a full,
+        # believable arm that ran the wrong path. Only this field can catch
+        # that. A missing value stays `None`. `compare_arms.py
+        # --treatment-fired` refuses a run that cannot say which path it
+        # took, and a guessed default would hide that.
         "loop_mode": metadata.get("stella_loop_mode"),
     }
 

--- a/bench/evidence/score_dev_baseline.py
+++ b/bench/evidence/score_dev_baseline.py
@@ -172,6 +172,15 @@ def extract_trial(result_path: Path) -> dict[str, Any]:
         "binary_sha256": metadata.get("stella_binary_sha256"),
         "source_commit": metadata.get("stella_source_commit"),
         "harbor_version": metadata.get("stella_harbor_version"),
+        # Which loop the binary actually ran. `assurance_arm` above answers
+        # which verification tiers the posture asks for, not which loop ran —
+        # a launcher that drops the plugin selector produces a full,
+        # plausible arm that ran the control path, and only this field can
+        # tell the two apart. Missing lands as `None`, never guessed:
+        # `compare_arms.py --treatment-fired` refuses a run whose evidence
+        # cannot say which path it took, and a defaulted value would silently
+        # forge the answer it refuses on.
+        "loop_mode": metadata.get("stella_loop_mode"),
     }
 
 

--- a/bench/evidence/tests/test_evidence_tooling.py
+++ b/bench/evidence/tests/test_evidence_tooling.py
@@ -343,6 +343,45 @@ def test_the_author_is_read_from_the_key_the_adapter_actually_writes(
     assert row["witness_author_model"] == "openrouter/moonshotai/kimi-k3"
 
 
+def test_extract_carries_which_loop_the_trial_ran(tmp_path: Path) -> None:
+    """`assurance_arm` names the declared verification tiers, not the loop.
+
+    A launcher that drops the plugin selector produces a full, plausible arm
+    that ran the control path — `compare_arms.py --treatment-fired` can only
+    refuse that on a per-trial field naming what actually ran. `extract_trial`
+    has no `loop_mode` key without this field, so this assertion is a
+    `KeyError` by construction rather than a changed value.
+    """
+    path = _result(
+        tmp_path,
+        {
+            "task_name": "task",
+            "verifier_result": {"rewards": {"reward": 1.0}},
+            "agent_result": {
+                "metadata": {"stella_loop_mode": "bare_step_loop"},
+            },
+        },
+    )
+    row = scorer.extract_trial(path)
+
+    assert row["loop_mode"] == "bare_step_loop"
+
+
+def test_a_missing_loop_mode_extracts_null_not_a_guess(tmp_path: Path) -> None:
+    """Absent must never read as a default path the trial may not have taken."""
+    path = _result(
+        tmp_path,
+        {
+            "task_name": "task",
+            "verifier_result": {"rewards": {"reward": 1.0}},
+            "agent_result": {"metadata": {}},
+        },
+    )
+    row = scorer.extract_trial(path)
+
+    assert row["loop_mode"] is None
+
+
 def test_a_trial_that_closed_no_verdict_extracts_null_not_false(tmp_path: Path) -> None:
     """Tri-state, or "not measured" starts reading as "measured and honest"."""
     path = _result(


### PR DESCRIPTION
## What

`bench/evidence/score_dev_baseline.py::extract_trial` carried the run's
identity into every `trials.jsonl` row — `source_commit`, `binary_sha256`,
`engine_posture_sha256`, `assurance_arm` — but dropped `stella_loop_mode`,
which the Harbor adapter already records on the trial manifest
(`bench/harbor_adapter/stella_harbor/__init__.py:1668`).

## Why

`assurance_arm` answers which verification tiers the engine posture asks
for. It says nothing about which loop the binary actually ran. The
retroactive side-by-side benchmark (#6155, under epic #4029) compares two
builds where the treatment arm is a plugin path selected by a CLI flag — a
launcher that drops the flag produces a full, plausible arm that ran the
control path, and `compare_arms.py`'s `check_path_fired` (its
`--treatment-fired FIELD=VALUE` cross-build mode) can only catch that on a
per-trial field naming what actually ran. `bench/evidence/tests/
test_compare_arms_cross_sut.py` already exercises that consumer against a
`loop_mode` row key — this PR is what makes a real extraction populate it.

## The fix

Add `"loop_mode": metadata.get("stella_loop_mode")` to `extract_trial`'s
returned dict, stripping the `stella_` prefix the same way every other
identity field on the row does. A missing value stays `None`, never
defaulted to a path the trial may not have taken — `compare_arms.py
--treatment-fired` refuses a run whose evidence cannot say which path it
took, and a guessed default would silently forge the answer it refuses on.

Only one producer spelling exists today
(`bench/harbor_adapter/stella_harbor/loop_mode.py::loop_mode_name`), so
this reads `stella_loop_mode` directly rather than adding a second-spelling
fallback the way `witness_author_model` needed after a producer rename.

`bench/evidence/README.md`'s row-description sentence now names loop mode
alongside the posture digest, assurance arm, binary SHA, source commit and
Harbor version it already listed.

## Witness

Two new cases in `bench/evidence/tests/test_evidence_tooling.py`:
- `test_extract_carries_which_loop_the_trial_ran` — a manifest carrying
  `stella_loop_mode` produces a row carrying `loop_mode`.
- `test_a_missing_loop_mode_extracts_null_not_a_guess` — a manifest without
  it produces `None`.

Both fail on `main` today with `KeyError: 'loop_mode'` (verified by
stashing the two non-test file changes and re-running with the new test
file in place), because `extract_trial` never returned that key at all.
Confirmed green with the fix applied:

```
uv run --with pytest --no-project pytest -q bench/evidence/tests
35 passed
```

## Exemplar

Follows the existing `witness_author_model` field's shape in the same
function (identity field read from `agent_result.metadata`, `stella_`
prefix stripped on the way into the row).

## Tests deleted

None.

## Residue

None outside this issue's scope. The producer-side gap this issue's
comments distinguish it from — the adapter never emitting `--pipeline
<id>` in the first place — is tracked separately as #6178.

Closes #6179

## Summary by Sourcery

Carry each trial's recorded loop mode into evidence rows so cross-arm validation can verify which execution path actually ran.

Bug Fixes:
- Preserve the loop mode recorded by each trial in extracted evidence rows, while retaining null when the trial does not provide it.

Enhancements:
- Document loop mode as part of the trial identity recorded in evidence manifests.

Documentation:
- Update evidence documentation to include loop mode among the identity fields carried by each trial row.

Tests:
- Add coverage for extracting recorded loop modes and for preserving missing loop modes as null.