### PR TITLE
feat(stella-autonomy,stella-cli): run the lens the driver re-armed

### DIFF
--- a/crates/stella-autonomy/README.md
+++ b/crates/stella-autonomy/README.md
@@ -86,7 +86,7 @@ the CLI does — so the dashboard and the terminal cannot disagree.
 | [`src/ready.rs`](src/ready.rs) | `ready_queue`: which backlog issues may be taken next, and in what order. `Blocked by: #N` lines, the `status:ready` override, and the escalation cooldown. |
 | [`src/escalation.rs`](src/escalation.rs) | Escalation as a cooldown: `classify` reads an abort message, `retry_after` says how long to wait, `park_after` says when waiting ends. The record is written into the issue body and read back from it. |
 | [`src/gate.rs`](src/gate.rs) | Which checks are allowed to block a merge, and which have stopped earning that right. |
-| [`src/supply.rs`](src/supply.rs) | Where the loop looks when the ranked queue is empty: `WorkSupply`, `SupplyPolicy` (every switch off), the `rearm` rule that re-opens a dry ladder against a moved base, and `novel`, which drops a finding the seen set already holds. |
+| [`src/supply.rs`](src/supply.rs) | Where the loop looks when the ranked queue is empty: `WorkSupply`, `SupplyPolicy` (every switch off), the `rearm` rule that re-opens a dry ladder against a moved base, `Reading`/`read`, which turn a lens command's output into findings with no model, and `novel`, which drops a finding the seen set already holds. |
 | [`src/seen.rs`](src/seen.rs) | The dedup set, and the one thing that ages a line out of it: `Filing` pairs a digest with the issue it became, and `live` drops a line whose every issue closed on a cited change. A line with no filing record never decays. |
 | [`src/regress.rs`](src/regress.rs) | Re-checking the fixes the loop has claimed: `ClosureReceipt`, `check`, and the `sweep` that turns a change gone from the base branch into a fresh defect. |
 | [`src/meta.rs`](src/meta.rs) | The loop read against its own ledger: a raised signal nobody acted on, and a lens that has looked several times and found nothing. |
@@ -151,7 +151,10 @@ Adding a new aperture lens: add a [`Lens`] entry to [`LENSES`] naming its
 [`Tooling`] (a concrete `run`/`interpret` command, or `ModelOnly` with a note
 saying what tooling would close the gap — no lens may be silently a no-op,
 #1549), then extend `the_ladder_is_the_shell_drivers_ladder_in_order` in
-`src/tests.rs` with the new name in its position.
+`src/tests.rs` with the new name in its position. A `Command` lens also says
+whether the driver can read its output with no model: give it a
+`supply::Reading` only when its `interpret` line asks for no judgement, and
+make sure `run` is a command a shell can run as written.
 
 Adding a new self-improvement signal: extend [`metrics`] (or add a
 `starved`-shaped standalone function if the signal reads the calibration

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -295,6 +295,10 @@ pub enum Tooling {
     Command {
         run: &'static str,
         interpret: &'static str,
+        /// How the driver reads this command's output with no model, or
+        /// `None` when only a model can read it. See
+        /// [`crate::supply::Reading`].
+        reading: Option<crate::supply::Reading>,
     },
     /// No mechanical backing exists yet; the model audits unaided and the
     /// note says what tooling would close the gap.
@@ -321,6 +325,7 @@ pub const LENSES: &[Lens] = &[
         tooling: Tooling::Command {
             run: "/ultraudit (deep) or /reaudit (fast)",
             interpret: "the report's findings, deduped by digest against seen.txt",
+            reading: None,
         },
         heavy_only: false,
     },
@@ -332,6 +337,7 @@ pub const LENSES: &[Lens] = &[
                   crates/stella-fleet/src crates/stella-tui/src",
             interpret: "each listed file that holds pure decision logic and has \
                         no property test is a finding",
+            reading: None,
         },
         heavy_only: false,
     },
@@ -342,6 +348,7 @@ pub const LENSES: &[Lens] = &[
             interpret: "numbering/citation violations mechanically; the semantic \
                         half — does the code still honor each numbered invariant \
                         in AGENTS.md — is read by the model against that list",
+            reading: None,
         },
         heavy_only: false,
     },
@@ -360,6 +367,7 @@ pub const LENSES: &[Lens] = &[
                   fixtures (cargo test -p stella-model)",
             interpret: "a regression against the previous loop-bench run or a \
                         golden diff is a finding",
+            reading: None,
         },
         heavy_only: true,
     },
@@ -370,6 +378,7 @@ pub const LENSES: &[Lens] = &[
             interpret: "every advisory, ban, source, or license finding is a \
                         defect (this is a separate CI job, so running it in a \
                         cycle is additive, not duplicated work)",
+            reading: Some(supply::Reading::ErrorLines),
         },
         heavy_only: false,
     },
