### PR TITLE
feat(ci): reject a PR that negates a closing keyword

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,25 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: ./scripts/check-deleted-tests.sh
 
+      # Also toolchain-free, and reads the same two channels as the guard
+      # above for the same reason: `pull_request` only, since a PR body is a
+      # GitHub-side fact no local tree carries. GitHub's own closing-keyword
+      # parser reads a keyword ("close", "fix", "resolve") and the issue
+      # reference right after it — it does not read a negation in front of
+      # the keyword, so "This does not close #6155" still closes #6155
+      # (#6190, hit for real in #6180). PR_NUMBER lets the guard fetch both
+      # the PR's live description and its live commit messages through the
+      # API rather than the stale event-payload snapshot, the same #4495
+      # channel the guard above uses; PR_BODY is the fallback when the API
+      # call fails.
+      - name: no negated closing keyword still closes the issue
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' && github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python3 ./scripts/check-closing-keywords.py
+
       # Also toolchain-free. AGENTS.md and CONTRIBUTING.md each restate what
       # `make gate` runs, and both had drifted twice — each time by omitting a
       # newly added guard, which is the direction that misleads a reader into

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -71,6 +71,14 @@ jobs:
   gate-steps:
     name: gate steps no other workflow runs
     runs-on: ubuntu-latest
+    # `pull-requests: read` is this job's alone, and only the closing-keywords
+    # step uses it: that guard reads the PR's live description and commit
+    # messages through the API, and the workflow-level `contents: read` sets
+    # every other scope to `none`, which would leave it on the event-payload
+    # snapshot an edited description never reaches (#4495).
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -93,12 +101,38 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 ./scripts/check-transcript-surfaces.py
 
-      # The three steps above run here because this trigger carries no
-      # `paths:` filter at all -- that is what lets them fire on a
-      # scripts-only pull request. Nothing enforced that absence except a
-      # comment, so this reads it back: at least one workflow must run each
-      # of the three with an unfiltered `pull_request:` trigger, or a future
-      # edit narrowing this one would silently reopen the gap (#5448).
+      # ci.yml runs this guard too, but as a step in its `check` job, which is
+      # gated on `needs.changes.outputs.rust != 'false'`. A prose-only diff
+      # answers `rust=false`, so `check` is skipped and the guard never reads
+      # the body -- and a prose-only pull request, being almost entirely
+      # narrative text, is the shape most likely to carry a negated closing
+      # keyword. That is the same reason `prose` sits in this job rather than
+      # that one (#6190).
+      #
+      # `github.event_name == 'pull_request'` because `merge_group` carries no
+      # PR to read; the guard prints "nothing to check" and exits 0 there, and
+      # this skips the step rather than logging that on every queued entry.
+      - name: no negated closing keyword still closes the issue
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python3 ./scripts/check-closing-keywords.py
+
+      # The steps above run here because this trigger carries no `paths:`
+      # filter at all -- that is what lets them fire on a scripts-only pull
+      # request. Nothing enforced that absence except a comment, so this reads
+      # it back: at least one workflow must run each guard it names with an
+      # unfiltered `pull_request:` trigger, or a future edit narrowing this one
+      # would silently reopen the gap (#5448).
+      #
+      # It does not cover the closing-keywords step above, and adding it to
+      # `WATCHED_GUARDS` would read as protection it cannot give: this guard
+      # reads a workflow's *trigger*, and ci.yml's `pull_request:` trigger
+      # carries no `paths:` key either, so that copy alone would satisfy it
+      # while the job-level `if:` still skipped the guard. #6248 is where that
+      # blind spot is tracked.
       - name: each guard above still runs with no paths filter somewhere
         if: ${{ !cancelled() }}
         run: python3 ./scripts/check-guard-trigger-coverage.py

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -191,6 +191,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-deleted-tests.sh
 
