### PR TITLE
Delete the engine builder shims so a turn cannot be built with no seams answered

### DIFF
--- a/crates/stella-cli/src/agent/engine.rs
+++ b/crates/stella-cli/src/agent/engine.rs
@@ -842,8 +842,8 @@ pub(crate) fn session_router(cfg: &Config, worker_ref: &ModelRef) -> Router {
 /// Mid-turn fallback resolution for the bare (non-pipeline) loops (#2679):
 /// when the worker's retry ladder exhausts, the engine asks this port for a
 /// replacement, and the answer is a fresh [`Router::resolve`] of the worker
-/// role — whose breaker the failing calls already fed via
-/// `with_provider_outcomes`, so resolution routes around the sick provider.
+/// role — whose breaker the failing calls already fed through the seam set's
+/// `outcomes` slot, so resolution routes around the sick provider.
 /// The replacement adapter is built from the discovered credentials on
 /// first use and owned here (set-once), so the engine can borrow it for the
 /// rest of the turn. Every miss is soft, matching

--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -198,13 +198,9 @@ pub(crate) async fn run_resume(cfg: &Config, id: Option<&str>) -> Result<(), Cli
         // Assembled, not built up by optional builders. This turn is the
         // `Resume` lane and says so. `lane_capabilities::resume` answers
         // every seam, so nothing is left to a chain.
-        let engine = Engine::assemble(
-            &*provider,
-            &tools,
-            engine_config,
-            &TokioSleeper,
-            crate::lane_capabilities::resume(cfg.hooks.as_ref(), &hook_runner, &calibration),
-        );
+        let seams =
+            crate::lane_capabilities::resume(cfg.hooks.as_ref(), &hook_runner, &calibration);
+        let engine = Engine::assemble(&*provider, &tools, engine_config, &TokioSleeper, seams);
         drive_resumed_turn(&engine, state, &events).await
     };
 