@@ -389,6 +398,7 @@ pub const LENSES: &[Lens] = &[
                   scripts/check-command-docs.sh",
             interpret: "stale citations, uncited documents, and undocumented \
                         commands are findings",
+            reading: None,
         },
         heavy_only: false,
     },
@@ -399,6 +409,7 @@ pub const LENSES: &[Lens] = &[
                   with --rig --dry-run first)",
             interpret: "aborts, stalls, and stuck-loop detections across the \
                         long run are findings",
+            reading: None,
         },
         heavy_only: true,
     },

--- a/crates/stella-autonomy/src/meta.rs
+++ b/crates/stella-autonomy/src/meta.rs
@@ -25,9 +25,10 @@ use crate::{Calibration, CycleRecord, Metrics, Signal, metrics, starved};
 
 /// The label a finding about the loop carries.
 ///
-/// The loop wasting its own cycles is a defect, and the type axis of a backlog
-/// convention spells that `bug`.
-pub const DEFECT_LABEL: &str = "bug";
+/// The loop wasting its own cycles is a defect, and every supply files a
+/// defect under one word. One definition, in [`crate::supply::DEFECT_LABEL`],
+/// so two of them cannot drift apart.
+pub use crate::supply::DEFECT_LABEL;
 
 /// How many cycles a lens must have run before its silence counts.
 ///

--- a/crates/stella-autonomy/src/regress.rs
+++ b/crates/stella-autonomy/src/regress.rs
@@ -25,10 +25,10 @@ use crate::supply::Finding;
 
 /// The label a returning defect carries.
 ///
-/// A fix that came back out is a defect, and the type axis of a backlog
-/// convention spells that `bug`. A convention with no such member refuses the
-/// draft, and the refusal stands. Nothing here invents a word.
-pub const DEFECT_LABEL: &str = "bug";
+/// A fix that came back out is a defect, and every supply files a defect under
+/// one word. One definition, in [`crate::supply::DEFECT_LABEL`], so two of
+/// them cannot drift apart. Nothing here invents a word.
+pub use crate::supply::DEFECT_LABEL;
 
 /// What the loop wrote down when it closed an issue.
 ///

--- a/crates/stella-autonomy/src/supply.rs
+++ b/crates/stella-autonomy/src/supply.rs
@@ -212,6 +212,117 @@ pub fn rearm(aperture: &str, base: &Baseline, policy: &SupplyPolicy) -> Rearm {
     }
 }
 
+/// The label a lens finding carries.
+///
+/// The same word `regress` and `meta` file under. A defect a lens found is a
+/// defect, and the type axis of a backlog convention spells that `bug`. A
+/// convention with no such member refuses the draft, and the refusal stands.
+pub const DEFECT_LABEL: &str = "bug";
+
+/// How many findings one lens pass offers at most.
+///
+/// A tool that prints a hundred errors would otherwise become a hundred
+/// issues in one pass. Ten is a bound and not a measurement: enough that a
+/// real run is not cut short, small enough that a broken tool cannot flood a
+/// tracker. What is over the cap is offered again on the next pass, because
+/// nothing wrote it down as seen.
+pub const MAX_LENS_FINDINGS: usize = 10;
+
+/// How the driver reads one lens command's output, with no model.
+///
+/// A lens declares one only when its output can be read without judgement.
+/// Most `interpret` lines ask for a judgement — "each listed file that holds
+/// pure decision logic" — and a mechanical read of those would file noise.
+/// That is how `doc:backlog-self-driving` §4.4 says this supply turns into
+/// make-work. A lens that asks for judgement declares no reading, and the
+/// model-driven audit phase still reads it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reading {
+    /// Every line the tool prints as an error is one defect.
+    ///
+    /// `error: text` and `error[code]: text` are both read, and the text is
+    /// the finding. That is the shape `cargo deny` writes, which is what the
+    /// `supply-chain` lens declares. A reading that matches nothing yields
+    /// nothing, so a tool that changes its output costs the loop a supply and
+    /// never a wrong filing.
+    ErrorLines,
+}
+
+/// Turn one lens command's output into findings.
+///
+/// Empty for a lens that declares no reading, and for output the reading does
+/// not match. Both mean one thing to the caller: this lens offered nothing.
+///
+/// The order is the order the tool printed. A repeat of one line is dropped,
+/// so a tool that says the same thing twice is one finding.
+#[must_use]
+pub fn read(lens: &crate::Lens, output: &str) -> Vec<Finding> {
+    let crate::Tooling::Command {
+        run,
+        reading: Some(reading),
+        ..
+    } = lens.tooling
+    else {
+        return Vec::new();
+    };
+
+    let mut taken: Vec<&str> = Vec::new();
+    let mut found = Vec::new();
+    for line in output.lines() {
+        let Some(message) = (match reading {
+            Reading::ErrorLines => error_message(line),
+        }) else {
+            continue;
+        };
+        if taken.contains(&message) {
+            continue;
+        }
+        taken.push(message);
+        found.push(lens_finding(lens.name, run, message));
+        if found.len() == MAX_LENS_FINDINGS {
+            break;
+        }
+    }
+    found
+}
+
+/// What a tool said on a line it printed as an error, if it did.
+///
+/// `error: text` and `error[code]: text` both yield `text`. A line with the
+/// word somewhere else in it — a path, a sentence — is not one, so the prefix
+/// is what is matched.
+fn error_message(line: &str) -> Option<&str> {
+    let rest = line.trim().strip_prefix("error")?;
+    let rest = match rest.strip_prefix('[') {
+        Some(tail) => tail.split_once(']')?.1,
+        None => rest,
+    };
+    let message = rest.strip_prefix(':')?.trim();
+    (!message.is_empty()).then_some(message)
+}
+
+/// One defect a lens read out of its own tool's output.
+fn lens_finding(lens: &str, run: &str, message: &str) -> Finding {
+    Finding {
+        title: format!("the `{lens}` lens reports: {message}"),
+        body: format!(
+            "The `{lens}` rung of the aperture ladder ran `{run}`. It printed this \
+             line as an error:\n\n\
+             ```\n{message}\n```\n\n\
+             The loop read the line and did not judge it. That lens says every error \
+             its tool prints is a defect, so the line is filed rather than weighed.\n\n\
+             ## How to check\n\n\
+             1. Run `{run}` at the root of this repository.\n\
+             2. Find the error above in what it prints.\n\
+             3. Fix the cause, or say on this issue why the tool is wrong here.\n\n\
+             ## Definition of done\n\n\
+             - [ ] `{run}` no longer prints this error, or this issue records why the \
+             error is not a defect.\n"
+        ),
+        labels: vec![DEFECT_LABEL.to_owned()],
+    }
+}
+
 /// The findings whose digest is absent from the seen set.
 ///
 /// The key is [`crate::finding_digest`] over the title, which is the key the
