### PR TITLE
feat(stella-core,stella-serve): a turn has no step cap by default

### DIFF
--- a/crates/stella-cli/src/agent/resume.rs
+++ b/crates/stella-cli/src/agent/resume.rs
@@ -363,6 +363,11 @@ mod tests {
         CompletionRequestRef, CompletionResult, CompletionUsage, ProviderError, ToolSchema,
     };
 
+    /// The step cap the resume-at-the-cap tests set. The default config
+    /// carries none (ADR 0030), so a test about resuming at a cap has to
+    /// name one.
+    const HOST_CAP: usize = 40;
+
     /// A provider that answers "resumed answer" and records every request's
     /// transcript, so the witness below can look at what a resumed turn
     /// actually sent.
@@ -554,17 +559,21 @@ mod tests {
         ));
     }
 
-    /// The step cap survives the crash: a turn checkpointed AT the cap gets
-    /// no further model calls — the allowance does not reset to zero.
+    /// The step cap a host set survives the crash: a turn checkpointed AT
+    /// the cap gets no further model calls — the allowance does not reset to
+    /// zero.
     #[tokio::test]
     async fn a_resumed_turn_keeps_its_spent_step_allowance() {
         let provider = ScriptedProvider {
             requests: Mutex::new(Vec::new()),
         };
         let tools = NoTools;
-        let config = EngineConfig::default();
+        let config = EngineConfig {
+            max_steps: Some(HOST_CAP),
+            ..EngineConfig::default()
+        };
         let mut at_cap = killed_mid_turn();
-        at_cap.step = config.max_steps;
+        at_cap.step = HOST_CAP;
         let state = TurnState::from_checkpoint(at_cap, &config);
         let engine = Engine::with_sleeper(&provider, &tools, config, &crate::runtime::TokioSleeper);
         let (tx, _rx) = mpsc::unbounded_channel::<AgentEvent>();
@@ -607,9 +616,12 @@ mod tests {
             requests: Mutex::new(Vec::new()),
         };
         let tools = NoTools;
-        let config = EngineConfig::default();
+        let config = EngineConfig {
+            max_steps: Some(HOST_CAP),
+            ..EngineConfig::default()
+        };
         let mut at_cap = killed_mid_turn();
-        at_cap.step = config.max_steps;
+        at_cap.step = HOST_CAP;
         let state = TurnState::from_checkpoint(at_cap, &config);
         let engine = Engine::with_sleeper(&provider, &tools, config, &crate::runtime::TokioSleeper);
         let (tx, _rx) = mpsc::unbounded_channel::<AgentEvent>();

--- a/crates/stella-cli/src/candidate_workspaces.rs
+++ b/crates/stella-cli/src/candidate_workspaces.rs
@@ -752,10 +752,10 @@ async fn dispatch_candidate_turn(
         // is read-only; a candidate that could not write would have
         // nothing to adopt.
         write_access: true,
-        // The session's own cap, not `SubAgentSpec`'s 16: a candidate is
-        // not a searcher summarizing for a parent, it is the work, and
-        // capping it below the turn it stands in for would make best-of-N
-        // structurally worse than the single turn it replaces.
+        // The session's own cap — none, by default — not `SubAgentSpec`'s
+        // 16: a candidate is not a searcher summarizing for a parent, it is
+        // the work, and capping it below the turn it stands in for would
+        // make best-of-N structurally worse than the single turn it replaces.
         max_steps: crate::agent::engine_config_for(cfg).max_steps,
         max_report_chars: CANDIDATE_REPORT_CHARS,
         ..SubAgentSpec::read_only(work.agent_id, work.instruction)

--- a/crates/stella-cli/src/subagent/tests.rs
+++ b/crates/stella-cli/src/subagent/tests.rs
@@ -968,7 +968,7 @@ fn looping_spec() -> SubAgentSpec {
     SubAgentSpec {
         // Comfortably more than one, so a child that ignored the orphan stop
         // would be visibly distinguishable from one that took it.
-        max_steps: 6,
+        max_steps: Some(6),
         ..SubAgentSpec::read_only("orphan", "investigate")
     }
 }

--- a/crates/stella-core/README.md
+++ b/crates/stella-core/README.md
@@ -176,8 +176,9 @@ lib.rs), never as a planning assumption.
 ## Key concepts
 
 **The step loop is a fixed phase sequence.** `run_turn`
-([`src/driver.rs:618`](src/driver.rs)) iterates up to `EngineConfig::max_steps`,
-and each step runs the same phases in the same order: pause gate → drain
+([`src/driver.rs`](src/driver.rs)) loops until the model answers or a bound
+fires. A step cap is one such bound, and the default sets none (ADR 0030).
+Each step runs the same phases in the same order: pause gate → drain
 steering / check soft stop → budget check → snapshot tool-result identities →
 compaction pass → loop detection → model call (wrapped in retry+backoff) →
 committed-step bookkeeping → dispatch → parked wait (when a tool deposited

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -313,7 +313,7 @@ pub struct Engine<'a> {
     pub(crate) provider_override: Arc<std::sync::OnceLock<&'a dyn Provider>>,
 }
 
-/// Why a turn that never produced a terminal step ends. A function rather
+/// Why a turn that reached a host-set step cap ends. A function rather
 /// than an inline `format!` because it is written by two loops —
 /// [`Engine::run_turn_with_sender`] and any host driving
 /// [`Engine::run_step`] itself (`stella-serve`, #1129) — and this string
@@ -322,8 +322,8 @@ pub struct Engine<'a> {
 #[must_use]
 pub fn step_cap_reason(max_steps: usize) -> String {
     format!(
-        "reached the step cap ({max_steps}) without completing — this is the belt-and-suspenders \
-         backstop; loop detection should normally catch a stuck turn first"
+        "reached the step cap ({max_steps}) the host set for this turn without completing; \
+         loop detection normally ends a stuck turn long before a cap does"
     )
 }
 
@@ -575,12 +575,12 @@ impl<'a> Engine<'a> {
         self
     }
 
-    /// The step cap this engine enforces — the loop bound a host driving
-    /// [`Engine::run_step`] itself must apply, since the cap belongs to the
-    /// engine's config and a host tracking its own copy is a second source of
-    /// truth for the same number (#1129).
+    /// The step cap this engine enforces, if its config carries one — the
+    /// loop bound a host driving [`Engine::run_step`] itself must apply, since
+    /// the cap belongs to the engine's config and a host tracking its own copy
+    /// is a second source of truth for the same number (#1129).
     #[must_use]
-    pub fn max_steps(&self) -> usize {
+    pub fn max_steps(&self) -> Option<usize> {
         self.config.max_steps
     }
 

--- a/crates/stella-core/src/driver/config.rs
+++ b/crates/stella-core/src/driver/config.rs
@@ -123,13 +123,27 @@ pub struct EngineConfig {
     /// Messages at the conversation tail the summarizer never touches —
     /// the recent work the model is actively reasoning over.
     pub summarize_keep_recent: usize,
-    /// Hard backstop on step count, independent of loop detection — belt
-    /// and suspenders, never the *primary* stuck-loop defense (that's
-    /// `crate::loop_detect`).
-    pub max_steps: usize,
+    /// A ceiling on this turn's step count, or `None` for no ceiling.
+    ///
+    /// `None` is the default (ADR 0030). A count cannot tell a turn that is
+    /// doing ten thousand steps of real work from one that is wandering, and
+    /// a default ceiling ends both. What ends a wandering turn is evidence
+    /// the count never carries: `crate::loop_detect` reads what the calls
+    /// returned, the stall rung reads how long the turn slept, the
+    /// [`BudgetGuard`] reads what it cost, [`Self::turn_budget`] reads how
+    /// long it ran, and [`Self::turn_halt`] reads whether the goal is met.
+    /// Each of those fires on the first evidence of its failure, where a
+    /// count fires only after every step under it has been paid for.
+    ///
+    /// A host still sets one when a count is what it means: a test that must
+    /// end, a served turn whose caller asked for a bound. The turn then ends
+    /// with [`AbortKind::DeliberateStop`] and the reason
+    /// [`super::step_cap_reason`] writes.
+    ///
+    /// [`AbortKind::DeliberateStop`]: crate::step::AbortKind::DeliberateStop
+    pub max_steps: Option<usize>,
     /// Hard backstop on how long one tool dispatch may run, independent of
-    /// each tool's own bound — the same belt-and-suspenders philosophy as
-    /// [`Self::max_steps`], and never the *primary* mechanism.
+    /// each tool's own bound, and never the *primary* mechanism.
     ///
     /// Per-tool bounds are the real defense (bash clamps its own timeout,
     /// scripts cap out, MCP bounds each call), but each is that tool's own
@@ -266,7 +280,7 @@ pub struct EngineConfig {
     ///
     /// `None` — the default — is exactly the behaviour every caller had
     /// before: the turn runs until the model stops asking for tools, the
-    /// budget bites, or the step cap does.
+    /// budget bites, or a step cap the host set does.
     ///
     /// This exists because those are all *external* stopping conditions, and
     /// an agent that has already met its goal will happily keep spending
@@ -391,7 +405,9 @@ impl Default for EngineConfig {
             tool_result_horizon_steps: Some(8),
             summarize_overflow: true,
             summarize_keep_recent: 8,
-            max_steps: 200,
+            // No ceiling: see the field. A turn ends on evidence — a loop,
+            // a stall, the budget, the deadline, the goal — never on a count.
+            max_steps: None,
             tool_timeout: Some(Duration::from_secs(15 * 60)),
             model_timeout: Some(Duration::from_secs(816)),
             // Off by default: only a caller that knows its own deadline can

--- a/crates/stella-core/src/driver/drive.rs
+++ b/crates/stella-core/src/driver/drive.rs
@@ -26,8 +26,8 @@
 //!   was a claim about a caller the engine cannot see — it arrived while a
 //!   staged run was in `Witness`, which is why the pipeline had to drop it
 //!   (#3416). Every run owner emits its own;
-//! - **gate on the step cap the state carries** — a turn restored at step 37
-//!   of 40 gets 3 more, not 40;
+//! - **gate on a step cap the host set** — a turn restored at step 37 of 40
+//!   gets 3 more, not 40;
 //! - **run exactly one committed step** through [`Engine::run_step`];
 //! - **persist on every `Continue`** — the checkpoint seam (#971), the one
 //!   moment the transcript is guaranteed well-paired, so a resumed run stays
@@ -71,8 +71,8 @@ use crate::step::{AbortKind, TurnState};
 ///
 /// A cap reached after a step lands on a well-paired transcript, so this
 /// finds nothing to close. A cap already met on entry does not: the transcript
-/// is still the caller's own, and a caller resuming at `max_steps` can hand in
-/// a tail nothing answered. Closing it is the repair every other exit at this
+/// is still the caller's own, and a caller resuming at its cap can hand in a
+/// tail nothing answered. Closing it is the repair every other exit at this
 /// boundary performs.
 const STEP_CAP_TOOL_RESULT: &str = "not executed — turn aborted at the step cap";
 
@@ -122,11 +122,12 @@ impl Engine<'_> {
     /// one of them.
     async fn step_loop(&self, state: &mut TurnState, events: &EventSender) -> TurnOutcome {
         loop {
-            if state.step() >= self.config.max_steps {
-                // The belt-and-suspenders backstop. `DeliberateStop`, not a
-                // failure: the run stopped by policy, it did not fall over
-                // (#1524).
-                let reason = step_cap_reason(self.config.max_steps);
+            if let Some(cap) = self.config.max_steps
+                && state.step() >= cap
+            {
+                // A ceiling the host set. `DeliberateStop`, not a failure:
+                // the run stopped by policy, it did not fall over (#1524).
+                let reason = step_cap_reason(cap);
                 crate::step::close_open_tool_calls(
                     state.messages_mut(),
                     STEP_CAP_TOOL_RESULT,

--- a/crates/stella-core/src/driver/lifecycle.rs
+++ b/crates/stella-core/src/driver/lifecycle.rs
@@ -46,6 +46,9 @@ use super::{StepOutcome, TurnOutcome};
 /// with, the loop bound it runs under, which role is driving it, and which
 /// lane assembled it. No message *content* — see the module docs.
 ///
+/// `max_steps` is `null` for a turn with no step cap, which is the default:
+/// the turn ends on evidence rather than on a count (`EngineConfig::max_steps`).
+///
 /// `lane` is `null` for an engine built through the legacy
 /// [`Engine::with_sleeper`](super::Engine::with_sleeper) path, which names no
 /// lane. That null is a positive statement — "this engine was not assembled
@@ -53,7 +56,7 @@ use super::{StepOutcome, TurnOutcome};
 /// own bucket rather than dropping the turn (#3410).
 pub fn turn_started_payload(
     message_count: usize,
-    max_steps: usize,
+    max_steps: Option<usize>,
     role: stella_protocol::ModelCallRole,
     lane: Option<&stella_protocol::TurnLane>,
 ) -> serde_json::Value {

--- a/crates/stella-core/src/driver/loop_escalation.rs
+++ b/crates/stella-core/src/driver/loop_escalation.rs
@@ -23,9 +23,9 @@
 //! into a genuinely different loop was killed for a loop it was never told
 //! about (#1743). That is a resolve-rate loss and it is unfair to the
 //! compliant model — but unbounded steers are not the alternative, because a
-//! model alternating between two loops would then burn every step of
-//! `EngineConfig::max_steps`, which is the exact outcome loop detection
-//! exists to prevent. [`MAX_LOOP_STEERS`] is the bound.
+//! model alternating between two loops would then spin until its budget ran
+//! out, which is the exact outcome loop detection exists to prevent.
+//! [`MAX_LOOP_STEERS`] is the bound.
 //!
 //! # The stall rung
 //!
@@ -69,9 +69,9 @@ use super::{EngineConfig, LOOP_STEER_PREFIX, TurnMemos, TurnOutcome};
 /// for it is one additional step.
 ///
 /// Not unbounded, and not larger, for the same reason the abort exists at
-/// all: `crate::loop_detect`'s contract is that it fires orders of magnitude
-/// before `EngineConfig::max_steps`, and a model that alternates between two
-/// loops would earn a fresh warning every time it switched.
+/// all: `crate::loop_detect`'s contract is that it ends a stuck turn within
+/// a handful of calls, and a model that alternates between two loops would
+/// earn a fresh warning every time it switched.
 ///
 /// The cap and [`LoopSteerBudget`]'s single memory slot are one decision, not
 /// two. Comparing only against the MOST RECENT warned loop is sufficient at

--- a/crates/stella-core/src/driver/tests.rs
+++ b/crates/stella-core/src/driver/tests.rs
@@ -1683,8 +1683,8 @@ async fn malformed_tool_call_input_is_repaired_not_executed_blindly() {
 async fn stuck_loop_aborts_the_turn_cleanly_before_the_step_cap() {
     // Every call returns the identical tool call and the tool answers with
     // identical output — well past the default exact-repeat threshold (3)
-    // — so loop detection must end the turn long before
-    // EngineConfig::default()'s 200-step cap.
+    // — so loop detection must end the turn within a handful of calls.
+    // Nothing else would: EngineConfig::default() carries no step cap.
     let repeated = tool_call_result("call_1", "bash");
     let provider = ScriptedProvider {
         id: "scripted".into(),
@@ -1709,7 +1709,7 @@ async fn stuck_loop_aborts_the_turn_cleanly_before_the_step_cap() {
         TurnOutcome::Aborted { reason, .. } => assert!(reason.contains("stuck-loop")),
         other => panic!("expected a stuck-loop abort, got {other:?}"),
     }
-    // Well under the 200-step cap — loop detection caught it early.
+    // Loop detection caught it early.
     assert!(tool_calls.load(Ordering::SeqCst) < 10);
 
     let events = drain_events(&mut rx);
@@ -2101,11 +2101,6 @@ async fn run_synthetic_survival_turn(dialect: &str, id_style: fn(u32) -> String)
         // A tight-ish compaction budget so the growing tool output
         // actually forces multiple compaction passes over 200 steps.
         compaction_budget_tokens: 4_000,
-        // 200 tool-call steps plus the final text response is 201 model
-        // calls — one more than EngineConfig::default()'s own step cap
-        // (200), which exists as an *independent* backstop above loop
-        // detection, not a ceiling this test should be fighting.
-        max_steps: STEPS as usize + 1,
         ..EngineConfig::default()
     };
     let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
@@ -2603,6 +2598,7 @@ mod parked_wait;
 mod provider_outcomes;
 mod requery;
 mod steer_midturn;
+mod unbounded_by_default;
 mod usage_anchor;
 mod usage_completeness;
 mod user_hooks;

--- a/crates/stella-core/src/driver/tests/audit_fixes.rs
+++ b/crates/stella-core/src/driver/tests/audit_fixes.rs
@@ -1369,7 +1369,7 @@ async fn the_system_prefix_stays_byte_stable_across_a_compacting_turn() {
         // overflow summarizer fires too.
         compaction_budget_tokens: 300,
         summarize_keep_recent: 2,
-        max_steps: 8,
+        max_steps: Some(8),
         ..EngineConfig::default()
     };
     let engine = Engine::with_sleeper(&provider, &BulkyTools, config, &sleeper);

--- a/crates/stella-core/src/driver/tests/loop_abort.rs
+++ b/crates/stella-core/src/driver/tests/loop_abort.rs
@@ -125,10 +125,10 @@ async fn a_loop_that_resumes_after_a_successful_course_correction_still_aborts()
         calls: tool_calls.clone(),
     };
     let sleeper = NoopSleeper;
-    // A low cap so a broken ladder shows up as "ground to the cap" in a
-    // second rather than 200 steps of grinding.
+    // A low cap, so a broken ladder shows up as "ground to the cap" in a
+    // second.
     let config = EngineConfig {
-        max_steps: 30,
+        max_steps: Some(30),
         ..EngineConfig::default()
     };
     let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);
@@ -175,7 +175,7 @@ async fn a_loop_that_resumes_after_a_successful_course_correction_still_aborts()
 /// uses for the cycle rung.
 fn exact_repeat_only(max_steps: usize) -> EngineConfig {
     EngineConfig {
-        max_steps,
+        max_steps: Some(max_steps),
         loop_detection: LoopDetectionConfig {
             exact_repeat_threshold: 3,
             short_cycle_repeats: 0,
@@ -440,7 +440,7 @@ async fn a_tool_answering_identically_to_every_new_argument_is_steered_then_kill
     };
     let sleeper = NoopSleeper;
     let config = EngineConfig {
-        max_steps: 60,
+        max_steps: Some(60),
         ..EngineConfig::default()
     };
     let engine = Engine::with_sleeper(&provider, &tools, config, &sleeper);

--- a/crates/stella-core/src/driver/tests/unbounded_by_default.rs
+++ b/crates/stella-core/src/driver/tests/unbounded_by_default.rs
@@ -66,7 +66,8 @@ async fn run_productive_turn(steps: u32, config: EngineConfig) -> (TurnOutcome, 
         calls: Arc::new(AtomicU32::new(0)),
     };
     let sleeper = NoopSleeper;
-    let engine = Engine::with_sleeper(&provider, &DistinctTools, config, &sleeper);
+    let seams = TurnCapabilities::none();
+    let engine = Engine::assemble(&provider, &DistinctTools, config, &sleeper, seams);
     let mut messages = vec![
         CompletionMessage::system("sys"),
         CompletionMessage::user("do the long task"),

--- a/crates/stella-core/src/driver/tests/unbounded_by_default.rs
+++ b/crates/stella-core/src/driver/tests/unbounded_by_default.rs
@@ -1,0 +1,128 @@
+//! A turn carries no step cap unless the host sets one (ADR 0030).
+//!
+//! Before this, every turn stopped at 200 steps. A count cannot tell real
+//! work from wandering. It ended both. The runs it ended were the long ones
+//! the engine exists to run. Evidence is what ends a wandering turn: a loop,
+//! a stall, the budget, the deadline, the goal. All of those are still armed
+//! on the turn below.
+//!
+//! Two tests. The first is the witness. A turn of a thousand new steps
+//! completes under the default config. A cap of 200 refused that. The second
+//! pins the mechanism. A host that asks for a cap still gets one.
+
+use super::*;
+
+/// Each call gets a new answer. `loop_detect` compares outputs, so this
+/// never reads as a loop. Real work answers each step with something new.
+struct DistinctTools;
+
+#[async_trait]
+impl ToolExecutor for DistinctTools {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: "bash".into(),
+            description: "run a command".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            read_only: false,
+            speculation_safe: false,
+        }]
+    }
+    async fn execute(&self, _name: &str, input: &Value) -> ToolOutput {
+        let cmd = input.get("cmd").and_then(Value::as_str).unwrap_or("?");
+        ToolOutput::Ok {
+            content: format!("ran {cmd}"),
+            data: None,
+        }
+    }
+}
+
+/// `steps` tool calls, each new, then one text answer.
+fn productive_script(steps: u32) -> Vec<Result<CompletionResultAlias, ProviderError>> {
+    let mut script: Vec<_> = (0..steps)
+        .map(|i| {
+            Ok(CompletionResultAlias {
+                upstream_provider: None,
+                text: String::new(),
+                tool_calls: vec![ToolCall {
+                    call_id: format!("call_{i}"),
+                    name: "bash".into(),
+                    input: serde_json::json!({"cmd": format!("step {i}")}),
+                }],
+                usage: CompletionUsage::reported_zero(),
+                model: "scripted".into(),
+                cost_usd: 0.00001,
+                finish_reason: None,
+            })
+        })
+        .collect();
+    script.push(Ok(text_result("done")));
+    script
+}
+
+async fn run_productive_turn(steps: u32, config: EngineConfig) -> (TurnOutcome, u32) {
+    let provider = ScriptedProvider {
+        id: "scripted".into(),
+        script: TokioMutex::new(productive_script(steps)),
+        calls: Arc::new(AtomicU32::new(0)),
+    };
+    let sleeper = NoopSleeper;
+    let engine = Engine::with_sleeper(&provider, &DistinctTools, config, &sleeper);
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("do the long task"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let outcome = engine.run_turn(&mut messages, &mut budget, &tx).await;
+    (outcome, provider.calls.load(Ordering::SeqCst))
+}
+
+/// The witness. A thousand steps is five times the old cap. A cap that came
+/// back at any round number under it would fail this.
+#[tokio::test]
+async fn a_long_productive_turn_runs_to_completion_under_the_default_config() {
+    const STEPS: u32 = 1_000;
+    assert_eq!(
+        EngineConfig::default().max_steps,
+        None,
+        "the default carries no step cap"
+    );
+
+    let (outcome, model_calls) = run_productive_turn(STEPS, EngineConfig::default()).await;
+
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { .. }),
+        "a productive turn ends when the model is done, not on a count: {outcome:?}"
+    );
+    assert_eq!(
+        model_calls,
+        STEPS + 1,
+        "every scripted step ran, plus the answer"
+    );
+}
+
+/// A host that sets a cap still gets it. The stop is a `DeliberateStop` and
+/// it names the number the host set.
+#[tokio::test]
+async fn a_host_set_cap_still_ends_the_turn_where_it_says() {
+    const CAP: usize = 25;
+    let config = EngineConfig {
+        max_steps: Some(CAP),
+        ..EngineConfig::default()
+    };
+
+    let (outcome, model_calls) = run_productive_turn(1_000, config).await;
+
+    match outcome {
+        TurnOutcome::Aborted { reason, kind, .. } => {
+            assert_eq!(
+                kind,
+                AbortKind::DeliberateStop,
+                "a cap is policy, not a crash"
+            );
+            assert_eq!(reason, step_cap_reason(CAP));
+        }
+        other => panic!("expected the host's cap to end the turn, got {other:?}"),
+    }
+    assert_eq!(model_calls, CAP as u32, "no model call past the cap");
+}

--- a/crates/stella-core/src/goal.rs
+++ b/crates/stella-core/src/goal.rs
@@ -381,7 +381,7 @@ impl Engine<'_> {
             ),
             // A verdict needs a handful of evidence lookups, not a work
             // session.
-            max_steps: 8,
+            max_steps: Some(8),
             max_output_tokens: goal_config.verifier_max_output_tokens,
             temperature: Some(0.0),
             // Sized so a verdict is never clipped: a clipped JSON object

--- a/crates/stella-core/src/loop_detect.rs
+++ b/crates/stella-core/src/loop_detect.rs
@@ -39,7 +39,7 @@
 //!    Invisible to all three above precisely because they read a contiguous
 //!    suffix: an agent alternating a failing `cargo test` with a varying
 //!    `read_file` has period 2 with one varying element, so every one of them
-//!    resets at offset 1 and the turn spins to `max_steps` unsteered. This is
+//!    resets at offset 1 and the turn spins on unsteered. This is
 //!    the shape a real wedge takes — re-run the failing test, peek at a
 //!    different file, repeat. It is guarded by `window_is_progressing` so it
 //!    cannot fire on correct polling, where a repeating spacer sits beside a
@@ -253,10 +253,9 @@ impl Default for LoopDetectionConfig {
     /// rule out coincidence without flagging a legitimately-repeated
     /// read-then-fix-then-verify pattern (which changes some output every
     /// pass and so never matches anyway). These thresholds are the PRIMARY
-    /// stuck-turn defense and fire orders of magnitude before the
-    /// step-driver's belt-and-suspenders backstop
-    /// (`EngineConfig::max_steps`, 200 by default), so a stuck turn costs
-    /// a handful of wasted calls, never a whole cap's worth.
+    /// stuck-turn defense: a turn carries no step cap by default
+    /// (`EngineConfig::max_steps`), so a stuck turn costs a handful of
+    /// wasted calls here or it costs whatever the budget allows.
     ///
     /// Stagnation sits at double the exact-repeat threshold. It is the
     /// backstop for the two above rather than a peer of them: it asks only
@@ -327,7 +326,7 @@ pub enum LoopVerdict {
     /// alternating a failing `cargo test` with a varying `read_file` has
     /// period 2 with one varying element: exact-repeat resets at offset 1,
     /// short-cycle breaks on the mismatched element, stagnation's run ends
-    /// there too — and the turn spins to `max_steps` unsteered. That is what
+    /// there too — and the turn spins on unsteered. That is what
     /// a real wedge looks like: re-run the failing test, peek at a different
     /// file, repeat (#1851).
     InterleavedRepeat {

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -259,8 +259,14 @@ pub struct SubAgentSpec {
     pub system_prompt: Option<String>,
     /// The task, seeded as the child's first user message.
     pub instruction: String,
-    /// Hard cap on the child's model calls.
-    pub max_steps: usize,
+    /// Hard cap on the child's model calls, or `None` for none.
+    ///
+    /// A research child gets one (`Default` sets it): its report is what the
+    /// parent wanted, and a bounded search is the whole economy of the
+    /// primitive. A child that *is* the work — a best-of-N candidate standing
+    /// in for the parent's own turn — carries the parent's cap, which by
+    /// default is none (`EngineConfig::max_steps`).
+    pub max_steps: Option<usize>,
     /// Output-token cap per child call.
     pub max_output_tokens: Option<u32>,
     /// Sampling temperature for the child. `Some(0.0)` for anything whose
@@ -334,7 +340,7 @@ impl Default for SubAgentSpec {
             instruction: String::new(),
             // Enough for a real search-and-read task; small enough that a
             // confused child cannot become a work session.
-            max_steps: 16,
+            max_steps: Some(16),
             max_output_tokens: None,
             temperature: None,
             // ~2k tokens: a substantial paragraph plus a code excerpt, and
@@ -899,7 +905,7 @@ impl Engine<'_> {
         // The child's private transcript. It is a local: nothing outside
         // this function can observe it, and it is dropped on return. That
         // is the primitive's whole point, expressed as a scope.
-        let mut messages = Vec::with_capacity(2 + spec.max_steps * 2);
+        let mut messages = Vec::with_capacity(2 + spec.max_steps.unwrap_or(0) * 2);
         if let Some(system) = &spec.system_prompt {
             messages.push(CompletionMessage::system(system.clone()));
         }

--- a/crates/stella-core/src/subagent/tests/failure_and_events.rs
+++ b/crates/stella-core/src/subagent/tests/failure_and_events.rs
@@ -33,7 +33,7 @@ async fn an_aborted_child_salvages_the_last_answer_it_paid_for() {
     let (tx, _rx) = mpsc::unbounded_channel();
 
     let spec = SubAgentSpec {
-        max_steps: 2,
+        max_steps: Some(2),
         ..SubAgentSpec::read_only("capped", "look")
     };
     let outcome = parent

--- a/crates/stella-engine/src/lib.rs
+++ b/crates/stella-engine/src/lib.rs
@@ -22,16 +22,17 @@
 //! let mut state = engine.new_turn(messages, budget).with_cancel_token(cancel.clone());
 //!
 //! loop {
-//!     // The step cap is the HOST's loop bound when driving steps directly —
-//!     // `run_turn` applies it internally, but `run_step` deliberately does
-//!     // not (the cap is the host's, exposed via [`Engine::max_steps`] so it
-//!     // never keeps a second copy of the number). Without this gate a model
-//!     // that keeps varying its arguments — the shape loop detection
-//!     // deliberately ignores — drives the loop forever. A real host also
-//!     // emits the non-retryable `Error` event `run_turn` pairs with this
-//!     // exit (see `stella-serve`'s session loop for the production pattern).
-//!     if state.step() >= engine.max_steps() {
-//!         eprintln!("turn ended: {}", step_cap_reason(engine.max_steps()));
+//!     // A step cap is the HOST's loop bound when driving steps directly.
+//!     // `run_turn` applies it; `run_step` does not, so the host reads it
+//!     // from [`Engine::max_steps`] rather than keeping its own copy. The
+//!     // default config carries none (ADR 0030): a turn ends on evidence,
+//!     // never on a count. A real host also emits the non-retryable `Error`
+//!     // event `run_turn` pairs with this exit (see `stella-serve`'s
+//!     // session loop for the production pattern).
+//!     if let Some(cap) = engine.max_steps()
+//!         && state.step() >= cap
+//!     {
+//!         eprintln!("turn ended: {}", step_cap_reason(cap));
 //!         return None;
 //!     }
 //!     match engine.run_step(&mut state, events).await {

--- a/crates/stella-serve/README.md
+++ b/crates/stella-serve/README.md
@@ -255,12 +255,13 @@ climbing count means a host is minting per-request provider ids.
   oldest-first to admit a new one, and a reclaimed id answers 404. That is what
   keeps the 32-turn cap a queue rather than a one-way latch — a host that
   abandons turns cannot wedge the server into refusing every later create.
-- **`max_steps` from the wire is validated, not trusted.** `0` is a 400 (it would
+- **`max_steps` from the wire is validated, not clamped.** `0` is a 400 (it would
   produce a zero-iteration turn that aborts with the misleading "reached the step
-  cap (0)"), and anything above `MAX_SERVED_STEPS` (10 000, fifty times
-  `EngineConfig::default`'s 200) is clamped — the host also supplies the budget
-  mode, which may be `Off`, so an unclamped cap would remove the last bound on a
-  turn holding an OS thread.
+  cap (0)"); any other value is the cap the turn runs under. A served turn has
+  no step cap unless the caller sets one (ADR 0030), so a ceiling on the value
+  would bound only the caller who asked for a bound. What bounds a turn holding
+  an OS thread is the reverse-request deadline, the caller's budget, and loop
+  detection.
 - **Chunked request bodies are not decoded.** A chunked POST parses as an empty
   body and fails validation with a 400. That is safe rather than a smuggling hole
   only because this layer serves one request per connection and then closes.

--- a/crates/stella-serve/src/routes.rs
+++ b/crates/stella-serve/src/routes.rs
@@ -179,8 +179,8 @@ fn default_true() -> bool {
 /// A goal round is a whole agent turn plus a verifier call, so the round cap is
 /// the dominant term in what a goal run can cost and how long it can hold a
 /// thread. The engine's own default is 8; 32 is four times that — past any
-/// run that is still converging — while keeping the worst case bounded, which
-/// is the same argument [`MAX_SERVED_STEPS`] makes one level down.
+/// run that is still converging — while keeping the worst case bounded, the
+/// same argument [`MAX_REVERSE_REQUEST_TIMEOUT`] makes for the deadline.
 const MAX_SERVED_GOAL_ROUNDS: usize = 32;
 
 /// Lower a caller's `goal` block into the engine's own configuration, with
@@ -253,29 +253,24 @@ struct TurnCreated<'a> {
     clamped: Vec<ClampedKnob>,
 }
 
-/// Ceiling on a host-supplied [`TurnRequest::max_steps`].
+/// Validate a host-supplied step cap. `None` when it is unusable: `0` makes a
+/// zero-iteration turn that aborts with the misleading "reached the step cap
+/// (0)". Otherwise the value as asked.
 ///
-/// The step cap is the engine's belt-and-suspenders backstop against a turn
-/// that never terminates, and the host also supplies the budget mode (which may
-/// be `Off`), so an unclamped `max_steps` lets a caller remove the last bound on
-/// a turn that already holds an OS thread. `EngineConfig::default` uses 200;
-/// 10 000 is fifty times that — far above any turn a real agentic task runs,
-/// while still terminating in bounded time.
-const MAX_SERVED_STEPS: usize = 10_000;
-
-/// Validate a host-supplied step cap: `None` when it is unusable (`0` produces
-/// a zero-iteration turn that aborts with the misleading "reached the step cap
-/// (0)"), otherwise the value clamped down to [`MAX_SERVED_STEPS`].
+/// No ceiling. A served turn has no step cap unless the caller sets one (ADR
+/// 0030). A ceiling here would bound only the caller who asked for a bound.
+/// What bounds a served turn is the reverse-request deadline on every call,
+/// the caller's budget, and loop detection.
 fn validate_max_steps(requested: usize) -> Option<usize> {
-    (requested > 0).then(|| requested.min(MAX_SERVED_STEPS))
+    (requested > 0).then_some(requested)
 }
 
 /// Ceiling on a host-supplied reverse-request deadline: one hour.
 ///
-/// Same reasoning as [`MAX_SERVED_STEPS`]. The deadline is what bounds a turn
-/// holding an OS thread on a host that never answers, so letting a caller set it
-/// to `u64::MAX` would hand back the unbounded wait it exists to remove. An hour
-/// is far past any legitimate model call or tool run.
+/// The deadline is what bounds a turn holding an OS thread on a host that
+/// never answers, so letting a caller set it to `u64::MAX` would hand back the
+/// unbounded wait it exists to remove. An hour is far past any legitimate
+/// model call or tool run.
 const MAX_REVERSE_REQUEST_TIMEOUT: Duration = Duration::from_secs(3600);
 
 /// Validate a host-supplied reverse-request deadline: `None` when it is unusable
@@ -422,7 +417,7 @@ pub(crate) async fn handle_create(
                 )
                 .await;
         };
-        config.max_steps = effective;
+        config.max_steps = Some(effective);
     }
     let mut reverse_request_timeout = SessionSpec::DEFAULT_REVERSE_REQUEST_TIMEOUT;
     if let Some(requested_ms) = turn.reverse_request_timeout_ms {
@@ -1209,18 +1204,14 @@ mod tests {
         assert_eq!(validate_max_steps(1), Some(1));
     }
 
+    /// A caller who asks for a cap gets the cap it asked for. The served
+    /// default is no cap at all, so lowering an explicit ask would bound only
+    /// the caller who wanted a bound.
     #[test]
-    fn step_cap_is_clamped_to_the_ceiling() {
-        assert_eq!(validate_max_steps(MAX_SERVED_STEPS), Some(MAX_SERVED_STEPS));
-        assert_eq!(
-            validate_max_steps(MAX_SERVED_STEPS + 1),
-            Some(MAX_SERVED_STEPS)
-        );
-        assert_eq!(
-            validate_max_steps(usize::MAX),
-            Some(MAX_SERVED_STEPS),
-            "an unbounded step loop must not be reachable from the wire"
-        );
+    fn a_requested_step_cap_is_honoured_as_asked() {
+        for asked in [1, 200, 10_001, 1_000_000, usize::MAX] {
+            assert_eq!(validate_max_steps(asked), Some(asked), "asked for {asked}");
+        }
     }
 
     #[test]

--- a/crates/stella-serve/src/routes/sessions.rs
+++ b/crates/stella-serve/src/routes/sessions.rs
@@ -217,7 +217,7 @@ pub(crate) async fn handle_session_turn(
                 )
                 .await;
         };
-        config.max_steps = effective;
+        config.max_steps = Some(effective);
     }
     // Share the session's learned output ceilings with this turn (#3568).
     // Filled in here, and not left to the host, for the same reason

--- a/crates/stella-serve/src/subagents.rs
+++ b/crates/stella-serve/src/subagents.rs
@@ -501,7 +501,7 @@ impl ToolExecutor for DelegatingTools<'_> {
             agent_id: slug(description),
             system_prompt: Some(CHILD_SYSTEM_PROMPT.to_string()),
             instruction: prompt.to_string(),
-            max_steps: self.child_steps,
+            max_steps: Some(self.child_steps),
             max_report_chars: REPORT_CHARS,
             // Not model-settable: this tool delegates *research*. A child that
             // could edit would need the parent's review gates around it.

--- a/crates/stella-tools/src/loop_comparability.rs
+++ b/crates/stella-tools/src/loop_comparability.rs
@@ -11,9 +11,9 @@
 //! `exact_repeat_threshold` counts identical `(name + input + output)` calls,
 //! and the stagnation rung counts byte-identical outputs. One timestamp, one
 //! elapsed-milliseconds figure, one running counter in a `ToolOutput` makes
-//! both rungs permanently blind *for that tool* — the tool's own bytes disarm
-//! the detector, and nothing errors, so the only symptom is a turn that spins
-//! until `max_steps`.
+//! both rungs permanently blind *for that tool*. The tool's own bytes disarm
+//! the detector, and nothing errors, so the only symptom is a turn that never
+//! ends.
 //!
 //! The rule against it existed only as prose in this crate's README plus
 //! scattered discipline: `save_state`'s success line carries a

--- a/crates/stella-tools/src/subagent.rs
+++ b/crates/stella-tools/src/subagent.rs
@@ -296,7 +296,7 @@ impl Tool for SpawnSubAgent {
             agent_id: self.mint_agent_id(description),
             system_prompt: Some(CHILD_SYSTEM_PROMPT.to_string()),
             instruction: prompt.to_string(),
-            max_steps: MAX_STEPS,
+            max_steps: Some(MAX_STEPS),
             max_report_chars: REPORT_CHARS,
             // Write access is deliberately not model-settable: this tool
             // delegates *research*. A child that could edit would need the

--- a/crates/stella-tui/src/views/transcript_source.rs
+++ b/crates/stella-tui/src/views/transcript_source.rs
@@ -292,11 +292,10 @@ pub fn call_duration(call_id: &str, following: &[TranscriptEntry]) -> Option<u64
 ///
 /// SPEC 6.3's second clause — `n of m budgeted model calls this turn` — is
 /// **elided**, because nothing in this workspace budgets model calls per turn.
-/// `EngineConfig::max_steps` is the nearest number and its own doc calls it a
-/// "hard backstop on step count … never the *primary* stuck-loop defense", so
-/// `3 of 200 budgeted` would report a backstop as a plan. `n` alone cannot
-/// stand in either: `n of m` is one reading, and half of it says something
-/// else. #5234 is where a real per-turn model-call budget is tracked; when one
+/// `EngineConfig::max_steps` is the nearest number, and it is `None` unless a
+/// host sets a ceiling, so there is no `m` to report. `n` alone cannot stand
+/// in either: `n of m` is one reading, and half of it says something else.
+/// #5234 is where a real per-turn model-call budget is tracked; when one
 /// exists, the clause comes back here.
 const MODEL_FOOTER: &str = "   irreducible generation";
 

--- a/crates/stella-tui/src/views/transcript_source/tests.rs
+++ b/crates/stella-tui/src/views/transcript_source/tests.rs
@@ -220,9 +220,9 @@ fn a_settled_model_call_renders_its_rate_from_the_drivers_own_metering() {
 ///
 /// `irreducible generation` is a fact about the call. The
 /// `n of m budgeted model calls this turn` clause is elided because
-/// nothing budgets model calls per turn — `EngineConfig::max_steps` is a
-/// declared backstop, not a plan — and a fabricated `m` on the one row
-/// that prices model work would be worse than no clause. See
+/// nothing budgets model calls per turn — `EngineConfig::max_steps` is
+/// `None` unless a host sets a ceiling — and a fabricated `m` on the one
+/// row that prices model work would be worse than no clause. See
 /// `MODEL_FOOTER`.
 #[test]
 fn the_model_footer_claims_no_budget_nobody_set() {

--- a/docs/adr/0030-a-turn-has-no-step-cap-by-default.md
+++ b/docs/adr/0030-a-turn-has-no-step-cap-by-default.md
@@ -1,0 +1,94 @@
+---
+id: adr/0030-a-turn-has-no-step-cap-by-default
+title: "ADR 0030: A turn has no step cap by default"
+status: implemented
+---
+
+# ADR 0030: A turn has no step cap by default
+
+- Status: accepted
+- Date: 2026-09-06
+- Decides: `#6237`
+- Not part of the Phase 0 series.
+
+## Context
+
+Before this, every turn stopped at 200 steps. `EngineConfig::default()` set
+`max_steps: 200`. The step loop in `crates/stella-core/src/driver/drive.rs`
+ended the turn there with a `DeliberateStop`. Its own doc called it a backstop
+behind loop detection.
+
+A count has a flaw the other bounds do not. It cannot tell real work from
+wandering. A prompt that asks for a whole feature can take thousands of steps.
+So can a run that keeps going until its tests pass. Every one of those steps
+is real work. The cap ended those runs. It ended them at the point where the
+engine was doing its job. A wandering turn was ended at the same point, after
+all 200 steps had been paid for.
+
+The engine has bounds that read evidence instead of a count:
+
+- **Loop detection** (`crates/stella-core/src/loop_detect.rs`) reads what each
+  call returned. It has five rungs. They fire on the same output twice, on a
+  short cycle, on arguments that change with no new output, on a repeat with
+  other work between, and on a sweep that wrapped. Each fires within a few
+  calls. The steer-then-abort ladder in `driver/loop_escalation.rs` ends the
+  turn if the model does not change course.
+- **The stall rung** (`driver/loop_escalation.rs`) reads how long the turn has
+  slept.
+- **The budget guard** (`crates/stella-core/src/budget.rs`) reads what the turn
+  has cost, when the caller sets a mode that enforces.
+- **The turn budget** (`EngineConfig::turn_budget`) reads how long the turn has
+  run.
+- **The turn halt** (`EngineConfig::turn_halt`) reads whether the goal is met.
+- **The cancel token** and the soft stop are a person's hand on the switch.
+
+One case is left for a count. A model makes new but useless calls. The budget
+mode is `Off`. There is no deadline. Nobody is watching. The record says the
+count did not catch that case either. `crates/stella-tools/src/read.rs` records
+a turn that spent $7.83 and 18.8M input tokens paging through one file. It ran
+off the end, wrapped, and started over. No loop verdict fired. The step cap
+"had not been reached when the user killed it by hand". The fix was a new
+detector rung and a ceiling inside the tool. Both read evidence. The cap did
+nothing.
+
+## Decision
+
+`EngineConfig::max_steps` is `Option<usize>`. The default is `None`.
+
+A turn ends when the model stops asking for tools. It ends when loop detection
+or the stall rung says it is stuck. It ends when the budget or the deadline is
+spent. It ends when the host's halt predicate says the goal is met. It ends
+when a person stops it. It does not end on a count.
+
+The mechanism stays for a host that means a count. A test must end. A served
+turn's caller may ask for a bound. A research sub-agent is a short search by
+design. Each sets `Some(n)`. Each gets the same `DeliberateStop` it always got,
+with the same reason string. `SubAgentSpec::max_steps` is `Option<usize>` for
+the same reason. A best-of-N candidate carries the parent's cap, which is none
+by default. A research child keeps its sixteen.
+
+`stella-serve` passes a caller's `max_steps` through as asked. Before this it
+clamped the value to 10,000. The clamp kept a caller from removing "the last
+bound" on a turn that holds an OS thread. With no cap by default, that clamp
+would bound only the caller who asked for a bound. The caller who asked for
+none would stay unbounded. A served turn is bounded by the reverse-request
+deadline on every call, by the caller's budget, and by loop detection. That
+was always true.
+
+## Consequences
+
+- A long run completes. The witness is `driver::tests::unbounded_by_default`.
+  A thousand new steps under the default config end in `Completed`. A cap of
+  200 refused that at step 200.
+- A stuck turn still ends within a few calls, on the same rungs as before.
+  Nothing here touches loop detection.
+- Take a turn with budget mode `Off`, no deadline, and no halt predicate. Give
+  it a model that keeps making new but useless calls. It now runs until a
+  person stops it. That is the tradeoff. Anyone running with no human watching
+  should set a budget or a deadline. Those bounds measure the thing they care
+  about. A new stuck shape gets a new detector rung, never a count.
+- The `agent.turn.started` payload carries `max_steps: null` for a turn with no
+  cap. It is a `serde_json::Value`, so no wire schema changes.
+- A host that drives `run_step` itself reads `Engine::max_steps()` as an
+  `Option<usize>`. It gates only when the value is `Some`. The `stella-engine`
+  crate docs carry the loop.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -96,6 +96,7 @@ open; nothing before Phase 3 forces it.
 | [0027](0027-a-fleet-worker-gets-its-own-worktree.md) | A Fleet Worker Gets Its Own Worktree | Accepted |
 | [0028](0028-panel-cells-are-glyphs-in-the-contract.md) | A Panel Cell Is a Glyph in the Contract and a Column in the Host | Accepted |
 | [0029](0029-branch-protection-stays-non-strict.md) | Branch Protection Stays Non-Strict | Accepted |
+| [0030](0030-a-turn-has-no-step-cap-by-default.md) | A Turn Has No Step Cap by Default | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -155,3 +156,10 @@ up-to-date requirement serialize merges to a handful an hour; the composition
 risk it would have caught is left to `main-canary.yml` and
 `main-red-hold.yml` as an after-the-fact backstop, with the durable close
 tracked at `#4998` rather than a merge queue enabled here.
+
+ADR 0030 removes the 200-step default from every turn. A count cannot tell a
+long productive run from a wandering one, so it ended both; what ends a
+wandering turn is loop detection, the stall rung, the budget, the deadline and
+the goal predicate, each of which reads evidence. `max_steps` is now
+`Option<usize>`, `None` by default, and a host that means a count still sets
+one.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -150,6 +150,11 @@
       "status": "implemented",
       "title": "ADR 0029: Branch protection stays non-strict"
     },
+    "adr/0030-a-turn-has-no-step-cap-by-default": {
+      "path": "docs/adr/0030-a-turn-has-no-step-cap-by-default.md",
+      "status": "implemented",
+      "title": "ADR 0030: A turn has no step cap by default"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",

--- a/docs/spec/engine-embedding.md
+++ b/docs/spec/engine-embedding.md
@@ -104,7 +104,7 @@ sequenceDiagram
     participant T as your ToolExecutor impl
 
     Host->>Engine: new_turn(messages, budget) [+ gate, steering, hooks, calibration]
-    loop until Done / Aborted / your step cap
+    loop until Done / Aborted / a step cap you set
         Host->>Engine: run_step(&mut state, events)
         Engine->>P: complete_observed_ref(request)
         P-->>Engine: streamed completion
@@ -119,8 +119,9 @@ What you get for free at this layer: the step-boundary contract (cancel,
 pause, steer — never mid-tool), compaction and prompt-cache discipline,
 loop detection, budget enforcement, drift calibration, the goal loop and
 sub-agents, and a serde `Checkpoint` that resumes in another process.
-What you owe: the loop bound (`engine.max_steps()` — see the crate docs'
-canonical example), event handling, and persistence.
+What you owe: event handling, persistence, and a loop bound when your config
+sets one. `engine.max_steps()` is that bound, `None` by default (ADR 0030);
+the crate docs' canonical example shows the gate.
 
 Licensing note for this mode: linking the AGPL-3.0-only crates in-process
 carries AGPL obligations for the combined work; the commercial track exists


### PR DESCRIPTION
## What & why

A turn no longer stops at 200 steps. `EngineConfig::max_steps` is now `Option<usize>` and the default is `None`.

A count cannot tell a turn doing ten thousand steps of real work from one that is wandering, so a default cap ended both. What ends a wandering turn is evidence the count never carries: loop detection reads what each call returned, the stall rung reads how long the turn slept, the budget guard reads what it cost, the turn budget reads how long it ran, and the halt predicate reads whether the goal is met. Each fires on the first evidence of its failure. The repository's own record (`crates/stella-tools/src/read.rs`, the $7.83 paging sweep) shows the cap did not catch the one case people think it is for; a new detector rung did.

The mechanism stays for a host that means a count: a test that must end, a served turn whose caller asks for a bound, a research sub-agent. Each sets `Some(n)` and gets the same `DeliberateStop` with the same reason string.

Also in this PR, because leaving them made the change incoherent:

- `SubAgentSpec::max_steps` is `Option<usize>`, so a best-of-N candidate (`candidate_workspaces.rs`, which copies the session's cap) carries none. Research children keep `Some(16)`.
- `stella-serve` passes a caller's `max_steps` through as asked instead of clamping it to 10,000. The clamp existed to keep a caller from removing "the last bound"; once the default is no bound, it bounded only the caller who asked for one. Zero is still refused.
- ADR 0031 records the decision. Every comment, README, and spec that said a 200-step cap exists is rewritten.

Exemplar for the shape: an `Option` for "no ceiling" rather than a sentinel, the same way `tool_timeout: Option<Duration>` and `turn_budget: Option<Duration>` already spell it in the same struct.

Closes #6237

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here): `driver::tests::unbounded_by_default::a_long_productive_turn_runs_to_completion_under_the_default_config` runs a thousand distinct productive steps under `EngineConfig::default()` and asserts `Completed`. On `main` the field is a `usize` (the test does not compile) and the default aborts at step 200 with the step-cap reason. The sibling `a_host_set_cap_still_ends_the_turn_where_it_says` pins that a host-set cap still ends the turn as a `DeliberateStop` with `step_cap_reason(cap)`.

## The gate

- [x] `cargo fmt --check`
- [x] clippy on the crates with logic changes: `cargo clippy -p stella-core -p stella-serve --all-targets -- -D warnings`, clean
- [x] tests run locally, scoped per SCR-001: `stella-core driver::` (314 passed) and `subagent::` (41), `stella-serve step` (unit + http), `stella-cli resume::tests` (3), `stella-tui model_footer`, `stella-tools subagent` (19), `stella-engine --doc`; the workspace run is this PR's CI
- [x] `make doc-warnings CARGO_SCOPE="-p stella-core"` clean; `make guards-fast` green including `prose`, `doc-links`, `adr-numbering`, `line-citations`
- [x] Docs updated where behavior changed: `EngineConfig::max_steps` doc, `stella-engine` crate docs' loop, `crates/stella-core/README.md`, `crates/stella-serve/README.md`, `docs/spec/engine-embedding.md`, ADR 0031 + `docs/adr/README.md` + `docs/manifest.json`
- [x] CLA signed
- [x] `Closes #6237` appears both above and as a commit trailer

## Nothing left behind

- [x] Filed: #6238 (the CLI has no flag or setting to opt into a step cap now that there is no default), #6239 (decide, with a census, whether research sub-agents keep their 16-step count cap)

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types; the `agent.turn.started` lifecycle payload is a `serde_json::Value` and now carries `max_steps: null` for a turn with no cap (no wire schema changes)

## Anything reviewers should know?

The tradeoff, stated plainly and in the ADR: a turn with budget mode `Off`, no deadline, no halt predicate, and a model that keeps producing new but useless calls now runs until a person stops it. Anyone running with no human watching should set a budget or a deadline, which measure the thing they care about. A new stuck shape gets a new detector rung, never a count.

One test is deleted on purpose: `step_cap_is_clamped_to_the_ceiling` in `crates/stella-serve/src/routes.rs` pinned the 10,000 clamp this PR removes, and `a_requested_step_cap_is_honoured_as_asked` replaces it with the opposite claim.

`driver/tests.rs` is a god file at its ceiling; this PR removes five lines from it (the test override that existed only to fight the old cap) and adds one (`mod unbounded_by_default;`), so it ends four lines under.

## Summary by Sourcery

Remove the default step cap from turns while preserving explicit host-configured limits and documenting the resulting execution model.

New Features:
- Allow turns to run without a step limit by default while retaining optional host-configured step caps.
- Represent engine and sub-agent step limits as optional values and propagate them through candidate, research, served, resumed, and lifecycle turn flows.

Bug Fixes:
- Prevent productive turns from being terminated by the previous default 200-step limit.
- Ensure served requests honor explicit step caps instead of silently clamping them to 10,000.

Enhancements:
- Document evidence-based turn termination and the updated embedding and serving behavior.
- Preserve deliberate-stop semantics and cap reasons for hosts that explicitly configure a limit.

Documentation:
- Add ADR 0031 and update repository documentation, specifications, READMEs, and lifecycle documentation for the no-cap default.

Tests:
- Add coverage proving long productive turns complete under the default configuration and explicit host caps still terminate turns as requested.
- Update affected tests for optional step-cap configuration and resumed turns.