### PR TITLE
fix(stella-core): charge the steering allowance one turn at a time

### DIFF
--- a/crates/stella-cli/src/config.rs
+++ b/crates/stella-cli/src/config.rs
@@ -396,9 +396,12 @@ pub struct Config {
     ///
     /// A shared cell, not a resolved value. Its two users meet at different
     /// times. The recall block is written first, and
-    /// `memory::inject_opening_recall` spends here. The tool list is built
-    /// after, and `agent::tool_stack` reads here. One number, so a rule and a
-    /// tool schema can be weighed against each other.
+    /// `memory::inject_opening_recall` opens the turn and spends here. The
+    /// tool list is built after, and `agent::tool_stack` reads here. One
+    /// number, so a rule and a tool schema can be weighed against each other.
+    ///
+    /// The spend is one turn's and the settled array is the session's, which
+    /// is why the cell holds both rather than being rebuilt per turn.
     ///
     /// It rides `Config` for the reason [`Self::output_ceilings`] does: every
     /// driver already hands a `&Config` to both call sites, so no one has to

--- a/crates/stella-cli/src/config/reload/completeness.rs
+++ b/crates/stella-cli/src/config/reload/completeness.rs
@@ -209,11 +209,11 @@ fn ledger(before: &Config, after: &Config) -> Vec<Field> {
         Field {
             name: "steering_ledger",
             posture: Posture::StartupOnly(
-                "a shared cell holding what this session's volatile block already spent and the \
-                 tool array that spend settled; a fresh one would re-rank the advertised tools \
+                "a shared cell holding what the open turn's volatile block spent and the tool \
+                 array that spend settled; a fresh one would re-rank the advertised tools \
                  mid-session, and that array is cache prefix. An operator who edits the \
                  allowance is served by `tool_advertisement` above: the ledger settles again \
-                 whenever the declared allowance changes",
+                 whenever the declared allowance changes, against the open turn's spend alone",
             ),
             // A handle, not a value. `SteeringLedger` has no equality, and
             // what it holds is spend rather than settings.

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -204,7 +204,7 @@ impl OpeningRecall {
 /// shares with the tool array. The cost is measured over the injected bytes,
 /// so what the plane records and what the provider is sent are one number. It
 /// is charged only when the block is really appended. A block the dedup
-/// refuses is one an earlier turn paid for, and spent here.
+/// refuses costs this turn nothing, since the model already carries it.
 ///
 /// **This is the turn boundary the allowance is measured on.** The allowance
 /// is what one turn's volatile block may take. Every driver opens a turn

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -204,12 +204,22 @@ impl OpeningRecall {
 /// shares with the tool array. Measured over the injected bytes, so what the
 /// plane records and what the provider is sent are one number; and charged
 /// only when the block is genuinely appended, since a block the dedup refuses
-/// is one an earlier turn already paid for and already spent here.
+/// is one the model is already carrying in the cached prefix, and this turn
+/// pays nothing to show it again.
+///
+/// **This is the turn boundary the allowance is measured on.** That
+/// allowance is what one turn's volatile block may take, and this is the one
+/// seam every driver reaches a turn through, so
+/// [`stella_core::steering::ledger::SteeringLedger::open_turn`] belongs here
+/// rather than threaded through each of them. A ledger that added every turn
+/// up instead charged an operator who raised the allowance for the whole
+/// session, and far enough in advertised no tools at all.
 pub(crate) fn inject_opening_recall(
     messages: &mut Vec<CompletionMessage>,
     recalled: RecalledBlock,
     ledger: &stella_core::steering::ledger::SteeringLedger,
 ) -> OpeningRecall {
+    ledger.open_turn();
     let events = recalled.telemetry_events();
     let cost = recalled
         .text

--- a/crates/stella-cli/src/memory/tests.rs
+++ b/crates/stella-cli/src/memory/tests.rs
@@ -38,6 +38,9 @@ mod skill_creation;
 // #5031: whether a turn says which skills it injected. `golden_block` pins
 // what the block contains; this asks what the stream reports about it.
 mod skill_event;
+// The injection is where a turn opens on the steering ledger, so the
+// allowance a re-settle reads is one turn's block and not the session's sum.
+mod steering_ledger_turn;
 // #3243 D1/D2: what selection is allowed to call "relevant to this turn" —
 // per-turn domain scope, and a lexical score that can fire on a real prompt.
 mod steering_selection;

--- a/crates/stella-cli/src/memory/tests/steering_ledger_turn.rs
+++ b/crates/stella-cli/src/memory/tests/steering_ledger_turn.rs
@@ -1,0 +1,84 @@
+//! The steering allowance is one turn's, and this is the seam that says
+//! when a turn starts.
+//!
+//! `stella_core::steering::ledger` holds the arithmetic and tests it there.
+//! This asks the other half of the question. Every driver opens a turn
+//! through `inject_opening_recall`, so that is where the ledger is told a new
+//! turn began. Leave the call out and the arithmetic is still right and
+//! nothing ever resets: the spend grows all session, and an operator who
+//! raises the allowance is charged for every turn behind them.
+
+use stella_core::steering::ledger::SteeringLedger;
+use stella_core::steering::tools::ToolBudget;
+
+use crate::memory::recall::RecalledBlock;
+use crate::memory::{RECALL_MARKER, inject_opening_recall};
+
+/// A block shaped the way a rendered one is — marked, so the injection's own
+/// dedup reads it as a recall block rather than as ordinary talk.
+fn rendered(body: &str) -> String {
+    format!("{RECALL_MARKER}\n{body}")
+}
+
+/// The recall a turn hands the injection. Only the text matters here; the
+/// skills and handles beside it are another seam's subject.
+fn block(text: &str) -> RecalledBlock {
+    RecalledBlock {
+        text: Some(text.to_string()),
+        ..RecalledBlock::default()
+    }
+}
+
+/// **The witness.** Two turns, two distinct blocks, one ledger.
+/// The allowance is charged for the turn that is open, not for both.
+///
+/// Before the turn boundary the spend was a running total, so this read the
+/// sum of the two blocks. Twenty turns in, the sum was larger than the
+/// allowance itself and the tool array emptied.
+#[test]
+fn a_turn_charges_the_allowance_for_its_own_block_alone() {
+    let ledger = SteeringLedger::new();
+    let mut messages = Vec::new();
+
+    let first = rendered("turn one recalled the billing migration window");
+    let second = rendered("turn two recalled the streaming dialect notes, at some length");
+
+    inject_opening_recall(&mut messages, block(&first), &ledger);
+    inject_opening_recall(&mut messages, block(&second), &ledger);
+
+    assert_eq!(
+        ledger.spent(),
+        stella_protocol::estimate_tokens(&second),
+        "the open turn is charged for its own block"
+    );
+    assert!(
+        stella_protocol::estimate_tokens(&first) > 0,
+        "and turn one's block was not free, so the two readings differ"
+    );
+}
+
+/// The array a session settles holds still across turns. It sits ahead of
+/// the prompt in every cache, so re-ranking it bills the whole chat again.
+/// A new turn resets the spend and must not touch the answer.
+#[test]
+fn a_later_turn_does_not_move_an_array_the_session_settled() {
+    let ledger = SteeringLedger::new();
+    let mut messages = Vec::new();
+    let declared = ToolBudget {
+        max_tokens: 8_000,
+        mcp_max_tokens: 4_000,
+    };
+
+    inject_opening_recall(&mut messages, block(&rendered("turn one")), &ledger);
+    let settled = ledger.settle(declared);
+
+    inject_opening_recall(
+        &mut messages,
+        block(&rendered(
+            "turn two, a much longer block than the one before it",
+        )),
+        &ledger,
+    );
+
+    assert_eq!(ledger.settle(declared), settled);
+}

--- a/crates/stella-core/src/steering/ledger.rs
+++ b/crates/stella-core/src/steering/ledger.rs
@@ -25,19 +25,32 @@
 //! and keeps that answer. A later spend is noted and changes nothing. A
 //! `/reload` that moves the budget settles a new one. That is a cold write an
 //! operator asked for.
+//!
+//! # The spend is one turn's, the answer is the session's
+//!
+//! The two halves have different clocks, and reading one on the other's is
+//! the bug this ledger shipped with. The allowance is what a single
+//! turn's volatile block may take, so the spend resets every turn
+//! ([`SteeringLedger::open_turn`]). The answer is cache prefix, so it is kept
+//! for as long as the budget it was asked for stands. Add every turn's spend
+//! up instead and the operator who raises the allowance is billed for the
+//! whole session: twenty turns of recall against a raised budget left less
+//! room than the old one, and far enough in, none at all.
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::tools::ToolBudget;
 
-/// What one session's block has spent, and the tool budget it settled.
+/// What the open turn's block has spent, and the tool budget the session
+/// settled.
 ///
 /// Shared by handle (`Arc`). The recall path holds one end. The tool stack
 /// holds the other. Every method is cheap. None holds a lock across an
 /// await.
 #[derive(Debug, Default)]
 pub struct SteeringLedger {
+    /// What the open turn's block has spent. [`Self::open_turn`] clears it.
     spent: AtomicU64,
     /// The budget this session answered for, and the answer. `None` until
     /// the first [`Self::settle`].
@@ -51,7 +64,23 @@ impl SteeringLedger {
         Self::default()
     }
 
-    /// Note `tokens` of volatile context.
+    /// Start a turn: drop what earlier turns spent, keep what the session
+    /// settled.
+    ///
+    /// The allowance is one turn's, so the figure [`Self::settle`] subtracts
+    /// has to be one turn's too. Only the spend is cleared. The settled
+    /// answer is cache prefix and outlives every turn that follows it, which
+    /// is the byte-stable prompt rule and is what a `/reload` still finds
+    /// waiting.
+    ///
+    /// A reset rather than a store, so that two charges inside one turn add
+    /// up. A store would keep the second and lose the first, and the loss
+    /// would be silent.
+    pub fn open_turn(&self) {
+        self.spent.store(0, Ordering::Relaxed);
+    }
+
+    /// Note `tokens` of volatile context for the open turn.
     ///
     /// The sum saturates. A sum that wrapped would hand the tool layer room
     /// the turn had already used. Past the budget the answer is the same
@@ -67,18 +96,21 @@ impl SteeringLedger {
             });
     }
 
-    /// What this session's block has spent so far.
+    /// What the open turn's block has spent so far. [`Self::open_turn`] puts
+    /// it back to zero, so this is never a session total.
     #[must_use]
     pub fn spent(&self) -> u64 {
         self.spent.load(Ordering::Relaxed)
     }
 
-    /// The tool budget under `declared`: what the block left of it.
+    /// The tool budget under `declared`: what the open turn's block left of
+    /// it.
     ///
     /// Answered once, then kept. Ask again with the same `declared` and the
     /// answer is the same, however much was spent since. The list is cache
     /// prefix. Moving it mid-session bills the whole chat again. Ask with a
-    /// different `declared` and it settles anew.
+    /// different `declared` and it settles anew, against the turn that is
+    /// open then — not against every turn the session has run.
     ///
     /// `mcp_max_tokens` shrinks too. It is a share of the budget. Left at its
     /// full size it would let one server take more than the whole
@@ -171,6 +203,59 @@ mod tests {
         ledger.spend(400);
 
         assert_eq!(ledger.settle(declared(2_000)).max_tokens, 1_600);
+    }
+
+    /// A turn starts with nothing spent. What it settled is still there:
+    /// the list is cache prefix and a new turn is not a reason to move it.
+    #[test]
+    fn a_new_turn_clears_the_spend_and_keeps_the_settled_answer() {
+        let ledger = SteeringLedger::new();
+        ledger.spend(400);
+        let settled = ledger.settle(declared(1_000));
+
+        ledger.open_turn();
+
+        assert_eq!(ledger.spent(), 0, "the new turn has spent nothing");
+        assert_eq!(ledger.settle(declared(1_000)), settled);
+    }
+
+    /// Two charges inside one turn add up. This is why a turn opens with a
+    /// reset and not with a store: a store would keep the last charge and
+    /// lose the rest of the block, and say nothing.
+    #[test]
+    fn two_charges_in_one_turn_add_up() {
+        let ledger = SteeringLedger::new();
+        ledger.open_turn();
+        ledger.spend(300);
+        ledger.spend(200);
+
+        assert_eq!(ledger.settle(declared(1_000)).max_tokens, 500);
+    }
+
+    /// **The witness.** An operator raises the allowance twenty
+    /// turns in and gets more room, not less.
+    ///
+    /// Every turn recalls a distinct block of the same size, so a spend that
+    /// carried across turns would read twenty times one block. Against the
+    /// raised 12_000 that reads 2_000 — under the 8_000 they started with,
+    /// and on a longer session zero, which advertises no tools at all. One
+    /// turn's block is 500, so the answer is 11_500.
+    #[test]
+    fn a_raised_allowance_is_charged_one_turn_not_the_session() {
+        const BLOCK: u64 = 500;
+        let ledger = SteeringLedger::new();
+
+        for _ in 0..20 {
+            ledger.open_turn();
+            ledger.spend(BLOCK);
+        }
+        assert_eq!(ledger.settle(declared(8_000)).max_tokens, 8_000 - BLOCK);
+
+        // The operator edits `context.steering.max_tokens` and reloads.
+        ledger.open_turn();
+        ledger.spend(BLOCK);
+
+        assert_eq!(ledger.settle(declared(12_000)).max_tokens, 12_000 - BLOCK);
     }
 
     /// A block bigger than the budget leaves nothing. It must not wrap to a


### PR DESCRIPTION
## What and why

`SteeringLedger::spent` was a running total for the whole session. `settle`
subtracts it, and re-settles whenever the declared allowance changes — which
`/reload` is a live path to, because `tool_advertisement` is `Posture::Reloaded`
while the ledger cell itself is `StartupOnly`.

So an operator who raised `context.steering.max_tokens` after twenty turns of
recall was charged for all twenty turns at once:

- 20 turns of ~500 tokens of distinct recall leaves `spent() == 10_000`
- raise 8_000 to 12_000, `/reload`
- `settle(12_000)` answers `12_000 - 10_000` = **2_000**

They raised the allowance and the tool array shrank. Far enough in,
`saturating_sub` floors at 0, `mcp_max_tokens` follows it down, and the session
advertises no tools until it restarts.

Every doc around this cell already said the allowance was one turn's —
`ToolBudget`'s ("the allowance the whole volatile block shares"),
`ToolAdvertisement::Lean`'s ("what the turn's volatile block left of it"),
`Config::steering_ledger`'s ("what this turn's block spent"), and #6110's own
first DoD box ("one **per-turn** allowance"). The accumulating counter was the
one thing that disagreed.

## The fix

`SteeringLedger::open_turn` stores 0 in `spent` and leaves `settled` untouched.
`memory::inject_opening_recall` calls it before it injects.

Two choices worth naming, both from the issue's own "the decision a fix has to
make":

1. **A reset, not a store.** The issue's smallest shape has `spend` store rather
   than add. That is correct for today's single charger and silently wrong for
   the second one: a store keeps the last charge and drops the rest of the block
   with nothing to notice it. A reset composes — `two_charges_in_one_turn_add_up`
   is the test that pins it.
2. **The seam, not the six drivers.** The issue's fuller shape threads
   `open_turn()` through `agent.rs`, `agent/goal.rs`, `command_deck.rs` and
   `fleet_cmd/steering.rs`. It does not need to: `memory.rs` already states that
   every driver reaches a turn through `inject_opening_recall`, and
   `memory/tests/skill_event.rs` scans those driver sources to enforce it. So
   that function *is* the turn boundary, and a driver cannot route around it
   without failing an existing test. Threading four call sites would add four
   places to forget and hold nothing the seam does not already hold.

`settled` stays session-scoped, so the advertised array is still settled once and
still holds still inside a turn (the byte-stable prompt rule), and the
`StartupOnly` note on `steering_ledger` still holds — a reload finds the settled
array waiting, and only the turn figure is fresh.

## Witness mechanism

`a_raised_allowance_is_charged_one_turn_not_the_session`
(`crates/stella-core/src/steering/ledger.rs`) drives twenty turns of a 500-token
block, then settles at 8_000, opens a twenty-first turn, and re-settles at
12_000. It asserts 11_500.

It fails on the old code by arithmetic, not by accident: with the spend carried
across turns, `spent()` at the first settle is 10_000 (so the answer is 0, not
7_500) and 10_500 at the re-settle (so the answer is 1_500, not 11_500). The
existing `a_changed_allowance_settles_again` could not see this because it spends
exactly once before re-settling — the one shape where a per-turn counter and a
session-cumulative one give the same number.

`crates/stella-cli/src/memory/tests/steering_ledger_turn.rs` is the other half:
it proves the seam actually opens the turn. Two blocks through
`inject_opening_recall` on one ledger, and the spend is the second block's cost
alone. Without the `open_turn()` call the ledger arithmetic is right and nothing
ever resets it, which no `stella-core` test can see.

`a_later_turn_does_not_move_an_array_the_session_settled` and
`a_new_turn_clears_the_spend_and_keeps_the_settled_answer` hold the other
direction: opening a turn must not move the settled array.

## Prose kept in step

Three comments described the old scope and now describe the new one:
`Config::steering_ledger`, the `StartupOnly` note in
`config/reload/completeness.rs`, and `inject_opening_recall`'s paragraph on when
a deduped block is charged. That last one said the block was "one an earlier turn
paid for, and spent here", which the reset makes false — no earlier turn's figure
survives on the ledger. What is true is simpler: the model already carries the
block, so showing it again costs this turn nothing.

Two ratchets were paid rather than baselined. The new test file read at grade
6.48 against the 6.00 a new file is held to, and the header section added to
`ledger.rs` took `stella-core`'s mean header length to 30.02 against 29.97. Both
were fixed by cutting words, not by editing a baseline. `python3
scripts/check-prose.py` exits 0 on this tree; `make guards-fast` is green.

## Files

- `crates/stella-core/src/steering/ledger.rs` — `open_turn`, the doc scope, four tests.
- `crates/stella-cli/src/memory/recall.rs` — the `open_turn()` call at the seam.
- `crates/stella-cli/src/memory/tests/steering_ledger_turn.rs` — new, the seam's witness.
- `crates/stella-cli/src/config.rs`, `crates/stella-cli/src/config/reload/completeness.rs` — the prose.

No new file lands in `scripts/file-size-baseline.txt`; nothing here is a god
file. Pure arithmetic in `stella-core` (invariant 2), the I/O-side call in
`stella-cli`.

## Base

Cut from `9136a2092`, the `main` whose `fleet_cmd.rs` issue-reference count had
`check-prose` red (#6196). That repair landed in #6203, so `main` is merged in
here rather than the fix being repeated. The merge conflicted in
`inject_opening_recall`'s doc block, which both changes rewrote; the resolution
keeps #6203's plain-language sentences and corrects the one that the reset makes
untrue.

Tests deleted: None.

Residue issues filed: none — nothing was noticed and left unfixed.

Closes #6186