@@ -387,5 +498,108 @@ mod tests {
         let seen = vec![crate::finding_digest(&first.title)];
 
         assert!(novel(&[again], &seen).is_empty());
+    }
+
+    /// The lens the shipped table gives a reading to.
+    fn mechanical() -> &'static crate::Lens {
+        crate::LENSES
+            .iter()
+            .find(|lens| match lens.tooling {
+                crate::Tooling::Command { reading, .. } => reading.is_some(),
+                crate::Tooling::ModelOnly { .. } => false,
+            })
+            .expect("one lens declares a reading")
+    }
+
+    /// **The witness for the mechanical read.** A tool's error lines become
+    /// findings, and its other lines do not.
+    #[test]
+    fn a_reading_turns_error_lines_into_findings() {
+        let out = read(
+            mechanical(),
+            "checking 412 crates\n\
+             error[vulnerability]: a crate has a known advisory\n\
+             warning[unmaintained]: a crate is unmaintained\n\
+             error: a crate carries a license this workspace refuses\n\
+             advisories FAILED, bans ok\n",
+        );
+
+        assert_eq!(out.len(), 2, "two error lines, two findings");
+        assert!(out[0].title.ends_with("a crate has a known advisory"));
+        assert!(
+            out[1]
+                .title
+                .ends_with("a crate carries a license this workspace refuses")
+        );
+        assert_eq!(out[0].labels, vec![DEFECT_LABEL.to_owned()]);
+    }
+
+    /// One line said twice is one defect, so a tool that repeats itself does
+    /// not open two issues.
+    #[test]
+    fn a_repeated_line_is_one_finding() {
+        let out = read(
+            mechanical(),
+            "error: the same thing\nerror: the same thing\n",
+        );
+
+        assert_eq!(out.len(), 1);
+    }
+
+    /// A broken tool cannot flood the tracker in one pass.
+    #[test]
+    fn a_pass_offers_no_more_than_the_cap() {
+        let flood: String = (0..MAX_LENS_FINDINGS * 3)
+            .map(|n| format!("error: defect number {n}\n"))
+            .collect();
+
+        assert_eq!(read(mechanical(), &flood).len(), MAX_LENS_FINDINGS);
+    }
+
+    /// A lens with no reading offers nothing, so the audit phase keeps it.
+    #[test]
+    fn a_lens_with_no_reading_offers_nothing() {
+        let model_read = crate::lens("rubric").expect("the first rung");
+
+        assert!(read(model_read, "error: something went wrong").is_empty());
+    }
+
+    /// The word has to be the prefix. A path or a sentence that holds it is
+    /// not a tool reporting one.
+    #[test]
+    fn the_word_error_inside_a_line_is_not_a_finding() {
+        let out = read(
+            mechanical(),
+            "compiling crates/stella-core/src/error.rs\n\
+             an error is not what this line reports\n\
+             error:\n",
+        );
+
+        assert!(out.is_empty(), "got {out:?}");
+    }
+
+    /// A lens that declares a reading must name a command a shell can run.
+    /// Several `run` strings are prose — "/ultraudit (deep) or /reaudit
+    /// (fast)" — and the driver runs the string as written.
+    #[test]
+    fn a_lens_with_a_reading_names_a_runnable_command() {
+        for lens in crate::LENSES {
+            let crate::Tooling::Command {
+                run,
+                reading: Some(_),
+                ..
+            } = lens.tooling
+            else {
+                continue;
+            };
+            for word in ["(", ")", " or "] {
+                assert!(
+                    !run.contains(word),
+                    "the `{}` lens declares a reading, so the driver runs `{run}` as \
+                     written, and `{word}` says that string is prose",
+                    lens.name
+                );
+            }
+        }
     }
 }

