### PR TITLE
feat(stella-protocol,stella-cli): age a digest out when somebody else closes its issue

### DIFF
--- a/crates/stella-cli/src/issue_provider.rs
+++ b/crates/stella-cli/src/issue_provider.rs
@@ -26,7 +26,8 @@ use std::process::Command;
 
 use async_trait::async_trait;
 use stella_protocol::issue::{
-    Issue, IssueClass, IssueDraft, IssueError, IssueKey, IssueLabel, IssueProvider, IssueState,
+    Issue, IssueClass, IssueClosure, IssueDraft, IssueError, IssueKey, IssueLabel, IssueProvider,
+    IssueState, RESOLUTION_COMPLETED, RESOLUTION_DUPLICATE, RESOLUTION_NOT_PLANNED,
 };
 
 /// The provider id this adapter answers to, and the one an error names.
@@ -69,6 +70,49 @@ struct GhIssue {
 #[derive(serde::Deserialize)]
 struct GhLabel {
     name: String,
+}
+
+/// What `gh issue list --state closed --json number,stateReason,closedAt`
+/// writes. Private to this module, like [`GhIssue`] beside it: `stateReason`
+/// is GitHub's word and it stops here.
+#[derive(serde::Deserialize)]
+struct GhClosure {
+    number: u64,
+    #[serde(rename = "stateReason", default)]
+    state_reason: Option<String>,
+    #[serde(rename = "closedAt", default)]
+    closed_at: String,
+}
+
+impl GhClosure {
+    fn into_closure(self) -> IssueClosure {
+        IssueClosure {
+            key: IssueKey(self.number.to_string()),
+            resolution: canonical_resolution(self.state_reason.as_deref()),
+            closed_at: self.closed_at,
+        }
+    }
+}
+
+/// Map GitHub's `stateReason` back onto stella's canonical resolution.
+///
+/// The inverse of [`gh_close_reason`], and it cannot be its exact inverse:
+/// that function maps both `not_planned` and `duplicate` onto GitHub's one
+/// `not planned`, so reading a closure back can only say the work was not
+/// done, never which of the two reasons it was. Both decay nothing, so the
+/// distinction the read cannot recover is one no caller here branches on.
+///
+/// Anything else — an absent reason, a `reopened`, a word this build has not
+/// seen — is `None`, meaning the tracker would not say. Guessing `completed`
+/// here would report declined work as fixed, which is the failure
+/// [`gh_close_reason`]'s own doc comment records happening once already.
+fn canonical_resolution(state_reason: Option<&str>) -> Option<String> {
+    match state_reason?.trim().to_ascii_lowercase().as_str() {
+        "completed" => Some(RESOLUTION_COMPLETED.to_owned()),
+        "not_planned" | "not planned" => Some(RESOLUTION_NOT_PLANNED.to_owned()),
+        "duplicate" => Some(RESOLUTION_DUPLICATE.to_owned()),
+        _ => None,
+    }
 }
 
 impl GhIssue {
@@ -343,6 +387,44 @@ impl IssueProvider for GhIssueProvider {
             .collect())
     }
 
+    /// `gh issue list --state closed --search "closed:>=<date>"` — one call for
+    /// the whole window.
+    ///
+    /// The search qualifier takes a date, so `since` is truncated to its day.
+    /// That re-reads the closures of one day the caller has already seen,
+    /// which costs nothing: the caller folds the answer into a set. A finer
+    /// window would risk the opposite, and a closure missed by a gap is a
+    /// digest that suppresses a real defect for ever.
+    async fn closed_since(
+        &self,
+        since: &str,
+        limit: usize,
+    ) -> Result<Vec<IssueClosure>, IssueError> {
+        let mut args: Vec<String> = vec![
+            "issue".into(),
+            "list".into(),
+            "--state".into(),
+            "closed".into(),
+            "--limit".into(),
+            limit.max(1).to_string(),
+            "--json".into(),
+            "number,stateReason,closedAt".into(),
+        ];
+        let day: String = since.trim().chars().take(10).collect();
+        if !day.is_empty() {
+            args.push("--search".into());
+            args.push(format!("closed:>={day}"));
+        }
+        let borrowed: Vec<&str> = args.iter().map(String::as_str).collect();
+        let raw = gh_json(&borrowed)?;
+        let rows: Vec<GhClosure> =
+            serde_json::from_str(&raw).map_err(|error| IssueError::Malformed {
+                provider: GITHUB.into(),
+                reason: error.to_string(),
+            })?;
+        Ok(rows.into_iter().map(GhClosure::into_closure).collect())
+    }
+
     async fn labels(&self, query: &str, limit: usize) -> Result<Vec<IssueLabel>, IssueError> {
         // `gh label list -S` searches names *and* descriptions and sorts by
         // best match, which is what a picker wants; an empty query lists the
@@ -563,6 +645,40 @@ mod tests {
     #[test]
     fn an_unrecognised_resolution_still_closes() {
         assert_eq!(gh_close_reason("cannot_reproduce"), "completed");
+    }
+
+    /// GitHub's own words for a closure decode, and the two the loop must
+    /// tell apart land on different sides.
+    #[test]
+    fn the_closed_payload_maps_onto_the_canonical_resolutions() {
+        let payload = r#"[
+          {"number":4100,"stateReason":"COMPLETED","closedAt":"2026-09-01T10:00:00Z"},
+          {"number":4200,"stateReason":"NOT_PLANNED","closedAt":"2026-09-02T10:00:00Z"},
+          {"number":4300,"stateReason":null,"closedAt":"2026-09-03T10:00:00Z"}
+        ]"#;
+
+        let rows: Vec<GhClosure> = serde_json::from_str(payload).expect("decode");
+        let closures: Vec<IssueClosure> = rows.into_iter().map(GhClosure::into_closure).collect();
+
+        assert_eq!(closures[0].key, IssueKey::from("4100"));
+        assert_eq!(closures[0].resolution.as_deref(), Some("completed"));
+        assert_eq!(closures[0].closed_at, "2026-09-01T10:00:00Z");
+        assert_eq!(closures[1].resolution.as_deref(), Some("not_planned"));
+        assert_eq!(
+            closures[2].resolution, None,
+            "a tracker that would not say must not read as fixed"
+        );
+    }
+
+    /// A reason this build has never seen reads as unknown, never as done.
+    #[test]
+    fn an_unknown_state_reason_is_not_a_fix() {
+        assert_eq!(canonical_resolution(Some("reopened")), None);
+        assert_eq!(canonical_resolution(None), None);
+        assert_eq!(
+            canonical_resolution(Some("Duplicate")).as_deref(),
+            Some("duplicate")
+        );
     }
 
     #[test]

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -19,6 +19,7 @@ mod budget;
 pub(crate) mod claim;
 mod claim_mirror;
 mod claude_worker;
+mod closures;
 // `pub(crate)` rather than private: `plugin_cmd::configure` asserts against
 // this reader directly (#3999). A package that configures attribution has to
 // be shown changing what the loop *reads*, not merely what a file *holds* —
@@ -933,6 +934,11 @@ fn cycle_begin(st: &LoopState) -> Result<(), String> {
         run_info(st).in_cycle(n),
         None,
     );
+
+    // One tracker read a cycle: which issues this loop filed have closed since
+    // it last looked. A closure somebody else made writes no receipt, so
+    // without this the digest it was filed under would suppress for ever.
+    closures::reconcile(st, &crate::issue_provider::GhIssueProvider);
 
     let aperture = st.aperture();
     let streak = stella_autonomy::dry_streak(&st.cycles().rows, &aperture);

--- a/crates/stella-cli/src/self_driving_cmd/closures.rs
+++ b/crates/stella-cli/src/self_driving_cmd/closures.rs
@@ -1,0 +1,466 @@
+//! The closures the loop did not make, and how they reach the dedup set.
+//!
+//! A digest drops a repeat. It stops once the issue it was filed as closes on
+//! a fix (`stella_autonomy::seen`). One signal for that is the loop's own
+//! receipt. It is written as `stella self-driving close` runs, and nothing
+//! else writes one.
+//!
+//! Most of this loop's issues close some other way. A person closes them, or
+//! a merge that says `Closes #N` does. That leaves no receipt. So the digest
+//! keeps dropping repeats for ever, and ending that is what the decay rule is
+//! for.
+//!
+//! The tracker knows. [`reconcile`] asks it once a cycle. Which issues have
+//! closed since the last look, and how did each one close? Only `completed`
+//! ages a digest out. A declined issue is not a fix. Nor is a copy of another
+//! issue.
+//!
+//! # What it costs
+//!
+//! One tracker read a cycle. The list of filings grows for the life of a
+//! loop. Asking about each key would cost a call per filing per pass. One
+//! read over a window answers for all of them. It asks for every issue closed
+//! since the last read. Rows for keys this loop did not file are dropped.
+//!
+//! The answer is kept in `closures.json`, beside the loop's other state. The
+//! cycle it was taken on is kept with it. A second call in that cycle reads
+//! the file and asks nothing.
+//!
+//! # What it does when it cannot ask
+//!
+//! Nothing. A tracker that refuses is an unknown. So is a read this provider
+//! cannot answer, and so is a payload that will not parse. An unknown age
+//! reads as live. The mark of how far it has read stays where it was, so the
+//! next good read covers this window too. Offline ages nothing out.
+//!
+//! The window is one page. More than [`WINDOW`] issues can close inside it.
+//! Then the read covers part of the window, and says so in the audit trail. A
+//! row missed that way costs one digest that keeps dropping repeats, which is
+//! what this module found. A read that keeps up on a busy day is its own work.
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use stella_autonomy::seen::Filing;
+use stella_protocol::issue::{IssueClosure, IssueProvider, RESOLUTION_COMPLETED};
+
+use super::audit::{self, Action as Audit};
+use super::state::LoopState as Durable;
+
+/// How many closed issues one pass reads.
+///
+/// A page over the newest closures. It is not a promise to see them all. Wide
+/// enough for a repository that closes a few dozen issues a day. Small enough
+/// that the read stays one cheap call.
+pub(super) const WINDOW: usize = 200;
+
+/// What the tracker has said about the issues this loop filed.
+///
+/// One `closures.json` in the loop's state directory. Every field has a
+/// default. So a file an older build wrote is read here, not refused.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct Ledger {
+    /// The cycle this was last asked on. `None` on a loop that has never
+    /// asked. That is what lets the first call happen at cycle zero.
+    #[serde(default)]
+    pub asked_on_cycle: Option<u64>,
+    /// The window already read, RFC3339. Empty until a read works. Only a
+    /// read that works moves it.
+    #[serde(default)]
+    pub through: String,
+    /// The keys the tracker says closed on a fix. Only keys this loop filed
+    /// are kept. Somebody else's issue ages nothing out here.
+    #[serde(default)]
+    pub completed: Vec<String>,
+}
+
+/// Ask which of this loop's filings have closed. Once a cycle, at most.
+///
+/// A cycle begins in one place and a sweep draws in another. Both call this.
+/// The second call in one cycle costs a file read.
+pub(super) fn reconcile(durable: &Durable, provider: &dyn IssueProvider) {
+    let cycle = durable.cycle_counter();
+    let mut ledger = durable.tracker_closures();
+    if ledger.asked_on_cycle == Some(cycle) {
+        return;
+    }
+
+    let filings = durable.filings();
+    if filings.is_empty() {
+        // Nothing filed, so no closure could age anything out. This is not
+        // recorded as asked. The first filing is then read in the cycle after
+        // it, rather than the one after that.
+        return;
+    }
+    let filed: BTreeSet<String> = filings.iter().map(|filing| key(&filing.key)).collect();
+    let since = window_start(&ledger, &filings);
+
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            audit::record(
+                durable,
+                Audit::Transient,
+                None,
+                &format!("could not start a runtime to read closed issues: {error}"),
+            );
+            return;
+        }
+    };
+
+    // Asked, whatever the answer. A tracker that is down costs one read a
+    // cycle, not one per pass.
+    ledger.asked_on_cycle = Some(cycle);
+    match runtime.block_on(provider.closed_since(&since, WINDOW)) {
+        Ok(rows) => {
+            let learned = absorb(&mut ledger, &rows, &filed);
+            ledger.through = crate::timefmt::rfc3339_utc_now();
+            let saturated = if rows.len() >= WINDOW {
+                format!(" — the window was full at {WINDOW}, so older closures in it were not read")
+            } else {
+                String::new()
+            };
+            audit::record(
+                durable,
+                Audit::Swept,
+                None,
+                &format!(
+                    "closures: {} closed issue(s) read since `{}`, {learned} of them this loop's \
+                     own fix(es){saturated}",
+                    rows.len(),
+                    if since.is_empty() {
+                        "the start"
+                    } else {
+                        since.as_str()
+                    },
+                ),
+            );
+        }
+        Err(error) => audit::record(
+            durable,
+            Audit::Transient,
+            None,
+            &format!("could not ask the tracker which issues closed: {error}; nothing decays"),
+        ),
+    }
+
+    if let Err(error) = durable.write_tracker_closures(&ledger) {
+        audit::record(
+            durable,
+            Audit::Transient,
+            None,
+            &format!("could not write down what the tracker said about closures: {error}"),
+        );
+    }
+}
+
+/// Fold one page of answers into the ledger. Says how many keys it learned.
+///
+/// A row is kept when this loop filed that key and the tracker calls it a
+/// fix. A row the provider could not place is an unknown, and is skipped. So
+/// an issue closed with no word on why ages nothing out.
+fn absorb(ledger: &mut Ledger, rows: &[IssueClosure], filed: &BTreeSet<String>) -> usize {
+    let mut learned = 0;
+    for row in rows {
+        if row.resolution.as_deref() != Some(RESOLUTION_COMPLETED) {
+            continue;
+        }
+        let key = key(row.key.as_str());
+        if !filed.contains(&key) || ledger.completed.contains(&key) {
+            continue;
+        }
+        ledger.completed.push(key);
+        learned += 1;
+    }
+    learned
+}
+
+/// Where the next window starts.
+///
+/// The last read that worked, else the oldest filing this loop can date. A
+/// filing written before `Filing::at` has no stamp. Its issue could have
+/// closed at any time. One of those opens the first window to the whole
+/// range, which is read once.
+fn window_start(ledger: &Ledger, filings: &[Filing]) -> String {
+    let through = ledger.through.trim();
+    if !through.is_empty() {
+        return through.to_owned();
+    }
+    if filings.iter().any(|filing| filing.at.trim().is_empty()) {
+        return String::new();
+    }
+    // A UTC RFC3339 stamp sorts right as text. That is the rule
+    // `stella_protocol::issue::Issue` reads its own stamps under.
+    filings
+        .iter()
+        .map(|filing| filing.at.trim())
+        .min()
+        .unwrap_or_default()
+        .to_owned()
+}
+
+/// An issue key with its decoration removed, so `#412` and ` 412 ` match.
+fn key(raw: &str) -> String {
+    raw.trim().trim_start_matches('#').trim().to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use stella_protocol::issue::{Issue, IssueDraft, IssueError, IssueKey, RESOLUTION_NOT_PLANNED};
+
+    use super::*;
+
+    /// A tracker somebody else closes issues on.
+    ///
+    /// It counts the reads. This module claims one per cycle, and that claim
+    /// is about this number.
+    #[derive(Default)]
+    struct Tracker {
+        closed: Vec<IssueClosure>,
+        reads: Mutex<usize>,
+        dead: bool,
+    }
+
+    impl Tracker {
+        fn closing(key: &str, resolution: Option<&str>) -> Self {
+            Self {
+                closed: vec![IssueClosure {
+                    key: IssueKey::from(key),
+                    resolution: resolution.map(str::to_owned),
+                    closed_at: "2026-09-05T10:00:00Z".to_owned(),
+                }],
+                ..Self::default()
+            }
+        }
+
+        fn unreachable() -> Self {
+            Self {
+                dead: true,
+                ..Self::default()
+            }
+        }
+
+        fn reads(&self) -> usize {
+            *self.reads.lock().expect("fixture lock")
+        }
+    }
+
+    #[async_trait]
+    impl IssueProvider for Tracker {
+        fn id(&self) -> &str {
+            "fixture"
+        }
+
+        async fn list_open(&self, _limit: usize) -> Result<Vec<Issue>, IssueError> {
+            Ok(Vec::new())
+        }
+
+        async fn file(&self, _draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+            Ok(IssueKey::from("1"))
+        }
+
+        async fn close(
+            &self,
+            _key: &IssueKey,
+            _receipt: &str,
+            _state: &str,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn comment(&self, _key: &IssueKey, _body: &str) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn relabel(
+            &self,
+            _key: &IssueKey,
+            _add: &[String],
+            _remove: &[String],
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn edit(
+            &self,
+            _key: &IssueKey,
+            _title: Option<&str>,
+            _body: Option<&str>,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn closed_since(
+            &self,
+            _since: &str,
+            _limit: usize,
+        ) -> Result<Vec<IssueClosure>, IssueError> {
+            *self.reads.lock().expect("fixture lock") += 1;
+            if self.dead {
+                return Err(IssueError::Unavailable {
+                    provider: "fixture".into(),
+                    reason: "no tracker here".into(),
+                });
+            }
+            Ok(self.closed.clone())
+        }
+    }
+
+    const DIGEST: &str = "d0d0d0d0d0d0d0d0";
+    const KEY: &str = "4100";
+
+    /// A loop that filed one finding as one issue, and closed nothing itself.
+    fn one_filing(dir: &Path) {
+        std::fs::create_dir_all(dir).expect("state dir");
+        std::fs::write(dir.join("seen.txt"), format!("{DIGEST}\n")).expect("seen");
+        std::fs::write(dir.join("cycle"), "7\n").expect("cycle");
+        std::fs::write(
+            dir.join("filings.jsonl"),
+            format!(
+                "{{\"digest\":\"{DIGEST}\",\"key\":\"{KEY}\",\"at\":\"2026-09-01T00:00:00Z\"}}\n"
+            ),
+        )
+        .expect("filings");
+    }
+
+    fn state(tmp: &tempfile::TempDir) -> Durable {
+        let dir = tmp.path().join("state");
+        one_filing(&dir);
+        Durable {
+            dir,
+            repo_root: tmp.path().to_path_buf(),
+        }
+    }
+
+    /// **The witness.** A person closed the issue the loop filed. The digest
+    /// stops dropping repeats, so the defect can be filed again.
+    ///
+    /// The one signal before this module was `receipts.jsonl`, and only
+    /// `stella self-driving close` writes that. A filing with no receipt and
+    /// a closed issue left the digest in force for ever. The first assert
+    /// below pins that.
+    #[test]
+    fn an_issue_a_person_closed_ages_its_digest_out() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let st = state(&tmp);
+        let tracker = Tracker::closing(KEY, Some(RESOLUTION_COMPLETED));
+
+        assert_eq!(
+            st.live_seen(),
+            st.seen(),
+            "with no receipt the digest still suppresses"
+        );
+
+        reconcile(&st, &tracker);
+
+        assert_eq!(st.seen(), vec![DIGEST.to_owned()], "the file is unchanged");
+        assert!(
+            st.live_seen().is_empty(),
+            "a closure the loop did not make must still decay, got {:?}",
+            st.live_seen()
+        );
+    }
+
+    /// A tracker nobody can reach ages nothing out. It leaves the window
+    /// where it was, so the next read that works still covers it.
+    #[test]
+    fn an_unreachable_tracker_decays_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let st = state(&tmp);
+
+        reconcile(&st, &Tracker::unreachable());
+
+        assert_eq!(st.live_seen(), st.seen(), "an unknown closure is not one");
+        assert_eq!(
+            st.tracker_closures().through,
+            "",
+            "a failed read must not advance the window"
+        );
+    }
+
+    /// Declined work is not a fix, so its digest keeps dropping repeats.
+    #[test]
+    fn a_closure_that_is_not_a_fix_decays_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let st = state(&tmp);
+
+        reconcile(&st, &Tracker::closing(KEY, Some(RESOLUTION_NOT_PLANNED)));
+
+        assert_eq!(st.live_seen(), st.seen());
+        assert!(st.tracker_closures().completed.is_empty());
+    }
+
+    /// An issue closed with no word on why is an unknown. An unknown is not
+    /// a fix.
+    #[test]
+    fn a_closure_with_no_resolution_decays_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let st = state(&tmp);
+
+        reconcile(&st, &Tracker::closing(KEY, None));
+
+        assert_eq!(st.live_seen(), st.seen());
+    }
+
+    /// The tracker is asked once a cycle, not once a pass. Both doors call
+    /// this, and the second one must cost a file read.
+    #[test]
+    fn the_tracker_is_asked_once_a_cycle() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let st = state(&tmp);
+        let tracker = Tracker::closing(KEY, Some(RESOLUTION_COMPLETED));
+
+        reconcile(&st, &tracker);
+        reconcile(&st, &tracker);
+        assert_eq!(tracker.reads(), 1, "the cached answer must be reused");
+
+        st.set_cycle_counter(8).expect("counter");
+        reconcile(&st, &tracker);
+        assert_eq!(tracker.reads(), 2, "a new cycle asks again");
+    }
+
+    /// Somebody else's closed issue is not this loop's business. It is not
+    /// kept, so the file stays as small as the list of filings.
+    #[test]
+    fn a_closure_of_an_unfiled_issue_is_not_kept() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let st = state(&tmp);
+
+        reconcile(&st, &Tracker::closing("9999", Some(RESOLUTION_COMPLETED)));
+
+        assert!(st.tracker_closures().completed.is_empty());
+        assert_eq!(st.live_seen(), st.seen());
+    }
+
+    /// The window starts where the last read stopped. With no such mark, it
+    /// starts at the oldest filing the loop can date.
+    #[test]
+    fn the_window_starts_at_the_watermark_then_at_the_oldest_filing() {
+        let dated = Filing::new(DIGEST, KEY, "2026-09-01T00:00:00Z");
+        let older = Filing::new("aaaa", "4000", "2026-08-01T00:00:00Z");
+        let undated = Filing::new("bbbb", "3900", "");
+
+        let fresh = Ledger::default();
+        assert_eq!(
+            window_start(&fresh, &[dated.clone(), older]),
+            "2026-08-01T00:00:00Z"
+        );
+        assert_eq!(
+            window_start(&fresh, &[dated.clone(), undated]),
+            "",
+            "a filing with no stamp makes the first window unbounded"
+        );
+
+        let read = Ledger {
+            through: "2026-09-04T12:00:00Z".to_owned(),
+            ..Ledger::default()
+        };
+        assert_eq!(window_start(&read, &[dated]), "2026-09-04T12:00:00Z");
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/state.rs
+++ b/crates/stella-cli/src/self_driving_cmd/state.rs
@@ -285,6 +285,9 @@ impl LoopState {
     fn filings_path(&self) -> PathBuf {
         self.dir.join("filings.jsonl")
     }
+    fn closures_path(&self) -> PathBuf {
+        self.dir.join("closures.json")
+    }
 
     /// Snapshot the ranked queue as the loop last saw it.
     ///
@@ -464,12 +467,17 @@ impl LoopState {
     /// [`Self::seen`] stays the durable set, and `seen_count` still reports
     /// it: the file is what a move carries and what an operator counts.
     pub fn live_seen(&self) -> Vec<String> {
-        let fixed: Vec<String> = self
+        let mut fixed: Vec<String> = self
             .receipts()
             .into_iter()
             .filter(|receipt| receipt.by.is_some())
             .map(|receipt| receipt.key)
             .collect();
+        // The loop writes a receipt only for a closure it made itself, and
+        // most of its issues are closed by a person or by a merge. Those
+        // leave no receipt, so the tracker's own answer is the second source
+        // of a fix — [`super::closures`] is what fills it.
+        fixed.extend(self.tracker_closures().completed);
         stella_autonomy::seen::live(&self.seen(), &self.filings(), &fixed)
     }
 
@@ -528,6 +536,33 @@ impl LoopState {
     ) -> Result<(), String> {
         let line = serde_json::to_string(receipt).map_err(|e| e.to_string())?;
         append_line(&self.receipts_path(), &line)
+    }
+
+    // -- closures the loop did not make -------------------------------------
+
+    /// What the tracker has said about the issues this loop filed.
+    ///
+    /// A document rather than a synthesized receipt, because the two answer
+    /// different questions. A receipt names the change a closure cited and is
+    /// what `regress::sweep` re-checks; the tracker's answer names no change,
+    /// and inventing one to fit the receipt shape would hand the sweep a
+    /// phantom to re-check for ever.
+    ///
+    /// Absent or unreadable yields the empty document, which decays nothing.
+    pub fn tracker_closures(&self) -> super::closures::Ledger {
+        read_json(&self.closures_path())
+            .and_then(|value| serde_json::from_value(value).ok())
+            .unwrap_or_default()
+    }
+
+    /// Write that document back, atomically.
+    ///
+    /// Rewritten rather than appended: it is a fold of one window of tracker
+    /// answers into a set, and a half-written line in an append-only file
+    /// would cost the watermark that bounds the next read.
+    pub fn write_tracker_closures(&self, ledger: &super::closures::Ledger) -> Result<(), String> {
+        let value = serde_json::to_value(ledger).map_err(|e| e.to_string())?;
+        write_json_atomic(&self.closures_path(), &value)
     }
 
     // -- the run lifecycle ---------------------------------------------------

--- a/crates/stella-cli/src/self_driving_cmd/supply.rs
+++ b/crates/stella-cli/src/self_driving_cmd/supply.rs
@@ -95,6 +95,11 @@ pub(super) fn pass(
     root: &Path,
     lens: &str,
 ) -> bool {
+    // What the seen set drops depends on which of this loop's issues have
+    // closed, and most of them close with no receipt. Cached on the cycle
+    // counter, so a second pass in one cycle asks the tracker nothing.
+    super::closures::reconcile(durable, provider);
+
     let mut findings: Vec<Finding> = Vec::new();
 
     if cfg.supply.regress {

--- a/crates/stella-protocol/src/issue.rs
+++ b/crates/stella-protocol/src/issue.rs
@@ -294,6 +294,33 @@ pub struct IssueDraft {
     pub assignee: Option<String>,
 }
 
+/// One issue the tracker has closed, and what the closure resolved to.
+///
+/// [`IssueState::Closed`] is one bucket and cannot answer the question that
+/// matters to a caller re-checking its own filings: *was this fixed, or did
+/// somebody decline it?* Declining work is not a fix, so the two must be told
+/// apart, and a third state on [`IssueState`] would be modelling a workflow —
+/// the stated non-goal. The answer rides here instead, on the read that asks
+/// for it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueClosure {
+    /// The issue the tracker closed.
+    pub key: IssueKey,
+    /// Stella's **canonical** resolution — [`RESOLUTION_COMPLETED`],
+    /// [`RESOLUTION_NOT_PLANNED`] or [`RESOLUTION_DUPLICATE`], the same
+    /// vocabulary [`IssueProvider::close`] takes, read back.
+    ///
+    /// `None` when the tracker closed the issue and would not say why. That
+    /// is an unknown, and a caller reads an unknown as "not a fix": a closure
+    /// nobody can classify must never be counted as one that was.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<String>,
+    /// When it closed, RFC3339. Empty when the provider cannot say, on the
+    /// same contract as [`Issue::created_at`].
+    #[serde(default)]
+    pub closed_at: String,
+}
+
 /// How many rows [`IssueProvider::get`]'s default search asks for before it
 /// gives up on finding an exact key.
 ///
@@ -484,6 +511,36 @@ pub trait IssueProvider: Send + Sync {
             .ok_or_else(|| IssueError::NotFound { key: key.clone() })
     }
 
+    /// Every issue this tracker closed at or after `since`, newest first, with
+    /// what each closure resolved to.
+    ///
+    /// A window rather than a per-key read, and that is the whole point: the
+    /// caller holds a ledger of its own filings that grows for the life of a
+    /// loop, and asking about each one would cost a round trip per filing per
+    /// pass. One windowed read answers for all of them at once. `since` is
+    /// RFC3339; empty asks for the newest closures with no lower bound, which
+    /// is what a caller that has never asked before has to send.
+    ///
+    /// `limit` bounds the page exactly as [`IssueProvider::list_open`]'s does,
+    /// and the same warning applies: a caller that fills it has read part of
+    /// the window, not the whole of it.
+    ///
+    /// Default is a typed refusal rather than an empty list, following
+    /// [`IssueProvider::reopen`]. An empty list is a real answer — "nothing
+    /// closed in that window" — so a provider that cannot look must not
+    /// return one. A caller reads the refusal as "unknown", and an unknown
+    /// closure is not a closure.
+    async fn closed_since(
+        &self,
+        _since: &str,
+        _limit: usize,
+    ) -> Result<Vec<IssueClosure>, IssueError> {
+        Err(IssueError::Failed {
+            provider: self.id().to_owned(),
+            reason: "reading closed issues by window is not supported".to_owned(),
+        })
+    }
+
     /// The labels this tracker already knows, for a picker.
     ///
     /// `query` is passed through to the tracker's own label search rather than
@@ -604,6 +661,33 @@ mod tests {
         for (class, wire) in classes {
             assert_eq!(serde_json::to_string(&class).expect("serialize"), wire);
         }
+    }
+
+    /// AGENTS.md #4 for the closure read. An unclassified closure must not
+    /// serialize a null resolution: absent is the shape a provider that
+    /// cannot say writes, and it has to survive a round trip as absent.
+    #[test]
+    fn a_closure_round_trips_and_omits_an_unknown_resolution() {
+        let unknown = IssueClosure {
+            key: IssueKey::from("6188"),
+            resolution: None,
+            closed_at: "2026-09-05T09:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&unknown).expect("serialize");
+        assert!(!json.contains("resolution"), "{json}");
+        assert_eq!(
+            serde_json::from_str::<IssueClosure>(&json).expect("deserialize"),
+            unknown
+        );
+
+        let completed = IssueClosure {
+            resolution: Some(RESOLUTION_COMPLETED.to_owned()),
+            ..unknown
+        };
+        let json = serde_json::to_string(&completed).expect("serialize");
+        let back: IssueClosure = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, completed);
+        assert_eq!(serde_json::to_string(&back).expect("re-serialize"), json);
     }
 
     /// A key is transparent on the wire — a bare string, not `{"0": "..."}`.

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -628,6 +628,14 @@ residue_gate = "on"
 # `filings.jsonl` beside `seen.txt` is what pairs a digest with the issue it
 # became. A line with no such record never decays, which is every `seen.txt`
 # written before this pairing existed, so an upgrade re-files nothing.
+#
+# Most of those issues are closed by a person, or by a merge that says
+# `Closes #N`, and the loop writes no receipt for a closure it did not make.
+# So it asks the tracker instead: once a cycle, one call for every issue
+# closed since it last asked, kept in `closures.json` beside `seen.txt`. Only
+# a closure the tracker calls completed decays a digest. A tracker that
+# cannot be reached decays nothing, and a cycle in which more issues close
+# than that one call returns leaves the rest for a later cycle to notice.
 
 # Labels marking a tracking issue — a checklist of other issues, kept open as
 # bookkeeping rather than as work. `drive --backlog` never claims one of


### PR DESCRIPTION
## What and why

The self-driving loop's dedup set ages a digest out once the issue it was filed
as closes on a fix. The only signal for that was the loop's **own** closure
receipt, written by `supply::record_receipt` as `stella self-driving close`
runs. Nothing else writes one.

In this repository most issues the loop files are closed by a person, or by a
merge that says `Closes #N`. Those closures leave no receipt, so the digest
kept dropping repeats for ever — the behaviour #6149/#6187 set out to end,
still in force for the common case.

Two halves:

- **The port.** `IssueProvider::closed_since(since, limit)` returns
  `Vec<IssueClosure>` — one windowed read of what a tracker has closed, each
  row carrying stella's **canonical** resolution (`completed` / `not_planned` /
  `duplicate`), the same vocabulary `IssueProvider::close` takes. The default
  is a typed refusal, following `IssueProvider::reopen`: an empty list is a
  real answer ("nothing closed in that window"), so a provider that cannot look
  must not return one. `GhIssueProvider` reads `number,stateReason,closedAt`
  and maps it back through `canonical_resolution`, the inverse of the existing
  `gh_close_reason`. An unrecognised or absent `stateReason` is `None`, never
  `completed`.
- **The loop.** `self_driving_cmd::closures::reconcile` asks once per cycle,
  keyed on the cycle counter stored in `closures.json`, and keeps only the keys
  this loop filed that the tracker calls completed. `LoopState::live_seen`
  unions those with the receipts it already read.

## Two departures from the design pointer, and why

The pointer said `live_seen` should reconcile against the tracker, caching per
cycle, failing open.

1. **The tracker read is not inside `live_seen`.** That getter is called from
   four filing paths (`supply::pass`, `supply::file`, `residue`,
   `self_driving_cmd::file_finding`) and is synchronous; a network call there
   would spend a tracker read per filing and put I/O in a getter. The read runs
   in `closures::reconcile`, called from `cycle_begin` and from `supply::pass`,
   guarded by the cached cycle counter — the second call in a cycle asks
   nothing. `live_seen` still reads files only.
2. **The answer is its own document, not a synthesized receipt.** A receipt
   with `by: None` ages nothing out, and inventing a citation to make one age
   out would hand `regress::sweep` a change to re-check that nobody named — a
   phantom regression, reported as a defect. The issue body offers both shapes;
   this is the "`closed` flag written back beside the filing record" one.

Everything else follows the pointer: closed-state reconciliation against the
tracker, one windowed call per cycle, and unknown = keep.

`IssueState` alone cannot tell a fix from a declined issue, which is why the
resolution rides on `IssueClosure` rather than becoming a fourth `IssueState`
— modelling the workflow is `doc:agent-native-delivery` §4.1's stated non-goal.

## Witness

`closures.rs`'s `an_issue_a_person_closed_ages_its_digest_out`. It seeds a
state directory with `seen.txt` and `filings.jsonl` and **no**
`receipts.jsonl`, asserts the digest still suppresses, runs `reconcile` against
a fixture tracker reporting that issue closed as `completed`, and asserts
`live_seen()` is then empty.

It fails on the old code by construction: `closures::reconcile` and
`IssueProvider::closed_since` do not exist there, and `live_seen`'s only source
of "fixed" is `receipts.jsonl`, which this fixture never writes. Every existing
test seeds receipts by hand, because that was the only writer.

Beside it: an unreachable tracker ages nothing out and leaves the watermark
where it was; a `not_planned` closure ages nothing out; a closure with no
resolution ages nothing out; the tracker is asked once per cycle and again on
the next; somebody else's closed issue is not kept.
`the_seen_set_survives_the_move_byte_for_byte` and `finding_digest` are
untouched — no line of `seen.txt` changes shape.

## Exemplar

`stella-protocol`'s own `IssueProvider::reopen` — a read/write the trait
refuses loudly by default rather than no-opping — is the shape `closed_since`
copies, and `GhIssueProvider::search`'s `--search` handling is the shape its
adapter copies.

## Cost bound

One tracker call per cycle, whatever the loop filed. The bound is written where
an operator reads it, next to the decay rule in `stella.example.toml`.

## Files

- `crates/stella-protocol/src/issue.rs` — `IssueClosure`, `closed_since`,
  round-trip test.
- `crates/stella-cli/src/issue_provider.rs` — `GhClosure`,
  `canonical_resolution`, the `gh issue list --state closed` read.
- `crates/stella-cli/src/self_driving_cmd/closures.rs` — new; the reconcile
  and its ledger.
- `crates/stella-cli/src/self_driving_cmd/state.rs` — `tracker_closures`,
  `write_tracker_closures`, and the union in `live_seen`.
- `crates/stella-cli/src/self_driving_cmd.rs`, `.../supply.rs` — the two call
  sites.
- `stella.example.toml` — the decay note.

No new crate, no new dependency. No file crosses the 1500-line ceiling
(`self_driving_cmd.rs` 1483, `state.rs` 1287); `drive.rs` was left alone
because it sits at 1498.

## Inherited red

`main` is known broken on `prose` — `crates/stella-cli/src/fleet_cmd.rs`
`issue-reference` is 54 against a baseline of 53, tracked as #6196 and repaired
by #6203, which was still open when this branch was cut. That file is not in
this diff. Everything else in `make guards-fast` is green here, and this
branch's own new prose measures reading grade 3.50 against the 6.00 ceiling a
file with no baseline entry is held to.

Tests deleted: None

Residue filed: #6219 — a cycle in which more issues close than one window
returns leaves the older rows unread, which costs one digest that keeps
suppressing.

Closes #6188

## Summary by Sourcery

Reconcile externally closed issues with self-driving state so completed fixes age their filing digests out safely.

New Features:
- Add windowed issue-closure querying to the issue-provider protocol and GitHub adapter, including canonical resolution mapping.
- Reconcile tracker-reported completed closures with self-driving filings so digests can age out when issues are closed externally.

Bug Fixes:
- Allow externally closed, fixed issues to stop suppressing future findings without requiring a self-driving closure receipt.
- Ensure unknown, declined, duplicate, or unreachable closure results do not incorrectly age digests out.

Enhancements:
- Persist tracker closure state and watermarks, cache reconciliation per cycle, and retain a bounded one-call-per-cycle tracker read.
- Document the closure reconciliation behavior and its cost in the example configuration.

Tests:
- Add coverage for external completed closures, unknown and non-fix resolutions, unreachable trackers, unfiled issues, cycle-level caching, and closure-window behavior.