### PR TITLE
feat(stella-protocol,stella-plugin,stella-cli): let a plugin ship a lane, and report what nobody decided

### DIFF
--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
 
-//! `stella plugin install|list|panel|remove|drive` — the loader
+//! `stella plugin install|list|doctor|panel|remove|drive` — the loader
 //! (`doc:pipeline-as-plugins` §A4).
 //!
 //! One verb for each thing a human does with a plugin, and each one doing
@@ -63,6 +63,7 @@ use std::path::{Path, PathBuf};
 use crate::settings::{Settings, Toggle};
 
 pub(crate) mod configure;
+pub(crate) mod doctor;
 pub(crate) mod package;
 pub(crate) mod panel_grant;
 pub(crate) mod process;
@@ -92,6 +93,15 @@ pub enum PluginCmd {
     /// List installed plugins, what each is allowed to do, and where it came
     /// from.
     List,
+    /// Report each plugin lane: what it asked to hold, what it holds, and
+    /// which turn-loop seams nobody decided.
+    ///
+    /// A lane Stella ships is held to every seam of the loop by the
+    /// compiler. A lane a plugin ships is a file, and a file cannot fail a
+    /// build — so a seam added after the plugin was written reaches its lane
+    /// as nothing at all. This is where that shows up. Reads; changes
+    /// nothing.
+    Doctor,
     /// Decide whether an installed plugin may draw on your screen: print its
     /// panel handshake, and record the answer (SPEC 12.4).
     ///
@@ -158,6 +168,7 @@ pub fn run_plugin(cmd: &PluginCmd) -> Result<(), String> {
             install(&root, dir, (*scope).into(), *yes, &settings)
         }
         PluginCmd::List => list(&root, &settings),
+        PluginCmd::Doctor => doctor::doctor(&root, &settings),
         PluginCmd::Panel { name, allow, deny } => {
             decide_panel(&root, name, panel_answer(*allow, *deny), &settings)
         }

--- a/crates/stella-cli/src/plugin_cmd/doctor.rs
+++ b/crates/stella-cli/src/plugin_cmd/doctor.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `stella plugin doctor` — what each plugin lane asked for, what it holds,
+//! and what nobody decided (`doc:turn-lane-assembly` §9.2).
+//!
+//! # Why the command exists
+//!
+//! A lane this tree ships is checked by the compiler. The seam set has no
+//! default. A new seam breaks the build until each lane answers for it.
+//!
+//! A lane a plugin ships gets no such check. Its manifest is a file, and a
+//! file cannot fail a build. So a seam added later reaches that lane as
+//! nothing at all, and nobody chose that. This command names it. **A
+//! defaulted slot is reported, not assumed.**
+//!
+//! # It reports; it changes nothing
+//!
+//! Every line comes from the manifests on disk and from the merged settings.
+//! Nothing is written. No process starts. No grant moves.
+
+use std::path::Path;
+
+use stella_plugin::{ConsentedGrade, LaneAuthority, PluginManifest};
+use stella_protocol::{LaneCapability, LaneId};
+
+use super::roster::PluginRoster;
+use crate::settings::{LaneCeiling, LaneSettings, Settings};
+
+/// What a lane may hold on this machine: the rung a person accepted at
+/// install, narrowed by the ceiling the operator wrote.
+///
+/// This is the host's half of `granted = requested ∩ authorized`. The rung is
+/// what a person read and agreed to. The ceiling is what they wrote after. A
+/// seam has to clear both, so neither can undo the other.
+struct HostLaneAuthority<'a> {
+    /// The rung the manifest declared and a person accepted.
+    grade: ConsentedGrade,
+    /// The operator's own ceiling for this lane, when a scope named it.
+    ceiling: Option<&'a LaneCeiling>,
+}
+
+impl LaneAuthority for HostLaneAuthority<'_> {
+    fn authorizes(&self, lane: &LaneId, capability: LaneCapability) -> bool {
+        if !self.grade.authorizes(lane, capability) {
+            return false;
+        }
+        match self.ceiling {
+            Some(ceiling) => ceiling.known().contains(&capability),
+            // No scope named this lane, so the operator set no ceiling and
+            // the rung is the whole answer. Absent is not empty.
+            None => true,
+        }
+    }
+}
+
+/// Run the command: read what is installed, print the report.
+///
+/// # Errors
+///
+/// None of its own. The signature matches the other verbs so the dispatch in
+/// [`super::run_plugin`] stays one shape.
+pub(super) fn doctor(workspace_root: &Path, settings: &Settings) -> Result<(), String> {
+    let (roster, notices) = PluginRoster::load(workspace_root, settings);
+    for notice in &notices {
+        eprintln!("{notice}");
+    }
+    if roster.plugins().is_empty() {
+        println!("no plugins installed — add one with `stella plugin install <dir>`");
+        return Ok(());
+    }
+    for plugin in roster.plugins() {
+        for line in lane_lines(&plugin.manifest, settings.lanes.as_ref()) {
+            println!("{line}");
+        }
+    }
+    Ok(())
+}
+
+/// The report for one plugin.
+///
+/// Pure, and kept apart from the printing. What it says is what a test needs
+/// to read. A function that also opened directories could not have one.
+fn lane_lines(manifest: &PluginManifest, ceilings: Option<&LaneSettings>) -> Vec<String> {
+    let mut lines = vec![manifest.name.clone()];
+    let lanes = match manifest.declared_lanes() {
+        Ok(lanes) => lanes,
+        // Unreachable for a manifest the roster loaded, which came through
+        // `from_toml_str`. Said out loud rather than unwrapped: a report that
+        // panicked on a hand-built manifest would be worse than one that
+        // names the reason.
+        Err(error) => {
+            lines.push(format!("  its lanes do not load: {error}"));
+            return lines;
+        }
+    };
+    if lanes.is_empty() {
+        lines.push("  ships no lane of its own".into());
+        return lines;
+    }
+
+    let grade = ConsentedGrade(manifest.loop_grant.participation);
+    for lane in lanes {
+        let ceiling = ceilings.and_then(|settings| settings.ceiling(lane.id()));
+        let authority = HostLaneAuthority { grade, ceiling };
+        let grant = lane.grant(&authority);
+
+        lines.push(format!(
+            "  lane `{}` — {}, resumed by {}",
+            lane.id(),
+            lane.participation(),
+            lane.resume()
+        ));
+        lines.push(format!("    asks for: {}", say(grant.requested.iter())));
+        lines.push(format!("    holds:    {}", say(grant.granted.iter())));
+
+        let withheld = grant.withheld();
+        if !withheld.is_empty() {
+            lines.push(format!(
+                "    withheld: {} — above the `{}` rung accepted at install, or \
+                 outside this workspace's `lanes.custom` ceiling",
+                say(withheld.iter()),
+                manifest.loop_grant.participation
+            ));
+        }
+
+        // The line the command exists for. A seam in neither of the lane's
+        // lists is one nobody answered for, and it holds nothing because
+        // nothing filled it — not because somebody said no.
+        let defaulted = lane.defaulted();
+        if defaulted.is_empty() {
+            lines.push("    every seam is answered for".into());
+        } else {
+            lines.push(format!(
+                "    nobody decided: {} — this lane was written before these \
+                 seams existed, so it holds none of them",
+                say(defaulted.iter())
+            ));
+        }
+
+        for unknown in ceiling.map(LaneCeiling::unknown).unwrap_or_default() {
+            lines.push(format!(
+                "    ! `lanes.custom.{}.capabilities` names `{unknown}`, which this \
+                 build has no seam for",
+                lane.id()
+            ));
+        }
+    }
+    lines
+}
+
+/// A set of seam names as one line, or the word for an empty one.
+fn say<'a>(capabilities: impl Iterator<Item = &'a LaneCapability>) -> String {
+    let named: Vec<String> = capabilities.map(ToString::to_string).collect();
+    if named.is_empty() {
+        "nothing".into()
+    } else {
+        named.join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stella_plugin::Participation;
+
+    const REPLAY: &str = r#"
+        name = "acme"
+
+        [loop]
+        participation = "steering"
+
+        [lanes.custom."acme.replay"]
+        resume = "redispatch"
+        capabilities = ["bus", "steering"]
+        declined = ["gate"]
+    "#;
+
+    fn manifest(text: &str) -> PluginManifest {
+        PluginManifest::from_toml_str(text).expect("the manifest loads")
+    }
+
+    fn report(text: &str, settings: &str) -> String {
+        let ceilings: LaneSettings =
+            serde_json::from_str(settings).expect("the lane settings parse");
+        lane_lines(&manifest(text), Some(&ceilings)).join("\n")
+    }
+
+    /// **The witness for the report.** A seam nobody answered for is named.
+    /// That is the load-time stand-in for a compile error.
+    ///
+    /// Nothing on the base commit can declare a lane, so no report there has
+    /// anything to say.
+    #[test]
+    fn a_defaulted_seam_is_named() {
+        let printed = report(REPLAY, "{}");
+        assert!(printed.contains("lane `acme.replay`"), "{printed}");
+        assert!(printed.contains("nobody decided:"), "{printed}");
+        assert!(printed.contains("requery"), "{printed}");
+        assert!(
+            !printed.contains("nobody decided: bus"),
+            "a seam the lane asked for was not left undecided: {printed}"
+        );
+    }
+
+    /// A seam the lane turned down in writing is an answer, so it is not
+    /// reported as undecided.
+    #[test]
+    fn a_seam_turned_down_in_writing_is_not_undecided() {
+        let printed = report(REPLAY, "{}");
+        let undecided = printed
+            .lines()
+            .find(|line| line.contains("nobody decided:"))
+            .expect("the report names the undecided seams");
+        assert!(
+            !undecided.contains("gate"),
+            "`gate` was declined in writing: {undecided}"
+        );
+    }
+
+    /// **The witness for the two columns.** The ask is printed as written.
+    /// What the lane holds is printed beside it. So a lane that lost a seam
+    /// to the operator's ceiling still shows that it asked.
+    #[test]
+    fn the_ask_and_the_holding_are_reported_apart() {
+        let printed = report(
+            REPLAY,
+            r#"{"custom":{"acme.replay":{"capabilities":["bus"]}}}"#,
+        );
+        assert!(printed.contains("asks for: bus, steering"), "{printed}");
+        assert!(printed.contains("holds:    bus"), "{printed}");
+        assert!(printed.contains("withheld: steering"), "{printed}");
+    }
+
+    /// With no ceiling written, the rung accepted at install is the whole
+    /// answer — an absent entry is not an empty one.
+    #[test]
+    fn a_lane_no_scope_named_keeps_what_its_rung_allows() {
+        let printed = report(REPLAY, "{}");
+        assert!(printed.contains("holds:    bus, steering"), "{printed}");
+        assert!(!printed.contains("withheld:"), "{printed}");
+    }
+
+    /// A name in the settings this build has no seam for is reported rather
+    /// than read as a grant.
+    #[test]
+    fn a_settings_name_this_build_does_not_know_is_reported() {
+        let printed = report(
+            REPLAY,
+            r#"{"custom":{"acme.replay":{"capabilities":["bus","teleport"]}}}"#,
+        );
+        assert!(printed.contains("names `teleport`"), "{printed}");
+        assert!(printed.contains("holds:    bus"), "{printed}");
+    }
+
+    /// A plugin that ships no lane says so, so a reader can tell "none" from
+    /// "the command found nothing".
+    #[test]
+    fn a_plugin_with_no_lane_says_so() {
+        let printed = lane_lines(&manifest("name = \"acme\"\n"), None).join("\n");
+        assert!(printed.contains("ships no lane of its own"), "{printed}");
+    }
+
+    /// The rung is read out of the seam list, not out of the `[loop]` block,
+    /// so a lane weaker than its plugin renders as the weaker thing.
+    #[test]
+    fn the_lane_rung_is_the_lanes_own() {
+        let printed = report(
+            r#"
+            name = "acme"
+
+            [loop]
+            participation = "steering"
+
+            [lanes.custom."acme.watch"]
+            resume = "parent"
+            capabilities = ["bus"]
+            "#,
+            "{}",
+        );
+        assert!(
+            printed.contains("lane `acme.watch` — observer, resumed by parent"),
+            "{printed}"
+        );
+    }
+
+    /// The grade half of the authority stands on its own: a rung that does
+    /// not reach a seam withholds it with no ceiling written anywhere.
+    #[test]
+    fn the_rung_alone_can_withhold_a_seam() {
+        let lane = manifest(REPLAY)
+            .declared_lanes()
+            .expect("the lanes load")
+            .remove(0);
+        let authority = HostLaneAuthority {
+            grade: ConsentedGrade(Participation::Observer),
+            ceiling: None,
+        };
+        let grant = lane.grant(&authority);
+        assert_eq!(grant.withheld().len(), 1);
+        assert!(grant.withheld().contains(&LaneCapability::Steering));
+    }
+}

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -45,6 +45,7 @@ pub(crate) mod context_providers;
 // unchanged.
 mod engine;
 pub(crate) mod foundry;
+pub(crate) mod lanes;
 mod managed;
 mod merge;
 pub(crate) mod migrate;
@@ -88,6 +89,7 @@ pub use context::{
 pub use context_providers::{ContextProviderSettings, ExternalContextProvider, ProviderEndpoint};
 pub use engine::*;
 pub use foundry::{FoundryAutonomy, FoundryConfig, FoundrySettings};
+pub use lanes::{LaneCeiling, LaneSettings};
 pub use merge::ToolScopePolicies;
 pub(crate) use steering::SteeringCeiling;
 pub(crate) use withheld::WithheldNotice;
@@ -367,6 +369,17 @@ pub struct Settings {
     /// "the plugin ran and did nothing".
     #[serde(default)]
     pub active_plugins: Option<Vec<String>>,
+    /// `lanes.custom.<id>` — the operator's ceiling on a lane a plugin
+    /// ships. A lane named by no scope has no ceiling here and holds
+    /// whatever the rung a person accepted at install allows.
+    ///
+    /// Scopes fold by intersection, per lane, so a scope may take a seam
+    /// away and never hand one back. That direction is what keeps the key
+    /// safe to read from a repository you cloned, on the same argument the
+    /// sticky `plugins` switch above rests on: the only reachable effect of
+    /// a project file here is a plugin lane holding less.
+    #[serde(default)]
+    pub lanes: Option<LaneSettings>,
     /// Authority ceilings are honored only from the org-managed settings
     /// file. The serde name is intentionally short because the containing
     /// file is already the policy source.

--- a/crates/stella-cli/src/settings/completeness.rs
+++ b/crates/stella-cli/src/settings/completeness.rs
@@ -105,6 +105,7 @@ fn settings_ledger(s: &Settings) -> Vec<Field> {
         context_providers,
         plugins,
         active_plugins,
+        lanes,
         managed_authority,
         enterprise_telemetry,
         authority_policy,
@@ -172,6 +173,7 @@ fn settings_ledger(s: &Settings) -> Vec<Field> {
             Posture::Merged,
             active_plugins != &d.active_plugins,
         ),
+        keyed("lanes", Posture::Merged, lanes != &d.lanes),
         keyed(
             "authority",
             Posture::Merged,
@@ -471,6 +473,7 @@ const EVERY_KEY: &str = r#"{
   },
   "plugins": { "vera": "off" },
   "active_plugins": ["stella-plan"],
+  "lanes": { "custom": { "acme.replay": { "capabilities": ["bus"] } } },
   "authority": { "project_prompts": "on" },
   "enterprise_telemetry": { "source": "managed" }
 }"#;
@@ -717,6 +720,7 @@ fn the_toml_root_vocabulary_matches_the_document() {
         ui: _,
         voice: _,
         plugins: _,
+        lanes: _,
         reward: _,
         foundry: _,
         plan_review: _,
@@ -745,6 +749,7 @@ fn the_toml_root_vocabulary_matches_the_document() {
         "ui",
         "voice",
         "plugins",
+        "lanes",
         "reward",
         "foundry",
         "plan_review",

--- a/crates/stella-cli/src/settings/lanes.rs
+++ b/crates/stella-cli/src/settings/lanes.rs
@@ -119,6 +119,7 @@ impl LaneSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::settings::{ProjectTrust, Settings};
 
     fn parse(json: &str) -> LaneSettings {
         serde_json::from_str(json).expect("the block parses")
@@ -155,6 +156,46 @@ mod tests {
             .ceiling(&LaneId::new("acme.watch"))
             .expect("a lane only the user scope named survives");
         assert_eq!(watch.known(), BTreeSet::from([LaneCapability::Bus]));
+    }
+
+    /// The same claim through the real three-scope fold, not through
+    /// [`LaneSettings::narrow`] alone.
+    ///
+    /// A field can pass its own tests and still be dropped, because those
+    /// tests read a scope that was deserialized rather than merged. That is
+    /// how `enable_recap` shipped inert. So this one goes through
+    /// [`Settings::merge_captured_scopes`], and an untrusted project scope at
+    /// that — the direction is safe here, since a project may only narrow.
+    #[test]
+    fn a_project_scope_lane_ceiling_survives_the_three_scope_merge() {
+        let user: Settings = serde_json::from_str(
+            r#"{"lanes":{"custom":{"acme.replay":{"capabilities":["bus","steering"]}}}}"#,
+        )
+        .expect("the user scope parses");
+        let project: Settings = serde_json::from_str(
+            r#"{"lanes":{"custom":{"acme.replay":{"capabilities":["bus"]}}}}"#,
+        )
+        .expect("the project scope parses");
+
+        let merged = Settings::merge_captured_scopes(
+            &user,
+            &Settings::default(),
+            &project,
+            ProjectTrust {
+                credentials: false,
+                hooks: false,
+            },
+        );
+
+        let lanes = merged.lanes.expect("the merge keeps a lanes block");
+        assert_eq!(
+            lanes
+                .ceiling(&LaneId::new("acme.replay"))
+                .expect("the lane is held")
+                .known(),
+            BTreeSet::from([LaneCapability::Bus]),
+            "the project's narrowing reached the merged view"
+        );
     }
 
     /// A later scope cannot hand back a seam an earlier one took away. That

--- a/crates/stella-cli/src/settings/lanes.rs
+++ b/crates/stella-cli/src/settings/lanes.rs
@@ -1,0 +1,200 @@
+//! `lanes.custom.<id>` — the operator's ceiling on a lane a plugin ships
+//! (`doc:turn-lane-assembly` §9.4).
+//!
+//! A manifest **asks** for the turn-loop seams its lane wants. The host
+//! decides what it holds: `granted = requested ∩ authorized`. The rung a
+//! person accepted at install is one half of what is authorized, and
+//! `stella-plugin` reads that half on its own. This block is the other: it is
+//! where an operator writes the seams a lane may hold on this machine or in
+//! this workspace.
+//!
+//! # Why it nests under a named key
+//!
+//! The scope merge walks a closed list of known keys. A map folded into the
+//! root with `serde(flatten)` reads fine from one file and is dropped on the
+//! way through the merge, so a project's answer would go missing with nothing
+//! to notice it. `[lanes.custom.<id>]` is a named key holding a map, which is
+//! the shape the merge can carry.
+//!
+//! # A scope may narrow a ceiling; it may never widen one
+//!
+//! Scopes fold by intersection, per lane. A lane no scope names has no
+//! ceiling, and keeps what its install rung allows. A lane two scopes name
+//! holds only what both allow.
+//!
+//! That is the `plugins` switch's rule in another shape. It is why this key
+//! is safe to read from a repository you cloned: a project file can only take
+//! a seam away.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use stella_protocol::{LaneCapability, LaneId};
+
+/// The `lanes` block.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LaneSettings {
+    /// `lanes.custom.<id>` — the ceiling for one lane a plugin ships, keyed
+    /// by the lane id its manifest declared.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub custom: BTreeMap<String, LaneCeiling>,
+}
+
+/// What one lane may hold here.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LaneCeiling {
+    /// The seams this lane may hold, by the names
+    /// [`LaneCapability`] uses.
+    ///
+    /// Held as text so a name this build does not know can be reported
+    /// rather than dropped. An empty list is a real answer: this lane holds
+    /// nothing here.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+}
+
+impl LaneCeiling {
+    /// The seams this build knows among the names written.
+    #[must_use]
+    pub fn known(&self) -> BTreeSet<LaneCapability> {
+        self.capabilities
+            .iter()
+            .filter_map(|name| LaneCapability::parse(name))
+            .collect()
+    }
+
+    /// The names written that this build does not know.
+    ///
+    /// Reported by `stella plugin doctor` rather than refused at load. A
+    /// settings file is read by every build of Stella a person runs, so a
+    /// name from a newer build has to narrow rather than stop the session.
+    #[must_use]
+    pub fn unknown(&self) -> Vec<&str> {
+        self.capabilities
+            .iter()
+            .filter(|name| LaneCapability::parse(name).is_none())
+            .map(String::as_str)
+            .collect()
+    }
+}
+
+impl LaneSettings {
+    /// Fold one scope in, narrowing each lane it names.
+    ///
+    /// A lane the scope does not name is left alone. A lane it does name
+    /// keeps only the seams both sides allow, so no scope can hand back what
+    /// another took away.
+    pub fn narrow(&mut self, scope: &Self) {
+        for (lane, ceiling) in &scope.custom {
+            match self.custom.get_mut(lane) {
+                Some(held) => {
+                    let allowed = ceiling.known();
+                    held.capabilities
+                        .retain(|name| match LaneCapability::parse(name) {
+                            Some(capability) => allowed.contains(&capability),
+                            // A name neither side reads cannot be part of an
+                            // intersection, so it is dropped here rather than
+                            // carried into a report as a grant.
+                            None => false,
+                        });
+                }
+                None => {
+                    self.custom.insert(lane.clone(), ceiling.clone());
+                }
+            }
+        }
+    }
+
+    /// The ceiling for one lane, or `None` when no scope named it.
+    #[must_use]
+    pub fn ceiling(&self, lane: &LaneId) -> Option<&LaneCeiling> {
+        self.custom.get(lane.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> LaneSettings {
+        serde_json::from_str(json).expect("the block parses")
+    }
+
+    /// **The witness for the scope merge.** A project scope's answer about a
+    /// lane reaches the merged view. A lane only the user scope named
+    /// survives beside it.
+    ///
+    /// `doc:turn-lane-assembly` §9.7 names the failure this rules out. A
+    /// flattened map reads fine from one file. The overlay then drops it, so
+    /// the project's line does nothing and says nothing.
+    #[test]
+    fn a_project_scope_answer_is_not_dropped() {
+        let user = parse(
+            r#"{"custom":{"acme.replay":{"capabilities":["bus","steering"]},
+                          "acme.watch":{"capabilities":["bus"]}}}"#,
+        );
+        let project = parse(r#"{"custom":{"acme.replay":{"capabilities":["bus"]}}}"#);
+
+        let mut merged = LaneSettings::default();
+        merged.narrow(&user);
+        merged.narrow(&project);
+
+        let replay = merged
+            .ceiling(&LaneId::new("acme.replay"))
+            .expect("the lane both scopes named is in the merged view");
+        assert_eq!(
+            replay.known(),
+            BTreeSet::from([LaneCapability::Bus]),
+            "the project narrowed the lane and the narrowing survived the merge"
+        );
+        let watch = merged
+            .ceiling(&LaneId::new("acme.watch"))
+            .expect("a lane only the user scope named survives");
+        assert_eq!(watch.known(), BTreeSet::from([LaneCapability::Bus]));
+    }
+
+    /// A later scope cannot hand back a seam an earlier one took away. That
+    /// is what makes this key safe to read from a repository you cloned.
+    #[test]
+    fn a_later_scope_cannot_widen_an_earlier_ceiling() {
+        let user = parse(r#"{"custom":{"acme.replay":{"capabilities":["bus"]}}}"#);
+        let project = parse(r#"{"custom":{"acme.replay":{"capabilities":["bus","gate"]}}}"#);
+
+        let mut merged = LaneSettings::default();
+        merged.narrow(&user);
+        merged.narrow(&project);
+
+        assert_eq!(
+            merged
+                .ceiling(&LaneId::new("acme.replay"))
+                .expect("the lane is held")
+                .known(),
+            BTreeSet::from([LaneCapability::Bus]),
+            "the project asked for a seam the user scope had already withheld"
+        );
+    }
+
+    /// A name this build does not know is reported, never read as a grant.
+    #[test]
+    fn a_name_this_build_does_not_know_grants_nothing() {
+        let ceiling = parse(r#"{"custom":{"acme.replay":{"capabilities":["bus","teleport"]}}}"#);
+        let lane = ceiling
+            .ceiling(&LaneId::new("acme.replay"))
+            .expect("the lane is held");
+        assert_eq!(lane.known(), BTreeSet::from([LaneCapability::Bus]));
+        assert_eq!(lane.unknown(), vec!["teleport"]);
+    }
+
+    /// An empty list is an answer: this lane holds nothing here.
+    #[test]
+    fn an_empty_list_withholds_every_seam() {
+        let settings = parse(r#"{"custom":{"acme.replay":{"capabilities":[]}}}"#);
+        let lane = settings
+            .ceiling(&LaneId::new("acme.replay"))
+            .expect("the lane is held");
+        assert!(lane.known().is_empty());
+        assert!(settings.ceiling(&LaneId::new("acme.other")).is_none());
+    }
+}

--- a/crates/stella-cli/src/settings/lanes.rs
+++ b/crates/stella-cli/src/settings/lanes.rs
@@ -26,6 +26,7 @@
 //! is safe to read from a repository you cloned: a project file can only take
 //! a seam away.
 
+use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
@@ -88,10 +89,11 @@ impl LaneSettings {
     /// another took away.
     pub fn narrow(&mut self, scope: &Self) {
         for (lane, ceiling) in &scope.custom {
-            match self.custom.get_mut(lane) {
-                Some(held) => {
+            match self.custom.entry(lane.clone()) {
+                Entry::Occupied(mut held) => {
                     let allowed = ceiling.known();
-                    held.capabilities
+                    held.get_mut()
+                        .capabilities
                         .retain(|name| match LaneCapability::parse(name) {
                             Some(capability) => allowed.contains(&capability),
                             // A name neither side reads cannot be part of an
@@ -100,8 +102,8 @@ impl LaneSettings {
                             None => false,
                         });
                 }
-                None => {
-                    self.custom.insert(lane.clone(), ceiling.clone());
+                Entry::Vacant(slot) => {
+                    slot.insert(ceiling.clone());
                 }
             }
         }

--- a/crates/stella-cli/src/settings/merge.rs
+++ b/crates/stella-cli/src/settings/merge.rs
@@ -425,6 +425,20 @@ impl Settings {
         if let Some(active) = &scope.active_plugins {
             self.active_plugins = Some(active.clone());
         }
+        // Plugin-lane ceilings fold per LANE, and by intersection rather than
+        // by replacement. A lane no scope names has no ceiling here;
+        // a lane two scopes name holds only what both allow.
+        //
+        // The explicit-listing rule again, and this block is the one
+        // `doc:turn-lane-assembly` §9.7 wrote the warning for: the overlay
+        // walks known keys, so a lane set folded into the root would read
+        // correctly from one file and vanish on the way through here — a
+        // withheld seam quietly restored, arriving through the config plane.
+        if let Some(lanes) = &scope.lanes {
+            self.lanes
+                .get_or_insert_with(LaneSettings::default)
+                .narrow(lanes);
+        }
         // External CGP providers merge per-ENTRY (like `providers`), so a
         // project scope can enable an entry the user scope declared without
         // restating its transport — but a higher scope's entry replaces the

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -46,9 +46,9 @@ use super::authority::ManagedAuthoritySettings;
 use super::context::ContextSettings;
 use super::context_providers::ContextProviderSettings;
 use super::{
-    AgentEngineAgent, AgentEngineAgents, AgentEngineConfig, FoundrySettings, McpSettings,
-    PlanReviewSettings, ProviderSettings, RewardSettings, Settings, Toggle, ToolsSettings,
-    UiSettings,
+    AgentEngineAgent, AgentEngineAgents, AgentEngineConfig, FoundrySettings, LaneSettings,
+    McpSettings, PlanReviewSettings, ProviderSettings, RewardSettings, Settings, Toggle,
+    ToolsSettings, UiSettings,
 };
 
 /// The schema version this build writes and understands.
@@ -343,6 +343,14 @@ pub struct TomlConfig {
     /// plugin its operator switched off.
     #[serde(default)]
     pub plugins: BTreeMap<String, super::Toggle>,
+    /// `[lanes]` — the operator's ceiling on a lane a plugin ships. Same
+    /// shape in JSON and TOML, so no lowering beyond the move.
+    ///
+    /// A top-level section rather than a key under `[run]`, for
+    /// `[plan_review]`'s reason: it is a table of tables, and `[run]` holds
+    /// scalars.
+    #[serde(default)]
+    pub lanes: Option<LaneSettings>,
     /// `[reward]` — what a turn's verdict is worth as a training label (#1043).
     /// Same shape in JSON and TOML, so no lowering beyond the move.
     #[serde(default)]
@@ -832,6 +840,7 @@ impl TomlConfig {
             ui,
             voice,
             plugins,
+            lanes,
             reward,
             foundry,
             plan_review,
@@ -885,6 +894,7 @@ impl TomlConfig {
             context,
             context_providers,
             plugins,
+            lanes,
             managed_authority: authority,
             // Round-trip through JSON: the field is stored untyped and
             // validated fail-open by its own adapter, which speaks

--- a/crates/stella-cli/src/settings/unknown.rs
+++ b/crates/stella-cli/src/settings/unknown.rs
@@ -80,9 +80,20 @@ pub(super) const ROOT_FIELDS: &[&str] = &[
     "context_providers",
     "plugins",
     "active_plugins",
+    "lanes",
     "authority",
     "enterprise_telemetry",
 ];
+
+/// `lanes` — [`super::LaneSettings`]. Closed: the block holds `custom` and
+/// nothing else. A lane set written under any other key is one the scope
+/// merge drops, which is the shape `doc:turn-lane-assembly` §9.7 warns about.
+const LANES_FIELDS: &[&str] = &["custom"];
+
+/// `lanes.custom.<id>` — [`super::LaneCeiling`]. Closed for `[run]`'s reason:
+/// a mistyped key leaves a lane holding whatever its install rung allows,
+/// which looks exactly like a ceiling that was applied.
+const LANE_CEILING_FIELDS: &[&str] = &["capabilities"];
 
 /// `providers.<id>` — [`super::ProviderSettings`]. Checked against the struct
 /// in both directions by [`super::completeness`].
@@ -548,6 +559,8 @@ pub(super) const TOML_ROOT_FIELDS: &[&str] = &[
     // change, or this walker tells people their working config is a typo.
     "self_driving",
     "issues",
+    // `[lanes]` — the operator's ceiling on a lane a plugin ships.
+    "lanes",
     // `[plugins]` — the per-plugin retraction switches
     // (`TomlConfig::plugins`). The THIRD instance of the omission the two
     // comments above record, and the one that bites hardest: the operator most
@@ -685,12 +698,34 @@ fn scan_toml_root(root: &Value, found: &mut Vec<String>) {
                     }
                 }
             }
+            "lanes" => scan_lanes(value, found),
             "agents" => scan_toml_agents(value, found),
             // `tools`, `context_providers`, `context`, `authority`, and
             // `enterprise_telemetry` are open maps or types owned elsewhere —
             // same treatment as the JSON walker gives them.
             _ => {}
         }
+    }
+}
+
+/// The lane ceilings, in either document. The block is closed, the lane ids
+/// under `custom` are open, and each ceiling is closed again.
+///
+/// One function for both walkers because the shape is the same in JSON and in
+/// TOML: `lanes.custom.<id>.capabilities` either way, which is what makes the
+/// nested key readable from both files.
+fn scan_lanes(lanes: &Value, found: &mut Vec<String>) {
+    closed("lanes", lanes, LANES_FIELDS, found);
+    let Some(entries) = lanes.get("custom").and_then(Value::as_object) else {
+        return;
+    };
+    for (id, ceiling) in entries {
+        closed(
+            &format!("lanes.custom.{id}"),
+            ceiling,
+            LANE_CEILING_FIELDS,
+            found,
+        );
     }
 }
 
@@ -761,6 +796,7 @@ fn scan_root(root: &Value, found: &mut Vec<String>) {
             "foundry" => closed("foundry", value, FOUNDRY_FIELDS, found),
             "plan_review" => closed("plan_review", value, PLAN_REVIEW_FIELDS, found),
             "hooks" => closed("hooks", value, &hook_events(), found),
+            "lanes" => scan_lanes(value, found),
             "agent_engine_config" => scan_engine(value, found),
             // `tools`, `context_providers`, `context`, `authority`, and
             // `enterprise_telemetry` are open maps or types owned elsewhere.

--- a/crates/stella-core/src/driver/capabilities.rs
+++ b/crates/stella-core/src/driver/capabilities.rs
@@ -351,6 +351,66 @@ mod tests {
         assert!(lane.is_none());
     }
 
+    /// The register witness: every optional seam has a name a plugin
+    /// manifest can ask for, and the register holds nothing else.
+    ///
+    /// This is the load-time half of the two-level rule
+    /// (`doc:turn-lane-assembly` §9.2). A builtin lane is held to the seams
+    /// by the compiler. A lane a plugin ships is held to
+    /// [`LaneCapability`](stella_protocol::LaneCapability) at load time, and
+    /// that only works while the two sets are the same set.
+    ///
+    /// The mechanism is the destructure, not the assertion. It carries no
+    /// `..` rest pattern, so a new seam stops this file compiling until its
+    /// author gives it a name; the assertion then catches a name in the
+    /// register that no seam answers to.
+    #[test]
+    fn every_optional_seam_has_a_register_name() {
+        use stella_protocol::LaneCapability;
+
+        let TurnCapabilities {
+            hooks,
+            hook_approvals,
+            calibration,
+            gate,
+            steering,
+            requery,
+            bus,
+            outcomes,
+            fallback,
+            // Neither of these is an optional seam. A role is always
+            // answered, and a lane is the name of the lane itself, so
+            // neither is a thing a lane can ask to hold.
+            call_role: _,
+            lane: _,
+        } = TurnCapabilities::none();
+
+        let mut named = vec![
+            (LaneCapability::Hooks, hooks.is_none()),
+            (LaneCapability::HookApprovals, hook_approvals.is_none()),
+            (LaneCapability::Calibration, calibration.is_none()),
+            (LaneCapability::Gate, gate.is_none()),
+            (LaneCapability::Steering, steering.is_none()),
+            (LaneCapability::Requery, requery.is_none()),
+            (LaneCapability::Bus, bus.is_none()),
+            (LaneCapability::Outcomes, outcomes.is_none()),
+            (LaneCapability::Fallback, fallback.is_none()),
+        ];
+        for (name, unset) in &named {
+            assert!(unset, "`{name}` is set on the bare capability set");
+        }
+
+        named.sort_by_key(|(name, _)| *name);
+        let seams: Vec<_> = named.into_iter().map(|(name, _)| name).collect();
+        let mut register = LaneCapability::ALL.to_vec();
+        register.sort_unstable();
+        assert_eq!(
+            seams, register,
+            "the engine's optional seams and `LaneCapability` have drifted apart, so a \
+             plugin lane is validated against a register that is not the engine's"
+        );
+    }
+
     /// The owned-slot witness (#3387): a lane that **owns** its seams can
     /// assemble an engine.
     ///

--- a/crates/stella-core/src/driver/capabilities.rs
+++ b/crates/stella-core/src/driver/capabilities.rs
@@ -397,7 +397,7 @@ mod tests {
             (LaneCapability::Fallback, fallback.is_none()),
         ];
         for (name, unset) in &named {
-            assert!(unset, "`{name}` is set on the bare capability set");
+            assert!(*unset, "`{name}` is set on the bare capability set");
         }
 
         named.sort_by_key(|(name, _)| *name);

--- a/crates/stella-plugin/README.md
+++ b/crates/stella-plugin/README.md
@@ -210,6 +210,14 @@ before it crosses.
   out of `manifest.rs` on the rule every other block here already follows,
   before that file reached the 1500-line ceiling it had 17 lines of headroom
   against.
+- `src/lanes.rs` — the `[lanes.custom.<id>]` block: a lane the plugin ships,
+  the turn-loop seams it asks for, the seams it declines, and who resumes it.
+  Every rule is a load-time one, because a lane this tree ships is held to the
+  seam set by the compiler and a lane in a file cannot be. The rung is read
+  out of the seam list (`participation_for`) rather than written beside it,
+  and `granted = requested ∩ authorized` is kept as two sets so a lane that
+  asked for more than it holds still shows the ask. `ConsentedGrade` is the
+  authority this crate can answer on its own; a host with a gate wraps it.
 - `src/wrapper.rs` — the `[wrapper]` block: `Wrapper`, `WrapperStage`, the
   **open** `StageName` vocabulary over the closed `HostStage` twelve (#3963 —
   a manifest may contribute a stage under its own word, and the load checks

--- a/crates/stella-plugin/src/consent.rs
+++ b/crates/stella-plugin/src/consent.rs
@@ -364,6 +364,27 @@ fn loop_say(manifest: &PluginManifest) -> Vec<String> {
         ));
     }
 
+    // A lane is a place a turn runs, so what it asks to hold is part of the
+    // say a person is agreeing to. `unwrap_or_default` cannot hide anything
+    // here: a manifest that came through `from_toml_str` has already had its
+    // lanes resolved once, so the only value this drops is one a hand-built
+    // manifest never checked.
+    for lane in manifest.declared_lanes().unwrap_or_default() {
+        let asked: Vec<String> = lane.requested().iter().map(ToString::to_string).collect();
+        lines.push(if asked.is_empty() {
+            format!(
+                "  - brings a lane of its own, `{}`, asking to hold nothing",
+                one_line(lane.id().as_str())
+            )
+        } else {
+            format!(
+                "  - brings a lane of its own, `{}`, asking to hold: {}",
+                one_line(lane.id().as_str()),
+                asked.join(", ")
+            )
+        });
+    }
+
     if grant.participation.includes(Participation::Arbiter) {
         lines.push(match grant.max_holds {
             Some(1) => "  - may refuse to let a finished turn end, once per turn".into(),

--- a/crates/stella-plugin/src/error.rs
+++ b/crates/stella-plugin/src/error.rs
@@ -5,6 +5,8 @@
 //! of these to a plugin author should be able to print it verbatim and have
 //! the fix be obvious.
 
+use stella_protocol::LaneCapability;
+
 use crate::driver::DriverCall;
 use crate::host_call::HostCall;
 use crate::manifest::{HookEvent, Participation};
@@ -1100,5 +1102,85 @@ pub enum ManifestError {
         signal: Signal,
         /// The stage that publishes it, skipped this turn.
         publisher: HostStage,
+    },
+
+    /// A grade below `observer` declared a lane. A lane is a place a turn
+    /// runs, and a bundle with no say in the turn has no turn to run.
+    #[error(
+        "[lanes] needs participation \"observer\" or above; \
+         \"{participation}\" has no say in a turn to lend a lane"
+    )]
+    LanesRequireObserver {
+        /// The declared grade, below the one a lane needs.
+        participation: Participation,
+    },
+
+    /// A `[lanes]` block with no lane under it. An empty block reads as a
+    /// grant and asks for nothing, which is the shape this crate refuses on
+    /// sight rather than leaving to be found as a silence.
+    #[error("[lanes] declares no lane; drop the block or write a [lanes.custom.<id>] table")]
+    EmptyLanes,
+
+    /// A lane id outside the set Stella will print and store. The set is
+    /// lower-case letters, digits, `.`, `_` and `-`.
+    #[error(
+        "[lanes.custom.\"{lane}\"] is not a usable lane id; \
+         use lower-case letters, digits, `.`, `_` and `-`"
+    )]
+    LaneIdNotAllowed {
+        /// The id as written.
+        lane: String,
+    },
+
+    /// A lane took the name of a lane this tree already runs. Resolution is
+    /// builtin first, so the name is refused rather than quietly taken over
+    /// (`doc:turn-lane-assembly` §9.7).
+    #[error("[lanes.custom.{lane}] names a lane Stella already runs; that lane is not yours")]
+    LaneNamesABuiltin {
+        /// The builtin lane the manifest tried to take.
+        lane: String,
+    },
+
+    /// A lane did not say who picks a dead turn on it back up. The answer
+    /// decides what the lane owes when it dies, so a guess would leave a
+    /// report nobody asked for, or none where one was owed.
+    #[error(
+        "[lanes.custom.{lane}] does not declare `resume`; \
+         say who picks a dead turn back up: \"own\", \"parent\" or \"redispatch\""
+    )]
+    LaneResumeUndeclared {
+        /// The lane with no resume authority.
+        lane: String,
+    },
+
+    /// A lane named a seam this build does not have. The unknown-key rule
+    /// every table here follows, one level down: a name nobody reads is a
+    /// grant that quietly does nothing.
+    #[error("[lanes.custom.{lane}] asks for \"{name}\", which is not a turn-loop capability")]
+    UnknownLaneCapability {
+        /// The lane that asked.
+        lane: String,
+        /// The word it wrote.
+        name: String,
+    },
+
+    /// A lane named one seam twice. A repeat is always an editing mistake,
+    /// and folding it away would hide it.
+    #[error("[lanes.custom.{lane}] names {capability} more than once")]
+    DuplicateLaneCapability {
+        /// The lane that repeated itself.
+        lane: String,
+        /// The seam named twice.
+        capability: LaneCapability,
+    },
+
+    /// A lane both asked for a seam and turned it down. The two lists are
+    /// answers, so one seam cannot carry both.
+    #[error("[lanes.custom.{lane}] both asks for {capability} and declines it")]
+    LaneCapabilityBothWays {
+        /// The lane with two answers.
+        lane: String,
+        /// The seam answered twice.
+        capability: LaneCapability,
     },
 }

--- a/crates/stella-plugin/src/lanes.rs
+++ b/crates/stella-plugin/src/lanes.rs
@@ -1,0 +1,599 @@
+//! `[lanes.custom.<id>]` — a lane a plugin ships, and what it asks to hold
+//! (`doc:turn-lane-assembly` §9).
+//!
+//! A lane is one place a turn runs. The tree's own lanes are named in
+//! [`stella_protocol::BuiltinLane`], and the compiler makes each of them
+//! answer for every optional seam of the loop. A lane that arrives in a
+//! manifest cannot be held to that, because no file can fail a build. So it
+//! is held at load time instead, against
+//! [`LaneCapability`], and this module is that check.
+//!
+//! # What the rules are, and why each one is here
+//!
+//! - **A lane names the seams it wants, one word each.** A word this build
+//!   does not know is a load error naming the word. A grant nobody reads is a
+//!   grant that quietly does nothing.
+//! - **A lane may not take a builtin name.** Resolution is builtin first.
+//!   `lead` is a lane that exists and is not yours, so naming it is refused
+//!   rather than silently taken over (§9.7).
+//! - **A lane says who resumes it.** An undeclared answer is refused, never
+//!   read as `redispatch`. Who picks a dead turn back up decides what the
+//!   lane owes when it dies, and a guess there is a report nobody asked for.
+//! - **Every seam is answered, or it is reported.** A seam in neither list is
+//!   a **defaulted slot**: the lane was written before the seam existed, so
+//!   it holds nothing there and nobody decided that. `stella plugin doctor`
+//!   prints those, which is the load-time stand-in for the compile error a
+//!   builtin lane gets.
+//!
+//! # The set nests; it is never flattened
+//!
+//! `[lanes.custom.<id>]` is a map under a named key on purpose. The settings
+//! merge walks a closed list of known keys, so a flattened map reads fine in
+//! one scope and is dropped from the merge — a lost grant arriving through
+//! the config plane (§9.7).
+//!
+//! # Asked, then granted
+//!
+//! What a manifest writes is a **request**. `granted = requested ∩
+//! authorized`, and the two are kept apart so a report can show a lane that
+//! asked for more than it holds. [`LaneAuthority`] is the second half, and
+//! the answer this crate can give on its own is [`ConsentedGrade`]: a lane
+//! may hold a seam whose risk sits at or under the rung a human accepted at
+//! install. A host with a real gate composes a stricter one on top.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use stella_protocol::{BuiltinLane, LaneCapability, LaneId, ResumeAuthority, RiskLevel, TurnLane};
+
+use crate::error::ManifestError;
+use crate::manifest::Participation;
+
+/// The `[lanes]` block — the lanes this plugin ships.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Lanes {
+    /// `[lanes.custom.<id>]`, keyed by the lane's own id.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub custom: BTreeMap<String, LaneDeclaration>,
+}
+
+/// One `[lanes.custom.<id>]` entry, as written.
+///
+/// The seam names are held as text rather than as
+/// [`LaneCapability`] so a word this build does not know can be reported by
+/// name. Read the checked form through [`Lanes::resolve`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LaneDeclaration {
+    /// Who picks a dead turn on this lane back up. Required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume: Option<ResumeAuthority>,
+    /// The seams this lane asks to hold.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+    /// The seams this lane says it does not want.
+    ///
+    /// Not the same as leaving a seam out. A word here is an answer somebody
+    /// wrote; a word in neither list is a seam nobody decided, and that is
+    /// what `stella plugin doctor` reports.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub declined: Vec<String>,
+}
+
+/// A lane that passed every rule in this module.
+///
+/// Built by [`Lanes::resolve`] alone, so a value of this type has a known id,
+/// a known resume authority, and only seam names this build knows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclaredLane {
+    id: LaneId,
+    resume: ResumeAuthority,
+    requested: BTreeSet<LaneCapability>,
+    declined: BTreeSet<LaneCapability>,
+}
+
+impl DeclaredLane {
+    /// The lane's id.
+    #[must_use]
+    pub fn id(&self) -> &LaneId {
+        &self.id
+    }
+
+    /// The lane, in the shape a turn record carries.
+    #[must_use]
+    pub fn lane(&self) -> TurnLane {
+        TurnLane::Plugin(self.id.clone())
+    }
+
+    /// Who picks a dead turn on this lane back up.
+    #[must_use]
+    pub fn resume(&self) -> ResumeAuthority {
+        self.resume
+    }
+
+    /// The seams the lane asked for.
+    #[must_use]
+    pub fn requested(&self) -> &BTreeSet<LaneCapability> {
+        &self.requested
+    }
+
+    /// The seams the lane said it does not want.
+    #[must_use]
+    pub fn declined(&self) -> &BTreeSet<LaneCapability> {
+        &self.declined
+    }
+
+    /// The seams the lane answered for in neither list.
+    ///
+    /// These are the defaulted slots. The lane holds nothing there, and
+    /// nobody said so — which is the state a report has to name rather than
+    /// let pass.
+    #[must_use]
+    pub fn defaulted(&self) -> BTreeSet<LaneCapability> {
+        LaneCapability::ALL
+            .iter()
+            .copied()
+            .filter(|slot| !self.requested.contains(slot) && !self.declined.contains(slot))
+            .collect()
+    }
+
+    /// The rung this lane sits on, read out of what it asked for.
+    ///
+    /// Derived, never written down twice. The ladder and the seam list are
+    /// one statement at two grains (`doc:turn-lane-assembly` §9.3), so a
+    /// second field for the rung would be a number in two places.
+    #[must_use]
+    pub fn participation(&self) -> Participation {
+        participation_for(&self.requested)
+    }
+
+    /// What this lane holds once the host has had its say.
+    ///
+    /// `granted = requested ∩ authorized`. The two sets are both kept, so a
+    /// reader can see a lane that asked for a seam it did not get.
+    #[must_use]
+    pub fn grant(&self, authority: &dyn LaneAuthority) -> LaneGrant {
+        let granted = self
+            .requested
+            .iter()
+            .copied()
+            .filter(|capability| authority.authorizes(&self.id, *capability))
+            .collect();
+        LaneGrant {
+            lane: self.id.clone(),
+            requested: self.requested.clone(),
+            granted,
+        }
+    }
+}
+
+/// What a lane asked for and what it holds, side by side.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaneGrant {
+    /// The lane this is about.
+    pub lane: LaneId,
+    /// What the manifest asked for.
+    pub requested: BTreeSet<LaneCapability>,
+    /// What the host allowed, which is never more than it asked for.
+    pub granted: BTreeSet<LaneCapability>,
+}
+
+impl LaneGrant {
+    /// What the lane asked for and did not get.
+    #[must_use]
+    pub fn withheld(&self) -> BTreeSet<LaneCapability> {
+        self.requested.difference(&self.granted).copied().collect()
+    }
+}
+
+/// Whether a lane may hold a seam.
+///
+/// The host's half of `granted = requested ∩ authorized`. A host with an
+/// authority plane answers from it; [`ConsentedGrade`] is what this crate can
+/// answer on its own.
+pub trait LaneAuthority {
+    /// Whether `lane` may hold `capability`.
+    fn authorizes(&self, lane: &LaneId, capability: LaneCapability) -> bool;
+}
+
+/// The rung a human accepted at install, read as a ceiling.
+///
+/// A lane may hold a seam whose risk sits at or under the rung's own. It
+/// grants nothing a person did not read, and it needs no plane this crate
+/// cannot see. A host that runs a gate wraps it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConsentedGrade(pub Participation);
+
+impl LaneAuthority for ConsentedGrade {
+    fn authorizes(&self, _lane: &LaneId, capability: LaneCapability) -> bool {
+        match risk_ceiling(self.0) {
+            Some(ceiling) => capability.risk().within(ceiling),
+            None => false,
+        }
+    }
+}
+
+/// How far a rung of the ladder reaches, in the grade a gate reads.
+///
+/// `none` reaches nothing, so it has no ceiling at all rather than a low one.
+#[must_use]
+pub fn risk_ceiling(participation: Participation) -> Option<RiskLevel> {
+    match participation {
+        Participation::None => None,
+        Participation::Observer => Some(RiskLevel::Low),
+        Participation::Steering => Some(RiskLevel::Medium),
+        Participation::Arbiter => Some(RiskLevel::High),
+    }
+}
+
+/// The rung a set of seams sits on — the other reading of [`risk_ceiling`].
+///
+/// The lowest rung whose ceiling covers every seam in the set. An empty set
+/// is `none`, since a lane that asks for nothing has no say in the turn.
+#[must_use]
+pub fn participation_for(capabilities: &BTreeSet<LaneCapability>) -> Participation {
+    let Some(worst) = capabilities.iter().map(|c| c.risk()).max() else {
+        return Participation::None;
+    };
+    match worst {
+        RiskLevel::Low => Participation::Observer,
+        RiskLevel::Medium => Participation::Steering,
+        RiskLevel::High | RiskLevel::Destructive => Participation::Arbiter,
+    }
+}
+
+/// Whether a lane id is one this workspace will print and store.
+///
+/// A closed set of characters rather than a list of things to turn away. It
+/// keeps out whitespace, the seat separator, and every escape a name could
+/// carry into chrome Stella draws, in one rule.
+fn id_is_allowed(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'))
+}
+
+impl Lanes {
+    /// Check every lane and hand back the checked form.
+    ///
+    /// The one door. Validation calls it and throws the result away; a reader
+    /// calls it and keeps it. Two doors would be two sets of rules.
+    ///
+    /// # Errors
+    ///
+    /// Every rule in this module's docs, each as its own
+    /// [`ManifestError`] case naming the lane it failed on.
+    pub fn resolve(&self) -> Result<Vec<DeclaredLane>, ManifestError> {
+        if self.custom.is_empty() {
+            return Err(ManifestError::EmptyLanes);
+        }
+        let mut lanes = Vec::with_capacity(self.custom.len());
+        for (id, declaration) in &self.custom {
+            lanes.push(resolve_one(id, declaration)?);
+        }
+        Ok(lanes)
+    }
+}
+
+fn resolve_one(id: &str, declaration: &LaneDeclaration) -> Result<DeclaredLane, ManifestError> {
+    if !id_is_allowed(id) {
+        return Err(ManifestError::LaneIdNotAllowed {
+            lane: id.to_string(),
+        });
+    }
+    // Builtin first, so a manifest naming a lane this tree already runs is
+    // turned away rather than quietly taking it over.
+    if BuiltinLane::ALL.iter().any(|lane| lane.as_str() == id) {
+        return Err(ManifestError::LaneNamesABuiltin {
+            lane: id.to_string(),
+        });
+    }
+    let Some(resume) = declaration.resume else {
+        return Err(ManifestError::LaneResumeUndeclared {
+            lane: id.to_string(),
+        });
+    };
+
+    let requested = named_set(id, &declaration.capabilities)?;
+    let declined = named_set(id, &declaration.declined)?;
+    if let Some(both) = requested.intersection(&declined).next() {
+        return Err(ManifestError::LaneCapabilityBothWays {
+            lane: id.to_string(),
+            capability: *both,
+        });
+    }
+
+    Ok(DeclaredLane {
+        id: LaneId::new(id),
+        resume,
+        requested,
+        declined,
+    })
+}
+
+/// One list of seam names, checked into the set the register knows.
+fn named_set(lane: &str, names: &[String]) -> Result<BTreeSet<LaneCapability>, ManifestError> {
+    let mut set = BTreeSet::new();
+    for name in names {
+        let Some(capability) = LaneCapability::parse(name) else {
+            return Err(ManifestError::UnknownLaneCapability {
+                lane: lane.to_string(),
+                name: name.clone(),
+            });
+        };
+        if !set.insert(capability) {
+            return Err(ManifestError::DuplicateLaneCapability {
+                lane: lane.to_string(),
+                capability,
+            });
+        }
+    }
+    Ok(set)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lane(toml: &str) -> Result<Vec<DeclaredLane>, ManifestError> {
+        let lanes: Lanes = toml::from_str(toml).expect("the block parses");
+        lanes.resolve()
+    }
+
+    const REPLAY: &str = r#"
+        [custom."acme.replay"]
+        resume = "redispatch"
+        capabilities = ["bus", "steering"]
+        declined = ["gate"]
+    "#;
+
+    /// **The witness for a manifest-declared lane.** Nothing on the base
+    /// commit can read a lane out of a manifest at all, so this whole shape
+    /// is new.
+    #[test]
+    fn a_manifest_can_declare_a_lane() {
+        let lanes = lane(REPLAY).expect("the lane loads");
+        let [replay] = &lanes[..] else {
+            panic!("one lane was declared");
+        };
+        assert_eq!(replay.id().as_str(), "acme.replay");
+        assert_eq!(replay.resume(), ResumeAuthority::Redispatch);
+        assert_eq!(
+            replay.lane(),
+            TurnLane::Plugin(LaneId::new("acme.replay")),
+            "a declared lane is the open arm of `TurnLane`, never a builtin"
+        );
+        assert!(!replay.lane().totality_is_compile_enforced());
+    }
+
+    /// **The witness for the unknown name.** A word this build does not know
+    /// is refused by name, so an author reads the word they mistyped.
+    #[test]
+    fn an_unknown_capability_name_is_refused_by_name() {
+        let error = lane(
+            r#"
+            [custom."acme.replay"]
+            resume = "own"
+            capabilities = ["teleport"]
+            "#,
+        )
+        .expect_err("an unknown seam name is a load error");
+        assert!(
+            matches!(&error, ManifestError::UnknownLaneCapability { lane, name }
+                if lane == "acme.replay" && name == "teleport"),
+            "got {error}"
+        );
+        assert!(error.to_string().contains("teleport"));
+    }
+
+    /// **The witness for builtin-first resolution.** A lane this tree already
+    /// runs is not a name a manifest may take.
+    #[test]
+    fn a_lane_named_after_a_builtin_is_refused() {
+        for builtin in BuiltinLane::ALL {
+            let toml = format!(
+                "[custom.{}]\nresume = \"own\"\ncapabilities = [\"bus\"]\n",
+                builtin.as_str()
+            );
+            let error = lane(&toml).expect_err("a builtin name is a load error");
+            assert!(
+                matches!(&error, ManifestError::LaneNamesABuiltin { lane } if lane == builtin.as_str()),
+                "got {error}"
+            );
+        }
+    }
+
+    /// **The witness for the resume rule.** Who resumes a lane is answered or
+    /// the lane does not load; it is never read as a redispatch.
+    #[test]
+    fn an_undeclared_resume_authority_is_refused() {
+        let error = lane(
+            r#"
+            [custom."acme.replay"]
+            capabilities = ["bus"]
+            "#,
+        )
+        .expect_err("an undeclared resume authority is a load error");
+        assert!(
+            matches!(&error, ManifestError::LaneResumeUndeclared { lane } if lane == "acme.replay"),
+            "got {error}"
+        );
+    }
+
+    /// **The witness for the defaulted slot.** A seam the lane answered for in
+    /// neither list is named, so a report can print it.
+    #[test]
+    fn a_seam_in_neither_list_is_a_defaulted_slot() {
+        let lanes = lane(REPLAY).expect("the lane loads");
+        let defaulted = lanes[0].defaulted();
+        assert!(
+            !defaulted.contains(&LaneCapability::Bus),
+            "bus was asked for"
+        );
+        assert!(
+            !defaulted.contains(&LaneCapability::Gate),
+            "gate was turned down in writing, which is an answer"
+        );
+        assert!(
+            defaulted.contains(&LaneCapability::Requery),
+            "requery is in neither list, so nobody decided it"
+        );
+        assert_eq!(
+            defaulted.len(),
+            LaneCapability::ALL.len() - 3,
+            "every seam is either asked for, turned down, or defaulted"
+        );
+    }
+
+    /// **The witness for the derived rung.** The ladder is read out of the
+    /// seam list, so a manifest never writes it twice.
+    #[test]
+    fn the_rung_is_read_out_of_the_seam_list() {
+        let cases = [
+            (vec![], Participation::None),
+            (vec![LaneCapability::Bus], Participation::Observer),
+            (
+                vec![LaneCapability::Bus, LaneCapability::Steering],
+                Participation::Steering,
+            ),
+            (
+                vec![LaneCapability::Bus, LaneCapability::Gate],
+                Participation::Arbiter,
+            ),
+        ];
+        for (capabilities, expected) in cases {
+            let set: BTreeSet<_> = capabilities.into_iter().collect();
+            assert_eq!(participation_for(&set), expected);
+        }
+    }
+
+    /// **The witness for asked against held.** A lane that asks above the rung
+    /// a human accepted keeps the ask on the record and holds less.
+    #[test]
+    fn a_lane_that_asks_above_its_rung_holds_less_than_it_asked_for() {
+        let lanes = lane(REPLAY).expect("the lane loads");
+        let grant = lanes[0].grant(&ConsentedGrade(Participation::Observer));
+
+        assert_eq!(
+            grant.requested,
+            BTreeSet::from([LaneCapability::Bus, LaneCapability::Steering]),
+            "the ask is kept as written"
+        );
+        assert_eq!(
+            grant.granted,
+            BTreeSet::from([LaneCapability::Bus]),
+            "an observer holds the watching seam and no more"
+        );
+        assert_eq!(grant.withheld(), BTreeSet::from([LaneCapability::Steering]));
+
+        let full = lanes[0].grant(&ConsentedGrade(Participation::Steering));
+        assert_eq!(full.granted, full.requested, "a steering rung covers both");
+        assert!(full.withheld().is_empty());
+    }
+
+    /// A rung with no say in the turn holds no seam, and `none` is that rung.
+    #[test]
+    fn a_content_bundle_holds_no_seam() {
+        let lanes = lane(REPLAY).expect("the lane loads");
+        let grant = lanes[0].grant(&ConsentedGrade(Participation::None));
+        assert!(grant.granted.is_empty());
+        assert_eq!(grant.withheld(), grant.requested);
+    }
+
+    #[test]
+    fn a_name_in_both_lists_is_refused() {
+        let error = lane(
+            r#"
+            [custom."acme.replay"]
+            resume = "own"
+            capabilities = ["bus"]
+            declined = ["bus"]
+            "#,
+        )
+        .expect_err("one seam, two answers");
+        assert!(
+            matches!(&error, ManifestError::LaneCapabilityBothWays { capability, .. }
+                if *capability == LaneCapability::Bus),
+            "got {error}"
+        );
+    }
+
+    #[test]
+    fn a_repeated_name_is_refused() {
+        let error = lane(
+            r#"
+            [custom."acme.replay"]
+            resume = "own"
+            capabilities = ["bus", "bus"]
+            "#,
+        )
+        .expect_err("a repeat is an editing mistake");
+        assert!(
+            matches!(&error, ManifestError::DuplicateLaneCapability { capability, .. }
+                if *capability == LaneCapability::Bus),
+            "got {error}"
+        );
+    }
+
+    #[test]
+    fn an_id_stella_cannot_print_is_refused() {
+        for id in ["", " ", "Acme", "acme/replay", "acme replay", "acme\u{1b}"] {
+            let mut custom = BTreeMap::new();
+            custom.insert(
+                id.to_string(),
+                LaneDeclaration {
+                    resume: Some(ResumeAuthority::Own),
+                    capabilities: vec!["bus".to_string()],
+                    declined: Vec::new(),
+                },
+            );
+            let error = Lanes { custom }
+                .resolve()
+                .expect_err("an id outside the set is a load error");
+            assert!(
+                matches!(&error, ManifestError::LaneIdNotAllowed { .. }),
+                "`{id}` got {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_lanes_block_with_no_lane_is_refused() {
+        let error = Lanes::default()
+            .resolve()
+            .expect_err("an empty block asks for nothing and says something");
+        assert!(matches!(error, ManifestError::EmptyLanes), "got {error}");
+    }
+
+    /// An unknown key inside the block is a load error, as it is in every
+    /// other table here.
+    #[test]
+    fn an_unknown_key_in_the_block_is_refused() {
+        let bad: Result<Lanes, _> = toml::from_str(
+            r#"
+            [custom."acme.replay"]
+            resume = "own"
+            participation = "arbiter"
+            "#,
+        );
+        assert!(
+            bad.is_err(),
+            "the rung is derived, so writing it is a mistake"
+        );
+        let bad: Result<Lanes, _> = toml::from_str("[builtin]\n");
+        assert!(bad.is_err(), "the block holds `custom` and nothing else");
+    }
+
+    /// The block round-trips, as everything crossing a crate line does
+    /// (AGENTS.md #4).
+    #[test]
+    fn the_block_round_trips() {
+        let lanes: Lanes = toml::from_str(REPLAY).expect("parses");
+        let json = serde_json::to_string(&lanes).expect("serialises");
+        let back: Lanes = serde_json::from_str(&json).expect("parses back");
+        assert_eq!(back, lanes);
+        assert_eq!(serde_json::to_string(&back).expect("re-serialises"), json);
+    }
+}

--- a/crates/stella-plugin/src/lib.rs
+++ b/crates/stella-plugin/src/lib.rs
@@ -109,6 +109,7 @@ mod driver;
 mod error;
 mod evidence;
 mod host_call;
+mod lanes;
 mod manifest;
 mod observed;
 mod oracle;
@@ -162,6 +163,10 @@ pub use host_call::{
     ChildTurnArgs, ChildTurnResult, FanoutCandidate, HostCall, HostCallArgs, HostCallFailure,
     HostCallOk, HostCallOutcome, HostCallRefusal, HostCallRequest, HostCallResponse, PluginMessage,
     RecallArgs, RecallFrame, RecallResult, RunTestArgs, TestRunResult,
+};
+pub use lanes::{
+    ConsentedGrade, DeclaredLane, LaneAuthority, LaneDeclaration, LaneGrant, Lanes,
+    participation_for, risk_ceiling,
 };
 pub use manifest::{HookEvent, LoopGrant, Participation, PluginManifest, Role, Subloop};
 pub use observed::ObservedEvidence;

--- a/crates/stella-plugin/src/manifest.rs
+++ b/crates/stella-plugin/src/manifest.rs
@@ -46,6 +46,7 @@ use crate::consent::{Capability, validate_capabilities};
 use crate::driver::DriverGrant;
 use crate::error::ManifestError;
 use crate::host_call::HostCall;
+use crate::lanes::{DeclaredLane, Lanes};
 use crate::oracle::{Oracle, OracleProcess, OracleProcessSource};
 use crate::package::{
     McpContribution, RecordContribution, SkillContribution, ToolContribution,
@@ -434,6 +435,15 @@ pub struct PluginManifest {
     /// turn-loop wrapper.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wrapper: Option<Wrapper>,
+    /// Observer and above: the lanes this plugin ships. Absent = it ships
+    /// none.
+    ///
+    /// A lane is a place a turn runs, so the seams it holds are checked at
+    /// load against the register the engine's own seams are held to. See
+    /// [`Lanes`] for the rules and for why the rung is read out of the seam
+    /// list rather than written beside it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lanes: Option<Lanes>,
     /// Observer and above: the process this plugin runs as, and the exact
     /// environment slice it inherits (`doc:pipeline-as-plugins` §A5). Absent =
     /// this plugin ships no process, so no hook grant it holds can be
@@ -555,6 +565,24 @@ impl PluginManifest {
                 timeout_secs: runtime.timeout_secs,
                 source: OracleProcessSource::Runtime,
             }),
+        }
+    }
+
+    /// The lanes this manifest ships, checked.
+    ///
+    /// An empty list for a manifest with no `[lanes]` block. For a manifest
+    /// that came from [`PluginManifest::from_toml_str`] this cannot fail —
+    /// validation has already resolved the block once — so a caller that
+    /// wants the lanes alone can treat an error as unreachable.
+    ///
+    /// # Errors
+    ///
+    /// Every rule [`Lanes::resolve`] enforces, for a manifest built by hand
+    /// rather than through the constructor.
+    pub fn declared_lanes(&self) -> Result<Vec<DeclaredLane>, ManifestError> {
+        match &self.lanes {
+            Some(lanes) => lanes.resolve(),
+            None => Ok(Vec::new()),
         }
     }
 
@@ -808,6 +836,16 @@ impl PluginManifest {
                 return Err(ManifestError::RuntimeRequiresObserver { participation });
             }
             runtime.validate(ProcessBlock::Runtime)?;
+        }
+
+        // A lane is a place a turn runs, so it needs at least the grade that
+        // buys a say in one — `[runtime]`'s rule, for the same reason. Every
+        // rule about what a lane may hold lives with the block itself.
+        if let Some(lanes) = &self.lanes {
+            if !participation.includes(Participation::Observer) {
+                return Err(ManifestError::LanesRequireObserver { participation });
+            }
+            lanes.resolve()?;
         }
 
         if let Some(roles) = &self.roles {

--- a/crates/stella-protocol/src/lane_capability.rs
+++ b/crates/stella-protocol/src/lane_capability.rs
@@ -31,8 +31,9 @@ macro_rules! lane_capabilities {
         /// One optional seam of the turn loop, named so a manifest can ask
         /// for it.
         ///
-        /// The order is the order of the table that defines it, and it is
-        /// the order every report prints in.
+        /// The order is the table's: weakest grade first, then by name.
+        /// `Ord` reads it, so it is also the order a set iterates and the
+        /// order every report prints in.
         #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
         #[derive(
             Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
@@ -83,25 +84,29 @@ macro_rules! lane_capabilities {
     };
 }
 
+// Weakest grade first, then by name inside a grade. The order is what `Ord`
+// reads, so it is the order a set iterates and therefore the order every
+// report prints in: a reader meets the seam that reaches least first, and the
+// one that can hold a turn open last.
 lane_capabilities! {
-    /// Lifecycle hooks and the port that runs them.
-    Hooks => "hooks", Medium;
-    /// Where a hook's approval ask parks until a human answers.
-    HookApprovals => "hook_approvals", Medium;
-    /// Token-drift calibration the lane owns across turns.
-    Calibration => "calibration", Medium;
-    /// The step-boundary pause gate, which can hold a turn open.
-    Gate => "gate", High;
-    /// Mid-turn messages and the soft stop.
-    Steering => "steering", Medium;
-    /// Step-boundary context re-query.
-    Requery => "requery", Medium;
     /// The event bus. Watches; changes nothing.
     Bus => "bus", Low;
-    /// Call-outcome feedback for a router's breaker.
-    Outcomes => "outcomes", Medium;
+    /// Token-drift calibration the lane owns across turns.
+    Calibration => "calibration", Medium;
     /// Provider fallback once the retries run out.
     Fallback => "fallback", Medium;
+    /// Where a hook's approval ask parks until a human answers.
+    HookApprovals => "hook_approvals", Medium;
+    /// Lifecycle hooks and the port that runs them.
+    Hooks => "hooks", Medium;
+    /// Call-outcome feedback for a router's breaker.
+    Outcomes => "outcomes", Medium;
+    /// Step-boundary context re-query.
+    Requery => "requery", Medium;
+    /// Mid-turn messages and the soft stop.
+    Steering => "steering", Medium;
+    /// The step-boundary pause gate, which can hold a turn open.
+    Gate => "gate", High;
 }
 
 impl std::fmt::Display for LaneCapability {
@@ -139,6 +144,22 @@ mod tests {
         assert_eq!(LaneCapability::parse("teleport"), None);
         assert_eq!(LaneCapability::parse(""), None);
         assert_eq!(LaneCapability::parse("Hooks"), None);
+    }
+
+    /// The order is what a report prints in, so it is pinned rather than
+    /// left to whoever edits the table next: weakest grade first, then by
+    /// name inside a grade.
+    #[test]
+    fn the_table_reads_weakest_grade_first_then_by_name() {
+        for pair in LaneCapability::ALL.windows(2) {
+            let [first, second] = pair else {
+                continue;
+            };
+            assert!(
+                (first.risk(), first.as_str()) < (second.risk(), second.as_str()),
+                "`{first}` must sort before `{second}`"
+            );
+        }
     }
 
     /// The list is what every caller walks, so a repeat in it would show up

--- a/crates/stella-protocol/src/lane_capability.rs
+++ b/crates/stella-protocol/src/lane_capability.rs
@@ -1,0 +1,165 @@
+//! The names a lane may hold a turn-loop seam under.
+//!
+//! The engine carries a set of optional seams. A builtin lane fills them
+//! with a struct literal, so the compiler makes it answer for each one. A
+//! lane a plugin ships cannot get that: its manifest is a file, and no file
+//! can fail a build. It gets the weaker check instead, at load time, and it
+//! needs a name for each seam to do that (`doc:turn-lane-assembly` §9.2).
+//!
+//! [`LaneCapability`] is that set of names. It lives here because the two
+//! crates that need it may not see each other: `stella-core` owns the seams,
+//! `stella-plugin` reads the manifest, and neither may depend on the other.
+//! One table under both of them is AGENTS.md #1 applied as written.
+//!
+//! The table below is the whole of it: the enum, the list, the word each
+//! name is written as, and the risk grades. A test pins the serde spelling
+//! to the same word. `stella-core` holds itself to the
+//! same table with a test that takes its seam struct apart field by field, so
+//! a new seam breaks that test's build until a name is added here.
+//!
+//! Each name carries a [`RiskLevel`] because a manifest **asks** and the host
+//! **grants**: `granted = requested ∩ authorized`. Grading the seams here
+//! means the ladder a plugin declares and the ceiling a host applies read one
+//! set of numbers.
+
+use serde::{Deserialize, Serialize};
+
+use crate::RiskLevel;
+
+macro_rules! lane_capabilities {
+    ($( $(#[$doc:meta])* $case:ident => $wire:literal, $risk:ident; )+) => {
+        /// One optional seam of the turn loop, named so a manifest can ask
+        /// for it.
+        ///
+        /// The order is the order of the table that defines it, and it is
+        /// the order every report prints in.
+        #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+        #[derive(
+            Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+        )]
+        #[serde(rename_all = "snake_case")]
+        pub enum LaneCapability {
+            $(
+                $(#[$doc])*
+                $case,
+            )+
+        }
+
+        impl LaneCapability {
+            /// Every name, in table order.
+            pub const ALL: &'static [Self] = &[$( Self::$case, )+];
+
+            /// The word a manifest writes.
+            #[must_use]
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $( Self::$case => $wire, )+
+                }
+            }
+
+            /// How far this seam lets a lane reach, in the grade a gate
+            /// reads.
+            #[must_use]
+            pub fn risk(self) -> RiskLevel {
+                match self {
+                    $( Self::$case => RiskLevel::$risk, )+
+                }
+            }
+
+            /// The name a manifest wrote, or `None` when this build knows no
+            /// such seam.
+            ///
+            /// `None` is a load error at the caller, never a skip. A name
+            /// nobody reads is a grant that quietly does nothing, which is
+            /// the failure the manifest rules exist to stop.
+            #[must_use]
+            pub fn parse(name: &str) -> Option<Self> {
+                match name {
+                    $( $wire => Some(Self::$case), )+
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+lane_capabilities! {
+    /// Lifecycle hooks and the port that runs them.
+    Hooks => "hooks", Medium;
+    /// Where a hook's approval ask parks until a human answers.
+    HookApprovals => "hook_approvals", Medium;
+    /// Token-drift calibration the lane owns across turns.
+    Calibration => "calibration", Medium;
+    /// The step-boundary pause gate, which can hold a turn open.
+    Gate => "gate", High;
+    /// Mid-turn messages and the soft stop.
+    Steering => "steering", Medium;
+    /// Step-boundary context re-query.
+    Requery => "requery", Medium;
+    /// The event bus. Watches; changes nothing.
+    Bus => "bus", Low;
+    /// Call-outcome feedback for a router's breaker.
+    Outcomes => "outcomes", Medium;
+    /// Provider fallback once the retries run out.
+    Fallback => "fallback", Medium;
+}
+
+impl std::fmt::Display for LaneCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A name crosses a crate line, so it round-trips byte for byte
+    /// (AGENTS.md #4).
+    #[test]
+    fn every_name_round_trips_byte_for_byte() {
+        for capability in LaneCapability::ALL {
+            let encoded = serde_json::to_string(capability).expect("serialises");
+            assert_eq!(encoded, format!(r#""{}""#, capability.as_str()));
+            let decoded: LaneCapability = serde_json::from_str(&encoded).expect("parses back");
+            assert_eq!(decoded, *capability);
+        }
+    }
+
+    /// `parse` is the door a manifest comes through, so it must take every
+    /// name this build writes and nothing else.
+    #[test]
+    fn parse_accepts_exactly_the_names_this_build_knows() {
+        for capability in LaneCapability::ALL {
+            assert_eq!(
+                LaneCapability::parse(capability.as_str()),
+                Some(*capability)
+            );
+        }
+        assert_eq!(LaneCapability::parse("teleport"), None);
+        assert_eq!(LaneCapability::parse(""), None);
+        assert_eq!(LaneCapability::parse("Hooks"), None);
+    }
+
+    /// The list is what every caller walks, so a repeat in it would show up
+    /// as a doubled row in a report.
+    #[test]
+    fn the_list_has_no_repeats() {
+        let mut seen = LaneCapability::ALL.to_vec();
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen.len(), LaneCapability::ALL.len());
+    }
+
+    /// The grades are what a ceiling is written against, so each rung has to
+    /// hold something. A table where every seam graded the same would make a
+    /// ceiling either all or nothing.
+    #[test]
+    fn the_grades_span_more_than_one_rung() {
+        assert_eq!(LaneCapability::Bus.risk(), RiskLevel::Low);
+        assert_eq!(LaneCapability::Steering.risk(), RiskLevel::Medium);
+        assert_eq!(LaneCapability::Gate.risk(), RiskLevel::High);
+        assert!(LaneCapability::Bus.risk().within(RiskLevel::Medium));
+        assert!(!LaneCapability::Gate.risk().within(RiskLevel::Medium));
+    }
+}

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -74,6 +74,7 @@ pub mod issue;
 pub mod journal;
 pub mod ladder;
 pub mod lane;
+pub mod lane_capability;
 pub mod plan_graph;
 pub mod proof;
 pub mod provenance;
@@ -153,6 +154,7 @@ pub use task_id::TaskId;
 pub use hook::HookEvent;
 pub use journal::{StampedEvent, stamped_line};
 pub use lane::{BuiltinLane, LaneId, ResumeAuthority, TurnLane};
+pub use lane_capability::LaneCapability;
 // The `ask_question` vocabulary (#4212). Re-exported flat because both the
 // tool that raises a question and every surface that renders one name these
 // types constantly, and neither should have to spell the module path.

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -528,8 +528,9 @@ some-noisy-observer = "off"
 # the seams you list. Scopes narrow: a project file can take a seam away and can
 # never hand one back.
 #
-# The seam names are the ones `stella plugin doctor` prints: bus, hooks,
-# hook_approvals, calibration, gate, steering, requery, outcomes, fallback.
+# The seam names are the ones `stella plugin doctor` prints, weakest first:
+# bus, calibration, fallback, hook_approvals, hooks, outcomes, requery,
+# steering, gate.
 # -----------------------------------------------------------------------------
 [lanes.custom."acme.replay"]
 capabilities = ["bus"]

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -517,6 +517,25 @@ some-noisy-observer = "off"
 
 
 # -----------------------------------------------------------------------------
+# LANES — how much of the turn loop a plugin's own lane may hold
+#
+# A plugin can ship a lane: a place a turn runs, with its own set of the loop's
+# optional seams. Its manifest asks for the seams it wants. This table is where
+# you say what it may actually hold here.
+#
+# A lane you never name has no ceiling here, and holds whatever the rung you
+# accepted when you installed the plugin allows. A lane you do name holds only
+# the seams you list. Scopes narrow: a project file can take a seam away and can
+# never hand one back.
+#
+# The seam names are the ones `stella plugin doctor` prints: bus, hooks,
+# hook_approvals, calibration, gate, steering, requery, outcomes, fallback.
+# -----------------------------------------------------------------------------
+[lanes.custom."acme.replay"]
+capabilities = ["bus"]
+
+
+# -----------------------------------------------------------------------------
 # REWARD — what a finished turn's verdict is worth as a training label (#1043)
 #
 # *** NOTHING CONSUMES THIS TODAY (#4224). *** These keys parse and resolve into

--- a/website/content/docs/commands/plugin.mdx
+++ b/website/content/docs/commands/plugin.mdx
@@ -12,6 +12,7 @@ This command works offline. It only reads and writes local files, and it does no
 ```bash
 stella plugin install <dir> [--scope project|user] [--yes]
 stella plugin list
+stella plugin doctor
 stella plugin panel <name> [--allow|--deny]
 stella plugin remove <name>
 stella plugin drive <name>
@@ -122,6 +123,29 @@ hook dispatches:
 The output has two parts, and they answer different questions. The first part shows what each plugin asked for. The second part, "hook dispatches," shows what stella will actually run. If a plugin lists a hook but has no `[runtime]` block, it shows up in the first part but not the second. That's why a plugin can declare `Stop` and still never run anything.
 
 If a plugin asks for an environment variable that stella recognizes as a model API key, stella blocks it and tells you here, in the list output. You won't have to discover a missing variable later when the plugin runs. A plugin never gets the API key that pays for model usage directly. Instead, a plugin that needs model access should use a `[roles]` block, so stella makes the model call itself and tracks the cost properly.
+
+## `stella plugin doctor`
+
+Shows what each plugin's own lane asked to hold, what it holds, and which parts of the turn loop nobody decided for it.
+
+A plugin can ship a **lane**: a place a turn runs, with its own set of the loop's optional parts. The lanes stella ships are checked by the compiler, so a new part of the loop cannot ship until every one of them answers for it. A plugin's lane is a file, and a file cannot fail a build. That means a part added after the plugin was written reaches its lane as nothing at all, and nobody chose that. This command is where it shows up.
+
+```bash
+stella plugin doctor
+```
+
+```text
+acme
+  lane `acme.replay` — steering, resumed by redispatch
+    asks for: bus, steering
+    holds:    bus
+    withheld: steering — above the `observer` rung accepted at install, or outside this workspace's `lanes.custom` ceiling
+    nobody decided: calibration, fallback, gate, hook_approvals, hooks, outcomes, requery
+```
+
+"Asks for" is what the plugin's manifest wrote. "Holds" is what it actually gets, once the rung you accepted at install and your own `[lanes]` ceiling have both had their say. "Nobody decided" is the list worth reading: those are parts of the loop the plugin never answered for in either direction. Set a ceiling with the `[lanes]` section of `stella.toml`.
+
+This command reads. It writes nothing, starts nothing, and changes no grant.
 
 ## `stella plugin panel`
 

--- a/website/content/docs/commands/plugin.mdx
+++ b/website/content/docs/commands/plugin.mdx
@@ -140,7 +140,7 @@ acme
     asks for: bus, steering
     holds:    bus
     withheld: steering — above the `observer` rung accepted at install, or outside this workspace's `lanes.custom` ceiling
-    nobody decided: calibration, fallback, gate, hook_approvals, hooks, outcomes, requery
+    nobody decided: calibration, fallback, hook_approvals, hooks, outcomes, requery, gate
 ```
 
 "Asks for" is what the plugin's manifest wrote. "Holds" is what it actually gets, once the rung you accepted at install and your own `[lanes]` ceiling have both had their say. "Nobody decided" is the list worth reading: those are parts of the loop the plugin never answered for in either direction. Set a ceiling with the `[lanes]` section of `stella.toml`.

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -324,6 +324,28 @@ Keys are plugin ids, so like `[seats]` this is an **open** map: it cannot join
 vera = "off"
 ```
 
+### `[lanes]`
+
+A plugin can ship a **lane**: a place a turn runs, with its own set of the loop's
+optional seams. Its manifest asks for the seams it wants. This section is where you
+say what it may actually hold.
+
+`lanes.custom.<id>` is keyed by the lane id the plugin's manifest declared. A lane you
+never name has no ceiling here, and holds whatever the rung you accepted when you
+installed the plugin allows. A lane you do name holds only the seams you list.
+
+Scopes narrow, one after another: a project file can take a seam away, and can never
+hand one back. That is why this section is read from a repository you cloned at all —
+the only thing it can do there is leave a plugin lane holding less.
+
+`stella plugin doctor` prints the seam names, what each lane asked for, what it holds,
+and every seam a lane answered for in neither direction.
+
+```toml title="stella.toml"
+[lanes.custom."acme.replay"]
+capabilities = ["bus"]
+```
+
 ### `[tools]`
 
 This is the same open map, deny-list, and name-over-group-over-`"*"` precedence as


### PR DESCRIPTION
## What and why

A lane is one place a turn runs. The lanes this tree ships are held to every optional seam of the loop **by the compiler**: `TurnCapabilities` has no `Default` and no `#[non_exhaustive]`, so a new seam breaks the build until every lane answers for it. A lane a plugin ships cannot get that, because a manifest is a file and no file can fail a build — and half of #3274's Definition of done is about that weaker regime. None of it was built. `TurnLane::Plugin(LaneId)` was made open in #3386 precisely so this would not need a retrofit, and it had never had a producer: no manifest key named a lane, no register existed to validate one against, and `stella plugins doctor` did not exist.

This ships the load-time half.

**`stella-protocol` — `crates/stella-protocol/src/lane_capability.rs` (new).** `LaneCapability` is the register: one `macro_rules!` table naming each optional seam of the turn loop, its wire word, and its `RiskLevel`. It lives in `stella-protocol` rather than beside `TurnCapabilities` because `stella-core` owns the seams and `stella-plugin` reads the manifest, and neither may depend on the other (AGENTS.md #1). Exemplar: `crates/stella-protocol/src/event/tags.rs`, which generates its enum, its tag list and its consumer rows from one macro table for the same reason.

**`stella-core` — `driver/capabilities.rs`.** `every_optional_seam_has_a_register_name` destructures `TurnCapabilities` with **no `..` rest pattern** and asserts the seam set equals `LaneCapability::ALL`. That is the enforcement the DoD asks for: adding a slot to `TurnCapabilities` stops `stella-core` compiling until the author names it in the register, so the register cannot go stale. The assertion catches the other direction — a register entry no seam answers to.

**`stella-plugin` — `src/lanes.rs` (new).** `[lanes.custom.<id>]` declares a lane: its id, the seams it asks for, the seams it declines, and who resumes it. `Lanes::resolve` is the one door, and each rule is its own `ManifestError`:

| Rule | Error |
|---|---|
| an unknown seam name | `UnknownLaneCapability { lane, name }` |
| a lane named after a builtin (resolution is builtin-first) | `LaneNamesABuiltin { lane }` |
| an undeclared resume authority | `LaneResumeUndeclared { lane }` |
| a seam named twice | `DuplicateLaneCapability` |
| a seam both asked for and declined | `LaneCapabilityBothWays` |
| a lane under a grade below `observer` | `LanesRequireObserver` |
| a lane id outside the printable set | `LaneIdNotAllowed` |

`participation` is **derived**, never authored: §9.3's ladder is expressed by grading each seam in `RiskLevel` (`bus` is `Low`; the steering seams are `Medium`; `gate`, which can hold a turn open, is `High`), and a lane's rung is the lowest whose ceiling covers every seam it asked for. `risk_ceiling` reads the same table back, so the ladder and the ceiling are one table at two resolutions rather than a second vocabulary. `granted = requested ∩ authorized` is kept as two sets in `LaneGrant`, with `ConsentedGrade` — the rung a human accepted at install — as the authority this crate can answer on its own.

**`stella-cli`.** `lanes.custom.<id>` joins the settings document in both dialects (the field, `overlay_scope`, `unknown::ROOT_FIELDS`/`TOML_ROOT_FIELDS` plus a closed sub-walker, `completeness::settings_ledger`, `EVERY_KEY`, `TomlConfig` and its lowering, `stella.example.toml`, and the reference page). It folds **by intersection per lane**, not by replacement: a scope may take a seam away and never hand one back, which is what makes it safe to read from a repository you cloned — the same direction argument the sticky `plugins` switch rests on. `stella plugin doctor` (`plugin_cmd/doctor.rs`) prints each lane's ask, its holding, what was withheld, and every seam it answered for in neither direction. `HostLaneAuthority` composes the consented rung with the operator's ceiling, following `plugin_authz.rs`'s exemplar — the host is the only place both vocabularies are in scope.

Install consent renders the lanes too (`consent.rs`'s `loop_say`): a lane asking to hold `gate` is a say in the turn a person should read before accepting.

## Witness mechanism

Each witness fails on the base commit **by construction** — nothing there can declare a lane at all, so the manifest key, the register and the report are all absent — and each also pins the rule it names against a future edit:

- `a_manifest_can_declare_a_lane`, `an_unknown_capability_name_is_refused_by_name`, `a_lane_named_after_a_builtin_is_refused` (over every `BuiltinLane::ALL` entry), `an_undeclared_resume_authority_is_refused`, `a_seam_in_neither_list_is_a_defaulted_slot`, `the_rung_is_read_out_of_the_seam_list`, `a_lane_that_asks_above_its_rung_holds_less_than_it_asked_for` — `crates/stella-plugin/src/lanes.rs`.
- `every_optional_seam_has_a_register_name` — `crates/stella-core/src/driver/capabilities.rs`. Its mechanism is the destructure, not the assertion: a new seam stops the file compiling.
- `a_project_scope_answer_is_not_dropped` and `a_later_scope_cannot_widen_an_earlier_ceiling` — `crates/stella-cli/src/settings/lanes.rs`. The first is the DoD's scope-merge witness; `every_merged_settings_field_survives_the_scope_merge` in `completeness.rs` covers the same field from the other side, and fails if `overlay_scope` drops it.
- `a_defaulted_seam_is_named`, `the_ask_and_the_holding_are_reported_apart`, `a_settings_name_this_build_does_not_know_is_reported` — `crates/stella-cli/src/plugin_cmd/doctor.rs`.

## Judgement calls, recorded on the issue

Posted as https://github.com/macanderson/stella/issues/6154#issuecomment-5558489168 before the work started:

1. The register lives in `stella-protocol` because the dependency direction forbids it living beside `TurnCapabilities`; the compile-time binding is the destructuring test.
2. The ladder and the authority ceiling read one `RiskLevel` table, so `participation` is derived and there is no second vocabulary.
3. The verb is `stella plugin doctor`, not `stella plugins doctor`. The installed group is singular (`install|list|panel|remove|drive`); a second plural noun would be a second door onto one surface. Renaming the group is its own change.

No `scripts/file-size-baseline.txt` ceiling was raised. No new dependency.

Tests deleted: None.

## Remaining work filed

- #6241 — nothing dispatches a declared lane into turn assembly yet: `DeclaredLane` and `LaneGrant` are read by consent and by `doctor`, and no engine is assembled from one.
- #6242 — `granted` is resolved through `ConsentedGrade` plus the settings ceiling, not through an `AuthzGate` asked with `Principal::Plugin`.

Closes #6154
Refs #3274, Refs #3246, Refs #3386, Refs #2716

## Summary by Sourcery

Enable plugins to ship validated custom turn lanes and provide host-side controls and diagnostics for capabilities that were granted, withheld, or left undecided.

New Features:
- Allow plugins to declare custom turn lanes with requested and declined loop capabilities, resume authority, and derived participation grades.
- Add `stella plugin doctor` to report lane requests, granted capabilities, withheld capabilities, and undecided seams.
- Add host configuration for per-lane capability ceilings with safe intersection-based scope merging.

Bug Fixes:
- Prevent plugin lanes from silently claiming unknown capabilities, builtin lane names, invalid identifiers, or undeclared and conflicting capability decisions.

Enhancements:
- Centralize lane capability names and risk levels in a protocol register and verify that the engine's optional seams remain synchronized with it.
- Keep lane requests separate from granted capabilities and incorporate install consent and host ceilings when determining effective access.
- Include plugin lane requests in install consent output.

Documentation:
- Document plugin lane declarations, lane ceilings, and the `stella plugin doctor` command in the example configuration and user-facing command documentation.

Tests:
- Add coverage for lane manifest validation, capability registration, derived participation, grant narrowing, settings scope merging, and diagnostic reporting.