--- a/crates/stella-autonomy/src/tests.rs
+++ b/crates/stella-autonomy/src/tests.rs
@@ -168,7 +168,7 @@ fn advancing_walks_every_lens_and_ends_in_watch_not_termination() {
 fn every_lens_declares_its_tooling_or_admits_it_has_none() {
     for l in LENSES {
         match l.tooling {
-            Tooling::Command { run, interpret } => {
+            Tooling::Command { run, interpret, .. } => {
                 assert!(!run.trim().is_empty(), "{} names an empty command", l.name);
                 assert!(
                     !interpret.trim().is_empty(),

--- a/crates/stella-cli/src/self_driving_cmd/query.rs
+++ b/crates/stella-cli/src/self_driving_cmd/query.rs
@@ -39,7 +39,15 @@ pub(super) fn aperture(
                 Tooling::Command { run, .. } => collapse_ws(run),
                 Tooling::ModelOnly { note } => format!("model-only — {}", collapse_ws(note)),
             };
-            println!("  {marker} {:<13} {backing}{heavy}", l.name);
+            // Which lens the driver can run and read on its own, and which one
+            // waits for the model-driven audit phase.
+            let driver_reads = match l.tooling {
+                Tooling::Command {
+                    reading: Some(_), ..
+                } => " [driver reads]",
+                _ => "",
+            };
+            println!("  {marker} {:<13} {backing}{driver_reads}{heavy}", l.name);
         }
         let marker = if open == stella_autonomy::WATCH {
             "*"

--- a/crates/stella-cli/src/self_driving_cmd/supply.rs
+++ b/crates/stella-cli/src/self_driving_cmd/supply.rs
@@ -5,8 +5,8 @@
 //!
 //! The ranked queue runs out. Three other supplies do not.
 //! `stella_autonomy::supply` holds the rules for them. This module is the half
-//! that touches the world. It asks git how far the base has moved, reads the
-//! loop's own files, and files what the rules hand back.
+//! that touches the world. It asks git how far the base has moved, runs the
+//! open lens, reads the loop's own files, and files what the rules hand back.
 //!
 //! Each supply is shut until an operator opens it in `stella.toml`. A build
 //! that gains this code changes no running loop.
@@ -25,6 +25,8 @@
 //! `doc:backlog-self-driving` §4 is the design.
 
 use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use stella_autonomy::regress::ClosureReceipt;
 use stella_autonomy::supply::{Baseline, Finding, Rearm};
@@ -86,6 +88,146 @@ pub(super) fn open_lens(durable: &Durable, cfg: &LoopConfig, root: &Path) -> Opt
     }
 }
 
+/// How one open lens is run and read.
+///
+/// A seam, so a test can hand [`pass_with`] a lens whose findings it wrote
+/// itself. [`Declared`] is the shipped one, and it runs what
+/// `stella_autonomy::LENSES` declares.
+pub(super) trait LensAudit {
+    /// What this lens offers, or why running it failed.
+    fn sweep(&self, lens: &str, root: &Path, work_dir: &Path) -> Result<Swept, String>;
+}
+
+/// What one run of a lens produced.
+pub(super) enum Swept {
+    /// The lens ran, and offers these.
+    Findings(Vec<Finding>),
+    /// Nothing to run here: the name is not a lens, or the lens declares no
+    /// mechanical reading. The model-driven audit phase still reads it.
+    NotMechanical,
+}
+
+/// Seconds one lens command may take before it is stopped.
+///
+/// Fifteen minutes is a bound and not a measurement. `make supply-chain`
+/// resolves a whole dependency graph, so a minute is too short; a lens still
+/// running after this has hung, and the loop has other work.
+const LENS_TIMEOUT_SECS: u64 = 900;
+
+/// How long to wait between asking whether the lens command has finished.
+const LENS_POLL: Duration = Duration::from_millis(200);
+
+/// Where a lens command's output is kept, under the loop's state directory.
+const LENS_OUTPUT_FILE: &str = "lens-output.txt";
+
+/// The shipped audit: run what the lens declares, and read what it printed.
+pub(super) struct Declared;
+
+impl LensAudit for Declared {
+    fn sweep(&self, lens: &str, root: &Path, work_dir: &Path) -> Result<Swept, String> {
+        let Some(open) = stella_autonomy::lens(lens) else {
+            return Ok(Swept::NotMechanical);
+        };
+        let stella_autonomy::Tooling::Command {
+            run,
+            reading: Some(_),
+            ..
+        } = open.tooling
+        else {
+            return Ok(Swept::NotMechanical);
+        };
+
+        let printed = run_lens(run, root, work_dir)?;
+        Ok(Swept::Findings(stella_autonomy::supply::read(
+            open, &printed,
+        )))
+    }
+}
+
+/// Run one lens command and hand back everything it printed.
+///
+/// Both streams go to a file rather than a pipe. A pipe that fills stops the
+/// child, and the loop would then be waiting on a command that is waiting on
+/// it. The file stays behind for a person to read.
+///
+/// The exit status is not read. A lens tool exits non-zero exactly when it
+/// found something, so a failing run is the finding rather than an error.
+fn run_lens(run: &str, root: &Path, work_dir: &Path) -> Result<String, String> {
+    let path = work_dir.join(LENS_OUTPUT_FILE);
+    let out = std::fs::File::create(&path)
+        .map_err(|error| format!("could not open {}: {error}", path.display()))?;
+    let errs = out
+        .try_clone()
+        .map_err(|error| format!("could not open {} twice: {error}", path.display()))?;
+
+    let mut child = Command::new("bash")
+        .arg("-lc")
+        .arg(run)
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(out))
+        .stderr(Stdio::from(errs))
+        .spawn()
+        .map_err(|error| format!("could not start `{run}`: {error}"))?;
+
+    let deadline = Instant::now() + Duration::from_secs(LENS_TIMEOUT_SECS);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                return Err(format!(
+                    "`{run}` outran {LENS_TIMEOUT_SECS}s and was stopped"
+                ));
+            }
+            Ok(None) => std::thread::sleep(LENS_POLL),
+            Err(error) => return Err(format!("could not wait on `{run}`: {error}")),
+        }
+    }
+
+    std::fs::read_to_string(&path)
+        .map_err(|error| format!("could not read {}: {error}", path.display()))
+}
+
+/// Run the open lens and add what it found.
+///
+/// Held to the `rearm` switch. The lens belongs to that supply, and a loop
+/// that opened only `meta` must not start running tool commands.
+fn draw_lens(
+    durable: &Durable,
+    root: &Path,
+    lens: &str,
+    audit_lens: &dyn LensAudit,
+    into: &mut Vec<Finding>,
+) {
+    match audit_lens.sweep(lens, root, &durable.dir) {
+        Ok(Swept::Findings(found)) => {
+            audit::record(
+                durable,
+                Audit::Swept,
+                None,
+                &format!(
+                    "{lens}: {} finding(s) from the lens's own tooling",
+                    found.len()
+                ),
+            );
+            into.extend(found);
+        }
+        Ok(Swept::NotMechanical) => audit::record(
+            durable,
+            Audit::Swept,
+            None,
+            &format!("{lens}: nothing to run — the audit phase reads this lens"),
+        ),
+        Err(error) => audit::record(
+            durable,
+            Audit::Transient,
+            None,
+            &format!("could not run the `{lens}` lens: {error}"),
+        ),
+    }
+}
+
 /// Draw from every open supply once. `true` when something reached the
 /// tracker.
 pub(super) fn pass(
@@ -95,7 +237,25 @@ pub(super) fn pass(
     root: &Path,
     lens: &str,
 ) -> bool {
+    pass_with(durable, provider, cfg, root, lens, &Declared)
+}
+
+/// One pass, against a named lens audit.
+///
+/// Split from [`pass`] so a test can supply the lens rather than the tree.
+fn pass_with(
+    durable: &Durable,
+    provider: &dyn IssueProvider,
+    cfg: &LoopConfig,
+    root: &Path,
+    lens: &str,
+    audit_lens: &dyn LensAudit,
+) -> bool {
     let mut findings: Vec<Finding> = Vec::new();
+
+    if cfg.supply.rearm {
+        draw_lens(durable, root, lens, audit_lens, &mut findings);
+    }
 
     if cfg.supply.regress {
         let receipts = durable.receipts();
@@ -347,7 +507,179 @@ fn file(
 
 #[cfg(test)]
 mod tests {
+    use async_trait::async_trait;
+    use stella_protocol::issue::{Issue, IssueError, IssueKey};
+
     use super::*;
+
+    /// A lens that offers one finding, whatever the tree holds.
+    ///
+    /// What is under test is the driver's own draw, so the fixture stands in
+    /// for the tool rather than running one.
+    struct OneFinding;
+
+    impl LensAudit for OneFinding {
+        fn sweep(&self, lens: &str, _root: &Path, _work_dir: &Path) -> Result<Swept, String> {
+            Ok(Swept::Findings(vec![Finding {
+                title: format!("the `{lens}` lens found a defect in the fixture"),
+                body: "The fixture lens offers one finding.".to_owned(),
+                labels: vec!["defect".to_owned()],
+            }]))
+        }
+    }
+
+    /// A tracker that keeps every draft, so a test can count what was filed.
+    #[derive(Default)]
+    struct FixtureProvider {
+        filed: std::sync::Mutex<Vec<IssueDraft>>,
+    }
+
+    impl FixtureProvider {
+        fn filed(&self) -> usize {
+            self.filed.lock().expect("fixture lock").len()
+        }
+    }
+
+    #[async_trait]
+    impl IssueProvider for FixtureProvider {
+        fn id(&self) -> &str {
+            "fixture"
+        }
+
+        async fn list_open(&self, _limit: usize) -> Result<Vec<Issue>, IssueError> {
+            Ok(Vec::new())
+        }
+
+        async fn file(&self, draft: &IssueDraft) -> Result<IssueKey, IssueError> {
+            let mut filed = self.filed.lock().expect("fixture lock");
+            filed.push(draft.clone());
+            Ok(IssueKey::from(format!("{}", 1000 + filed.len()).as_str()))
+        }
+
+        async fn close(
+            &self,
+            _key: &IssueKey,
+            _receipt: &str,
+            _state: &str,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn comment(&self, _key: &IssueKey, _body: &str) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn relabel(
+            &self,
+            _key: &IssueKey,
+            _add: &[String],
+            _remove: &[String],
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+
+        async fn edit(
+            &self,
+            _key: &IssueKey,
+            _title: Option<&str>,
+            _body: Option<&str>,
+        ) -> Result<(), IssueError> {
+            Ok(())
+        }
+    }
+
+    /// A workspace whose convention is bound, so a draft can be filed at all.
+    /// A proposed convention refuses every filing, which would hide what this
+    /// test is asking about.
+    fn bind_convention(root: &Path) {
+        let dir = root.join(".stella").join("issues");
+        std::fs::create_dir_all(&dir).expect("issues dir");
+        std::fs::write(
+            dir.join("convention.json"),
+            r#"{"axes":[{"name":"kind","members":["defect"],
+                 "requirement":"exactly_one","source":"declared"}],
+                 "reserved":[],"acceptance":"bound"}"#,
+        )
+        .expect("convention");
+    }
+
+    /// **The witness.** A re-armed lens produces a finding inside one pass,
+    /// and a second pass over the same tree files nothing because the digest
+    /// is in the seen set.
+    ///
+    /// Before this change `pass` drew from `regress` and `meta` alone, so a
+    /// pass with both shut filed nothing and returned `false`.
+    #[test]
+    fn a_rearmed_lens_is_drawn_from_once_and_then_deduped() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        bind_convention(root);
+        let dir = root.join("state");
+        std::fs::create_dir_all(&dir).expect("state dir");
+
+        let durable = Durable {
+            dir,
+            repo_root: root.to_path_buf(),
+        };
+        let cfg = LoopConfig {
+            supply: stella_autonomy::supply::SupplyPolicy {
+                rearm: true,
+                ..stella_autonomy::supply::SupplyPolicy::default()
+            },
+            ..LoopConfig::default()
+        };
+        let provider = FixtureProvider::default();
+
+        let first = pass_with(&durable, &provider, &cfg, root, "rubric", &OneFinding);
+        assert!(first, "the lens's finding reached the tracker");
+        assert_eq!(provider.filed(), 1);
+
+        let again = pass_with(&durable, &provider, &cfg, root, "rubric", &OneFinding);
+        assert!(!again, "the same finding is not filed twice");
+        assert_eq!(provider.filed(), 1, "the seen set holds that digest now");
+    }
+
+    /// A loop that opened only `meta` never runs a lens command, so a build
+    /// with this code cannot start spawning tools somebody did not ask for.
+    #[test]
+    fn a_shut_rearm_switch_draws_no_lens() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        bind_convention(root);
+        let dir = root.join("state");
+        std::fs::create_dir_all(&dir).expect("state dir");
+
+        let durable = Durable {
+            dir,
+            repo_root: root.to_path_buf(),
+        };
+        let provider = FixtureProvider::default();
+
+        let filed = pass_with(
+            &durable,
+            &provider,
+            &LoopConfig::default(),
+            root,
+            "rubric",
+            &OneFinding,
+        );
+
+        assert!(!filed);
+        assert_eq!(provider.filed(), 0);
+    }
+
+    /// A lens whose tooling has no reading offers nothing, and the driver says
+    /// so rather than reporting an empty sweep.
+    #[test]
+    fn a_model_only_lens_is_left_to_the_audit_phase() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        let swept = Declared
+            .sweep("concurrency", tmp.path(), tmp.path())
+            .expect("a lens with no command runs nothing");
+
+        assert!(matches!(swept, Swept::NotMechanical));
+    }
 
     /// **The witness.** A workspace that says nothing about supplies opens
     /// none, so a build that gains this code changes no running loop.

--- a/crates/stella-cli/tests/self_driving_cli.rs
+++ b/crates/stella-cli/tests/self_driving_cli.rs
@@ -234,6 +234,9 @@ fn aperture_list_names_the_tooling_and_admits_the_model_only_lenses() {
     assert!(text.contains("make supply-chain"), "{text}");
     assert!(text.contains("model-only"), "{text}");
     assert!(text.contains("[heavy tier]"), "{text}");
+    // The lens the driver runs and reads on its own says so, so an operator
+    // can tell it from the ones the audit phase still owns.
+    assert!(text.contains("[driver reads]"), "{text}");
     assert!(text.contains("watch"), "{text}");
 }
 

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -700,6 +700,18 @@ most want measured before the loop is trusted unattended for long stretches.
 §9's B4 therefore ships the sweep behind a per-supply switch that defaults to
 queue-only.
 
+**A mechanical read of a lens is opt-in, per lens.** The driver runs
+the open lens itself, so something has to turn a tool's output into findings.
+Most `interpret` lines ask for a judgement a model makes — "each listed file
+that holds pure decision logic" — and reading those mechanically would file
+the noise this section is about. So a lens declares a `Reading` only when its
+output can be read without one, and `supply-chain` is the only lens that does
+today: its own `interpret` line says every advisory, ban, source or license
+finding is a defect, which leaves nothing to judge. A lens with no reading is
+still the audit phase's, and the driver says so rather than reporting an empty
+sweep. `stella_autonomy::supply::MAX_LENS_FINDINGS` bounds what one pass
+offers, so a broken tool cannot become a hundred issues.
+
 ---
 
 ## 5. Re-audit, and what makes a `done` falsifiable later
@@ -945,7 +957,7 @@ The pipeline's discipline, carried forward without relaxation:
 | **Fixing the code** | — | ✔ `work` |
 | **Writing the witness** | — | ✔ (verifier resolution, never the worker) |
 | **Writing an issue body** | — | ✔ |
-| **Interpreting an audit lens's output** | — | ✔ where the lens is `ModelOnly` |
+| **Interpreting an audit lens's output** | `supply::read`, where the lens declares a `Reading` | ✔ where it declares none (§4.4) |
 
 Every row in the left column that could plausibly have been a model call and is
 not is a place this loop is cheaper and more replayable than the alternative.


### PR DESCRIPTION
## What & why

`crates/stella-cli/src/self_driving_cmd/supply.rs`'s `pass` drew findings from
`stella_autonomy::regress::sweep` and `stella_autonomy::meta::sweep` and never
ran the open lens's own tooling. The `lens` argument reached the audit lines
and nothing else, so a lens the loop had just re-armed produced nothing inside
one `drive` run.

`pass` now draws the lens first, through a `LensAudit` seam:

- **The seam.** `pass` keeps its signature and its one call site in `drive.rs`
  (that file has two lines of headroom under the 1500-line ceiling, so nothing
  new lands there) and hands a private `pass_with` the shipped audit.
- **The shipped audit.** `Declared` looks the lens up in
  `stella_autonomy::LENSES`, runs the declared `run` with `bash -lc` in the
  repository root, and hands what it printed to
  `stella_autonomy::supply::read`. Both streams go to a file under the loop's
  state directory rather than a pipe — a pipe that fills stops the child, and
  the loop would then be waiting on a command that is waiting on it — and the
  run is held to a ceiling. The exit status is not read: a lens tool exits
  non-zero exactly when it found something.
- **Which lenses run.** `Tooling::Command` gains
  `reading: Option<supply::Reading>`, which is route 2 of the two the issue
  asks between. Only `supply-chain` declares one today: its own `interpret`
  line says every advisory, ban, source or license finding is a defect, so
  there is no judgement left for a model. The other four ask for one — "each
  listed file that holds pure decision logic" — and reading those mechanically
  would file the noise `doc:backlog-self-driving` §4.4 is about. They report
  `NotMechanical`, the driver says so, and the model-driven audit phase keeps
  them. #6225 tracks the other half.
- **Bounded.** `MAX_LENS_FINDINGS` caps one pass, so a broken tool cannot
  become a hundred issues. What is over the cap is offered again next pass,
  because nothing recorded it as seen.
- **Nothing new by default.** The lens draw is held to the `rearm` switch, so
  a loop that opened only `meta` never starts running tool commands, and a
  default workspace opens no supply at all.

The findings then go where the other two supplies already went: `novel`
against the live seen set, then `backlog::file_finding`. `finding_digest` is
untouched.

Two smaller things the change forced, both in the diff:

- `DEFECT_LABEL` had two identical definitions (`regress` and `meta`). Rather
  than add a third, it is defined once in `supply` and re-exported from both,
  so the public paths are unchanged and there is one cell to edit.
- `stella self-driving aperture --list` marks the lens the driver can read on
  its own with `[driver reads]`, so an operator can tell it from the ones the
  audit phase still owns. A declaration nothing surfaces is one nobody can
  check.

Closes #6182

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_rearmed_lens_is_drawn_from_once_and_then_deduped` in
`crates/stella-cli/src/self_driving_cmd/supply.rs`: a fixture lens offers one
finding, the first `pass` files it and returns `true`, and a second pass over
the same tree files nothing because the digest is now in `seen.txt`.

**Why it fails on the old code, by construction.** `pass` drew from `regress`
and `meta` alone, so a pass with both shut offered no findings, filed nothing
and returned `false`. Neither the `LensAudit` seam nor `pass_with` existed, so
the test cannot even be written against the old signature.

Beside it: `a_shut_rearm_switch_draws_no_lens` (a `meta`-only loop runs no
tool), `a_model_only_lens_is_left_to_the_audit_phase` (a lens with no command
runs nothing), and in `stella-autonomy` four tests over `read` — error lines
become findings, a repeated line is one finding, the cap holds, a lens with no
reading offers nothing, the word `error` inside a line is not a finding, and a
lens that declares a reading names a command a shell can run.

## The gate

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — CI's job; this
      change was not compiled on the maintainer's laptop (CLAUDE.md, "CI builds
      and tests; this laptop does not")
- [ ] `cargo test --workspace` — same
- [x] Docs updated: `doc:backlog-self-driving` §4.4 and §8, and
      `crates/stella-autonomy/README.md`'s module table and extension recipe
- [x] `Closes #6182` above and as a commit trailer

Local guards that compile nothing: `make guards-fast` is green, including
`prose`, `line-citations` and `file-size`.

**Tests deleted:** None.

## Nothing left behind

- [x] Filed: #6225 (the driver still files nothing for a lens whose output
      needs judgement — the route-1 half of the decision), #6226 (three
      aperture lenses name prose where a command belongs)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] `Reading` is not a cross-boundary serialized type — `Tooling` is not
      `Serialize`, so it gets no serde derive, matching `Rearm` and `Hold`
      beside it