@@ -356,6 +352,7 @@ mod tests {
     use async_trait::async_trait;
 
     use super::*;
+    use stella_core::TurnCapabilities;
     use stella_core::step::{
         BudgetSnapshot, CHECKPOINT_VERSION, Checkpoint, CheckpointSink, TurnState,
     };
@@ -495,7 +492,14 @@ mod tests {
             ..EngineConfig::default()
         };
         let state = TurnState::from_checkpoint(killed_mid_turn(), &config);
-        let engine = Engine::with_sleeper(&provider, &tools, config, &crate::runtime::TokioSleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(
+            &provider,
+            &tools,
+            config,
+            &crate::runtime::TokioSleeper,
+            seams,
+        );
         let (tx, mut rx) = mpsc::unbounded_channel::<AgentEvent>();
         let events = stella_core::EventSender::new(tx);
 
@@ -566,7 +570,14 @@ mod tests {
         let mut at_cap = killed_mid_turn();
         at_cap.step = config.max_steps;
         let state = TurnState::from_checkpoint(at_cap, &config);
-        let engine = Engine::with_sleeper(&provider, &tools, config, &crate::runtime::TokioSleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(
+            &provider,
+            &tools,
+            config,
+            &crate::runtime::TokioSleeper,
+            seams,
+        );
         let (tx, _rx) = mpsc::unbounded_channel::<AgentEvent>();
         let events = stella_core::EventSender::new(tx);
 
@@ -611,7 +622,14 @@ mod tests {
         let mut at_cap = killed_mid_turn();
         at_cap.step = config.max_steps;
         let state = TurnState::from_checkpoint(at_cap, &config);
-        let engine = Engine::with_sleeper(&provider, &tools, config, &crate::runtime::TokioSleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(
+            &provider,
+            &tools,
+            config,
+            &crate::runtime::TokioSleeper,
+            seams,
+        );
         let (tx, _rx) = mpsc::unbounded_channel::<AgentEvent>();
         let events = stella_core::EventSender::new(tx);
 

--- a/crates/stella-cli/src/command_deck/lead_control.rs
+++ b/crates/stella-cli/src/command_deck/lead_control.rs
@@ -70,7 +70,7 @@ impl LeadPause {
         }
     }
 
-    /// The gate to hand to `Pipeline::with_turn_gate` and `Engine::with_gate`.
+    /// The gate to hand a seam set's `gate` slot.
     /// (`attach_turn_controls` wants the owned form — see [`turn_controls`].)
     pub(super) fn turn_gate(&self) -> &dyn stella_core::ports::TurnGate {
         self.gate.as_ref()
@@ -179,9 +179,9 @@ mod tests {
     use stella_core::ports::TurnGate;
     use tokio::sync::mpsc;
 
-    /// `p` on the lead row must reach the gate handed to
-    /// `Pipeline::with_turn_gate` and `Engine::with_gate`, so this asserts on
-    /// the real adapter's parking behavior rather than on the flag behind it.
+    /// `p` on the lead row must reach the gate the lead lane binds, so this
+    /// asserts on the real adapter's parking behavior rather than on the flag
+    /// behind it.
     /// Parking IS the acceptance criterion — the engine polls the gate once
     /// per step, so a gate that never parks is a pause that buys another
     /// model call.

--- a/crates/stella-cli/src/command_deck/lead_turn.rs
+++ b/crates/stella-cli/src/command_deck/lead_turn.rs
@@ -158,28 +158,21 @@ pub(super) async fn run_lead_turn(
             // The scoped skill's `effort:` override, for this turn.
             engine_config.effort = Some(effort);
         }
-        // Assembled rather than built up by optional builders (#6056): this
-        // turn is the `Lead` lane and now says so, and every seam it does not
-        // take is a written `None` in `lane_capabilities::lead` rather than
-        // whatever the builder chain happened not to attach. The conditional
-        // `with_hooks` / `with_requery` calls this replaces bound exactly the
-        // same two seams, which is why both arrive as `Option`s.
-        let engine = Engine::assemble(
-            provider,
-            &scoped_tap,
-            engine_config,
-            &TokioSleeper,
-            crate::lane_capabilities::lead(
-                cfg.hooks.as_ref(),
-                &hook_runner,
-                calibration,
-                pause.turn_gate(),
-                &**steering,
-                requery
-                    .as_ref()
-                    .map(|requery| requery as &dyn stella_core::ports::SteeringRequery),
-            ),
+        // Assembled from one value, not built up call by call (#6056).
+        // This turn is the `Lead` lane and says so. Every seam it does not
+        // take is a written `None` in `lane_capabilities::lead`. The two
+        // seams the deck binds only sometimes arrive as `Option`s.
+        let seams = crate::lane_capabilities::lead(
+            cfg.hooks.as_ref(),
+            &hook_runner,
+            calibration,
+            pause.turn_gate(),
+            &**steering,
+            requery
+                .as_ref()
+                .map(|requery| requery as &dyn stella_core::ports::SteeringRequery),
         );
+        let engine = Engine::assemble(provider, &scoped_tap, engine_config, &TokioSleeper, seams);
         let outcome = engine.run_turn_with_sender(messages, budget, &events).await;
         // The turn's plan graph, mirrored beside the board it was built from
         // (#5037): every revision, the `[:NEXT]` chain each of them authored,

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -1112,18 +1112,19 @@ async fn run_task(
             }
             let calibration = agent::seed_calibration(&store, &cfg);
             let hooks = cfg.hooks.as_ref();
-            let seams =
-                lane_capabilities::fleet_attempt(hooks, &hook_runner, &calibration, gate.as_ref());
-            let mut engine = Engine::assemble(&*provider, &scoped, config, &TokioSleeper, seams);
-            // Attached above the arms, not inside one: a `--pipeline` round
-            // drives this same engine, so a wrapped attempt re-queries too.
-            // It rides here rather than in `fleet_attempt`'s seam set because
-            // the port is built per attempt from this worker's own
-            // `WorkerSteering`, which the lane's capability constructor has no
-            // handle on.
-            if let Some(requery) = &requery {
-                engine = engine.with_requery(requery);
-            }
+            // The re-query plane rides the lane's seam set, not a call after
+            // it: a `--pipeline` round drives this same engine, so a wrapped
+            // attempt re-queries too.
+            let seams = lane_capabilities::fleet_attempt(
+                hooks,
+                &hook_runner,
+                &calibration,
+                gate.as_ref(),
+                requery
+                    .as_ref()
+                    .map(|requery| requery as &dyn stella_core::ports::SteeringRequery),
+            );
+            let engine = Engine::assemble(&*provider, &scoped, config, &TokioSleeper, seams);
             // A fleet worker owns its lane's stage vocabulary — the opener is
             // here; the closer rides `worker_event_sender` below, ahead of
             // the engine's `TurnComplete` (#3416, #3428).

--- a/crates/stella-cli/src/lane_capabilities.rs
+++ b/crates/stella-cli/src/lane_capabilities.rs
@@ -7,11 +7,11 @@
 //! all. Built here: the deck's lead turn, a resumed turn, a deck worker lane,
 //! a fleet attempt, the shared raw turn, and a judged goal arc.
 //!
-//! Each one goes to the engine through `Engine::assemble`. Its
-//! `TurnCapabilities` carries the lane name. The other way in,
-//! `Engine::with_sleeper` and a chain of `with_*` calls, cannot: it always
-//! writes `lane: None`. A turn with no lane lands in the `null` group with
-//! every other one, and a report keyed by lane then has nothing to show.
+//! Each one goes to the engine through `Engine::assemble`, the only
+//! constructor. Its `TurnCapabilities` carries the lane name. A seam set that
+//! leaves `lane` unset lands its turns in the `null` group with every other
+//! door that names none, and a report keyed by lane has nothing to show for
+//! them.
 //!
 //! Each function below answers every seam. Every literal is written out in
 //! full. So a new slot on [`TurnCapabilities`] breaks this file until someone
@@ -114,11 +114,16 @@ pub(crate) fn sub_session<'a>(
 }
 
 /// One fleet attempt — `BuiltinLane::FleetWorker`.
+///
+/// `requery` is an `Option` because the plane exists only where the attempt
+/// has a memory to query. The worker builds it per attempt from its own
+/// `WorkerSteering`, so it arrives as an argument rather than being made here.
 pub(crate) fn fleet_attempt<'a>(
     hooks: Option<&'a Hooks>,
     runner: &'a dyn HookRunner,
     calibration: &'a CalibrationMap,
     gate: &'a dyn TurnGate,
+    requery: Option<&'a dyn SteeringRequery>,
 ) -> TurnCapabilities<'a> {
     TurnCapabilities {
         hooks: hooks.map(|hooks| (hooks, runner)),
@@ -128,7 +133,7 @@ pub(crate) fn fleet_attempt<'a>(
         // A fleet worker has no input channel. Nobody is at a keyboard to
         // steer it, so this stays unbound.
         steering: None,
-        requery: None,
+        requery,
         bus: None,
         outcomes: None,
         fallback: None,
@@ -277,10 +282,10 @@ mod tests {
     /// **The lane witnesses.** Every lane this crate assembles says which
     /// lane it is.
     ///
-    /// This fails on a tree whose sites use `Engine::with_sleeper`. The
-    /// reason is structural, not behavioural. That call takes no lane and
-    /// always writes `lane: None`. There is no function to call, and nothing
-    /// that could answer.
+    /// This failed on the tree whose sites used the sleeper-only
+    /// constructor. The reason is structural, not behavioural. That call took
+    /// no lane and always wrote `lane: None`. There was no function to call,
+    /// and nothing that could answer.
     ///
     /// `stella-core`'s `a_turn_stamps_the_lane_that_assembled_it` covers what
     /// a named lane then does: it reaches `agent.turn.started` on the wire.
@@ -310,7 +315,7 @@ mod tests {
             ),
             (
                 "fleet_attempt",
-                fleet_attempt(None, &runner, &calibration, &gate).lane,
+                fleet_attempt(None, &runner, &calibration, &gate, None).lane,
                 BuiltinLane::FleetWorker,
             ),
             (
@@ -397,18 +402,19 @@ mod tests {
         assert!(worker.calibration.is_some() && worker.gate.is_some() && worker.steering.is_some(),);
         assert_eq!(worker.call_role, ModelCallRole::Worker);
 
-        let fleet = fleet_attempt(None, &runner, &calibration, &gate);
+        let fleet = fleet_attempt(None, &runner, &calibration, &gate, None);
         assert!(fleet.calibration.is_some() && fleet.gate.is_some());
         assert!(
             fleet.steering.is_none(),
             "a fleet attempt has no input channel to steer from",
         );
+        assert!(fleet.requery.is_none(), "no plane was handed in");
         assert_eq!(fleet.call_role, ModelCallRole::Worker);
+        let fleet_with_both =
+            fleet_attempt(Some(&hooks), &runner, &calibration, &gate, Some(&plane));
         assert!(
-            fleet_attempt(Some(&hooks), &runner, &calibration, &gate)
-                .hooks
-                .is_some(),
-            "a fleet attempt must run the hooks its caller handed it",
+            fleet_with_both.hooks.is_some() && fleet_with_both.requery.is_some(),
+            "a fleet attempt must pass on the seams its caller handed it",
         );
 
         let controls = TurnControls::none()
@@ -500,11 +506,11 @@ mod tests {
     /// **The call-site witnesses.** Each door that is not the deck reaches
     /// the engine through `Engine::assemble` and its own seams.
     ///
-    /// Fails on a tree where the three files build with the sleeper
-    /// constructor: that call takes no lane, so it writes `lane: None` and no
-    /// argument can say otherwise. The needles are built rather than written
-    /// out, so `turn_files`' driver fence reads this file as prose about a
-    /// constructor instead of a door that builds one.
+    /// Failed on the tree where the three files built with the sleeper-only
+    /// constructor: that call took no lane, so it wrote `lane: None` and no
+    /// argument could say otherwise. The needles are built rather than
+    /// written out, so `turn_files`' driver fence reads this file as prose
+    /// about a constructor instead of a door that builds one.
     #[test]
     fn each_door_that_is_not_the_deck_assembles_through_its_lane() {
         let blessed = format!("Engine::{}(", "assemble");
@@ -537,6 +543,42 @@ mod tests {
                  binds is one written literal rather than a chain",
             );
         }
+    }
+
+    /// **The host-engine witness.** The one engine this crate builds that is
+    /// not a lane still goes through the blessed constructor.
+    ///
+    /// `subagent.rs`'s `SessionSubAgents` builds an engine it never runs a
+    /// turn on. `run_sub_agent` builds the child that does, and that child
+    /// stamps `BuiltinLane::SubagentFork`. So this site binds no seam and
+    /// names no lane. It writes both answers down. `TurnCapabilities::none`
+    /// names every slot, so a new slot stops this site compiling too.
+    ///
+    /// It failed on a tree that built this engine through a constructor that
+    /// answered no seam. There, "no seam" and "no seam anyone chose" read the
+    /// same. `stella-serve`'s `subagents.rs` is the same shape one crate
+    /// over. It carries the same test beside its own source, the way the two
+    /// copies of the accept policy each carry theirs.
+    #[test]
+    fn the_host_engine_this_crate_builds_assembles_with_a_written_seam_set() {
+        let source = include_str!("subagent.rs");
+        let blessed = format!("Engine::{}(", "assemble");
+        let bare = format!("TurnCapabilities::{}()", "none");
+
+        assert!(
+            source.contains(&blessed),
+            "subagent.rs builds a host engine and must assemble it, or a seam added to the \
+             engine reaches it as a silent `None`",
+        );
+        assert!(
+            source.contains(&bare),
+            "subagent.rs must say in one written value that it binds no seam — `{bare}` is \
+             that value, and it is exhaustive, so a new slot stops this site compiling",
+        );
+        assert!(
+            !source.contains(&format!("Engine::with_{}(", "sleeper")),
+            "subagent.rs is back on a constructor that answers no seam and takes no lane",
+        );
     }
 
     /// `agent/turn.rs` assembles twice — once with the hook layer stripped by

--- a/crates/stella-cli/src/subagent.rs
+++ b/crates/stella-cli/src/subagent.rs
@@ -52,7 +52,7 @@ use stella_core::ports::TurnSteering;
 use stella_core::subagent::{
     SubAgentDispatcher, SubAgentHost, SubAgentOutcome, SubAgentSpec, push_sub_agent_spend,
 };
-use stella_core::{BudgetGuard, Engine, EngineConfig, EventSender};
+use stella_core::{BudgetGuard, Engine, EngineConfig, EventSender, TurnCapabilities};
 use stella_protocol::Provider;
 use stella_tools::ToolRegistry;
 
@@ -659,13 +659,18 @@ impl SessionSubAgents {
                 // `ChildSteering`, so this is what makes a child pausable and
                 // stoppable without letting it steal the parent's messages.
                 //
-                // Still the builder path, and it names no lane on purpose:
-                // this engine never drives a turn of its own. `run_sub_agent`
-                // assembles the child that does, and that child stamps
-                // `BuiltinLane::SubagentFork`. A lane declared here would
-                // reach no `agent.turn.started` at all.
-                let engine = Engine::with_sleeper(&*provider, child_tools, config, &TokioSleeper)
-                    .with_turn_controls(&controls);
+                // Every seam unbound, and no lane, on purpose: this engine
+                // never drives a turn of its own, so it has nothing to pause,
+                // steer or attribute. `run_sub_agent` assembles the child that
+                // does, and that child stamps `BuiltinLane::SubagentFork`. A
+                // lane declared here would reach no `agent.turn.started` at
+                // all. The controls below are the one thing this host engine
+                // does carry, and they reach the child rather than this
+                // engine's own turn.
+                let seams = TurnCapabilities::none();
+                let engine =
+                    Engine::assemble(&*provider, child_tools, config, &TokioSleeper, seams)
+                        .with_turn_controls(&controls);
                 // `catch_unwind` so a panic INSIDE the turn cannot skip the
                 // settle below (#1850). Without it the unwind leaves this
                 // frame directly and real dollars the child had already spent

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -611,7 +611,7 @@ pub(crate) fn route_mid_turn(text: String, settling: bool) -> MidTurnRoute {
 ///
 /// `pub(crate)` for one caller beyond this module: the deck's LEAD lane
 /// (#1219), which builds the same adapter over its own per-turn channel and
-/// hands it to `Pipeline::with_turn_gate` / `Engine::with_gate`. Deck worker
+/// binds it as its seam set's `gate`. Deck worker
 /// lanes and the deck lead sit on the same side of the deck/fleet boundary,
 /// so they share this item rather than duplicating it; `fleet_cmd.rs` keeps
 /// its own co-located twin precisely because it does not.

--- a/crates/stella-cli/src/turn_files.rs
+++ b/crates/stella-cli/src/turn_files.rs
@@ -791,10 +791,9 @@ mod tests {
     /// `run_goal` and the resume path are three different entries and
     /// building an engine is the one thing all of them do first.
     ///
-    /// **Both** constructors count: `Engine::with_sleeper` and
-    /// [`stella_core::Engine::assemble`], the blessed one a named lane uses.
-    /// A fence that saw only one spelling would read every driver on the
-    /// other as not building an engine at all.
+    /// Keyed on [`stella_core::Engine::assemble`]. That call is the only way
+    /// to build an engine. So a door has no second spelling to hide behind,
+    /// and this fence sees them all.
     ///
     /// Shipping files only. A `#[cfg(test)]` engine is a fixture, and the
     /// question here is which *door* drives a turn.
@@ -803,11 +802,8 @@ mod tests {
         // Built rather than written out, so this file is not its own match,
         // and with the open paren so a doc comment naming a constructor is
         // prose rather than a driver.
-        let constructors = [
-            format!("Engine::with_{}(", "sleeper"),
-            format!("Engine::{}(", "assemble"),
-        ];
-        let builds = |body: &str| constructors.iter().any(|ctor| body.contains(ctor));
+        let constructor = format!("Engine::{}(", "assemble");
+        let builds = |body: &str| body.contains(&constructor);
         let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
 
         for (file, posture) in ENGINE_DRIVERS {

--- a/crates/stella-cli/src/whistle.rs
+++ b/crates/stella-cli/src/whistle.rs
@@ -108,7 +108,8 @@ impl SessionWhistle {
         }
     }
 
-    /// What to hand `stella_core::Engine::with_steering`.
+    /// What to hand a seam set's `steering` slot. The engine drains it once
+    /// a step, at the same boundary as the pause gate.
     pub(crate) fn steering(&self) -> &dyn stella_core::ports::TurnSteering {
         self.tap.as_ref()
     }

--- a/crates/stella-core/README.md
+++ b/crates/stella-core/README.md
@@ -283,10 +283,11 @@ system message and the latest user message are never touched.
   or `modify` before any `Engine` exists. `SubagentStart`/`SubagentStop` are
   the opposite case: they fire from inside this crate
   ([`src/subagent.rs`](src/subagent.rs)), around a child turn, observe-only.
-- **`Engine::with_sleeper` is the only *public* constructor,** and it cannot
-  carry `gate`/`steering`/`hooks` — those are builder-set private fields. A
-  nested turn built through it silently drops all three, which is the bug
-  `goal.rs::assess` shipped with. Do not hand-roll a child engine: call
+- **`Engine::assemble` is the only constructor,** and its `TurnCapabilities`
+  answers every optional seam. Nothing else can build an engine. So no site
+  can leave a seam unanswered. That is the bug `goal.rs::assess` shipped
+  with: a nested turn that dropped `gate`, `steering` and `hooks` at once.
+  Do not hand-roll a child engine. Call
   [`src/subagent.rs`](src/subagent.rs)'s `run_sub_agent`, which constructs the
   child in-crate and carries every seam. The crate still exports the `Sleeper`
   port with no production implementation — wiring a real one is the binary's
@@ -342,9 +343,10 @@ here. An intended change edits the pin in the same pull request
 
 1. Define the trait next to the decision it serves — [`src/ports.rs`](src/ports.rs)
    for engine-wide seams, otherwise module-local like `hooks::HookRunner`.
-2. Attach it with a `with_*` builder on `Engine` that stores an `Option`, so an
-   engine built without it takes exactly the old path
-   (`with_hooks`/`with_calibration`/`with_gate`/`with_steering` are the pattern).
+2. Add an `Option` slot to `TurnCapabilities`
+   ([`src/driver/capabilities.rs`](src/driver/capabilities.rs)). Wire it
+   through `Engine::assemble`. The struct has no `Default`. So every site
+   that builds an engine stops compiling until someone answers the new slot.
 3. Implement it in `stella-cli` or `stella-tools`. Never here.
 4. Test it in-crate against a fake implementation.
 

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -247,45 +247,44 @@ pub struct Engine<'a> {
     pub(crate) config: EngineConfig,
     pub(crate) call_role: stella_protocol::ModelCallRole,
     /// Which lane assembled this engine (#3386/#3410), stamped onto
-    /// `agent.turn.started`. `None` means the engine came through
-    /// [`Engine::with_sleeper`] and the individual builders, which have no
-    /// lane to report -- an honest "unattributed", not a forgotten one.
+    /// `agent.turn.started`. `None` is an answer somebody wrote in the
+    /// assembling [`TurnCapabilities`](crate::TurnCapabilities) -- an honest
+    /// "unattributed", not a forgotten one.
     pub(crate) lane: Option<stella_protocol::TurnLane>,
-    /// Lifecycle hooks, off by default. Attached via [`Engine::with_hooks`]
-    /// so `with_sleeper` keeps its existing signature. When `None`,
+    /// Lifecycle hooks, off by default. Bound by the `hooks` slot of the
+    /// assembling [`TurnCapabilities`](crate::TurnCapabilities). When `None`,
     /// no hook is ever consulted and the turn path adds zero work.
     pub(crate) hooks: Option<HooksHandle<'a>>,
     /// Where a `PreToolUse` hook's `require_approval` decision parks
-    /// (#2684), off by default. Attached via
-    /// [`Engine::with_hook_approval_route`] (`driver::user_hooks`); when
+    /// (#2684), off by default. Bound by the `hook_approvals` slot; when
     /// `None` such a decision is refused with a grant-path message.
     pub(crate) hook_approvals: Option<&'a dyn crate::hooks::decision::ApprovalRoute>,
     /// Token-drift calibration (`crate::estimator::CalibrationMap`), off by
-    /// default. Attached via [`Engine::with_calibration`]; the caller owns
+    /// default. Bound by the `calibration` slot; the caller owns
     /// the map across turns (seeded from persisted telemetry at session
     /// start), the engine feeds it every committed step's (estimated,
     /// actual) pair and reads the correction back into the compaction
     /// decision. When `None` the turn path is the uncalibrated engine.
     pub(crate) calibration: Option<&'a CalibrationMap>,
     /// Boundary pause gate ([`crate::ports::TurnGate`]), off by default.
-    /// Attached via [`Engine::with_gate`]; consulted once per step, before
+    /// Bound by the `gate` slot; consulted once per step, before
     /// any model call — a paused turn parks at that safe boundary and
     /// spends nothing until resumed. `None` adds zero work.
     pub(crate) gate: Option<&'a dyn crate::ports::TurnGate>,
     /// Step-boundary steering ([`crate::ports::TurnSteering`]), off by
-    /// default. Attached via [`Engine::with_steering`]; drained once per
+    /// default. Bound by the `steering` slot; drained once per
     /// step at the same boundary as the pause gate — queued user messages
     /// become the model's next observation, and a latched soft stop ends
     /// the turn keeping every completed step. `None` adds zero work.
     pub(crate) steering: Option<&'a dyn crate::ports::TurnSteering>,
     /// Step-boundary context re-query ([`crate::ports::SteeringRequery`]),
-    /// off by default (#3243 Phase 3). Attached via [`Engine::with_requery`];
+    /// off by default (#3243 Phase 3). Bound by the `requery` slot;
     /// consulted once per step at the same boundary as steering, with the
     /// TurnSignal assembled from this turn's transcript. `None` adds zero
     /// work.
     pub(crate) requery: Option<&'a dyn crate::ports::SteeringRequery>,
     /// Extension hook bus ([`crate::bus::HookBus`]), off by default.
-    /// Attached via [`Engine::with_bus`]; receives the turn/step/model-call
+    /// Bound by the `bus` slot; receives the turn/step/model-call
     /// lifecycle events an out-of-process host uses to observe and, per
     /// ADR-033, apply policy at (#1133). `None` adds zero work — every emit
     /// site is behind the same `if let Some(bus)`.
@@ -296,12 +295,12 @@ pub struct Engine<'a> {
     /// points stay where they already are, on the tool-call path.
     pub(crate) bus: Option<&'a crate::bus::HookBus>,
     /// Call-outcome feedback ([`crate::ports::ProviderOutcomes`]), off by
-    /// default. Attached via [`Engine::with_provider_outcomes`]; each logical
+    /// default. Bound by the `outcomes` slot; each logical
     /// model call reports its terminal verdict against `provider.id()` so a
     /// router's circuit breaker trips from observed outcomes (#2673).
     pub(crate) outcomes: Option<&'a dyn crate::ports::ProviderOutcomes>,
     /// Mid-turn fallback resolution ([`crate::ports::FallbackResolver`]), off
-    /// by default. Attached via [`Engine::with_fallback_resolver`]; consulted
+    /// by default. Bound by the `fallback` slot; consulted
     /// at the retries-exhausted settlement boundary, at most once per engine
     /// (`driver::model_fallback`, #2679). `None` keeps the abort exactly as
     /// it always was.
@@ -375,39 +374,6 @@ struct CommittedStep {
 }
 
 impl<'a> Engine<'a> {
-    /// Construct an engine with an injected [`Sleeper`]. This is the only
-    /// constructor — `stella-core` exports the port, never a production
-    /// impl, so the caller wires a real sleeper (the CLI's tokio-backed
-    /// one) and tests wire a no-op to run retries with zero real
-    /// wall-clock delay.
-    pub fn with_sleeper(
-        provider: &'a dyn Provider,
-        tools: &'a dyn ToolExecutor,
-        config: EngineConfig,
-        sleeper: &'a dyn Sleeper,
-    ) -> Self {
-        Self {
-            provider,
-            tools,
-            sleeper,
-            config,
-            call_role: stella_protocol::ModelCallRole::Worker,
-            // The legacy builder path names no lane. `assemble` is where a
-            // lane is declared.
-            lane: None,
-            hooks: None,
-            hook_approvals: None,
-            calibration: None,
-            gate: None,
-            steering: None,
-            requery: None,
-            bus: None,
-            outcomes: None,
-            fallback: None,
-            provider_override: Arc::new(std::sync::OnceLock::new()),
-        }
-    }
-
     /// Attribute this engine's provider calls to a concrete pipeline role.
     /// Ordinary execution defaults to [`stella_protocol::ModelCallRole::Worker`].
     /// The role this engine attributes its model calls to — the reader for
@@ -507,74 +473,6 @@ impl<'a> Engine<'a> {
         }
     }
 
-    /// Attach lifecycle hooks (`crate::hooks`) to an engine, opt-in. Kept a
-    /// builder so [`Engine::with_sleeper`] retains its signature and every
-    /// existing call site is unchanged — an engine
-    /// built without this is exactly the pre-hooks engine. Takes both the
-    /// parsed [`Hooks`] config and the [`HookRunner`] that executes the
-    /// commands, because [`crate::hooks::run_hooks`] needs the port to run
-    /// anything (the config alone spawns nothing).
-    pub fn with_hooks(mut self, hooks: &'a Hooks, runner: &'a dyn HookRunner) -> Self {
-        self.hooks = Some(HooksHandle { hooks, runner });
-        self
-    }
-
-    /// Attach token-drift calibration, opt-in and by reference for the same
-    /// reason `run_turn` borrows `messages`: the caller (CLI session, REPL,
-    /// fleet worker) owns state that outlives any single turn — engines are
-    /// constructed per turn, calibration accumulates per session. An engine
-    /// built without this estimates exactly as before.
-    pub fn with_calibration(mut self, calibration: &'a CalibrationMap) -> Self {
-        self.calibration = Some(calibration);
-        self
-    }
-
-    /// Attach call-outcome feedback, opt-in: every logical model call
-    /// (retries collapsed) reports success or terminal failure against
-    /// `provider.id()`, so a [`crate::router::Router`]'s circuit breaker
-    /// trips failover from observed outcomes, not configuration (#2673).
-    pub fn with_provider_outcomes(
-        mut self,
-        outcomes: &'a dyn crate::ports::ProviderOutcomes,
-    ) -> Self {
-        self.outcomes = Some(outcomes);
-        self
-    }
-
-    /// Attach mid-turn provider fallback, opt-in: when a model call's retry
-    /// ladder exhausts, the engine re-resolves through this port and
-    /// continues the turn on the replacement instead of aborting — at most
-    /// one swap per engine (`driver::model_fallback`, #2679).
-    pub fn with_fallback_resolver(
-        mut self,
-        fallback: &'a dyn crate::ports::FallbackResolver,
-    ) -> Self {
-        self.fallback = Some(fallback);
-        self
-    }
-
-    /// Attach a boundary pause gate — Pause/Resume at step granularity,
-    /// never mid-tool.
-    pub fn with_gate(mut self, gate: &'a dyn crate::ports::TurnGate) -> Self {
-        self.gate = Some(gate);
-        self
-    }
-
-    /// Attach step-boundary steering — mid-turn user messages and the soft
-    /// stop, at step granularity, never mid-tool.
-    pub fn with_steering(mut self, steering: &'a dyn crate::ports::TurnSteering) -> Self {
-        self.steering = Some(steering);
-        self
-    }
-
-    /// Attach the step-boundary context re-query (#3243 Phase 3) — the
-    /// steering plane asked again when the turn's own evidence says the work
-    /// has moved, at step granularity, never mid-tool.
-    pub fn with_requery(mut self, requery: &'a dyn crate::ports::SteeringRequery) -> Self {
-        self.requery = Some(requery);
-        self
-    }
-
     /// The step cap this engine enforces — the loop bound a host driving
     /// [`Engine::run_step`] itself must apply, since the cap belongs to the
     /// engine's config and a host tracking its own copy is a second source of
@@ -582,18 +480,6 @@ impl<'a> Engine<'a> {
     #[must_use]
     pub fn max_steps(&self) -> usize {
         self.config.max_steps
-    }
-
-    /// Attach an extension hook bus, so the turn, step and model-call
-    /// boundaries this engine already crosses become observable (#1133).
-    /// Before this the only production emitter on the bus was the tool
-    /// registry — the catalog and `emit_named` existed, the call sites did
-    /// not, and they are here because this is where the boundaries are.
-    ///
-    /// Observer-only, by construction: see the `bus` field.
-    pub fn with_bus(mut self, bus: &'a crate::bus::HookBus) -> Self {
-        self.bus = Some(bus);
-        self
     }
 
     /// Emit one lifecycle event, if a bus is attached.

--- a/crates/stella-core/src/driver/capabilities.rs
+++ b/crates/stella-core/src/driver/capabilities.rs
@@ -3,22 +3,20 @@
 //!
 //! # The defect this closes
 //!
-//! [`Engine::with_sleeper`](super::Engine::with_sleeper) returns an engine
-//! with every optional seam set to `None`, and each one is turned on by its
-//! own builder call. Those builders are public and work correctly; the
-//! problem is that **nothing makes a caller use them**. An assembly site that
-//! wants the pause gate and forgets `with_gate` compiles, runs, and quietly
-//! spends through a pause — and reads identically to a site that decided it
-//! did not want a gate. `goal.rs::assess` shipped exactly that bug against
-//! three seams at once.
+//! A constructor that sets every optional seam to `None`, with one opt-in
+//! call per seam, gives a caller nothing that makes those calls happen. An
+//! assembly site that wants the pause gate and attaches no gate compiles,
+//! runs, and quietly spends through a pause — and reads exactly like a site
+//! that decided it did not want one. `goal.rs::assess` shipped that bug
+//! against three seams at once.
 //!
-//! It was tempting to state this as "the constructor *cannot* carry those
-//! seams" (the framing in #3274 slice 2 and slide 22 of the turn-loop deck).
-//! That is not true of this tree and a witness written against it passes
-//! unchanged on `main`: `with_gate`/`with_steering`/`with_hooks` are `pub`
-//! and callers outside this crate use them today. The real property is
-//! **totality** — a decision must be recorded for every slot — and that is
-//! what this type enforces.
+//! [`Engine::assemble`](super::Engine::assemble) is the only constructor, and
+//! the value it takes answers every seam, so a decision is recorded for every
+//! slot because there is no other way to build an engine. The property is
+//! **totality**. It is not "the constructor cannot carry those seams" — the
+//! framing in #3274 slice 2 and slide 22 of the turn-loop deck — which a
+//! witness could not hold on a tree where every seam had a public setter
+//! beside the constructor.
 //!
 //! # Why there is no `Default`, and no `#[non_exhaustive]`
 //!
@@ -26,7 +24,11 @@
 //!
 //! - **No `Default`.** A default is precisely the forgotten decision this
 //!   type exists to abolish. `..Default::default()` at an assembly site would
-//!   restore the defect with better syntax.
+//!   restore the defect with better syntax. A test fixture may write
+//!   `..TurnCapabilities::none()` over the seams it binds — [`Self::none`] is
+//!   itself an exhaustive literal, so a new slot still stops the build until
+//!   somebody answers it there. A lane writes every field out; `stella-cli`'s
+//!   `lane_capabilities` is where they all live.
 //! - **No `#[non_exhaustive]`.** That attribute forbids struct-literal
 //!   construction outside the defining crate, which would force every
 //!   external lane through setters — and setters are optional calls, which is
@@ -258,11 +260,10 @@ impl<'a> Engine<'a> {
     /// The blessed constructor: assemble an engine from its required ports
     /// and one [`TurnCapabilities`] answering every optional seam.
     ///
-    /// This is what a lane — builtin or plugin-driven — is expected to call.
-    /// [`Engine::with_sleeper`](Engine::with_sleeper) plus the individual
-    /// `with_*` builders remain for existing call sites and behave exactly as
-    /// before; what they cannot offer is the guarantee that every seam was
-    /// considered.
+    /// The only constructor. A lane — builtin or plugin-driven — reaches the
+    /// engine through here, and the seam set it hands over is what makes
+    /// "every seam was considered" a fact about the build rather than a
+    /// habit.
     pub fn assemble(
         provider: &'a dyn Provider,
         tools: &'a dyn ToolExecutor,
@@ -319,9 +320,9 @@ mod tests {
     /// rest pattern. Adding a slot to the struct without adding it here fails
     /// to compile, which is the property the type exists to provide.
     ///
-    /// It is not written as "a fork carries gate/steering/hooks":
-    /// that passes on `main` unchanged, because the fork already carries them
-    /// and the builders that attach them are public. See the module doc.
+    /// It is not written as "a fork carries gate/steering/hooks". That
+    /// passed unchanged while the per-seam builders were public, because the
+    /// fork already carried them. See the module doc.
     #[test]
     fn every_capability_slot_is_named_by_this_test() {
         let TurnCapabilities {
@@ -372,13 +373,8 @@ mod tests {
         let sleeper = crate::subagent::tests::NoSleep;
 
         let owned = built_elsewhere();
-        let engine = Engine::assemble(
-            &provider,
-            &tools,
-            EngineConfig::default(),
-            &sleeper,
-            owned.as_borrowed(),
-        );
+        let seams = owned.as_borrowed();
+        let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
 
         assert_eq!(engine.call_role, ModelCallRole::Verdict);
     }
@@ -415,13 +411,8 @@ mod tests {
         let tools = crate::subagent::tests::MixedTools::default();
         let sleeper = crate::subagent::tests::NoSleep;
 
-        let engine = Engine::assemble(
-            &provider,
-            &tools,
-            EngineConfig::default(),
-            &sleeper,
-            TurnCapabilities::none(),
-        );
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
 
         assert!(engine.hooks.is_none());
         assert!(engine.hook_approvals.is_none());
@@ -433,5 +424,64 @@ mod tests {
         assert!(engine.outcomes.is_none());
         assert!(engine.fallback.is_none());
         assert_eq!(engine.call_role, ModelCallRole::Worker);
+    }
+
+    /// **The deletion witness.** No per-seam builder survives on `Engine`,
+    /// so `assemble` is the only way to build one.
+    ///
+    /// The shape tests above are about the *value*: they hold
+    /// [`TurnCapabilities`] to naming every slot. Neither can see a second
+    /// constructor beside `assemble`, which is what made the totality claim
+    /// worth only what a caller chose to spend on it — a site could take the
+    /// sleeper-only constructor, reach the engine with every seam unset and
+    /// no lane, and nothing here would notice.
+    ///
+    /// Source text rather than a `compile_fail` doctest: a doctest passes on
+    /// any compile error at all, including a typo in its own setup, so it
+    /// cannot tell "the builder is gone" from "this snippet is broken".
+    /// Reading the two files back can.
+    ///
+    /// The needles are built rather than written out, so this test is not its
+    /// own match and neither is any prose above it.
+    #[test]
+    fn no_per_seam_builder_survives_beside_assemble() {
+        let sources = [
+            ("driver.rs", include_str!("../driver.rs")),
+            ("driver/user_hooks.rs", include_str!("user_hooks.rs")),
+        ];
+        let seams = [
+            "sleeper",
+            "hooks",
+            "calibration",
+            "gate",
+            "steering",
+            "requery",
+            "bus",
+            "provider_outcomes",
+            "fallback_resolver",
+            "hook_approval_route",
+        ];
+
+        for (path, source) in sources {
+            for seam in seams {
+                let needle = format!("pub fn with_{seam}(");
+                assert!(
+                    !source.contains(&needle),
+                    "{path} defines `{needle}` again — a caller taking it reaches the engine \
+                     with every other seam unset and no lane, which is the defect \
+                     `TurnCapabilities` exists to close",
+                );
+            }
+        }
+
+        // The other half: the constructor that replaced them is still here,
+        // so this cannot pass by the file having moved out from under it.
+        assert!(
+            sources
+                .iter()
+                .all(|(_, source)| source.contains("impl<'a> Engine<'a> {")),
+            "a source here stopped opening an Engine impl — this witness is reading the \
+             wrong files, and an empty search proves nothing",
+        );
     }
 }

--- a/crates/stella-core/src/driver/capabilities.rs
+++ b/crates/stella-core/src/driver/capabilities.rs
@@ -25,10 +25,11 @@
 //! - **No `Default`.** A default is precisely the forgotten decision this
 //!   type exists to abolish. `..Default::default()` at an assembly site would
 //!   restore the defect with better syntax. A test fixture may write
-//!   `..TurnCapabilities::none()` over the seams it binds — [`TurnCapabilities::none`] is
-//!   itself an exhaustive literal, so a new slot still stops the build until
-//!   somebody answers it there. A lane writes every field out; `stella-cli`'s
-//!   `lane_capabilities` is where they all live.
+//!   `..TurnCapabilities::none()` over the seams it binds.
+//!   [`TurnCapabilities::none`] is itself an exhaustive literal, so a new
+//!   slot still stops the build until somebody answers it there. A lane
+//!   writes every field out; `stella-cli`'s `lane_capabilities` is where
+//!   they all live.
 //! - **No `#[non_exhaustive]`.** That attribute forbids struct-literal
 //!   construction outside the defining crate, which would force every
 //!   external lane through setters — and setters are optional calls, which is

--- a/crates/stella-core/src/driver/capabilities.rs
+++ b/crates/stella-core/src/driver/capabilities.rs
@@ -25,7 +25,7 @@
 //! - **No `Default`.** A default is precisely the forgotten decision this
 //!   type exists to abolish. `..Default::default()` at an assembly site would
 //!   restore the defect with better syntax. A test fixture may write
-//!   `..TurnCapabilities::none()` over the seams it binds — [`Self::none`] is
+//!   `..TurnCapabilities::none()` over the seams it binds — [`TurnCapabilities::none`] is
 //!   itself an exhaustive literal, so a new slot still stops the build until
 //!   somebody answers it there. A lane writes every field out; `stella-cli`'s
 //!   `lane_capabilities` is where they all live.

--- a/crates/stella-core/src/driver/config.rs
+++ b/crates/stella-core/src/driver/config.rs
@@ -55,10 +55,11 @@ pub struct EngineConfig {
     pub retry_policy: RetryPolicy,
     pub loop_detection: LoopDetectionConfig,
     /// Compaction fires once the estimated conversation size exceeds this
-    /// many tokens (`crate::estimator`). When calibration is attached
-    /// ([`Engine::with_calibration`](super::Engine::with_calibration)) the comparison uses the
-    /// drift-corrected estimate, so this budget is honored in the model's
-    /// own observed tokens rather than raw heuristic tokens.
+    /// many tokens (`crate::estimator`). When the assembling
+    /// [`TurnCapabilities`](crate::TurnCapabilities) bound a `calibration`
+    /// map, the comparison uses the drift-corrected estimate, so this budget
+    /// is honored in the model's own observed tokens rather than raw
+    /// heuristic tokens.
     ///
     /// The value is unmeasured and stands (#4391). #2738 asked for the
     /// compaction defaults to be re-tuned if "thrash" — compaction firing

--- a/crates/stella-core/src/driver/dispatch.rs
+++ b/crates/stella-core/src/driver/dispatch.rs
@@ -273,7 +273,7 @@ mod tests {
     use crate::event_sender::EventSender;
     use crate::retry::Sleeper;
     use crate::step::{BudgetSnapshot, CHECKPOINT_VERSION, Checkpoint, TurnState};
-    use crate::{Engine, EngineConfig, TurnOutcome};
+    use crate::{Engine, EngineConfig, TurnCapabilities, TurnOutcome};
     use stella_protocol::{
         AgentEvent, BudgetMode, CompletionMessage, CompletionRequestRef, CompletionResult,
         CompletionUsage, Provider, ProviderError, ToolCall, ToolOutput, ToolSchema,
@@ -440,7 +440,8 @@ mod tests {
             ..EngineConfig::default()
         };
         let mut state = TurnState::from_checkpoint(step_one(), &config);
-        let engine = Engine::with_sleeper(&provider, &tools, config, &NoopSleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config, &NoopSleeper, seams);
         let (tx, mut rx) = mpsc::unbounded_channel();
         let events = EventSender::new(tx);
 
@@ -494,7 +495,8 @@ mod tests {
         let tools = FlagAndHang { flag, hang: false };
         let config = EngineConfig::default();
         let mut state = TurnState::from_checkpoint(step_one(), &config);
-        let engine = Engine::with_sleeper(&provider, &tools, config, &NoopSleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config, &NoopSleeper, seams);
         let (tx, mut rx) = mpsc::unbounded_channel();
         let events = EventSender::new(tx);
 

--- a/crates/stella-core/src/driver/drive.rs
+++ b/crates/stella-core/src/driver/drive.rs
@@ -208,7 +208,7 @@ mod tests {
     use crate::event_sender::EventSender;
     use crate::retry::Sleeper;
     use crate::step::{BudgetSnapshot, CHECKPOINT_VERSION, Checkpoint, TurnState};
-    use crate::{Engine, EngineConfig, TurnOutcome};
+    use crate::{Engine, EngineConfig, TurnCapabilities, TurnOutcome};
     use stella_protocol::{
         BudgetMode, CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage,
         Provider, ProviderError, ToolCall, ToolOutput, ToolSchema,
@@ -336,7 +336,8 @@ mod tests {
             ..EngineConfig::default()
         };
         let mut state = TurnState::from_checkpoint(restored_at_step_one(), &config);
-        let engine = Engine::with_sleeper(&provider, &tools, config, &NoopSleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config, &NoopSleeper, seams);
         let (tx, _rx) = mpsc::unbounded_channel();
         let events = EventSender::new(tx);
 
@@ -365,7 +366,8 @@ mod tests {
         let tools = OkTool;
         let config = EngineConfig::default();
         let mut state = TurnState::from_checkpoint(restored_at_step_one(), &config);
-        let engine = Engine::with_sleeper(&provider, &tools, config, &NoopSleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config, &NoopSleeper, seams);
         let (tx, _rx) = mpsc::unbounded_channel();
         let events = EventSender::new(tx);
 
@@ -395,7 +397,8 @@ mod tests {
             turn_halt: Some(Arc::new(AlwaysHalt)),
             ..EngineConfig::default()
         };
-        let engine = Engine::with_sleeper(&provider, &tools, config, &NoopSleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config, &NoopSleeper, seams);
         let mut state = engine.new_turn(
             vec![
                 CompletionMessage::system("sys"),

--- a/crates/stella-core/src/driver/lifecycle.rs
+++ b/crates/stella-core/src/driver/lifecycle.rs
@@ -46,11 +46,11 @@ use super::{StepOutcome, TurnOutcome};
 /// with, the loop bound it runs under, which role is driving it, and which
 /// lane assembled it. No message *content* — see the module docs.
 ///
-/// `lane` is `null` for an engine built through the legacy
-/// [`Engine::with_sleeper`](super::Engine::with_sleeper) path, which names no
-/// lane. That null is a positive statement — "this engine was not assembled
-/// by a named lane" — and an observer grouping by lane must read it as its
-/// own bucket rather than dropping the turn (#3410).
+/// `lane` is `null` when the assembling
+/// [`TurnCapabilities`](crate::TurnCapabilities) wrote `lane: None`. That
+/// null is a positive statement — "this engine was not assembled by a named
+/// lane" — and an observer grouping by lane must read it as its own bucket
+/// rather than dropping the turn (#3410).
 pub fn turn_started_payload(
     message_count: usize,
     max_steps: usize,

--- a/crates/stella-core/src/driver/restore.rs
+++ b/crates/stella-core/src/driver/restore.rs
@@ -570,6 +570,7 @@ mod tests {
     };
     use tokio::sync::mpsc;
 
+    use crate::TurnCapabilities;
     use crate::budget::BudgetGuard;
     use crate::driver::{Engine, EngineConfig};
     use crate::event_sender::EventSender;
@@ -741,7 +742,8 @@ mod tests {
             files: files.clone(),
             active: vec![],
         };
-        let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config(), &NoSleep, seams);
         let mut messages = vec![
             CompletionMessage::system("sys"),
             CompletionMessage::user("the task"),
@@ -781,7 +783,8 @@ mod tests {
             files: files.clone(),
             active: vec![],
         };
-        let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config(), &NoSleep, seams);
         let mut messages = vec![
             CompletionMessage::system("sys"),
             CompletionMessage::user("the task"),
@@ -824,7 +827,8 @@ mod tests {
             files: files.clone(),
             active: vec![],
         };
-        let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config(), &NoSleep, seams);
         let mut messages = vec![
             CompletionMessage::system("sys"),
             CompletionMessage::user("the task"),
@@ -869,7 +873,8 @@ mod tests {
             files: Arc::new(Mutex::new(HashMap::new())),
             active: vec!["deploy".into()],
         };
-        let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config(), &NoSleep, seams);
         let mut messages = vec![
             CompletionMessage::system("sys"),
             CompletionMessage::user("the task"),
@@ -909,7 +914,8 @@ mod tests {
             files: Arc::new(Mutex::new(HashMap::new())),
             active: vec![],
         };
-        let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config(), &NoSleep, seams);
         let mut messages = vec![
             CompletionMessage::system("sys"),
             CompletionMessage::user("the task"),
@@ -941,7 +947,8 @@ mod tests {
             files: Arc::new(Mutex::new(HashMap::new())), // gone from "disk"
             active: vec![],
         };
-        let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config(), &NoSleep, seams);
         let mut messages = vec![
             CompletionMessage::system("sys"),
             CompletionMessage::user("the task"),
@@ -1066,7 +1073,8 @@ mod tests {
             files: Arc::new(Mutex::new(HashMap::new())),
             active: vec![],
         };
-        let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config(), &NoSleep, seams);
         let mut messages = vec![
             CompletionMessage::system("sys"),
             CompletionMessage::user("the task"),
@@ -1120,7 +1128,8 @@ mod tests {
             files: Arc::new(Mutex::new(HashMap::new())),
             active: vec![],
         };
-        let engine = Engine::with_sleeper(&provider, &tools, config(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config(), &NoSleep, seams);
         let mut messages = vec![
             CompletionMessage::system("sys"),
             CompletionMessage::user("the task"),

--- a/crates/stella-core/src/driver/tests.rs
+++ b/crates/stella-core/src/driver/tests.rs
@@ -9,6 +9,7 @@ use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::mpsc;
 
 use super::{CONTINUATION_MARKER_PREFIX as NUDGE, *};
+use crate::TurnCapabilities;
 use crate::hooks::{HookAction, HookExecError, HookExecResult, HookMatcher};
 use crate::retry::Sleeper;
 
@@ -237,7 +238,8 @@ async fn run_speculation_turn(
     tools: &dyn ToolExecutor,
 ) -> (TurnOutcome, Vec<AgentEvent>) {
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(provider, tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(provider, tools, EngineConfig::default(), &sleeper, seams);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("read a.rs")];
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
@@ -428,7 +430,8 @@ async fn budget_abort_after_speculation_discards_the_pool() {
     };
 
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("read a.rs")];
     // The step-0 cost ($0.0001) crosses the enforced $0.00005 turn limit, so
@@ -540,7 +543,8 @@ async fn a_failed_attempts_speculative_pool_emits_discarded_events() {
         executed,
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![CompletionMessage::user("read a.rs")];
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -599,7 +603,8 @@ async fn text_deltas_precede_the_authoritative_text_and_concatenate_to_it() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("say hello")];
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
@@ -722,7 +727,8 @@ async fn a_wedged_generation_trips_the_deadline_once_instead_of_burning_the_retr
         model_timeout: Some(Duration::from_millis(50)),
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -758,7 +764,8 @@ async fn simple_turn_with_no_tool_calls_completes() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -831,7 +838,8 @@ async fn a_halt_ends_the_turn_at_the_next_step_boundary_as_completed() {
         turn_halt: Some(Arc::new(AlwaysHalt)),
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -878,7 +886,8 @@ async fn a_halt_that_never_fires_leaves_the_turn_exactly_as_it_was() {
         turn_halt: Some(Arc::new(NeverHalt)),
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -977,8 +986,11 @@ async fn steered_messages_inject_before_the_next_model_call() {
         stop_after_drains: None,
         drains: AtomicU32::new(0),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_steering(&steering);
+    let seams = TurnCapabilities {
+        steering: Some(&steering),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -1034,8 +1046,11 @@ async fn soft_stop_ends_the_turn_keeping_completed_steps() {
         stop_after_drains: Some(1),
         drains: AtomicU32::new(0),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_steering(&steering);
+    let seams = TurnCapabilities {
+        steering: Some(&steering),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -1071,7 +1086,8 @@ async fn overflow_of_protected_content_is_summarized_and_metered() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -1139,7 +1155,8 @@ async fn summarization_disabled_leaves_history_untouched() {
         summarize_overflow: false,
         ..overflow_config()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -1174,7 +1191,8 @@ async fn summarizer_failure_is_non_fatal_and_leaves_history() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -1212,7 +1230,8 @@ async fn summarization_never_orphans_tool_results_at_the_span_edge() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     // The naive span end (len - keep_recent) lands ON the tool-result
     // message; the summarizer must walk back so the assistant call and
     // its result stay together in the kept tail.
@@ -1297,7 +1316,8 @@ async fn empty_completion_aborts_with_a_visible_message_not_a_silent_success() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("build the feature"),
@@ -1347,7 +1367,8 @@ async fn a_step_out_of_time_completes_with_a_truthful_partial_instead_of_abortin
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(
         &provider,
         &tools,
         EngineConfig {
@@ -1355,6 +1376,7 @@ async fn a_step_out_of_time_completes_with_a_truthful_partial_instead_of_abortin
             ..EngineConfig::default()
         },
         &sleeper,
+        seams,
     );
     let mut messages = vec![
         CompletionMessage::system("sys"),
@@ -1439,7 +1461,8 @@ async fn a_length_truncated_tool_less_step_continues_the_turn_instead_of_complet
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("build the feature"),
@@ -1498,7 +1521,8 @@ async fn length_continuations_are_bounded_per_turn() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("build the feature"),
@@ -1554,7 +1578,8 @@ async fn tool_calls_execute_and_feed_back_into_history() {
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -1606,7 +1631,8 @@ async fn retry_never_re_executes_a_tool_call() {
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -1653,7 +1679,8 @@ async fn malformed_tool_call_input_is_repaired_not_executed_blindly() {
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -1696,7 +1723,8 @@ async fn stuck_loop_aborts_the_turn_cleanly_before_the_step_cap() {
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -1734,7 +1762,8 @@ async fn stuck_loop_steers_once_then_aborts_on_re_detection() {
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -1855,7 +1884,8 @@ async fn identical_polls_with_changing_output_complete_without_abort() {
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("run the build and wait for it"),
@@ -1929,7 +1959,8 @@ async fn period_three_cycle_with_no_progress_steers_then_aborts() {
         },
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("fix the test"),
@@ -1968,7 +1999,8 @@ async fn enforced_budget_aborts_the_turn_cleanly_between_steps() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -2108,7 +2140,8 @@ async fn run_synthetic_survival_turn(dialect: &str, id_style: fn(u32) -> String)
         max_steps: STEPS as usize + 1,
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("run the long task"),
@@ -2220,7 +2253,8 @@ async fn read_only_calls_in_one_step_execute_concurrently() {
         barrier: tokio::sync::Barrier::new(2),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("read two files"),
@@ -2317,7 +2351,8 @@ async fn mutating_calls_are_barriers_and_history_keeps_call_order() {
         read2_done: tokio::sync::Notify::new(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("work"),
@@ -2419,7 +2454,8 @@ async fn every_committed_step_emits_exactly_one_step_usage_record() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("do work"),
@@ -2513,7 +2549,8 @@ async fn a_wedged_tool_trips_the_dispatch_ceiling_instead_of_hanging() {
         tool_timeout: Some(Duration::from_secs(900)),
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &WedgedTools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &WedgedTools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -2568,7 +2605,8 @@ async fn a_none_ceiling_leaves_tool_dispatch_unbounded() {
         tool_timeout: None,
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &WedgedTools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &WedgedTools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -2603,185 +2641,11 @@ mod parked_wait;
 mod provider_outcomes;
 mod requery;
 mod steer_midturn;
+mod streaming_deadline;
 mod usage_anchor;
 mod usage_completeness;
 mod user_hooks;
 mod zero_copy_request;
-
-/// A provider that streams a fragment every `interval` forever: answering the
-/// whole time, never finishing. The shape a reasoning model at high effort
-/// presents on a hard task, where a single call can legitimately stream for
-/// far longer than any fixed wall-clock bound.
-struct SlowStreamingProvider {
-    interval: Duration,
-    calls: Arc<AtomicU32>,
-}
-#[async_trait]
-impl Provider for SlowStreamingProvider {
-    fn id(&self) -> &str {
-        "slow-streaming"
-    }
-    async fn complete_ref(
-        &self,
-        _req: CompletionRequestRef<'_>,
-    ) -> Result<CompletionResultAlias, ProviderError> {
-        unreachable!("the engine always takes the observed path")
-    }
-    async fn complete_observed_ref(
-        &self,
-        _req: CompletionRequestRef<'_>,
-        observer: &dyn stella_protocol::provider::ToolCallObserver,
-    ) -> Result<CompletionResultAlias, ProviderError> {
-        self.calls.fetch_add(1, Ordering::SeqCst);
-        loop {
-            tokio::time::sleep(self.interval).await;
-            observer.text_delta("thinking…");
-        }
-    }
-}
-
-/// The distinction the deadline is supposed to draw. This provider streams a
-/// fragment every 20ms against a 50ms deadline: under a wall-clock bound the
-/// call dies the moment total duration passes 50ms, even though something
-/// arrived 20ms ago. Under an idle bound it runs indefinitely, which is
-/// correct — it is answering.
-///
-/// Asserted by *not* aborting within a window many multiples of the deadline:
-/// the turn is still running when the timeout fires, so the future is dropped
-/// with the call still in flight.
-#[tokio::test]
-async fn a_streaming_generation_outlives_the_deadline_because_it_is_not_stalled() {
-    let calls = Arc::new(AtomicU32::new(0));
-    let provider = SlowStreamingProvider {
-        interval: Duration::from_millis(20),
-        calls: calls.clone(),
-    };
-    let tools = CountingTools {
-        calls: Arc::new(AtomicU32::new(0)),
-    };
-    let sleeper = NoopSleeper;
-    let config = EngineConfig {
-        model_timeout: Some(Duration::from_millis(50)),
-        ..EngineConfig::default()
-    };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
-    let mut messages = vec![
-        CompletionMessage::system("sys"),
-        CompletionMessage::user("hi"),
-    ];
-    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
-    let (tx, mut rx) = mpsc::unbounded_channel();
-
-    let outcome = tokio::time::timeout(
-        Duration::from_millis(600),
-        engine.run_turn(&mut messages, &mut budget, &tx),
-    )
-    .await;
-
-    assert!(
-        outcome.is_err(),
-        "a provider that keeps streaming must not trip the deadline: {outcome:?}"
-    );
-    assert_eq!(
-        calls.load(Ordering::SeqCst),
-        1,
-        "the streaming call is never re-issued"
-    );
-    drain_events(&mut rx);
-}
-
-/// A provider whose entire output streams as TOOL-CALL content — argument
-/// fragments and announced mutating calls, never a text or reasoning delta.
-/// The shape of a model emitting one large `write_file`, where the old
-/// text-only idle tap saw total silence.
-struct CallOnlyStreamingProvider {
-    interval: Duration,
-    calls: Arc<AtomicU32>,
-}
-#[async_trait]
-impl Provider for CallOnlyStreamingProvider {
-    fn id(&self) -> &str {
-        "call-only-streaming"
-    }
-    async fn complete_ref(
-        &self,
-        _req: CompletionRequestRef<'_>,
-    ) -> Result<CompletionResultAlias, ProviderError> {
-        unreachable!("the engine always takes the observed path")
-    }
-    async fn complete_observed_ref(
-        &self,
-        _req: CompletionRequestRef<'_>,
-        observer: &dyn stella_protocol::provider::ToolCallObserver,
-    ) -> Result<CompletionResultAlias, ProviderError> {
-        self.calls.fetch_add(1, Ordering::SeqCst);
-        let mut announced = false;
-        loop {
-            tokio::time::sleep(self.interval).await;
-            // Alternate the two tool-side signals: per-fragment argument
-            // liveness, and a whole announced MUTATING call (which the gate
-            // fences — it must still count as the provider answering).
-            if announced {
-                observer.tool_input_delta();
-            } else {
-                observer.tool_call_streamed(&ToolCall {
-                    call_id: "call_w".into(),
-                    name: "bash".into(),
-                    input: serde_json::json!({"cmd": "true"}),
-                });
-                announced = true;
-            }
-        }
-    }
-}
-
-/// The idle deadline's blind spot, witnessed: a healthy generation streaming
-/// ONLY tool-call content — no text, no reasoning — must not be killed as
-/// "stalled". The tick used to ride the gate's event sender, which only
-/// text/reasoning deltas traverse; a call-only stream (one large `write_file`
-/// spanning minutes) read as total silence and died at the deadline, after
-/// paying for the whole generation.
-#[tokio::test]
-async fn a_call_only_stream_outlives_the_deadline_because_it_is_not_stalled() {
-    let calls = Arc::new(AtomicU32::new(0));
-    let provider = CallOnlyStreamingProvider {
-        interval: Duration::from_millis(20),
-        calls: calls.clone(),
-    };
-    let tools = CountingTools {
-        calls: Arc::new(AtomicU32::new(0)),
-    };
-    let sleeper = NoopSleeper;
-    let config = EngineConfig {
-        model_timeout: Some(Duration::from_millis(50)),
-        ..EngineConfig::default()
-    };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
-    let mut messages = vec![
-        CompletionMessage::system("sys"),
-        CompletionMessage::user("hi"),
-    ];
-    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
-    let (tx, mut rx) = mpsc::unbounded_channel();
-
-    let outcome = tokio::time::timeout(
-        Duration::from_millis(600),
-        engine.run_turn(&mut messages, &mut budget, &tx),
-    )
-    .await;
-
-    assert!(
-        outcome.is_err(),
-        "a call-only stream is still an answering provider — the deadline \
-         must not fire: {outcome:?}"
-    );
-    assert_eq!(
-        calls.load(Ordering::SeqCst),
-        1,
-        "the streaming call is never re-issued"
-    );
-    drain_events(&mut rx);
-}
 
 /// A [`CheckpointSink`] that records what a turn wrote and how often it
 /// cleared, so a test can assert both halves of the durability contract.
@@ -2834,7 +2698,8 @@ async fn a_turn_checkpoints_at_every_step_boundary_and_clears_when_it_ends() {
         checkpoint_sink: Some(sink.clone() as Arc<dyn crate::step::CheckpointSink>),
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("go"),
@@ -2894,7 +2759,8 @@ async fn a_turn_without_a_sink_is_unchanged() {
         EngineConfig::default().checkpoint_sink.is_none(),
         "durability is opt-in: a default engine writes no checkpoints"
     );
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("go"),

--- a/crates/stella-core/src/driver/tests/audit_fixes.rs
+++ b/crates/stella-core/src/driver/tests/audit_fixes.rs
@@ -24,7 +24,8 @@ async fn summarize_keep_recent_zero_does_not_panic() {
         summarize_keep_recent: 0,
         ..overflow_config()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -61,7 +62,8 @@ async fn observed_budget_breach_emits_a_warning_event() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -115,7 +117,8 @@ async fn budget_abort_synthetic_results_are_visible_in_the_event_stream() {
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -158,7 +161,8 @@ async fn whitespace_only_completion_aborts_without_a_text_event() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -332,7 +336,8 @@ async fn hard_cancel_mid_stream_emits_a_cancelled_usage_envelope() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![CompletionMessage::user("secret prompt text")];
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -411,7 +416,8 @@ async fn hard_cancel_during_a_backoff_sleep_emits_no_phantom_cancelled_envelope(
     let sleeper = HangingSleeper {
         sleeping: sleeping.clone(),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![CompletionMessage::user("go")];
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -483,7 +489,8 @@ async fn overflow_summarizer_retries_a_transient_error() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut messages = overflow_messages();
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let mut health = SummarizerHealth::default();
@@ -536,7 +543,8 @@ async fn budget_aborted_summary_is_applied_not_discarded() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut messages = overflow_messages();
     let before_len = messages.len();
     // The single summarizer call overruns the enforced limit → budget abort
@@ -599,7 +607,8 @@ async fn overflow_summary_names_the_folded_tool_result_blocks() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
 
     // A tool-result block sits in the interior of the summarizable span,
     // paired with its assistant tool_call and surrounded by big assistant
@@ -699,7 +708,8 @@ async fn repeated_summarizer_failures_emit_events_and_latch() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let mut health = SummarizerHealth::default();
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -796,7 +806,8 @@ async fn observed_budget_breach_warns_once_per_axis_per_turn() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -852,7 +863,8 @@ async fn enforced_session_breach_abort_reason_names_the_axis() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -886,7 +898,8 @@ async fn enforced_session_breach_at_step_boundary_names_the_axis() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -1246,7 +1259,8 @@ async fn a_recycled_speculation_call_id_reports_the_execution_it_displaces() {
         executions: executions.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("read some files")];
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
@@ -1372,7 +1386,8 @@ async fn the_system_prefix_stays_byte_stable_across_a_compacting_turn() {
         max_steps: 8,
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &BulkyTools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &BulkyTools, config, &sleeper, seams);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut messages = vec![
         CompletionMessage::system(SYSTEM),

--- a/crates/stella-core/src/driver/tests/budget_boundaries.rs
+++ b/crates/stella-core/src/driver/tests/budget_boundaries.rs
@@ -72,7 +72,8 @@ async fn an_over_cap_budget_abort_hands_back_a_well_paired_transcript() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = transcript_with_an_unanswered_tool_call();
     let mut budget = BudgetGuard::new(BudgetMode::Enforced, None, Some(0.05));
     budget.reseed_session_spend(0.10);
@@ -107,7 +108,8 @@ async fn a_past_deadline_abort_hands_back_a_well_paired_transcript() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = transcript_with_an_unanswered_tool_call();
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     budget.set_task_deadline(Some(
@@ -210,7 +212,8 @@ async fn summary_induced_budget_breach_aborts_with_cost_before_next_provider_cal
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -261,7 +264,8 @@ async fn an_existing_budget_breach_stops_before_paid_compaction() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -307,7 +311,8 @@ async fn a_past_task_deadline_stops_the_turn_before_the_next_call_with_partial_w
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -359,7 +364,8 @@ async fn cancellation_after_billed_completion_before_speculation_finishes_keeps_
     };
     let tools = ForeverRead;
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![CompletionMessage::user("read")];
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -401,7 +407,8 @@ async fn a_normal_completion_charges_the_budget_exactly_once() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![CompletionMessage::user("answer")];
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -473,7 +480,8 @@ async fn a_slow_tool_stops_the_turn_before_the_deadline() {
     let provider_calls = provider.calls.clone();
     let tools = SlowTool { took: tool_time };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),

--- a/crates/stella-core/src/driver/tests/calibration.rs
+++ b/crates/stella-core/src/driver/tests/calibration.rs
@@ -79,8 +79,11 @@ async fn calibrated_estimate_changes_the_compaction_decision() {
         if calibrate {
             calibration.seed("scripted", &[(1000, 2000), (1000, 2000), (1000, 2000)]);
         }
-        let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper)
-            .with_calibration(&calibration);
+        let seams = TurnCapabilities {
+            calibration: Some(&calibration),
+            ..TurnCapabilities::none()
+        };
+        let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
         let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
         let (tx, mut rx) = mpsc::unbounded_channel();
         let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
@@ -140,8 +143,11 @@ async fn each_committed_step_feeds_the_calibration_and_reports_its_estimate() {
     };
     let sleeper = NoopSleeper;
     let calibration = CalibrationMap::new();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_calibration(&calibration);
+    let seams = TurnCapabilities {
+        calibration: Some(&calibration),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -224,8 +230,11 @@ async fn cache_write_tokens_count_toward_the_calibration_actual() {
     };
     let sleeper = NoopSleeper;
     let calibration = CalibrationMap::new();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_calibration(&calibration);
+    let seams = TurnCapabilities {
+        calibration: Some(&calibration),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -283,7 +292,8 @@ async fn attachment_weight_is_excluded_from_the_drift_sample_estimate() {
         attachment > 100_000,
         "fixture sanity: the attachment must dominate the estimate"
     );
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
@@ -353,8 +363,11 @@ async fn a_fresh_sessions_calibration_factor_leaves_identity_within_the_turn() {
     // Unseeded, exactly like a bench container's first run: warm-up happens
     // (or fails to matter) entirely inside this one turn.
     let calibration = CalibrationMap::new();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_calibration(&calibration);
+    let seams = TurnCapabilities {
+        calibration: Some(&calibration),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),

--- a/crates/stella-core/src/driver/tests/compute_passes.rs
+++ b/crates/stella-core/src/driver/tests/compute_passes.rs
@@ -40,7 +40,8 @@ async fn a_step_walks_the_transcript_to_estimate_it_at_most_twice() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -94,7 +95,8 @@ async fn the_receipt_and_the_usage_record_report_one_estimate_per_step() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -196,7 +198,8 @@ async fn per_step_hashing_grows_with_the_turn_not_with_its_square() {
         }
         let tools = EchoingTools;
         let sleeper = NoopSleeper;
-        let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
         let mut messages = vec![
             CompletionMessage::system("sys"),
             CompletionMessage::user("hi"),
@@ -389,7 +392,8 @@ async fn compaction_mid_turn_invalidates_the_receipt_ledgers_digest_memo() {
         summarize_overflow: false,
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -483,7 +487,8 @@ async fn a_compaction_pass_journals_the_replacement_bytes_it_wrote() {
         summarize_overflow: false,
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),

--- a/crates/stella-core/src/driver/tests/context_efficiency.rs
+++ b/crates/stella-core/src/driver/tests/context_efficiency.rs
@@ -64,7 +64,8 @@ async fn a_long_turn_ages_old_tool_results_far_below_the_compaction_budget() {
         compaction_budget_tokens: 20_000,
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -147,7 +148,8 @@ async fn a_spent_allowance_retains_an_elided_partial_not_the_scratchpad() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -212,7 +214,8 @@ async fn a_truncated_step_with_tool_calls_retains_elided_narration() {
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),

--- a/crates/stella-core/src/driver/tests/context_overflow.rs
+++ b/crates/stella-core/src/driver/tests/context_overflow.rs
@@ -177,10 +177,11 @@ async fn run_turn_with_fallback(
 ) -> (TurnOutcome, Vec<AgentEvent>) {
     let tools = NoTools;
     let sleeper = NoSleep;
-    let mut engine = Engine::with_sleeper(provider, &tools, EngineConfig::default(), &sleeper);
-    if let Some(resolver) = resolver {
-        engine = engine.with_fallback_resolver(resolver);
-    }
+    let seams = TurnCapabilities {
+        fallback: resolver,
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("do the thing")];
     let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
@@ -434,7 +435,8 @@ async fn a_summarizer_request_that_overflows_drops_its_head_and_still_folds_the_
         calls: std::sync::Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoSleep;
-    let engine = Engine::with_sleeper(&provider, &tools, super::overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, super::overflow_config(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -485,7 +487,8 @@ async fn head_dropping_is_bounded_when_no_span_size_is_accepted() {
         calls: std::sync::Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoSleep;
-    let engine = Engine::with_sleeper(&provider, &tools, super::overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, super::overflow_config(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),

--- a/crates/stella-core/src/driver/tests/context_overflow.rs
+++ b/crates/stella-core/src/driver/tests/context_overflow.rs
@@ -27,6 +27,7 @@ use serde_json::Value;
 use stella_protocol::{CompletionResult, ToolSchema, UsageIncompleteReason};
 
 use super::super::*;
+use crate::TurnCapabilities;
 
 /// Rejects the first `overflows` calls as context overflow, then completes.
 struct OverflowThenComplete {

--- a/crates/stella-core/src/driver/tests/deadline_notice.rs
+++ b/crates/stella-core/src/driver/tests/deadline_notice.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 use stella_protocol::{CompletionResult, ToolSchema};
 
 use super::super::*;
+use crate::TurnCapabilities;
 
 /// Answers immediately, recording the transcript it was handed.
 #[derive(Default)]

--- a/crates/stella-core/src/driver/tests/deadline_notice.rs
+++ b/crates/stella-core/src/driver/tests/deadline_notice.rs
@@ -87,7 +87,8 @@ async fn run_turn_with_deadline(
 ) {
     let tools = NoTools;
     let sleeper = NoSleep;
-    let engine = Engine::with_sleeper(provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("do the thing")];
     let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);

--- a/crates/stella-core/src/driver/tests/lifecycle_bus.rs
+++ b/crates/stella-core/src/driver/tests/lifecycle_bus.rs
@@ -15,6 +15,7 @@
 use std::sync::{Arc, Mutex};
 
 use super::super::*;
+use crate::TurnCapabilities;
 use crate::bus::{HookBus, HookEvent, names};
 use serde_json::Value;
 use stella_protocol::{CompletionResult, ToolSchema};

--- a/crates/stella-core/src/driver/tests/lifecycle_bus.rs
+++ b/crates/stella-core/src/driver/tests/lifecycle_bus.rs
@@ -138,8 +138,11 @@ impl crate::retry::Sleeper for NoSleep {
 async fn run_one_turn(provider: &dyn Provider, bus: &HookBus) -> TurnOutcome {
     let tools = NoTools;
     let sleeper = NoSleep;
-    let engine =
-        Engine::with_sleeper(provider, &tools, EngineConfig::default(), &sleeper).with_bus(bus);
+    let seams = TurnCapabilities {
+        bus: Some(bus),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("hi")];
     let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
@@ -154,17 +157,12 @@ async fn run_one_turn_in_lane(
 ) -> TurnOutcome {
     let tools = NoTools;
     let sleeper = NoSleep;
-    let engine = Engine::assemble(
-        provider,
-        &tools,
-        EngineConfig::default(),
-        &sleeper,
-        crate::driver::capabilities::TurnCapabilities {
-            bus: Some(bus),
-            lane: Some(lane),
-            ..no_seams()
-        },
-    );
+    let seams = crate::driver::capabilities::TurnCapabilities {
+        bus: Some(bus),
+        lane: Some(lane),
+        ..no_seams()
+    };
+    let engine = Engine::assemble(provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("hi")];
     let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
@@ -330,7 +328,14 @@ async fn a_step_reports_how_it_ended() {
 async fn an_engine_without_a_bus_runs_identically() {
     let tools = NoTools;
     let sleeper = NoSleep;
-    let engine = Engine::with_sleeper(&OneShotProvider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(
+        &OneShotProvider,
+        &tools,
+        EngineConfig::default(),
+        &sleeper,
+        seams,
+    );
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("hi")];
     let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);

--- a/crates/stella-core/src/driver/tests/live_services.rs
+++ b/crates/stella-core/src/driver/tests/live_services.rs
@@ -99,7 +99,8 @@ async fn run(
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("serve the docs on 8080"),

--- a/crates/stella-core/src/driver/tests/loop_abort.rs
+++ b/crates/stella-core/src/driver/tests/loop_abort.rs
@@ -131,7 +131,8 @@ async fn a_loop_that_resumes_after_a_successful_course_correction_still_aborts()
         max_steps: 30,
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("why is the cache write count wrong?"),
@@ -230,7 +231,8 @@ async fn a_second_distinct_loop_earns_its_own_steer_before_the_turn_dies() {
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, exact_repeat_only(30), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, exact_repeat_only(30), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("where is the graph store opened?"),
@@ -339,7 +341,8 @@ async fn a_third_loop_is_not_steered_and_is_not_blamed_on_the_warned_one() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, exact_repeat_only(30), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, exact_repeat_only(30), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("why is the cache write count wrong?"),
@@ -443,7 +446,8 @@ async fn a_tool_answering_identically_to_every_new_argument_is_steered_then_kill
         max_steps: 60,
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("where is the cache write count summed?"),
@@ -508,7 +512,8 @@ async fn a_confident_zero_never_reports_as_completed() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("check the gcov coverage"),
@@ -560,7 +565,8 @@ async fn a_direct_zero_tool_answer_still_completes() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("what's 2+2"),
@@ -596,7 +602,8 @@ async fn a_turn_that_did_mutating_work_still_completes_despite_a_bare_closing_li
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("run the build"),
@@ -634,7 +641,8 @@ async fn a_terminated_short_answer_after_investigation_still_completes() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("does config.toml exist?"),
@@ -684,7 +692,8 @@ async fn a_stuck_loop_steer_names_the_loop_rung_as_its_cause() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, exact_repeat_only(30), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, exact_repeat_only(30), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("where is the store opened?"),

--- a/crates/stella-core/src/driver/tests/model_fallback.rs
+++ b/crates/stella-core/src/driver/tests/model_fallback.rs
@@ -21,6 +21,7 @@ use serde_json::Value;
 use stella_protocol::{CompletionResult, ToolCall, ToolSchema, UsageIncompleteReason};
 
 use super::super::*;
+use crate::TurnCapabilities;
 use crate::ports::{FallbackResolver, ResolvedFallback};
 use crate::retry::RetryPolicy;
 

--- a/crates/stella-core/src/driver/tests/model_fallback.rs
+++ b/crates/stella-core/src/driver/tests/model_fallback.rs
@@ -181,10 +181,11 @@ async fn run_turn_collecting(
 ) -> (TurnOutcome, Vec<AgentEvent>) {
     let tools = NoTools;
     let sleeper = NoSleep;
-    let mut engine = Engine::with_sleeper(provider, &tools, config, &sleeper);
-    if let Some(resolver) = resolver {
-        engine = engine.with_fallback_resolver(resolver);
-    }
+    let seams = TurnCapabilities {
+        fallback: resolver,
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(provider, &tools, config, &sleeper, seams);
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);
     let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;

--- a/crates/stella-core/src/driver/tests/output_budget.rs
+++ b/crates/stella-core/src/driver/tests/output_budget.rs
@@ -24,6 +24,7 @@ use serde_json::Value;
 use stella_protocol::{CompletionResult, ToolSchema};
 
 use super::super::*;
+use crate::TurnCapabilities;
 use crate::driver::output_budget_recovery::SessionOutputCeilings;
 
 /// Rejects the first `refusals` calls as an unaffordable ceiling, naming

--- a/crates/stella-core/src/driver/tests/output_budget.rs
+++ b/crates/stella-core/src/driver/tests/output_budget.rs
@@ -175,7 +175,8 @@ async fn run_turn_with_ceiling_and_carry(
         session_output_ceilings: carry.cloned(),
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(provider, &tools, config, &sleeper, seams);
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("do the thing")];
     let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);

--- a/crates/stella-core/src/driver/tests/parked_wait.rs
+++ b/crates/stella-core/src/driver/tests/parked_wait.rs
@@ -125,7 +125,8 @@ async fn a_change_on_the_nth_probe_re_invokes_the_model_exactly_once() {
     let probe_calls = tools.probe_calls.clone();
     let wake_calls = tools.wake_calls.clone();
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("monitor CI and report"),
@@ -239,7 +240,8 @@ async fn an_unchanged_condition_wakes_once_at_the_deadline() {
     let probe_calls = tools.probe_calls.clone();
     let wake_calls = tools.wake_calls.clone();
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("monitor CI"),
@@ -296,7 +298,8 @@ async fn a_non_read_only_probe_is_refused_not_replayed() {
     let tools = ParkingTools::depositing(request, 1);
     let probe_calls = tools.probe_calls.clone();
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("monitor CI"),
@@ -359,7 +362,8 @@ async fn sustained_rate_limiting_parks_within_budget_and_recovers() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("do the task"),
@@ -422,7 +426,8 @@ async fn a_long_retry_after_hint_is_honored_by_parking_when_budget_allows() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("do the task"),
@@ -471,7 +476,8 @@ async fn a_hint_past_the_remaining_deadline_still_fails_fast_without_parking() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("do the task"),
@@ -529,7 +535,8 @@ async fn a_sustained_529_brownout_parks_within_budget_and_recovers() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("do the task"),
@@ -591,7 +598,8 @@ async fn a_sustained_transport_fault_still_exhausts_the_ladder_and_aborts() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("do the task"),
@@ -661,8 +669,11 @@ async fn a_soft_stop_during_a_park_ends_the_turn_as_a_deliberate_stop() {
         asks: AtomicU32::new(0),
         latch_on: 2,
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_steering(&steering);
+    let seams = TurnCapabilities {
+        steering: Some(&steering),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("do the task"),

--- a/crates/stella-core/src/driver/tests/provider_outcomes.rs
+++ b/crates/stella-core/src/driver/tests/provider_outcomes.rs
@@ -7,9 +7,9 @@
 //! `CircuitBreaker` and the engine observed every call outcome, but nothing
 //! connected them — `record_success`/`record_failure` had no production
 //! caller, so a provider could fail every call for hours and `resolve` kept
-//! routing to it. These tests drive real turns through
-//! [`Engine::with_provider_outcomes`] and assert the router's *next*
-//! resolution actually routes around the provider those turns watched fail.
+//! routing to it. These tests drive real turns whose seam set binds
+//! `outcomes` and assert the router's *next* resolution actually routes
+//! around the provider those turns watched fail.
 
 use super::super::*;
 use crate::ports::Clock;
@@ -112,8 +112,11 @@ fn router() -> Router {
 async fn run_turn_feeding(provider: &dyn Provider, router: &Router) -> TurnOutcome {
     let tools = NoTools;
     let sleeper = NoSleep;
-    let engine = Engine::with_sleeper(provider, &tools, EngineConfig::default(), &sleeper)
-        .with_provider_outcomes(router);
+    let seams = TurnCapabilities {
+        outcomes: Some(router),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("hi")];
     let mut budget = BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None);

--- a/crates/stella-core/src/driver/tests/provider_outcomes.rs
+++ b/crates/stella-core/src/driver/tests/provider_outcomes.rs
@@ -12,6 +12,7 @@
 //! around the provider those turns watched fail.
 
 use super::super::*;
+use crate::TurnCapabilities;
 use crate::ports::Clock;
 use crate::router::{CircuitBreaker, ProviderProfile, RoleTable, Router};
 use serde_json::Value;

--- a/crates/stella-core/src/driver/tests/requery.rs
+++ b/crates/stella-core/src/driver/tests/requery.rs
@@ -18,6 +18,7 @@ use stella_protocol::{
 use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::mpsc;
 
+use crate::TurnCapabilities;
 use crate::budget::BudgetGuard;
 use crate::driver::*;
 use crate::ports::SteeringRequery;

--- a/crates/stella-core/src/driver/tests/requery.rs
+++ b/crates/stella-core/src/driver/tests/requery.rs
@@ -153,8 +153,11 @@ async fn the_requery_port_sees_live_turn_evidence_and_its_block_lands_in_history
             crate::receipts::RECALL_MARKER
         ),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_requery(&requery);
+    let seams = TurnCapabilities {
+        requery: Some(&requery),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("fix the flaky test"),
@@ -226,8 +229,11 @@ async fn since_last_query_resets_when_the_port_answers() {
             crate::receipts::RECALL_MARKER
         ),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_requery(&requery);
+    let seams = TurnCapabilities {
+        requery: Some(&requery),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("fix the flaky test"),

--- a/crates/stella-core/src/driver/tests/steer_midturn.rs
+++ b/crates/stella-core/src/driver/tests/steer_midturn.rs
@@ -64,8 +64,11 @@ async fn a_soft_stop_closes_caller_supplied_open_tool_calls() {
     };
     let sleeper = NoopSleeper;
     let steering = StopNow;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_steering(&steering);
+    let seams = TurnCapabilities {
+        steering: Some(&steering),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     // A caller-injected assistant message whose call nothing answered.
     let mut messages = vec![
         CompletionMessage::system("sys"),
@@ -129,8 +132,11 @@ async fn a_steer_after_a_tool_round_keeps_every_call_paired_with_its_result() {
         fire_on_drain: 2,
         drains: AtomicU32::new(0),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_steering(&steering);
+    let seams = TurnCapabilities {
+        steering: Some(&steering),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),
@@ -199,8 +205,11 @@ async fn a_mid_tool_round_steer_leaves_a_tool_message_immediately_before_it() {
         fire_on_drain: 2,
         drains: AtomicU32::new(0),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_steering(&steering);
+    let seams = TurnCapabilities {
+        steering: Some(&steering),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("the task"),

--- a/crates/stella-core/src/driver/tests/streaming_deadline.rs
+++ b/crates/stella-core/src/driver/tests/streaming_deadline.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The model deadline counts idle time. It does not count total time.
+//!
+//! A model that keeps sending parts is still at work. It may take a long
+//! time. That is fine. A hard task can run for many minutes.
+//!
+//! Each test here starts such a call. Each one shows the deadline lets it
+//! run. One sends text. The other sends the parts of a tool call.
+
+use std::time::Duration;
+
+use super::*;
+
+/// Sends one part every `interval`, and never stops. It is at work the
+/// whole time. A model can do this on a hard task. It may last much longer
+/// than any fixed clock bound.
+struct SlowStreamingProvider {
+    interval: Duration,
+    calls: Arc<AtomicU32>,
+}
+#[async_trait]
+impl Provider for SlowStreamingProvider {
+    fn id(&self) -> &str {
+        "slow-streaming"
+    }
+    async fn complete_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResultAlias, ProviderError> {
+        unreachable!("the engine always takes the observed path")
+    }
+    async fn complete_observed_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+        observer: &dyn stella_protocol::provider::ToolCallObserver,
+    ) -> Result<CompletionResultAlias, ProviderError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        loop {
+            tokio::time::sleep(self.interval).await;
+            observer.text_delta("thinking…");
+        }
+    }
+}
+
+/// The line the deadline must draw. This model sends a part every 20ms. The
+/// deadline is 50ms. A clock bound would cut the call at 50ms, though a part
+/// came in 20ms ago. An idle bound lets it run. That is right. It is at work.
+///
+/// The test shows the turn does not stop in a span many times the deadline.
+/// It is still going when the test times out, so the call is dropped in
+/// flight.
+#[tokio::test]
+async fn a_streaming_generation_outlives_the_deadline_because_it_is_not_stalled() {
+    let calls = Arc::new(AtomicU32::new(0));
+    let provider = SlowStreamingProvider {
+        interval: Duration::from_millis(20),
+        calls: calls.clone(),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let config = EngineConfig {
+        model_timeout: Some(Duration::from_millis(50)),
+        ..EngineConfig::default()
+    };
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = tokio::time::timeout(
+        Duration::from_millis(600),
+        engine.run_turn(&mut messages, &mut budget, &tx),
+    )
+    .await;
+
+    assert!(
+        outcome.is_err(),
+        "a provider that keeps streaming must not trip the deadline: {outcome:?}"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "the streaming call is never re-issued"
+    );
+    drain_events(&mut rx);
+}
+
+/// Sends only tool-call content: parts of the input, and whole calls it
+/// names. It sends no text at all. A model writing one big file looks like
+/// this. A tap that watches text alone sees silence.
+struct CallOnlyStreamingProvider {
+    interval: Duration,
+    calls: Arc<AtomicU32>,
+}
+#[async_trait]
+impl Provider for CallOnlyStreamingProvider {
+    fn id(&self) -> &str {
+        "call-only-streaming"
+    }
+    async fn complete_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResultAlias, ProviderError> {
+        unreachable!("the engine always takes the observed path")
+    }
+    async fn complete_observed_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+        observer: &dyn stella_protocol::provider::ToolCallObserver,
+    ) -> Result<CompletionResultAlias, ProviderError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let mut announced = false;
+        loop {
+            tokio::time::sleep(self.interval).await;
+            // Take turns with the two tool-side signs of life: a part of
+            // the input, then a whole named call that changes state (the
+            // gate holds that one, and it still means the model is at work).
+            if announced {
+                observer.tool_input_delta();
+            } else {
+                observer.tool_call_streamed(&ToolCall {
+                    call_id: "call_w".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({"cmd": "true"}),
+                });
+                announced = true;
+            }
+        }
+    }
+}
+
+/// The blind spot in an idle bound. A call that sends only tool content is
+/// still at work. It must not be cut off as stuck.
+///
+/// Put the tick on the gate's event sender and only text goes through it. A
+/// call that writes one big file then looks silent. It dies at the deadline,
+/// and the whole call is paid for.
+#[tokio::test]
+async fn a_call_only_stream_outlives_the_deadline_because_it_is_not_stalled() {
+    let calls = Arc::new(AtomicU32::new(0));
+    let provider = CallOnlyStreamingProvider {
+        interval: Duration::from_millis(20),
+        calls: calls.clone(),
+    };
+    let tools = CountingTools {
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let config = EngineConfig {
+        model_timeout: Some(Duration::from_millis(50)),
+        ..EngineConfig::default()
+    };
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("hi"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = tokio::time::timeout(
+        Duration::from_millis(600),
+        engine.run_turn(&mut messages, &mut budget, &tx),
+    )
+    .await;
+
+    assert!(
+        outcome.is_err(),
+        "a call-only stream is still an answering provider — the deadline \
+         must not fire: {outcome:?}"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "the streaming call is never re-issued"
+    );
+    drain_events(&mut rx);
+}

--- a/crates/stella-core/src/driver/tests/usage_anchor.rs
+++ b/crates/stella-core/src/driver/tests/usage_anchor.rs
@@ -71,7 +71,8 @@ async fn compaction_fired_with_report(usage: CompletionUsage) -> bool {
         summarize_overflow: false,
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;

--- a/crates/stella-core/src/driver/tests/usage_completeness.rs
+++ b/crates/stella-core/src/driver/tests/usage_completeness.rs
@@ -15,7 +15,8 @@ async fn exhausted_worker_call_emits_one_content_free_incompleteness_event() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("work"),
@@ -97,7 +98,8 @@ async fn a_failed_call_names_the_model_that_made_it() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("work"),
@@ -163,7 +165,8 @@ async fn a_failed_attempts_recovered_usage_reaches_the_event_stream() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("work"),
@@ -219,7 +222,8 @@ async fn exhausted_retries_emit_typed_reasons_before_the_error() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("work"),
@@ -278,7 +282,8 @@ async fn auth_failure_on_first_attempt_reports_not_retryable() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("work"),
@@ -338,7 +343,8 @@ async fn successful_retry_keeps_the_failed_attempt_usage_incomplete() {
         retry_policy: RetryPolicy::new(1, 0, 0),
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("work"),
@@ -394,7 +400,8 @@ async fn step_usage_carries_the_requests_effort_and_output_ceiling() {
         max_output_tokens: Some(32_000),
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("work"),
@@ -455,7 +462,8 @@ async fn step_usage_carries_the_requests_generation_params() {
         params: Some(asked),
         ..EngineConfig::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("work"),
@@ -513,7 +521,8 @@ async fn overflow_summarizer_emits_its_own_usage_envelope() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut messages = overflow_messages();
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -547,7 +556,8 @@ async fn failed_overflow_summarizer_emits_content_free_incompleteness() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut messages = overflow_messages();
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -604,7 +614,8 @@ async fn two_calls_at_one_step_are_separable_by_their_usage_rows() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams)
         .with_turn_instance(TURN);
     let mut messages = vec![
         CompletionMessage::system("sys"),

--- a/crates/stella-core/src/driver/tests/user_hooks.rs
+++ b/crates/stella-core/src/driver/tests/user_hooks.rs
@@ -69,8 +69,11 @@ async fn pre_tool_use_hook_nonzero_exit_blocks_the_tool_and_model_sees_it() {
         }]),
         ..Hooks::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -142,8 +145,11 @@ async fn post_tool_use_hook_runs_after_the_tool_and_never_blocks() {
         }]),
         ..Hooks::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -205,8 +211,11 @@ async fn non_blocking_hook_failure_surfaces_as_one_retryable_error_event() {
         }]),
         ..Hooks::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -263,7 +272,8 @@ async fn no_hooks_configured_leaves_the_turn_path_unchanged() {
     };
     let sleeper = NoopSleeper;
     // Built WITHOUT `with_hooks` — `hooks` stays `None`.
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -324,8 +334,11 @@ async fn run_turn_never_fires_session_start_hooks() {
         }]),
         ..Hooks::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
 
     let mut messages = vec![
         CompletionMessage::system("sys"),
@@ -387,8 +400,11 @@ async fn a_hooked_read_fires_its_hook_once_never_for_a_dropped_speculative_attem
         }]),
         ..Hooks::default()
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![CompletionMessage::user("read a.rs")];
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
@@ -495,8 +511,11 @@ async fn pre_tool_use_modify_decision_rewrites_the_input_the_tool_receives() {
         }"#,
     )
     .unwrap();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -611,9 +630,12 @@ async fn a_hook_require_approval_parks_on_the_route_and_the_answer_decides() {
         calls: Arc::new(AtomicU32::new(0)),
         seen: Arc::new(TokioMutex::new(Vec::new())),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner)
-        .with_hook_approval_route(&route);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        hook_approvals: Some(&route),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -653,9 +675,12 @@ async fn a_hook_require_approval_parks_on_the_route_and_the_answer_decides() {
         calls: Arc::new(AtomicU32::new(0)),
         seen: Arc::new(TokioMutex::new(Vec::new())),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner)
-        .with_hook_approval_route(&route);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        hook_approvals: Some(&route),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -698,8 +723,11 @@ async fn require_approval_without_a_route_refuses_with_the_grant_path() {
         hooks,
     } = require_approval_fixture(ask);
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -757,8 +785,11 @@ async fn pre_tool_use_payload_carries_the_schemas_read_only_bit() {
         r#"{ "PreToolUse": [ { "matcher": "*", "hooks": [{ "command": "audit" }] } ] }"#,
     )
     .unwrap();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -849,8 +880,11 @@ async fn an_always_denying_stop_hook_is_consulted_to_the_bound_then_the_turn_sta
     let hooks: Hooks =
         serde_json::from_str(r#"{ "Stop": [ { "hooks": [{ "command": "checklist" }] } ] }"#)
             .unwrap();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -954,8 +988,11 @@ async fn a_deny_then_allow_is_reconsulted_and_the_allowed_completion_stands() {
     };
     let hooks: Hooks =
         serde_json::from_str(r#"{ "Stop": [ { "hooks": [{ "command": "verify" }] } ] }"#).unwrap();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -1024,8 +1061,11 @@ async fn a_failing_stop_hook_never_holds_the_turn_open() {
     let hooks: Hooks =
         serde_json::from_str(r#"{ "Stop": [ { "hooks": [{ "command": "checklist" }] } ] }"#)
             .unwrap();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -1101,9 +1141,12 @@ async fn a_stop_hooks_require_approval_resolves_both_ways() {
             calls: Arc::new(AtomicU32::new(0)),
             seen: Arc::new(TokioMutex::new(Vec::new())),
         };
-        let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-            .with_hooks(&hooks, &runner)
-            .with_hook_approval_route(&route);
+        let seams = TurnCapabilities {
+            hooks: Some((&hooks, &runner)),
+            hook_approvals: Some(&route),
+            ..TurnCapabilities::none()
+        };
+        let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
         let mut messages = vec![
             CompletionMessage::system("sys"),
             CompletionMessage::user("hi"),
@@ -1186,8 +1229,11 @@ async fn a_stop_hooks_require_approval_with_no_route_lets_the_turn_complete() {
     };
     let hooks: Hooks =
         serde_json::from_str(r#"{ "Stop": [ { "hooks": [{ "command": "vera" }] } ] }"#).unwrap();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -1240,8 +1286,11 @@ async fn pre_compact_hook_veto_skips_the_summarization_round() {
     let hooks: Hooks =
         serde_json::from_str(r#"{ "PreCompact": [ { "hooks": [{ "command": "gate" }] } ] }"#)
             .unwrap();
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut messages = overflow_messages_for_hooks();
     let before = messages.clone();
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
@@ -1308,8 +1357,11 @@ async fn pre_compact_modify_instructions_reach_the_summarizer_request() {
     let hooks: Hooks =
         serde_json::from_str(r#"{ "PreCompact": [ { "hooks": [{ "command": "steer" }] } ] }"#)
             .unwrap();
-    let engine = Engine::with_sleeper(&provider, &tools, overflow_config(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, overflow_config(), &sleeper, seams);
     let mut messages = overflow_messages_for_hooks();
     let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
     let mut health = SummarizerHealth::default();

--- a/crates/stella-core/src/driver/tests/user_hooks/verdicts.rs
+++ b/crates/stella-core/src/driver/tests/user_hooks/verdicts.rs
@@ -55,9 +55,12 @@ async fn a_structured_stop_denial_reaches_the_model_and_the_journal_intact() {
     })
     .detach();
 
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner)
-        .with_bus(&bus);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        bus: Some(&bus),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -130,8 +133,11 @@ async fn a_prose_only_stop_denial_grows_no_evidence_section() {
     };
     let hooks: Hooks =
         serde_json::from_str(r#"{ "Stop": [ { "hooks": [{ "command": "verify" }] } ] }"#).unwrap();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),
@@ -216,8 +222,11 @@ async fn run_always_denying_stop_gate(allowance: Option<u32>, answers: usize) ->
         stop_hold_allowance: allowance,
         ..EngineConfig::default()
     };
-    let engine =
-        Engine::with_sleeper(&provider, &tools, config, &sleeper).with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("hi"),

--- a/crates/stella-core/src/driver/tests/zero_copy_request.rs
+++ b/crates/stella-core/src/driver/tests/zero_copy_request.rs
@@ -66,7 +66,8 @@ async fn a_retried_attempt_re_sends_the_same_slices_it_did_the_first_time() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, _rx) = mpsc::unbounded_channel();
     let mut messages = vec![
         CompletionMessage::system("You are Stella."),
@@ -122,7 +123,8 @@ async fn the_adapter_serializes_off_the_callers_own_transcript() {
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, _rx) = mpsc::unbounded_channel();
     // Reserved up front so appending the turn's answer cannot reallocate the
     // buffer out from under the address recorded during the call — the test

--- a/crates/stella-core/src/driver/user_hooks.rs
+++ b/crates/stella-core/src/driver/user_hooks.rs
@@ -4,10 +4,14 @@
 //! the `PreCompact` summarization gate. A child module of `driver` so the
 //! engine internals stay reachable.
 //!
+//! The route a parked decision waits on is a seam. A host binds it in the
+//! turn's [`TurnCapabilities`](crate::TurnCapabilities), under
+//! `hook_approvals`. A turn that binds none refuses such a call.
+//!
 //! # PreToolUse is a permission gate now
 //!
 //! [`Engine::execute_with_hooks`] runs the matched hooks through
-//! [`crate::hooks::decision::run_decision_hooks`], so a hook's stdout JSON
+//! [`crate::hooks::decision::run_decision_hooks`]. So a hook's stdout JSON
 //! carries the extension bus's own vocabulary
 //! ([`crate::bus::HookDecision`]) — one enum, no shell-surface fork:
 //!
@@ -16,7 +20,8 @@
 //!   model sent);
 //! - `deny` blocks with the hook's reason;
 //! - `require_approval` parks the dispatch on the
-//!   [`ApprovalRoute`] port — implemented over the #2676
+//!   [`ApprovalRoute`](crate::hooks::decision::ApprovalRoute) port —
+//!   implemented over the #2676
 //!   `ApprovalBroker` by `stella-tools::hook_bridge`, so the emit-before-
 //!   park / TTL / audit-event contract is the broker's, not a copy. With
 //!   no route attached the call is refused with a grant-path message, the
@@ -66,7 +71,8 @@
 //! and a manifest must never be able to buy an unbounded loop.
 //!
 //! A `require_approval` decision parks the completion on the same
-//! [`ApprovalRoute`] a `PreToolUse` hook's does, carrying
+//! [`ApprovalRoute`](crate::hooks::decision::ApprovalRoute) a `PreToolUse`
+//! hook's does, carrying
 //! [`ApprovalSubject::TurnCompletion`] rather than a tool (#3486). Approved,
 //! the completion stands; denied, the refusal becomes the model's next
 //! observation on the `deny` path above and is bounded by the same counter.
@@ -103,8 +109,8 @@ use super::{Engine, HooksHandle};
 use crate::bus::names as bus_names;
 use crate::event_sender::EventSender;
 use crate::hooks::decision::{
-    ApprovalRoute, ApprovalRouteRequest, ApprovalRouteResolution, ApprovalSubject, GateVerdict,
-    OperatorPosture, run_decision_hooks,
+    ApprovalRouteRequest, ApprovalRouteResolution, ApprovalSubject, GateVerdict, OperatorPosture,
+    run_decision_hooks,
 };
 use crate::hooks::{HookEvent, HookPayload, run_hooks};
 
@@ -176,16 +182,6 @@ pub(super) struct PreCompactRuling {
 }
 
 impl<'a> Engine<'a> {
-    /// Attach the approval route a `PreToolUse` hook's `require_approval`
-    /// decision parks on — `stella-tools::hook_bridge`'s broker-backed
-    /// implementation in production. Opt-in like every other seam on this
-    /// builder; an engine without one refuses such calls with a grant-path
-    /// message instead of asking.
-    pub fn with_hook_approval_route(mut self, route: &'a dyn ApprovalRoute) -> Self {
-        self.hook_approvals = Some(route);
-        self
-    }
-
     /// The `read_only` bit `name` advertises on this engine's executor —
     /// `false` for a name the executor does not advertise, the cautious
     /// direction. Walks the full schema list, so hot paths thread the

--- a/crates/stella-core/src/goal.rs
+++ b/crates/stella-core/src/goal.rs
@@ -340,9 +340,9 @@ impl Engine<'_> {
     ///
     /// # Why this is the primitive and not a hand-rolled engine
     ///
-    /// It used to build its own [`Engine`] with [`Engine::with_sleeper`],
-    /// which cannot carry the pause gate, steering, or lifecycle hooks —
-    /// those are builder-set private fields. So a paused session kept
+    /// It built its own [`Engine`] once, through a constructor that carried
+    /// no pause gate, no steering, and no lifecycle hooks. Each of the three
+    /// was a separate opt-in call. So a paused session kept
     /// spending inside the verifier, a soft stop could not end a verifier turn,
     /// and `PreToolUse`/`PostToolUse` hooks never fired for the evidence
     /// the verifier gathered. Routing through the sub-agent primitive carries
@@ -551,6 +551,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
+    use crate::TurnCapabilities;
     use crate::driver::EngineConfig;
     use crate::ports::ToolExecutor;
     use crate::retry::Sleeper;
@@ -659,7 +660,8 @@ mod tests {
             )),
         ]);
         let tools = NoTools;
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
         let (tx, rx) = mpsc::unbounded_channel();
@@ -724,7 +726,8 @@ mod tests {
             )),
         ]);
         let tools = NoTools;
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
         let (tx, rx) = mpsc::unbounded_channel();
@@ -810,7 +813,8 @@ mod tests {
             )),
         ]);
         let tools = NoTools;
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
         let (tx, _rx) = mpsc::unbounded_channel();
@@ -869,7 +873,8 @@ mod tests {
             )),
         ]);
         let tools = NoTools;
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         // Mirrors `build_budget_guard(Some(0.05))`: the cap is on the session
         // axis. (A per-turn axis here would reset each round and let the loop
@@ -948,7 +953,8 @@ mod tests {
             )),
         ]);
         let tools = NoTools;
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
         let (tx, _rx) = mpsc::unbounded_channel();
@@ -970,10 +976,10 @@ mod tests {
         }
     }
 
-    /// Regression for the bug #922 names in `assess`: it used to build its
-    /// verifier with [`Engine::with_sleeper`], which cannot carry the pause
-    /// gate, steering, or hooks — so a paused session kept spending inside
-    /// the verifier and a soft stop could not end a verifier turn.
+    /// Regression for the bug #922 names in `assess`. It built its verifier
+    /// through a constructor that carried no pause gate, no steering and no
+    /// hooks. So a paused session kept spending inside the verifier, and a
+    /// soft stop could not end a verifier turn.
     ///
     /// Routing through the sub-agent primitive carries all three. The gate
     /// is the observable one: a verifier that polls it is a verifier a pause can
@@ -995,8 +1001,11 @@ mod tests {
         ))]);
         let tools = NoTools;
         let gate = CountingGate(AtomicU32::new(0));
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep)
-            .with_gate(&gate);
+        let seams = TurnCapabilities {
+            gate: Some(&gate),
+            ..TurnCapabilities::none()
+        };
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
         let (tx, _rx) = mpsc::unbounded_channel();
@@ -1046,7 +1055,8 @@ mod tests {
             )),
         ]);
         let tools = NoTools;
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
         let (tx, _rx) = mpsc::unbounded_channel();
@@ -1085,7 +1095,8 @@ mod tests {
         // Auth errors are non-retryable, so the verifier fails immediately.
         let verifier = ScriptedProvider::new(vec![Err(ProviderError::Auth("bad key".into()))]);
         let tools = NoTools;
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
         let (tx, _rx) = mpsc::unbounded_channel();
@@ -1116,7 +1127,8 @@ mod tests {
         let worker = ScriptedProvider::new(vec![Err(ProviderError::Auth("expired".into()))]);
         let verifier = ScriptedProvider::new(vec![]);
         let tools = NoTools;
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
         let (tx, _rx) = mpsc::unbounded_channel();
@@ -1173,7 +1185,8 @@ mod tests {
         ]);
         let verifier = ScriptedProvider::new(vec![]);
         let tools = NoTools;
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
         let (tx, _rx) = mpsc::unbounded_channel();
@@ -1207,7 +1220,8 @@ mod tests {
             0.001,
         ))]);
         let tools = NoTools;
-        let engine = Engine::with_sleeper(&worker, &tools, EngineConfig::default(), &NoSleep);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&worker, &tools, EngineConfig::default(), &NoSleep, seams);
         let mut messages = vec![CompletionMessage::system("sys")];
         let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
         budget.reseed_session_spend(0.75);

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -203,10 +203,9 @@ impl<'a> Engine<'a> {
     /// pause and the stop while keeping it from stealing the parent's queued
     /// messages.
     ///
-    /// Absent seams are left absent rather than overwritten: an engine
-    /// already carrying a per-turn `&dyn` gate keeps it if `controls` has
-    /// none, so this composes with [`Engine::with_gate`] instead of racing
-    /// it.
+    /// Absent seams are left absent rather than overwritten. An engine that
+    /// already carries a per-turn `&dyn` gate keeps it when `controls` has
+    /// none. So a gate the seam set bound stays bound. The two do not race.
     #[must_use]
     pub fn with_turn_controls(mut self, controls: &'a TurnControls) -> Self {
         if let Some(gate) = controls.gate.as_deref() {

--- a/crates/stella-core/src/subagent/tests.rs
+++ b/crates/stella-core/src/subagent/tests.rs
@@ -20,6 +20,7 @@ use stella_protocol::{
 use tokio::sync::mpsc;
 
 use super::*;
+use crate::TurnCapabilities;
 use crate::budget::BudgetOutcome;
 use crate::ports::TurnGate;
 use crate::retry::Sleeper;

--- a/crates/stella-core/src/subagent/tests/failure_and_events.rs
+++ b/crates/stella-core/src/subagent/tests/failure_and_events.rs
@@ -28,7 +28,14 @@ async fn an_aborted_child_salvages_the_last_answer_it_paid_for() {
         Ok(tool_call_result("read_file", "c2", 0.01)),
     ]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -60,7 +67,14 @@ async fn a_failed_child_never_becomes_an_error_the_parent_has_to_handle() {
     let parent_provider = ScriptedProvider::new(vec![]);
     let child_provider = ScriptedProvider::new(vec![]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -87,7 +101,14 @@ async fn nesting_deeper_than_the_cap_is_refused_before_spending() {
     let parent_provider = ScriptedProvider::new(vec![]);
     let child_provider = ScriptedProvider::new(vec![Ok(text_result("hi", 0.01))]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -123,7 +144,14 @@ async fn the_childs_stage_and_narration_never_reach_the_parents_stream() {
         Ok(text_result("the answer", 0.01)),
     ]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
 
@@ -177,7 +205,14 @@ async fn a_childs_metering_records_name_the_child_that_spent_them() {
     let parent_provider = ScriptedProvider::new(vec![]);
     let child_provider = ScriptedProvider::new(vec![Ok(text_result("done", 0.02))]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
 
@@ -218,7 +253,8 @@ async fn a_childs_metering_records_name_the_child_that_spent_them() {
 async fn the_leads_own_calls_name_no_sub_agent() {
     let provider = ScriptedProvider::new(vec![Ok(text_result("answered", 0.05))]);
     let tools = MixedTools::default();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &NoSleep, seams);
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("do it")];
@@ -246,7 +282,14 @@ async fn step_usage_and_tool_activity_reach_the_parent_so_cost_rolls_up() {
         Ok(text_result("done", 0.02)),
     ]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
 
@@ -304,7 +347,14 @@ async fn a_childs_tool_calls_name_the_child_that_ran_them() {
         Ok(text_result("done", 0.02)),
     ]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
 
@@ -345,7 +395,8 @@ async fn the_leads_own_tool_calls_name_no_sub_agent() {
         Ok(text_result("answered", 0.02)),
     ]);
     let tools = MixedTools::default();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &NoSleep, seams);
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut messages = vec![CompletionMessage::user("do it")];

--- a/crates/stella-core/src/subagent/tests/fork_scope.rs
+++ b/crates/stella-core/src/subagent/tests/fork_scope.rs
@@ -76,7 +76,14 @@ async fn a_grant_scoped_child_cannot_see_or_call_outside_its_grant() {
         Ok(text_result("done", 0.001)),
     ]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -126,7 +133,8 @@ async fn a_forked_skills_effort_overrides_the_parents_and_absent_inherits() {
         effort: Some(ReasoningEffort::Low),
         ..EngineConfig::default()
     };
-    let parent = Engine::with_sleeper(&parent_provider, &tools, config, &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(&parent_provider, &tools, config, &NoSleep, seams);
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 

--- a/crates/stella-core/src/subagent/tests/seams.rs
+++ b/crates/stella-core/src/subagent/tests/seams.rs
@@ -28,8 +28,17 @@ async fn a_child_honors_the_soft_stop_but_never_eats_the_parents_steering() {
         drained: AtomicUsize::new(0),
         stop: true,
     };
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep)
-        .with_steering(&steering);
+    let seams = TurnCapabilities {
+        steering: Some(&steering),
+        ..TurnCapabilities::none()
+    };
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -94,8 +103,17 @@ async fn a_child_polls_the_parents_pause_gate() {
     ]);
     let tools = MixedTools::default();
     let gate = CountingGate(AtomicUsize::new(0));
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep)
-        .with_gate(&gate);
+    let seams = TurnCapabilities {
+        gate: Some(&gate),
+        ..TurnCapabilities::none()
+    };
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -135,9 +153,18 @@ async fn owned_turn_controls_stop_a_child_without_clobbering_an_attached_gate() 
         stop: true,
     });
     let controls = TurnControls::none().with_steering(steering.clone());
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep)
-        .with_gate(&gate)
-        .with_turn_controls(&controls);
+    let seams = TurnCapabilities {
+        gate: Some(&gate),
+        ..TurnCapabilities::none()
+    };
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    )
+    .with_turn_controls(&controls);
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -188,7 +215,8 @@ fn turn_controls_carrying_both_seams_give_a_child_both() {
         }));
     assert!(!both.is_empty());
 
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &NoSleep)
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &NoSleep, seams)
         .with_turn_controls(&both);
 
     assert!(engine.gate.is_some(), "the pause must survive the steering");
@@ -205,8 +233,11 @@ fn empty_turn_controls_leave_an_engine_exactly_as_it_was() {
     let tools = MixedTools::default();
     let gate = CountingGate(AtomicUsize::new(0));
     let nothing = TurnControls::none();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &NoSleep)
-        .with_gate(&gate)
+    let seams = TurnCapabilities {
+        gate: Some(&gate),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &NoSleep, seams)
         .with_turn_controls(&nothing);
 
     assert!(
@@ -269,7 +300,8 @@ async fn the_child_claims_its_own_receipt_turn_slot() {
         lifecycle_enabled: true,
         ..EngineConfig::default()
     };
-    let parent = Engine::with_sleeper(&parent_provider, &tools, config, &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(&parent_provider, &tools, config, &NoSleep, seams);
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
 
@@ -346,8 +378,17 @@ async fn subagent_start_and_stop_hooks_fire_around_a_child_turn() {
         }]),
         ..Hooks::default()
     };
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep)
-        .with_hooks(&hooks, &runner);
+    let seams = TurnCapabilities {
+        hooks: Some((&hooks, &runner)),
+        ..TurnCapabilities::none()
+    };
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -423,8 +464,17 @@ async fn a_forked_child_stamps_the_subagent_fork_lane() {
     let parent_provider = ScriptedProvider::new(vec![]);
     let child_provider = ScriptedProvider::new(vec![Ok(text_result("done", 0.01))]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep)
-        .with_bus(&bus);
+    let seams = TurnCapabilities {
+        bus: Some(&bus),
+        ..TurnCapabilities::none()
+    };
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 

--- a/crates/stella-core/src/subagent/tests/spend_and_cancellation.rs
+++ b/crates/stella-core/src/subagent/tests/spend_and_cancellation.rs
@@ -57,7 +57,8 @@ async fn tool_dispatched_child_spend_aborts_the_parent_at_the_next_step_boundary
         per_call_usd: 0.60,
         drains: AtomicUsize::new(0),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &NoSleep, seams);
     let mut messages = vec![CompletionMessage::user("go")];
     let mut budget = BudgetGuard::new(BudgetMode::Enforced, None, Some(1.0));
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -123,7 +124,8 @@ async fn the_drain_is_destructive_so_child_spend_is_never_charged_twice() {
         per_call_usd: 0.25,
         drains: AtomicUsize::new(0),
     };
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &NoSleep, seams);
     let mut messages = vec![CompletionMessage::user("go")];
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
@@ -225,7 +227,14 @@ async fn a_cancelled_child_closes_its_bracket_with_committed_steps_and_cost() {
         hang_reached: hang_reached.clone(),
     };
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let spec = SubAgentSpec::read_only("search-1", "find it");
@@ -348,7 +357,8 @@ async fn a_child_is_bounded_by_the_ceiling_its_whole_run_sits_under() {
     let parent_provider = ScriptedProvider::new(vec![]);
     let child_provider = NeverAnswers;
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
         &parent_provider,
         &tools,
         EngineConfig {
@@ -358,6 +368,7 @@ async fn a_child_is_bounded_by_the_ceiling_its_whole_run_sits_under() {
             ..EngineConfig::default()
         },
         &NoSleep,
+        seams,
     );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
@@ -460,7 +471,8 @@ async fn a_ceiling_too_short_refuses_the_whole_spawn_loudly() {
     // Would answer happily if it were ever asked. It must not be.
     let child_provider = ScriptedProvider::new(vec![Ok(text_result("hello", 0.01))]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
         &parent_provider,
         &tools,
         EngineConfig {
@@ -468,6 +480,7 @@ async fn a_ceiling_too_short_refuses_the_whole_spawn_loudly() {
             ..EngineConfig::default()
         },
         &NoSleep,
+        seams,
     );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();

--- a/crates/stella-core/src/subagent/tests/tools_and_budget.rs
+++ b/crates/stella-core/src/subagent/tests/tools_and_budget.rs
@@ -10,7 +10,14 @@ async fn a_read_only_child_cannot_execute_a_mutating_tool_even_when_it_tries() {
         Ok(text_result("i tried", 0.001)),
     ]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -38,7 +45,14 @@ async fn write_access_is_opt_in_per_spawn() {
         Ok(text_result("done", 0.001)),
     ]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -63,7 +77,14 @@ async fn child_spend_settles_into_the_parent_exactly_once() {
         Ok(text_result("found it", 0.03)),
     ]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     budget.record_spend(0.10); // the parent's own prior work
     let (tx, _rx) = mpsc::unbounded_channel();
@@ -98,7 +119,14 @@ async fn an_enforced_carve_stops_the_child_without_touching_the_parents_turn() {
         Ok(text_result("never reached", 0.50)),
     ]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Enforced, None, Some(100.0));
     let (tx, _rx) = mpsc::unbounded_channel();
 
@@ -134,7 +162,14 @@ async fn a_child_can_never_be_carved_past_the_parents_remaining_headroom() {
     let parent_provider = ScriptedProvider::new(vec![]);
     let child_provider = ScriptedProvider::new(vec![Ok(text_result("hi", 0.001))]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Enforced, None, Some(1.0));
     budget.record_spend(0.96);
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -174,7 +209,14 @@ async fn an_enforced_parent_with_no_headroom_refuses_before_spending_anything() 
     // Would answer happily if it were ever asked. It must not be.
     let child_provider = ScriptedProvider::new(vec![Ok(text_result("hello", 0.99))]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Enforced, None, Some(1.0));
     budget.record_spend(1.5);
     let (tx, mut rx) = mpsc::unbounded_channel();

--- a/crates/stella-core/src/subagent/tests/witness.rs
+++ b/crates/stella-core/src/subagent/tests/witness.rs
@@ -25,7 +25,14 @@ async fn the_parent_transcript_does_not_grow_by_the_childs_intermediate_work() {
         Ok(text_result("the retry policy is in retry.rs", 0.001)),
     ]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
 
     let mut parent_messages = vec![
         CompletionMessage::system("sys"),
@@ -131,7 +138,8 @@ async fn a_child_turn_never_writes_or_clears_the_parents_resume_point() {
         checkpoint_sink: Some(sink.clone() as Arc<dyn crate::step::CheckpointSink>),
         ..EngineConfig::default()
     };
-    let parent = Engine::with_sleeper(&parent_provider, &tools, config, &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(&parent_provider, &tools, config, &NoSleep, seams);
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
 
@@ -175,7 +183,14 @@ async fn the_report_is_clamped_to_the_spec_cap_and_says_so() {
     let parent_provider = ScriptedProvider::new(vec![]);
     let child_provider = ScriptedProvider::new(vec![Ok(text_result(&"y".repeat(5_000), 0.001))]);
     let tools = MixedTools::default();
-    let parent = Engine::with_sleeper(&parent_provider, &tools, EngineConfig::default(), &NoSleep);
+    let seams = TurnCapabilities::none();
+    let parent = Engine::assemble(
+        &parent_provider,
+        &tools,
+        EngineConfig::default(),
+        &NoSleep,
+        seams,
+    );
     let mut budget = BudgetGuard::new(BudgetMode::Observed, None, None);
     let (tx, mut rx) = mpsc::unbounded_channel();
 

--- a/crates/stella-core/tests/engine_emits_no_stage.rs
+++ b/crates/stella-core/tests/engine_emits_no_stage.rs
@@ -24,7 +24,7 @@ use stella_core::budget::BudgetGuard;
 use stella_core::event_sender::EventSender;
 use stella_core::ports::ToolExecutor;
 use stella_core::retry::Sleeper;
-use stella_core::{Engine, EngineConfig};
+use stella_core::{Engine, EngineConfig, TurnCapabilities};
 use stella_protocol::{
     AgentEvent, BudgetMode, CompletionMessage, CompletionRequestRef, CompletionResult,
     CompletionUsage, Provider, ProviderError, ToolOutput, ToolSchema,
@@ -81,7 +81,8 @@ async fn a_turn_emits_no_stage_boundary_of_its_own() {
     let provider = AnswersOnce;
     let tools = NoTools;
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     let events = EventSender::new(tx);

--- a/crates/stella-core/tests/hard_drop_write_back.rs
+++ b/crates/stella-core/tests/hard_drop_write_back.rs
@@ -23,7 +23,7 @@ use stella_core::budget::BudgetGuard;
 use stella_core::event_sender::EventSender;
 use stella_core::ports::ToolExecutor;
 use stella_core::retry::Sleeper;
-use stella_core::{Engine, EngineConfig};
+use stella_core::{Engine, EngineConfig, TurnCapabilities};
 use stella_protocol::{
     BudgetMode, CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage,
     MessageRole, Provider, ProviderError, ToolCall, ToolOutput, ToolSchema,
@@ -93,7 +93,8 @@ async fn dropping_a_turn_mid_tool_still_leaves_the_partial_history_with_the_call
     let provider = AlwaysCallsATool;
     let tools = WedgedTool;
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
 
     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
     let events = EventSender::new(tx);

--- a/crates/stella-core/tests/parallel_dispatch.rs
+++ b/crates/stella-core/tests/parallel_dispatch.rs
@@ -26,7 +26,7 @@ use serde_json::Value;
 use stella_core::budget::BudgetGuard;
 use stella_core::ports::ToolExecutor;
 use stella_core::retry::Sleeper;
-use stella_core::{Engine, EngineConfig, TurnOutcome};
+use stella_core::{Engine, EngineConfig, TurnCapabilities, TurnOutcome};
 use stella_protocol::{
     BudgetMode, CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage,
     Provider, ProviderError, ToolCall, ToolOutput, ToolSchema,
@@ -126,7 +126,8 @@ async fn sibling_delegate_calls_in_one_step_execute_concurrently() {
         barrier: tokio::sync::Barrier::new(2),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("research two questions"),
@@ -236,7 +237,8 @@ async fn a_mutating_call_between_spawns_keeps_its_barrier() {
         barrier: tokio::sync::Barrier::new(2),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("research around an edit"),

--- a/crates/stella-core/tests/spend_gate.rs
+++ b/crates/stella-core/tests/spend_gate.rs
@@ -33,7 +33,7 @@ use stella_core::hooks::{
 };
 use stella_core::ports::{FallbackResolver, ResolvedFallback, ToolExecutor};
 use stella_core::retry::Sleeper;
-use stella_core::{Engine, EngineConfig, TurnOutcome};
+use stella_core::{Engine, EngineConfig, TurnCapabilities, TurnOutcome};
 use stella_protocol::{
     BudgetMode, CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage,
     Provider, ProviderError, ToolCall, ToolOutput, ToolSchema,
@@ -286,13 +286,17 @@ impl Turn {
         });
         let runner = self.stop_decision.map(|stdout| DecidingRunner { stdout });
 
-        let mut engine = Engine::with_sleeper(&provider, &tools, self.config, &sleeper);
-        if let Some(resolver) = &resolver {
-            engine = engine.with_fallback_resolver(resolver);
-        }
-        if let (Some(hooks), Some(runner)) = (&hooks, &runner) {
-            engine = engine.with_hooks(hooks, runner);
-        }
+        let seams = TurnCapabilities {
+            hooks: match (&hooks, &runner) {
+                (Some(hooks), Some(runner)) => Some((hooks, runner as &dyn HookRunner)),
+                _ => None,
+            },
+            fallback: resolver
+                .as_ref()
+                .map(|resolver| resolver as &dyn FallbackResolver),
+            ..TurnCapabilities::none()
+        };
+        let engine = Engine::assemble(&provider, &tools, self.config, &sleeper, seams);
 
         let mut messages = self.messages;
         let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);

--- a/crates/stella-engine/README.md
+++ b/crates/stella-engine/README.md
@@ -67,17 +67,17 @@ This section and the `# What earns a re-export` section of `src/lib.rs` state
 one rule in the same words. They used to state two: this file said a
 re-export is earned only when a host "genuinely cannot drive a turn
 without it", while `src/lib.rs` stated a strictly wider per-port closure. The
-gap between them was not theoretical — `Engine::with_requery` was reachable
-through the facade and callable by nobody, because neither the
-`SteeringRequery` it takes nor the `TurnSignal` that port's one method names
-could be spelled from this crate (#3715).
+gap between them was not theoretical. The re-query seam was reachable
+through the facade and bindable by nobody. Neither the `SteeringRequery` it
+takes nor the `TurnSignal` that port's one method names could be spelled from
+this crate (#3715).
 
 **The rule.** A host must be able to write, naming nothing but
 `stella_engine::` paths:
 
 1. an `impl` of every port this facade's engine accepts,
 2. a construction of every value it accepts — every `EngineConfig` field and
-   every builder argument, and
+   every `TurnCapabilities` seam, and
 3. a `match` on every value it hands back that the host must branch on.
 
 Closure is transitive through those three obligations and stops where they
@@ -96,9 +96,8 @@ still a design question; making an already-reachable one writable is not.
 Every entry arrives with doc prose explaining its place in the host-driving
 story.
 
-**The hook plane is the wrong layer, by design.** `Engine::with_hooks`
-(`Hooks`, `HookRunner`) and `Engine::with_bus` (`HookBus`) are not closed
-over. Their closure is the shell-command hook plane, an extension surface
+**The hook plane is the wrong layer, by design.** Two seams are not closed
+over: `hooks` (`Hooks`, `HookRunner`) and `bus` (`HookBus`). Their closure is the shell-command hook plane, an extension surface
 whose purpose is to *execute* things, fronted here by a crate that inherits
 `stella-core`'s I/O-free posture; the supported host-extension door is
 [`stella-runtime`](../stella-runtime)'s wrapper socket (#3380,

--- a/crates/stella-engine/src/lib.rs
+++ b/crates/stella-engine/src/lib.rs
@@ -107,8 +107,8 @@
 //! It re-exports and documents; it opens no sockets, spawns no processes and
 //! touches no files, exactly like the `stella-core` it fronts. Everything the
 //! engine needs from the outside world arrives through the ports, which the
-//! host implements: [`Sleeper`], which [`Engine::with_sleeper`] requires
-//! because it is the only constructor, and then [`Provider`],
+//! host implements: [`Sleeper`], which the only constructor
+//! [`Engine::assemble`] requires, and then [`Provider`],
 //! [`ToolExecutor`], [`TurnGate`], [`TurnSteering`], [`SteeringRequery`],
 //! [`TurnHalt`], [`ProviderOutcomes`], [`FallbackResolver`] and
 //! [`CheckpointSink`], each of which is optional.
@@ -143,10 +143,10 @@
 //!
 //! ## The hook plane is the wrong layer, by design
 //!
-//! Two of [`Engine`]'s builder methods are **not** closed over:
+//! Two of [`TurnCapabilities`]'s seams are **not** closed over:
 //!
-//! - **[`Engine::with_hooks`]** (`stella_core::hooks::{Hooks, HookRunner}`)
-//!   and **`Engine::with_bus`** (`stella_core::bus::HookBus`). Their closure
+//! - **`hooks`** (`stella_core::hooks::{Hooks, HookRunner}`) and **`bus`**
+//!   (`stella_core::bus::HookBus`). Their closure
 //!   is the shell-command hook plane — `HookAction`, `HookExecResult`,
 //!   `HookExecError`, `HookMatcher`, `HookEvent`, `HookDecision`,
 //!   `HookEventDraft` — an extension surface whose whole purpose is to
@@ -157,9 +157,9 @@
 //!   above this facade precisely because two of its four points do I/O.
 //!
 //! #3768 asked whether that is a permanent exclusion, whether the observer
-//! half (`with_bus`) should cross, or whether both should. **The answer is
+//! half (`bus`) should cross, or whether both should. **The answer is
 //! the first**, and this is the decision rather than a gap someone has yet to
-//! close. Closing over either method would let a host reach the engine's
+//! close. Closing over either seam would let a host reach the engine's
 //! shell-execution authority by naming `stella_engine::` paths alone, which
 //! is the one thing a facade over an I/O-free engine must not make look
 //! ordinary.
@@ -226,10 +226,10 @@ pub use stella_core::loop_detect::LoopDetectionConfig;
 
 // ── what a host has to supply, and what it gets back ──────────────────────
 //
-// Three of the ports here are builder methods the closure rule reaches that
-// the pre-#3715 list did not: `SteeringRequery` (`Engine::with_requery`)
+// Three of the ports here are seams the closure rule reaches that
+// the pre-#3715 list did not: `SteeringRequery` (`TurnCapabilities::requery`)
 // together with the `TurnSignal` its one method takes — neither was nameable
-// here, so the method could be called by nobody — plus `ProviderOutcomes` and
+// here, so the seam could be bound by nobody — plus `ProviderOutcomes` and
 // `FallbackResolver`, whose `ResolvedFallback` return type borrows a
 // `Provider` this crate already exports.
 //

--- a/crates/stella-engine/src/tests.rs
+++ b/crates/stella-engine/src/tests.rs
@@ -20,7 +20,7 @@ use crate::{
     AgentEvent, BudgetGuard, BudgetMode, CANCELLED_REASON, CancelToken, CompletionMessage,
     CompletionRequestRef, CompletionResult, CompletionUsage, Engine, EngineConfig, EventSender,
     MessageRole, Provider, ProviderError, Sleeper, StepOutcome, ToolCall, ToolExecutor, ToolOutput,
-    ToolSchema, TurnOutcome,
+    ToolSchema, TurnCapabilities, TurnOutcome,
 };
 
 /// A `Sleeper` that records but never actually waits.
@@ -209,7 +209,8 @@ async fn new_turn_then_run_step_drives_a_turn_to_done() {
     let tools = CountingTools::new();
     let tool_calls = tools.calls.clone();
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
 
     let (tx, mut rx) = mpsc::unbounded_channel();
     let events = EventSender::new(tx);
@@ -265,7 +266,8 @@ async fn run_turn_is_exactly_a_loop_over_run_step() {
         let provider = ScriptedProvider::new(script());
         let tools = CountingTools::new();
         let sleeper = NoopSleeper;
-        let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
         let (tx, mut rx) = mpsc::unbounded_channel();
         let events = EventSender::new(tx);
         let mut state = engine.new_turn(prompt(), free_budget());
@@ -280,7 +282,8 @@ async fn run_turn_is_exactly_a_loop_over_run_step() {
         let provider = ScriptedProvider::new(script());
         let tools = CountingTools::new();
         let sleeper = NoopSleeper;
-        let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
         let (tx, mut rx) = mpsc::unbounded_channel();
         let events = EventSender::new(tx);
         let mut messages = prompt();
@@ -333,7 +336,8 @@ async fn a_turn_resumed_from_a_checkpoint_emits_the_same_downstream_events() {
         let provider = ScriptedProvider::new(vec![tool_call_result("c1"), text_result("all done")]);
         let tools = CountingTools::new();
         let sleeper = NoopSleeper;
-        let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
         let (tx, mut rx) = mpsc::unbounded_channel();
         let events = EventSender::new(tx);
         let mut state = engine.new_turn(prompt(), free_budget());
@@ -353,7 +357,8 @@ async fn a_turn_resumed_from_a_checkpoint_emits_the_same_downstream_events() {
         let provider = ScriptedProvider::new(vec![tool_call_result("c1")]);
         let tools = CountingTools::new();
         let sleeper = NoopSleeper;
-        let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
         let (tx, _rx) = mpsc::unbounded_channel();
         let events = EventSender::new(tx);
         let mut state = engine.new_turn(prompt(), free_budget());
@@ -376,7 +381,8 @@ async fn a_turn_resumed_from_a_checkpoint_emits_the_same_downstream_events() {
     let tools = CountingTools::new();
     let resumed_tool_calls = tools.calls.clone();
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, mut rx) = mpsc::unbounded_channel();
     let events = EventSender::new(tx);
     let mut state = engine.resume_turn(checkpoint);
@@ -440,7 +446,8 @@ async fn a_mid_turn_cancel_stops_at_the_next_boundary_with_a_valid_transcript() 
     tools.cancel_on_call = Some(cancel.clone());
     let tool_calls = tools.calls.clone();
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let provider_calls = provider.calls.clone();
 
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -512,7 +519,8 @@ async fn a_cancel_before_the_first_step_costs_nothing() {
     let provider_calls = provider.calls.clone();
     let tools = CountingTools::new();
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
 
     let (tx, _rx) = mpsc::unbounded_channel();
     let events = EventSender::new(tx);
@@ -536,7 +544,8 @@ async fn a_checkpoint_taken_between_steps_round_trips_through_the_facade() {
     let provider = ScriptedProvider::new(vec![tool_call_result("c1"), text_result("done")]);
     let tools = CountingTools::new();
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
     let (tx, _rx) = mpsc::unbounded_channel();
     let events = EventSender::new(tx);
 

--- a/crates/stella-engine/tests/embedding.rs
+++ b/crates/stella-engine/tests/embedding.rs
@@ -14,8 +14,8 @@
 //! trait it must implement. `stella-serve` had already reached around the
 //! facade with `use stella_core::step::CheckpointSink;`.
 //!
-//! The same shape recurred at `Engine::with_requery` (#3715): the method was
-//! reachable through the facade and callable by nobody, because neither the
+//! The same shape recurred at the re-query seam (#3715): it was reachable
+//! through the facade and bindable by nobody, because neither the
 //! `SteeringRequery` it takes nor the `TurnSignal` that port's one method names
 //! could be spelled from this crate. `a_host_can_requery_its_context_plane`
 //! below is that gap's witness.
@@ -47,8 +47,8 @@ use stella_engine::{
     AbortKind, AgentEvent, BudgetGuard, BudgetMode, CheckpointSink, CompletionMessage,
     CompletionRequestRef, CompletionResult, CompletionUsage, DispatchAdmission, DispatchGate,
     Engine, EngineConfig, LiveService, Provider, ProviderError, RECALL_MARKER, Sleeper,
-    SteeringRequery, ToolCall, ToolContract, ToolExecutor, ToolOutput, ToolSchema, TurnOutcome,
-    TurnSignal, WaitCall, WaitRequest, admit_dispatch,
+    SteeringRequery, ToolCall, ToolContract, ToolExecutor, ToolOutput, ToolSchema,
+    TurnCapabilities, TurnOutcome, TurnSignal, WaitCall, WaitRequest, admit_dispatch,
 };
 
 /// The one tool the host advertises. Its only job is to make the model's first
@@ -405,7 +405,8 @@ async fn a_host_can_drive_a_turn_through_the_facade_alone() {
     let provider = HostProvider::default();
     let tools = HostTools::default();
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
 
     let (tx, _rx) = mpsc::unbounded_channel::<AgentEvent>();
     let mut messages = vec![CompletionMessage::user("say done")];
@@ -445,21 +446,24 @@ async fn a_host_can_drive_a_turn_through_the_facade_alone() {
 }
 
 /// **Witness (#3715).** A host implements the step-boundary re-query port and
-/// attaches it with `Engine::with_requery`, naming nothing but
-/// `stella_engine::` paths.
+/// binds it in its `TurnCapabilities`, naming nothing but `stella_engine::`
+/// paths.
 ///
 /// This test does not compile on the pre-fix crate: `SteeringRequery` and the
 /// `TurnSignal` its one method takes were both unreachable through the facade,
-/// so the `impl` block could not be written at all — which is what made
-/// `with_requery` a method callable by nobody who took the facade at its word.
+/// so the `impl` block could not be written at all — which is what made the
+/// re-query seam bindable by nobody who took the facade at its word.
 #[tokio::test]
 async fn a_host_can_requery_its_context_plane_through_the_facade_alone() {
     let provider = HostProvider::default();
     let tools = HostTools::default();
     let sleeper = NoopSleeper;
     let requery = HostRequery::default();
-    let engine = Engine::with_sleeper(&provider, &tools, EngineConfig::default(), &sleeper)
-        .with_requery(&requery);
+    let seams = TurnCapabilities {
+        requery: Some(&requery),
+        ..TurnCapabilities::none()
+    };
+    let engine = Engine::assemble(&provider, &tools, EngineConfig::default(), &sleeper, seams);
 
     let (tx, _rx) = mpsc::unbounded_channel::<AgentEvent>();
     let mut messages = vec![CompletionMessage::user("probe then say done")];
@@ -517,10 +521,9 @@ mod hook_plane {
 /// The closure rule's other half: what must stay *out*.
 ///
 /// The rule says a host names nothing but `stella_engine::` paths to fill
-/// every builder argument, and `Engine::with_hooks` / `Engine::with_bus` are
-/// the two arguments it cannot fill (`src/lib.rs`, "The hook
-/// plane is the wrong layer, by design"). A declaration in prose is a
-/// reviewer's note; this module is the guard.
+/// every `TurnCapabilities` seam, and `hooks` / `bus` are the two it cannot
+/// fill (`src/lib.rs`, "The hook plane is the wrong layer, by design"). A
+/// declaration in prose is a reviewer's note; this module is the guard.
 mod the_exclusion_is_enforced {
     use super::hook_plane::*;
     use stella_engine::*;

--- a/crates/stella-parity/src/lane.rs
+++ b/crates/stella-parity/src/lane.rs
@@ -6,9 +6,9 @@
 //! `stella_protocol::BuiltinLane` names every place a turn runs.
 //! `Engine::assemble` lets each of them put its own name on
 //! `agent.turn.started`. Having a name and saying it are two facts. A site
-//! that builds its engine with `Engine::with_sleeper` writes `lane: None` and
-//! cannot say anything. Its turns then land in one `null` bucket. This table
-//! keeps the two facts together.
+//! that hands over a seam set writing `lane: None` says nothing, and its
+//! turns land in one `null` bucket. This table keeps the two facts
+//! together.
 //!
 //! Same instrument as the two matrices beside it, pointed at lanes. One row
 //! per case. A witness test per row, named and checked. The compiler enforces
@@ -244,8 +244,8 @@ mod tests {
     /// lane.
     ///
     /// On a tree where only the fork stamps itself, this fails for the other
-    /// five rows at once. A site that builds its engine with
-    /// `Engine::with_sleeper` takes no lane, so it never spells one.
+    /// five rows at once. A site whose seam set leaves `lane` unset never
+    /// spells one.
     #[test]
     fn every_bound_lane_is_stamped_at_its_site() {
         for row in LANES {

--- a/crates/stella-parity/src/lane/capability.rs
+++ b/crates/stella-parity/src/lane/capability.rs
@@ -502,10 +502,7 @@ lane_capabilities! {
         steering: SeamClaim::declined(
             "a fleet worker has no input channel. Nobody is at a keyboard to steer it",
         ),
-        requery: SeamClaim::deferred(
-            "Refs #6158",
-            "a decision on whether a fleet attempt may ask the workspace context plane again",
-        ),
+        requery: SeamClaim::bound("requery,", CLI_SEAMS),
         bus: SeamClaim::declined(DECK_BUS),
         outcomes: SeamClaim::declined(DECK_OUTCOMES),
         fallback: SeamClaim::declined(DECK_FALLBACK),

--- a/crates/stella-parity/src/lib.rs
+++ b/crates/stella-parity/src/lib.rs
@@ -100,12 +100,12 @@ pub struct Capability {
 /// ever expose them directly. Anything swept from the engine sources that is
 /// neither claimed by a row nor listed here fails the completeness test.
 pub const COMPOSITION_SEAMS: &[&str] = &[
-    // The blessed constructor (#3390): required ports plus one
-    // `TurnCapabilities` answering every optional seam. Assembly in the same
-    // sense `with_sleeper` is — a host builds a stack with it, and no surface
-    // exposes it — so it belongs here rather than in a capability row.
+    // The only constructor (#3390): the required ports, plus one
+    // `TurnCapabilities` that answers every optional seam. A host builds a
+    // stack with it. No surface exposes it. So it belongs here, not in a
+    // capability row. Every seam a row below names is a field of the value it
+    // takes, which is why those rows claim no entry point of their own.
     "assemble",
-    "with_sleeper",
     "with_call_role",
     // The reader for `with_call_role`, and an assembly detail for the same
     // reason the setter is: a host that drives `run_step` itself owns the turn
@@ -227,8 +227,9 @@ pub static CAPABILITIES: &[Capability] = &[
     },
     Capability {
         id: "turn.steer",
-        engine_home: "stella-core TurnSteering port — mid-turn user messages at step boundaries",
-        engine_entries: &["with_steering"],
+        engine_home: "stella-core TurnSteering port — mid-turn user messages at step \
+                      boundaries, bound by TurnCapabilities::steering",
+        engine_entries: &[],
         cli: SurfacePosture::Shipped {
             mechanism: "deck mid-turn input via the SteeringTap",
             witness: "a_live_turn_still_steers_on_the_marker_and_spawns_otherwise",
@@ -283,8 +284,8 @@ pub static CAPABILITIES: &[Capability] = &[
         id: "turn.steering_requery",
         engine_home: "stella-core SteeringRequery port — the steering plane re-queried at step \
                       boundaries when TurnSignal drift says the opening prompt stopped \
-                      describing the turn",
-        engine_entries: &["with_requery"],
+                      describing the turn, bound by TurnCapabilities::requery",
+        engine_entries: &[],
         cli: SurfacePosture::Shipped {
             mechanism: "agent::run_turn, the deck, and a fleet worker each attach a \
                         SessionRequery over SessionMemory, so a drifted turn re-selects \
@@ -335,8 +336,9 @@ pub static CAPABILITIES: &[Capability] = &[
     },
     Capability {
         id: "turn.pause_resume",
-        engine_home: "stella-core TurnGate port — park at a step boundary, never mid-tool",
-        engine_entries: &["with_gate"],
+        engine_home: "stella-core TurnGate port — park at a step boundary, never mid-tool, \
+                      bound by TurnCapabilities::gate",
+        engine_entries: &[],
         cli: SurfacePosture::Shipped {
             mechanism: "deck pause/resume controls (`p`), on worker lanes and on the lead's own \
                         turn alike (#1219 — raw and pipeline paths); a paused turn parks its \
@@ -475,8 +477,9 @@ pub static CAPABILITIES: &[Capability] = &[
         id: "hooks.lifecycle",
         engine_home: "stella-core hooks (PreToolUse/PostToolUse/SessionStart/Stop/PreCompact/\
                       UserPromptSubmit/SubagentStart/SubagentStop, the #2684 stdout-decision \
-                      plane in hooks::decision) and the observer-only HookBus",
-        engine_entries: &["with_hooks", "with_bus", "with_hook_approval_route"],
+                      plane in hooks::decision) and the observer-only HookBus, bound by \
+                      TurnCapabilities::{hooks, hook_approvals, bus}",
+        engine_entries: &[],
         cli: SurfacePosture::Shipped {
             mechanism: "workspace hooks wired via with_session_hook_context on every driver \
                         path. SessionStart firing is a HOST obligation (#2674): the engine \
@@ -515,14 +518,14 @@ pub static CAPABILITIES: &[Capability] = &[
     },
     Capability {
         id: "calibration.drift",
-        engine_home: "stella-core estimator CalibrationMap: per-model token-drift correction feeding compaction",
-        engine_entries: &["with_calibration"],
+        engine_home: "stella-core estimator CalibrationMap: per-model token-drift correction \
+                      feeding compaction, bound by TurnCapabilities::calibration",
+        engine_entries: &[],
         cli: SurfacePosture::ShippedUnwitnessed {
-            mechanism: "seed_calibration from the store plus with_calibration on all seven \
-                        assembly sites: the interactive, raw one-shot, goal, deck and \
-                        sub-session paths hand it to the engine directly, and the default \
-                        `stella run` staged-pipeline path and fleet workers lend it to the \
-                        Pipeline, which attaches it to every engine it builds (#1595)",
+            mechanism: "seed_calibration from the store, then the `calibration` slot of the \
+                        seam set every lane in lane_capabilities builds: the interactive, raw \
+                        one-shot, goal, deck, sub-session and fleet-worker lanes all bind it \
+                        (#1595)",
             missing: "a CLI-side test pinning that persisted drift samples reach the engine's \
                       calibration on session start (stella-core and stella-store each test their \
                       half; the CLI seam between them has no witness). The pipeline half of the \
@@ -652,8 +655,9 @@ pub static CAPABILITIES: &[Capability] = &[
         id: "provider.breaker_feedback",
         engine_home: "stella-core router CircuitBreaker + the ProviderOutcomes port: every \
                       logical model call's terminal verdict feeds the breaker, so `resolve` \
-                      fails over from observed outcomes, not configuration (#2673)",
-        engine_entries: &["with_provider_outcomes"],
+                      fails over from observed outcomes, not configuration (#2673), bound by \
+                      TurnCapabilities::outcomes",
+        engine_entries: &[],
         cli: SurfacePosture::ShippedUnwitnessed {
             // Was ALSO fed from PipelinePorts.attach() before the staged
             // pipeline was removed (#3865); that feed is gone with the crate, and every CLI
@@ -679,8 +683,9 @@ pub static CAPABILITIES: &[Capability] = &[
         engine_home: "stella-core driver/model_fallback + the FallbackResolver port: a retry \
                       ladder exhausting mid-turn re-resolves the role through the router — \
                       whose breaker the failing calls already fed — and continues the turn on \
-                      the replacement, transcript repaired, at most one swap per engine (#2679)",
-        engine_entries: &["with_fallback_resolver"],
+                      the replacement, transcript repaired, at most one swap per engine \
+                      (#2679), bound by TurnCapabilities::fallback",
+        engine_entries: &[],
         cli: SurfacePosture::ShippedUnwitnessed {
             // Was ALSO attached by the staged pipeline's execute/revise
             // engines before it was removed (#3865); that attach

--- a/crates/stella-runtime/README.md
+++ b/crates/stella-runtime/README.md
@@ -228,10 +228,10 @@ One piece of that design is no longer the open risk `doc:turn-loop-wrappers`
 `Engine::assemble` is what
 [`stella-core::subagent`](../stella-core/src/subagent.rs) builds its child
 fork through today. Read `TurnCapabilities`'s own module doc before citing it
-as "the constructor cannot carry those seams" — that framing turned out false
-of this tree (`with_gate`/`with_steering`/`with_hooks` are `pub` and still
-directly callable); the property it actually enforces is *totality*, a
-decision recorded for every seam at every `assemble` call site. Whatever
+as "the constructor cannot carry those seams". That framing was false of this
+tree while a public setter stood beside the constructor for every seam. The
+property the type enforces is *totality*: a decision recorded for every seam
+at every `assemble` call site. Whatever
 implements the wrapper socket's future child-turn port earns the same
 discipline only by calling `assemble` itself — nothing today connects the two.
 

--- a/crates/stella-serve/src/extensions.rs
+++ b/crates/stella-serve/src/extensions.rs
@@ -135,8 +135,8 @@ pub type Extensions = Vec<std::sync::Arc<dyn ServeExtension>>;
 ///
 /// Returns `None` when nothing is installed, so a turn on a serve deployment
 /// with no extensions never mints a bus and the engine's every emit site stays
-/// behind its `if let Some(bus)` — the "`None` adds zero work" contract
-/// `Engine::with_bus` is written to.
+/// behind its `if let Some(bus)`. That is the "`None` adds zero work"
+/// contract the engine's `bus` seam is written to.
 pub(crate) fn install_for_turn(
     extensions: &Extensions,
     turn_id: impl Into<String>,

--- a/crates/stella-serve/src/session.rs
+++ b/crates/stella-serve/src/session.rs
@@ -777,21 +777,16 @@ fn run_session(
         // Assembled rather than built up by optional builders: this turn is
         // the `ServeSession` lane and says so, and `served_capabilities`
         // answers every seam rather than only the ones a chain attached.
-        let engine = Engine::assemble(
-            &provider,
-            tool_view,
-            spec.config.clone(),
-            &sleeper,
-            served_capabilities(
-                spec.calibration.as_deref(),
-                &gate,
-                &*steering,
-                requery
-                    .as_ref()
-                    .map(|r| r as &dyn stella_core::ports::SteeringRequery),
-                bus.as_ref(),
-            ),
+        let seams = served_capabilities(
+            spec.calibration.as_deref(),
+            &gate,
+            &*steering,
+            requery
+                .as_ref()
+                .map(|r| r as &dyn stella_core::ports::SteeringRequery),
+            bus.as_ref(),
         );
+        let engine = Engine::assemble(&provider, tool_view, spec.config.clone(), &sleeper, seams);
 
         // Two mutually exclusive modes: plain turn, judged goal run (#1297).
         let outcome = match &spec.goal {
@@ -924,6 +919,7 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use async_trait::async_trait;
+    use stella_core::TurnCapabilities;
     use stella_core::driver::TurnHalt;
     use stella_protocol::{
         BudgetMode, CompletionRequestRef, CompletionUsage, Provider, ProviderError, ToolCall,
@@ -1008,7 +1004,8 @@ mod tests {
         let provider = ToolThenText { calls };
         let tools = OkTool;
         let sleeper = TokioSleeper;
-        let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
+        let seams = TurnCapabilities::none();
+        let engine = Engine::assemble(&provider, &tools, config, &sleeper, seams);
         let (tx, _rx) = mpsc::unbounded_channel();
         drive_turn(
             &engine,
@@ -1102,9 +1099,9 @@ mod tests {
     /// so a host grouping turns by lane sees this one as its own bucket
     /// rather than as an unattributed `null`.
     ///
-    /// Fails on a tree that builds this engine with `Engine::with_sleeper`,
-    /// for a structural reason: that constructor has no parameter that could
-    /// carry a lane and writes `None`, so there is no `served_capabilities`
+    /// Failed on a tree that built this engine with the sleeper-only
+    /// constructor, for a structural reason: it had no parameter that could
+    /// carry a lane and wrote `None`, so there was no `served_capabilities`
     /// to call and nothing that could answer. What the value then does is
     /// `stella-core`'s `a_turn_stamps_the_lane_that_assembled_it`.
     #[test]

--- a/crates/stella-serve/src/subagents.rs
+++ b/crates/stella-serve/src/subagents.rs
@@ -58,7 +58,7 @@ use stella_core::ports::{
 use stella_core::subagent::{
     SubAgentDispatcher, SubAgentHost, SubAgentOutcome, SubAgentSpec, push_sub_agent_spend,
 };
-use stella_core::{BudgetGuard, Engine, EventSender};
+use stella_core::{BudgetGuard, Engine, EventSender, TurnCapabilities};
 use stella_protocol::{AgentEvent, BudgetMode, ToolOutput, ToolSchema};
 use tokio::sync::mpsc;
 
@@ -259,16 +259,19 @@ impl SubAgentDispatcher for ServedSubAgents {
                     // prompt — and the reason nesting is structurally capped
                     // at one level: `delegate` is not in this view.
                     let read_only = ReadOnlyTools::new(&*tools);
-                    // The builder path, naming no lane on purpose: this engine
-                    // never drives a turn of its own. `run_sub_agent` assembles
+                    // Every seam unbound, and no lane, on purpose. This
+                    // engine never drives a turn of its own. It has nothing
+                    // to pause, steer or attribute. `run_sub_agent` builds
                     // the child that does, and that child stamps
-                    // `BuiltinLane::SubagentFork` — a lane declared here would
+                    // `BuiltinLane::SubagentFork`. A lane named here would
                     // reach no `agent.turn.started` at all.
-                    let engine = Engine::with_sleeper(
+                    let seams = TurnCapabilities::none();
+                    let engine = Engine::assemble(
                         &*provider,
                         &read_only,
                         config,
                         &crate::remote::TokioSleeper,
+                        seams,
                     );
                     // Carve from the shared pool, run, settle. The lock is
                     // taken twice and never held across the run.
@@ -1115,5 +1118,41 @@ mod tests {
             })
             .expect("allowed");
         assert_eq!(effective.child_steps, 1);
+    }
+
+    /// **The host-engine witness.** The engine this module builds is not a
+    /// lane. It still goes through the blessed constructor.
+    ///
+    /// It never drives a turn of its own. `run_sub_agent` builds the child
+    /// that does, and that child stamps `BuiltinLane::SubagentFork`. So this
+    /// site binds no seam and names no lane. It writes both answers down.
+    /// `TurnCapabilities::none` names every slot, so a new slot stops this
+    /// site compiling too.
+    ///
+    /// It failed on a tree that built this engine through a constructor that
+    /// answered no seam. There, "no seam" and "no seam anyone chose" read the
+    /// same. `stella-cli`'s `subagent.rs` is the same shape one crate over.
+    /// It carries the same test beside its own source, the way the two copies
+    /// of the accept policy each carry theirs.
+    #[test]
+    fn this_host_engine_assembles_with_a_written_seam_set() {
+        let source = include_str!("subagents.rs");
+        let blessed = format!("Engine::{}(", "assemble");
+        let bare = format!("TurnCapabilities::{}()", "none");
+
+        assert!(
+            source.contains(&blessed),
+            "this module builds a host engine and must assemble it, or a seam added to the \
+             engine reaches it as a silent `None`",
+        );
+        assert!(
+            source.contains(&bare),
+            "this module must say in one written value that it binds no seam — `{bare}` is \
+             that value, and it is exhaustive, so a new slot stops this site compiling",
+        );
+        assert!(
+            !source.contains(&format!("Engine::with_{}(", "sleeper")),
+            "this module is back on a constructor that answers no seam and takes no lane",
+        );
     }
 }

--- a/crates/stella-tools/src/gated.rs
+++ b/crates/stella-tools/src/gated.rs
@@ -215,9 +215,9 @@ impl<'a> GatedToolSet<'a> {
     /// `stella-tools::hook_bridge`'s broker-backed implementation in
     /// production, stamped with this gate's `name()` via
     /// [`crate::hook_bridge::BrokerApprovalRoute::with_gate_name`] so the
-    /// audit trail names the producer. Opt-in like the engine's
-    /// `with_hook_approval_route`; a set without one refuses such calls
-    /// with a grant-path message instead of asking.
+    /// audit trail names the producer. Opt-in, like the engine's own
+    /// `hook_approvals` seam. A set with no route refuses such a call. It
+    /// sends back a grant-path message, and asks nobody.
     #[must_use]
     pub fn with_approval_route(mut self, route: Arc<dyn ApprovalRoute>) -> Self {
         self.approvals = Some(route);

--- a/crates/stella-tools/src/hook_bridge.rs
+++ b/crates/stella-tools/src/hook_bridge.rs
@@ -16,7 +16,7 @@
 //!
 //! ```ignore
 //! let route = BrokerApprovalRoute::for_registry(&registry);
-//! let engine = engine.with_hooks(hooks, &runner).with_hook_approval_route(&route);
+//! seams.hook_approvals = Some(&route);
 //! ```
 //!
 //! The decision fold itself (stdout JSON → [`stella_core::bus::HookDecision`]


### PR DESCRIPTION
## What and why

`Engine::assemble` exists so that every optional seam on a turn gets an answer
somebody typed. A second constructor stood beside it and answered none of
them: `Engine::with_sleeper`, plus one public setter per seam — `with_hooks`,
`with_calibration`, `with_gate`, `with_steering`, `with_requery`, `with_bus`,
`with_provider_outcomes`, `with_fallback_resolver` and
`with_hook_approval_route`.

While those stood, the totality property was worth only what a caller chose to
spend on it. A capability added to the loop reached such a site as a silent
`None` instead of as a build error, which is the whole property
`TurnCapabilities` was added to give. #3274 slice 3 asks for the deletion by
name; #6109 did the lane migration, and this is its deletion half.

All ten are deleted from `crates/stella-core/src/driver.rs` and
`crates/stella-core/src/driver/user_hooks.rs` (`driver.rs` is a god file — this
change only removes lines from it). `with_call_role`, `with_turn_instance`,
`with_turn_halt` and `with_turn_controls` are not named by the issue and stay.

## What the census actually found

The design pointer named four callers. Measured on `main` with a
balanced-paren scan rather than `rg -c`, there were **219 `Engine::with_sleeper`
sites in 43 files**, 43 of them carrying a chain of a deleted setter. The
pointer's four are the *lane doors*, which already assembled. The rest are
tests plus two non-lane hosts. Every one of the 219 is migrated here.

**The two shipping host engines take option 1 from the issue.**
`crates/stella-cli/src/subagent.rs` and `crates/stella-serve/src/subagents.rs`
now write `TurnCapabilities::none()` with a comment saying why: the engine
never drives a turn of its own, so it has nothing to pause, steer or
attribute, and `run_sub_agent` assembles the child that stamps
`BuiltinLane::SubagentFork`.

**Test sites write the seams they bind over `..TurnCapabilities::none()`.** A
lane writes every field out — that is what `lane_capabilities.rs` is for. A
fixture writes only what it binds, because `none()` is itself an exhaustive
literal: a new slot still stops the build there until somebody answers it.
`capabilities.rs`'s module doc now states that split, beside the reason there
is no `Default`.

**One behaviour change, in `crates/stella-cli/src/fleet_cmd.rs`.** It attached
its re-query port with `engine.with_requery(...)` after `assemble`. That seam
moves into `lane_capabilities::fleet_attempt`'s argument list, so the fleet
lane binds what it binds in one written literal, the way every other lane
does. `each_lane_binds_what_its_call_site_bound_before` gains the both-ways
assertion for it.

## Witness mechanism

Two, both source-text, both failing on `main` by construction.

- `crates/stella-core/src/driver/capabilities.rs` —
  `no_per_seam_builder_survives_beside_assemble` reads `driver.rs` and
  `driver/user_hooks.rs` back and asserts neither defines `pub fn with_<seam>(`
  for any of the ten. On `main` `driver.rs` contains `    pub fn with_sleeper(`,
  so it fails. It asserts both files still open an `impl<'a> Engine<'a>` block,
  so an empty search cannot pass for a clean one. Source text rather than a
  `compile_fail` doctest on purpose: a doctest passes on any compile error at
  all, including a typo in its own setup, so it cannot tell "the builder is
  gone" from "this snippet is broken".
- The two shipping hosts are each held by a test beside their own source:
  `the_host_engine_this_crate_builds_assembles_with_a_written_seam_set`
  (`lane_capabilities.rs`, reading `subagent.rs`) and
  `this_host_engine_assembles_with_a_written_seam_set` (`subagents.rs`, reading
  itself). Each asserts the file names `Engine::assemble(` and
  `TurnCapabilities::none()` and does not name the sleeper constructor. One
  test per crate rather than one test reading across the crate boundary,
  following the `accept.rs` twin already in the tree, so each crate's gate
  stays self-contained.

Needles are built with `format!` in every case, so no witness is its own match
and `turn_files`' driver fence reads these files as prose rather than as doors.

## The fences that had to move with it

- `crates/stella-cli/src/turn_files.rs`'s driver fence drops its
  `Engine::with_sleeper` needle: there is one constructor now, so a door has no
  second spelling to hide behind. `subagent.rs`'s `ENGINE_DRIVERS` row still
  matches.
- `crates/stella-parity/src/lib.rs` drops `with_sleeper` from
  `COMPOSITION_SEAMS`, and the seven `Capability` rows that claimed a deleted
  method now claim no engine entry point and name the `TurnCapabilities` field
  in `engine_home` instead. `every_public_engine_entry_point_is_claimed` and
  `every_claimed_engine_entry_exists` both still hold.

## Exemplar

`crates/stella-cli/src/lane_capabilities.rs` — the shape this repository
already chose for "one written literal per assembly site", including the
`let seams = …; Engine::assemble(…, seams)` spelling every call site here now
uses.

## A god file had to be split

`crates/stella-core/src/driver/tests.rs` sits at its 2907-line ceiling and 36
of these sites are in it, so the migration would have pushed it over. No
ceiling was raised. Its two streaming-deadline tests move to a new sibling,
`crates/stella-core/src/driver/tests/streaming_deadline.rs`, which lands at
2773 lines. The moved prose is rewritten plainly, because a new file is held to
a 6.00 reading grade; it measures 2.58.

## Tests deleted

None. `a_streaming_generation_outlives_the_deadline_because_it_is_not_stalled`
and `a_call_only_stream_outlives_the_deadline_because_it_is_not_stalled` moved
from `driver/tests.rs` to `driver/tests/streaming_deadline.rs` under the same
names.

## Also repaired here

`main` was red on the prose guard before this branch: #6168 added an
issue-number comment to `crates/stella-cli/src/fleet_cmd.rs` without the
baseline moving with it. #6203 fixed the same line while this branch was in
flight and the rebase kept its wording, so nothing of that repair is left in
this diff.

`crates/stella-runtime/README.md` carried a live claim that
`with_gate`/`with_steering`/`with_hooks` "are `pub` and still directly
callable". They are not, so it says so.

## Evidence

`make guards-fast` green locally — prose (count, header density and reading
grade), file-size, line-citations, dead-code-allows, lockfile-sync, fmt.
Everything that compiles is CI's.

## Remaining work filed

See the comment below for the issues this PR files.

Closes #6164
Refs #3274, Refs #6109