+      - name: closing-keywords guard catches a negated keyword (#6190)
+        if: ${{ !cancelled() }}
+        run: python3 ./scripts/test-closing-keywords.py
+
       - name: dependabot pip directory guard catches an empty directory (#3459)
         if: ${{ !cancelled() }}
         run: ./scripts/test-dependabot-pip-dirs.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1463,6 +1463,18 @@ failure the section opens with — an issue whose work shipped, staying open, wi
 nothing to notice it but an audit — reached by a different wrong guess about
 what the parser reads, and #5210 is where it happened.
 
+**A negation in front of the keyword is invisible to the same parser.**
+`#6180`'s trailer had `Refs #6155`, the right spelling for "this helps but
+does not finish the issue." Its body also said "This does not close
+`#6155`." GitHub still closed `#6155`. The parser reads `close #6155` and
+skips the three words in front of it. A person had to reopen the issue by
+hand. `scripts/check-closing-keywords.py` now checks every pull request. It
+reads the body and every commit message. It fails when a negation word
+(`not`, `never`, `without`, `doesn't`) sits in front of a closing keyword and
+its issue number, in one sentence. Its fix is the safe spelling: put the
+issue number in backticks, or write "advances #N" instead of a closing
+keyword.
+
 ---
 
 ## Testing approach

--- a/Makefile
+++ b/Makefile
@@ -887,6 +887,13 @@ main-canary-test: ## Test the post-merge canary, announcements included (not par
 deleted-tests-test: ## Test the deleted-test guard's live-vs-stale PR body handling (hermetic; not part of `gate`; #4495)
 	./scripts/test-deleted-tests.sh
 
+# Deliberately not a gate step, for the same reason as the one above: it
+# reads a PR's description and commit messages, which a single local tree
+# does not carry (#6190).
+.PHONY: closing-keywords-test
+closing-keywords-test: ## Test the negated-closing-keyword guard (hermetic; not part of `gate`; #6190)
+	python3 ./scripts/test-closing-keywords.py
+
 # The canary's other half: it detects, this is what consumes the detection at
 # the point a merge is still a decision (#3917). Not a gate step for the same
 # reason the canary is not — it asks the issue tracker a question, and `gate`

--- a/scripts/check-closing-keywords.py
+++ b/scripts/check-closing-keywords.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Guard: a pull request that says it does NOT close an issue must not close it.
+
+See `#6190`. GitHub's own parser reads a closing keyword (`close`, `fix`,
+`resolve`, and their inflections) and the issue reference right after it. It
+does not read the words in front of the keyword, so a sentence written to
+*deny* the close reads to GitHub exactly like one that asks for it.
+
+`#6180` hit this for real: its commit trailer carried `Refs #6155` (the
+correct spelling for "this advances the issue but does not finish it"), but
+its description also said:
+
+    This does not close `#6155`. Only its first done-item is satisfied here.
+
+GitHub closed `#6155` anyway, because `close #6155` is in that sentence and
+"does not" in front of it is invisible to the parser. AGENTS.md's "One
+keyword per issue" paragraph already covers the sibling mistake — a keyword
+meant for two issues landing on only one (`Closes #A, #B`) — and `#6190` is
+the same class of bug reached from the other side: a keyword the author
+meant to negate, applied anyway.
+
+What this checks, over the PR body and every commit message on the PR:
+
+    a negation word (not / never / without / doesn't) ... up to a few words
+    ... a closing keyword ... up to a few words ... an issue reference
+
+within one sentence, where the reference is not wrapped in backticks (the
+safe spelling this guard's own remedy recommends). A sentence carrying only
+`Refs #N`, only a backticked `` `#N` ``, or a genuine unnegated `Closes #N`
+all pass — none of those match the keyword-after-negation shape.
+
+Sentence boundary is a period/question mark/exclamation point followed by
+whitespace, or a newline — a trailer line like `Closes #6190` carries no
+terminal punctuation, so treating a newline as a boundary is what keeps that
+line's keyword from being read alongside negation words in the paragraph
+above it.
+
+Not a `make gate` step: like `check-deleted-tests.sh`, this reads the PR's
+description and commit messages, which are not information a single local
+tree carries (a PR body is a GitHub-side ask; the description a contributor
+is drafting locally is not it). It runs only as a `pull_request`-triggered
+CI step. See `scripts/test-closing-keywords.py` for the hermetic self-test
+and the two channels' fixture seams.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+KEYWORD = r"(?:clos(?:e|es|ed)|fix(?:es|ed)?|resolv(?:e|es|ed))"
+NEGATION = r"(?:not|never|without|doesn['\u2019]t)"
+
+# `(?:\s+\S+){0,N}?` is a bounded, non-greedy "up to N filler words" — bounded
+# so the match cannot stretch past the sentence it is found in (sentences are
+# split out before this ever runs, so "past the sentence" already means
+# "never"), non-greedy so it prefers the nearest keyword/reference rather than
+# the furthest one a longer sentence might also contain.
+NEGATED_CLOSE = re.compile(
+    r"\b"
+    + NEGATION
+    + r"\b(?:\s+\S+){0,6}?\s+\b(?P<keyword>"
+    + KEYWORD
+    + r")\b(?:\s+\S+){0,3}?\s*(?P<ref>#\d+)",
+    re.IGNORECASE,
+)
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split on sentence-ending punctuation or a bare newline.
+
+    A commit trailer or a `## Definition of done` checkbox line ends with
+    neither `.`, `!` nor `?`, so a newline alone has to count too — otherwise
+    "This does not close the loop.\\nCloses #99999" would read as one
+    sentence and flag a trailer that is nowhere near the negation.
+    """
+    return [s for s in re.split(r"(?<=[.!?])\s+|\n+", text) if s.strip()]
+
+
+def is_backticked(sentence: str, match: re.Match[str]) -> bool:
+    """True when the `#N` reference itself sits inside a `` `...` `` span.
+
+    Only the reference is checked, not the whole negated phrase, because the
+    remedy this guard recommends is "write the issue number in backticks" —
+    a rewrite that leaves the surrounding prose (keyword and all) untouched.
+    """
+    start, end = match.start("ref"), match.end("ref")
+    before = sentence[:start].rstrip()
+    after = sentence[end:].lstrip()
+    return before.endswith("`") and after.startswith("`")
+
+
+def find_violations(
+    text: str, source: str
+) -> list[tuple[str, str, re.Match[str]]]:
+    """Return (source, sentence, match) for every violation."""
+    violations = []
+    for sentence in split_sentences(text):
+        for match in NEGATED_CLOSE.finditer(sentence):
+            if is_backticked(sentence, match):
+                continue
+            violations.append((source, sentence.strip(), match))
+    return violations
+
+
+def safe_spelling(match: re.Match[str]) -> str:
+    ref = match.group("ref")
+    return (
+        f"write the issue number in backticks (`` {ref} `` ...) or say "
+        f'"advances {ref}" instead of using a closing keyword there.'
+    )
+
+
+def fetch_pr_body(pr_number: str | None) -> tuple[str, bool]:
+    """Return (body, fetched_live). Mirrors check-deleted-tests.sh's
+    `#4495` live-vs-stale channel: a re-run should see an edited description
+    without a new push."""
+    if not pr_number:
+        return os.environ.get("PR_BODY", ""), False
+    gh = os.environ.get("GH_CLOSING_KEYWORDS_BIN", "gh")
+    args = [gh, "pr", "view", pr_number, "--json", "body", "--jq", ".body"]
+    repo = os.environ.get("GH_REPO")
+    if repo:
+        args += ["--repo", repo]
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, check=True, timeout=30
+        )
+        return result.stdout, True
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ):
+        return os.environ.get("PR_BODY", ""), False
+
+
+def fetch_commit_messages(pr_number: str | None) -> tuple[str, bool]:
+    """Every commit message on the PR, headline plus body. The GitHub API is
+    ground truth here regardless of checkout depth — a shallow `git log`
+    cannot see a PR's full history the way `check-deleted-tests.sh` already
+    documents for the same job."""
+    if not pr_number:
+        return "", False
+    gh = os.environ.get("GH_CLOSING_KEYWORDS_BIN", "gh")
+    args = [
+        gh,
+        "pr",
+        "view",
+        pr_number,
+        "--json",
+        "commits",
+        "--jq",
+        ".commits[] | (.messageHeadline // \"\") + \"\\n\" + (.messageBody // \"\")",
+    ]
+    repo = os.environ.get("GH_REPO")
+    if repo:
+        args += ["--repo", repo]
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, check=True, timeout=30
+        )
+        return result.stdout, True
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ):
+        return "", False
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixture-pr-body",
+        help="stand in for a live `gh pr view` body fetch (test-only)",
+    )
+    parser.add_argument(
+        "--fixture-commit-messages",
+        help="stand in for a live `gh pr view` commits fetch (test-only)",
+    )
+    args = parser.parse_args(argv)
+
+    pr_number = os.environ.get("PR_NUMBER")
+
+    if args.fixture_pr_body is not None:
+        body, body_live = args.fixture_pr_body, True
+    else:
+        body, body_live = fetch_pr_body(pr_number)
+
+    if args.fixture_commit_messages is not None:
+        commits, commits_live = args.fixture_commit_messages, True
+    else:
+        commits, commits_live = fetch_commit_messages(pr_number)
+
+    if not body and not commits:
+        print(
+            "check-closing-keywords: nothing to check — no PR body and no "
+            "commit messages were available (not a pull_request event, or "
+            "PR_NUMBER/PR_BODY were both unset). Skipping."
+        )
+        return 0
+
+    violations = find_violations(body, "the PR description") + find_violations(
+        commits, "a commit message"
+    )
+
+    if not violations:
+        channels = []
+        if body:
+            channels.append("PR description" + ("" if body_live else " (stale snapshot)"))
+        if commits:
+            channels.append("commit messages" + ("" if commits_live else " (stale snapshot)"))
+        print(
+            "check-closing-keywords: OK — no negated closing keyword found in "
+            + " or ".join(channels)
+            + "."
+        )
+        return 0
+
+    print("check-closing-keywords: FAILED", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "GitHub's closing-keyword parser reads the keyword and the issue "
+        "reference right after it. It does not read the negation in front "
+        "of the keyword, so a sentence written to DENY a close reads to "
+        "GitHub exactly like one that asks for it.",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    for source, sentence, match in violations:
+        print(f"  in {source}: \"{sentence}\"", file=sys.stderr)
+        print(f"    offending phrase: \"{match.group(0)}\"", file=sys.stderr)
+        print(f"    fix: {safe_spelling(match)}", file=sys.stderr)
+        print("", file=sys.stderr)
+    print(
+        "AGENTS.md \u00a7 \"Closing the issue on merge\" has the full rule.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test-closing-keywords.py
+++ b/scripts/test-closing-keywords.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Directions `scripts/check-closing-keywords.py` must fail in.
+
+Each case runs the real guard as a subprocess with `--fixture-pr-body` and/or
+`--fixture-commit-messages` standing in for a live `gh pr view` fetch — the
+same fixture-flag idiom `check-deleted-tests.sh`'s own
+`--fixture-pr-body`/`--fixture-pr-body-error` use, and the reason neither
+`gh` nor a network is needed here. No git repository is built: this guard
+reads text, not a tree, so there is nothing to check out.
+
+The three cases named in `#6190`'s own "How to verify" section anchor the
+suite: a body that negates a closing keyword fails; a `Refs #N` body passes;
+a genuine `Closes #N` body passes. The rest cover the shape the guard is
+built to get right without going brittle — backtick escaping, the negation
+list, the sentence boundary, and the commit-message channel.
+
+Not part of `make gate`: `check-closing-keywords.py` has no `make gate` step
+either, for the reason `check-deleted-tests.sh` gives — it reads a PR's
+description and commit messages, which are not information a single local
+tree carries. Run it with `make closing-keywords-test`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+GUARD = HERE / "check-closing-keywords.py"
+
+# A fake issue number for the fixture bodies below. It is built here, not
+# typed out by hand each time. Most fixtures must stay un-backticked, or the
+# check would pass instead of failing.
+ISSUE_NUM = 99999
+REF = f"#{ISSUE_NUM}"
+
+pass_count = 0
+fail_count = 0
+
+
+def run(body: str = "", commits: str = "") -> subprocess.CompletedProcess[str]:
+    args = [sys.executable, str(GUARD)]
+    if body:
+        args += ["--fixture-pr-body", body]
+    if commits:
+        args += ["--fixture-commit-messages", commits]
+    return subprocess.run(args, capture_output=True, text=True)
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global pass_count, fail_count
+    if condition:
+        pass_count += 1
+        print(f"ok   {name}")
+    else:
+        fail_count += 1
+        print(f"FAIL {name}")
+        if detail:
+            print(f"     {detail}")
+
+
+# ── The three cases `#6190`'s "How to verify" names ──────────────────────────
+
+result = run(body=f"This does not close {REF}. Only the first item is done.")
+check(
+    "a body negating a closing keyword fails",
+    result.returncode == 1,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+check(
+    "the failure names the offending phrase",
+    f"does not close {REF}" in result.stderr,
+    result.stderr,
+)
+check(
+    "the failure prints a safe spelling",
+    "backticks" in result.stderr and REF in result.stderr,
+    result.stderr,
+)
+
+result = run(body=f"This advances the fix. Refs {REF}.")
+check(
+    "a Refs body passes",
+    result.returncode == 0,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+
+result = run(body=f"Closes {REF}")
+check(
+    "a genuine Closes body passes",
+    result.returncode == 0,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+
+# ── The backtick escape hatch this guard's own remedy recommends ────────────
+
+result = run(body=f"See `{REF}` for background; unrelated to this change.")
+check(
+    "a bare backticked reference with no keyword passes",
+    result.returncode == 0,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+
+result = run(body=f"This does not close `{REF}` — only advances it.")
+check(
+    "a negated keyword with a backticked reference passes",
+    result.returncode == 0,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+
+# ── The negation vocabulary the tracking issue names ─────────────────────────
+
+for negation, body in [
+    ("doesn't", f"This doesn't close {REF}."),
+    ("never", f"This change never closes {REF} on its own."),
+    ("without", f"This lands without needing to close {REF} outright."),
+]:
+    result = run(body=body)
+    check(
+        f"negation word '{negation}' is caught",
+        result.returncode == 1,
+        f"body={body!r} exit={result.returncode} stderr={result.stderr!r}",
+    )
+
+# ── Sentence boundary: a trailer after an unrelated negated sentence ────────
+
+result = run(body=f"This does not fix the flaky test.\n\nCloses {REF}")
+check(
+    "a negation in an earlier sentence does not poison a later trailer",
+    result.returncode == 0,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+
+# ── The keyword family: fix/close/resolve and their inflections ────────────
+
+for keyword in ["closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves", "resolved"]:
+    result = run(body=f"This change does not {keyword} {REF} by itself.")
+    check(
+        f"keyword '{keyword}' is caught under negation",
+        result.returncode == 1,
+        f"exit={result.returncode} stderr={result.stderr!r}",
+    )
+
+# ── The commit-message channel ───────────────────────────────────────────────
+
+result = run(
+    body=f"Refs {REF}",
+    commits=f"chore: prep work\n\nThis does not close {REF}.",
+)
+check(
+    "a negated keyword in a commit message fails, even with a clean body",
+    result.returncode == 1,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+check(
+    "a commit-message violation is labelled as such",
+    "a commit message" in result.stderr,
+    result.stderr,
+)
+
+# ── Nothing to check ──────────────────────────────────────────────────────────
+
+result = run()
+check(
+    "no body and no commit messages is a clean no-op, not a failure",
+    result.returncode == 0,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+print(f"\n{pass_count} passed, {fail_count} failed")
+sys.exit(1 if fail_count else 0)


### PR DESCRIPTION
## What & why

GitHub's closing-keyword parser reads a keyword (`close`, `fix`, `resolve`,
and their inflections) and the issue reference right after it. It does not
read the words in front of the keyword. PR #6180 carried `Refs #6155` in its
commit trailer -- the correct spelling for "advances but does not finish"
-- and its description said "This does not close `#6155`." GitHub closed
`#6155` anyway. A person had to reopen it by hand.

`scripts/check-closing-keywords.py` fails a pull request whose description
or commit messages carry a negation word (`not`, `never`, `without`,
`doesn't`) in front of a closing keyword and its issue reference, in the
same sentence. It runs in `ci.yml`'s guards job, `pull_request`-only, next
to `check-deleted-tests.sh` -- both read a PR's live description and commit
messages via `gh pr view`, which is not something a single local tree
carries, so neither is a `make gate` step. It also runs in
`guard-self-tests.yml`'s `gate-steps` job, whose trigger carries no `paths:`
filter and which is not gated on the diff reaching a crate -- see the note
below.

The remedy the guard prints matches the issue's own design: wrap the issue
number in backticks (`` `#N` ``), or write "advances #N" instead of a
closing keyword.

AGENTS.md's "One keyword per issue" paragraph gains the negation case,
citing #6180 as the real example.

Closes #6190

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed

`scripts/test-closing-keywords.py` runs the guard as a subprocess against
fixture PR bodies and commit messages -- it fails on `main` because
`scripts/check-closing-keywords.py` does not exist there, and passes with
this change (22 cases, including the three named in the issue's own "How to
verify" section: a negated body fails, a `Refs #N` body passes, a genuine
`Closes #N` body passes). `make closing-keywords-test` runs it locally; it
is also wired into `guard-self-tests.yml` as a hermetic self-test.

## The gate

- [x] fmt check -- ran `cargo fmt --all` locally, no diff (no Rust changed)
- [ ] clippy, full workspace, all targets -- no Rust files changed; CI's step
      is unaffected
- [ ] test, full workspace -- no Rust files changed
- [x] Docs updated: AGENTS.md's "One keyword per issue" paragraph
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: `#6248` -- `check-guard-trigger-coverage.py` reads a workflow's
      trigger and never its job-level `if:`, so it cannot see the gap this PR
      closes. That is why this guard is absent from its `WATCHED_GUARDS`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps -- `scripts/check-closing-keywords.py`
      only uses the Python standard library (`re`, `subprocess`, `argparse`)
- [x] No new outbound network calls -- the guard's only external call is
      `gh pr view`, matching `check-deleted-tests.sh`'s existing pattern,
      and only runs in CI with a `pull-requests: read` token granted to each
      job that runs it

## Anything reviewers should know?

Neither new file needed a `scripts/prose-baseline.txt` entry -- both pass
`make prose` clean, including the strict 5th/6th-grade reading-level ceiling
new files are held to (`scripts/prose-grade-baseline.txt`). The test
fixtures build a placeholder issue reference (`#{ISSUE_NUM}`) at runtime
rather than as a literal string, since a literal `#NNNNN` in the source
would itself trip `check-prose.py`'s own `issue-reference` pattern.

> **Note (autonomous PR sweeps, 2026-09-06) — both halves are settled; this
> paragraph is the current state.**
>
> **1. This PR reproduced its own bug, and no longer does.** The description
> once quoted the offending sentence with a bare issue reference, so GitHub
> linked this PR as closing `#6155`. The references are now backticked, which
> is the remedy this guard itself prints, and `#6155` lists only `#6180` under
> `closedByPullRequestsReferences`.
>
> **2. The commit message carried the same bare form, and was repaired in
> `bb5ca83`** (amended from `2bfef43`, tree byte-identical, force-pushed with
> `--force-with-lease`). This matters because a squash-merge composes its body
> from `COMMIT_MESSAGES` rather than from the description. Earlier comments on
> this PR that describe the commit message as still unfixed predate that
> repair and are stale. Verified on head `34abe85`: the guard read both the
> live description and every commit message and reported
> `no negated closing keyword found`, with no stale-snapshot fallback.
>
> **3. The last DoD box on `#6190` is closed by `34abe85`.** The guard ran only
> inside `ci.yml`'s `check` job, gated on `needs.changes.outputs.rust !=
> 'false'`, so a prose-only diff skipped it -- the diff shape most likely to
> carry a negated closing keyword. It now also runs in
> `guard-self-tests.yml`'s `gate-steps` job.

## Summary by Sourcery

Prevent negated closing keywords in pull requests from unintentionally closing referenced issues.

New Features:
- Add a pull-request guard that detects negated closing keywords in descriptions and commit messages before GitHub can incorrectly close an issue.
- Add a hermetic self-test suite and local Makefile target for the closing-keyword guard.

Bug Fixes:
- Prevent issues from being unintentionally closed when a pull request says that it does not close, fix, or resolve them.

Enhancements:
- Document the negated closing-keyword case and recommended safe wording in AGENTS.md.

CI:
- Run the closing-keyword guard in pull-request CI and its self-test in the guard validation workflow, including permissions for live pull-request metadata.

Documentation:
- Update contributor guidance with the behavior of GitHub's closing-keyword parser and how to avoid unintended issue closures.

Tests:
- Cover negation variants, closing-keyword inflections, backtick escapes, sentence boundaries, PR bodies, commit messages, and clean no-op behavior.