## Anything reviewers should know?

- **Route 2, not route 1, and the reason is in the diff.** The issue asks for
  a choice. A model seat for the lens read is the larger design and it is
  filed as #6225; what ships here is the seam plus one honest mechanical
  reader, so the driver's draw is real rather than declared.
- **The reader fails safe.** `Reading::ErrorLines` matches `error:` /
  `error[code]:` at the start of a line, which is the shape `cargo deny`
  writes. If that shape ever changes, the reader matches nothing, the lens
  offers nothing, and the loop is back to today's behaviour — it cannot file
  something wrong.
- `run_lens` executes a lens's declared `run` string with `bash -lc`. The
  string is a constant in `stella_autonomy::LENSES`, never user input. #6226
  is where the lenses whose `run` is prose rather than a command are tracked;
  a guard test keeps a lens that declares a reading from being one of them.

## Summary by Sourcery

Run mechanically readable tooling for re-armed lenses during self-driving passes while leaving judgment-based lenses to the audit phase.

New Features:
- Run re-armed lenses during self-driving supply passes and convert mechanically readable tool output into deduplicated backlog findings.
- Expose driver-readable lenses in the aperture listing and allow lens declarations to specify their mechanical output reader.

Bug Fixes:
- Ensure lens findings are discovered within the same drive run instead of being deferred indefinitely to the audit phase.

Enhancements:
- Bound lens findings per pass and preserve model-only lenses for the audit phase.
- Centralize the shared defect label while preserving the existing public paths.

Documentation:
- Document mechanical lens readings, their opt-in behavior, and the lens extension requirements.

Tests:
- Add coverage for lens execution, rearm gating, deduplication, model-only handling, error-line parsing, repeated findings, and the per-pass cap.