### PR TITLE
fix(gate): the prose ratchets judge the change, not the tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,14 @@
     `make prose-update` refuses to raise a count or add a pair, so a red gate
     is cleared by deleting the prose. The baseline records debt older than
     the guard, it is meant to reach empty, and adding a line to it is the
-    expedient this file forbids. Adding a *pattern* is the one exception, and
+    expedient this file forbids. Each of the three ratchets — the counts,
+    the reading grade, and the header density below — judges your change
+    and not the whole tree, the way `check-file-size.sh` does. A number
+    fails only when it is over its own ceiling *and* over the same value in
+    the base tree, so drift you inherited is named in the run and does not
+    fail you. `--absolute` skips the base tree, which is what the
+    after-merge check runs; a base that does not resolve makes the check
+    strict again. Adding a *pattern* is the one exception, and
     it has its own door: `make prose-adopt PATTERN=<name>` records that
     pattern's pre-existing hits, once, and refuses to touch any other
     pattern's numbers. A backticked span or a fenced block is exempt: naming

--- a/scripts/check-prose.py
+++ b/scripts/check-prose.py
@@ -63,13 +63,15 @@ The baseline is a shared cell in the sense AGENTS.md describes for
 and compose into a red `main`. Two doors close that, mirroring
 `check-file-size.sh`'s own split:
 
-- The plain check judges a unit against `max(its baseline, its mean in the
-  base tree)`. Inherited drift is reported as drift and does not fail a
-  branch that did not cause it, so landing one ordinary header cannot
-  redden `main` on its own. `--absolute` opts out of the base comparison for
-  the one caller that must not get this mercy: a post-merge canary is
+- The plain check judges a count, a grade and a unit's mean against
+  `max(its baseline, the same value in the base tree)`. Inherited drift is
+  named on the way past and does not fail a branch that did not cause it, so
+  landing one ordinary header, or leaving somebody else's hard sentence
+  alone, cannot redden `main`. `--absolute` opts out of the base comparison
+  for the one caller that must not get this mercy: a post-merge canary is
   exactly asking whether drift already reached `main`, and the base-relative
-  reading would forgive the thing it exists to catch.
+  reading would forgive the thing it exists to catch. A file the base tree
+  does not have inherits nothing, so a first-time offender still fails.
 - `--update` alone leaves every unit's ceiling where it stands, except for a
   unit a file move took a header out of or into: that entry is re-based
   against the same files' lengths in the base tree, because a move changes a
@@ -105,9 +107,10 @@ Usage:
                   when the grade ratchet arrived
     --report      print every offending line, grouped by file, then each
                   unit's mean header length; changes nothing
-    --absolute    judge every unit's density against its baseline alone,
-                  ignoring the base tree. For the post-merge canary, which
-                  must catch drift a base-relative check would forgive.
+    --absolute    judge every count, grade and unit density against its
+                  baseline alone, ignoring the base tree. For the post-merge
+                  canary, which must catch drift a base-relative check would
+                  forgive.
 """
 
 from __future__ import annotations
@@ -343,12 +346,11 @@ GRADE_HEADER = """\
 def renamed_paths(root: Path, commit: str = "HEAD") -> dict[str, str]:
     """Old path -> new path, for every file git sees as renamed against `commit`.
 
-    The count and grade ratchets consult this from `--update` alone, against
-    HEAD: the plain check judges the tree as it stands, so a move fails until
-    someone runs `--update` — the same workflow the file-size ratchet has.
-    The density ratchet also consults it from the plain check, against the
-    base commit, because a unit's mean is arithmetic over a file *set* and a
-    move changes that set without anyone writing a word.
+    `--update` asks against HEAD, so a moved file's baseline entry follows it
+    to the new path. The plain check asks against the base commit, so every
+    ratchet reads the moved file's old path when it looks up what the base
+    tree held: a rename is not new prose, and a unit's mean is arithmetic
+    over a file *set* that a move changes with nobody writing a word.
 
     Fails open at every unknown (no git, no HEAD, an unreadable tree): an
     empty map means no entry is carried, which is the behaviour this had
@@ -430,18 +432,23 @@ def prose_only(text: str) -> list[str]:
     return CODE_SPAN.sub(lambda m: _blank(m.group(0)), "\n".join(lines)).split("\n")
 
 
-def scan(root: Path, path: str) -> list[tuple[int, str, str, str]]:
-    """Return (lineno, pattern name, matched text, remedy) for one file."""
-    try:
-        text = (root / path).read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return []
+def scan_text(text: str) -> list[tuple[int, str, str, str]]:
+    """Return (lineno, pattern name, matched text, remedy) for one file's text."""
     hits: list[tuple[int, str, str, str]] = []
     for lineno, line in enumerate(prose_only(text), start=1):
         for name, rx, remedy in PATTERNS:
             for m in rx.finditer(line):
                 hits.append((lineno, name, m.group(0), remedy))
     return hits
+
+
+def scan(root: Path, path: str) -> list[tuple[int, str, str, str]]:
+    """[`scan_text`] over one file in the working tree."""
+    try:
+        text = (root / path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    return scan_text(text)
 
 
 def counts(root: Path) -> tuple[dict[tuple[str, str], int], dict[str, list]]:
@@ -627,7 +634,7 @@ def _git(root: Path, args: list[str]) -> str:
 
 
 def resolve_base_commit(root: Path, absolute: bool) -> str:
-    """The commit a unit's density is judged against, or "" for none.
+    """The commit this change is judged against, or "" for none.
 
     Mirrors `check-file-size.sh`'s `resolve_base_commit`: an explicit
     override (`PROSE_BASE_REF`, for hermetic tests with no `origin/main`),
@@ -710,6 +717,32 @@ def density_at_commit(root: Path, commit: str, unit: str, paths: list[str]) -> i
         total += length
         files += 1
     return round(total * 100 / files) if files else 0
+
+
+def counts_at_commit(root: Path, commit: str, path: str) -> dict[str, int]:
+    """Per-pattern hit counts for one file, read from `commit` by `git show`.
+
+    An empty map when the file did not exist there, which is what holds a
+    first-time offender to zero: a file the base tree never had cannot
+    inherit anything.
+    """
+    text = _git(root, ["show", f"{commit}:{path}"])
+    if not text:
+        return {}
+    per_pattern: dict[str, int] = {}
+    for _, name, _, _ in scan_text(text):
+        per_pattern[name] = per_pattern.get(name, 0) + 1
+    return per_pattern
+
+
+def grade_at_commit(root: Path, commit: str, path: str) -> int | None:
+    """One file's reading grade at `commit`, or None when it cannot be scored
+    there -- the file is absent, or holds too little prose."""
+    text = _git(root, ["show", f"{commit}:{path}"])
+    if not text:
+        return None
+    scored = reading_grade(prose_lines(path, prose_only(text)))
+    return None if scored is None else scored[0]
 
 
 def read_density_baseline(path: Path) -> dict[str, int]:
@@ -1105,16 +1138,29 @@ def main() -> int:
         print(f"check-prose: {BASELINE} retightened to {sum(merged.values())}, {density_msg}")
         return 0
 
-    # Judged against max(the recorded ceiling, this unit's mean in the base
-    # tree) -- the same rule check-file-size.sh uses, and for the same
-    # reason: a unit already over its ceiling before this change landed is
-    # inherited drift, and failing the branch that merely did not fix it is
-    # what turned this ratchet into a main-red generator. `--absolute` (the
-    # post-merge canary) skips the base entirely, because that is exactly
-    # the drift a canary exists to catch.
+    # All three ratchets are judged against max(the recorded ceiling, the same
+    # thing's value in the base tree) -- the rule check-file-size.sh uses, and
+    # for the same reason: a file or unit already over its ceiling before this
+    # change landed is inherited drift, and failing the branch that merely did
+    # not fix it is what turned these ratchets into main-red generators.
+    # `--absolute` (the post-merge canary) skips the base entirely, because
+    # that is exactly the drift a canary exists to catch. Inherited drift is
+    # still named on the way past, so forgiving it never means hiding it.
     absolute = "--absolute" in flagset
     base_commit = resolve_base_commit(root, absolute)
     base_moves = renamed_paths(root, base_commit) if base_commit else {}
+    came_from = {new: old for old, new in base_moves.items()}
+    inherited: list[str] = []
+
+    base_counts: dict[str, dict[str, int]] = {}
+
+    def counts_in_base(path: str) -> dict[str, int]:
+        if path not in base_counts:
+            base_counts[path] = counts_at_commit(
+                root, base_commit, came_from.get(path, path)
+            )
+        return base_counts[path]
+
     over = []
     for unit, mean in sorted(per_unit.items()):
         ceiling = density_baseline.get(unit, NEW_UNIT_MEAN)
@@ -1122,16 +1168,59 @@ def main() -> int:
             continue
         if base_commit:
             base_paths = base_tracked_paths(root, base_commit, unit, tracked, base_moves)
-            ceiling = max(ceiling, density_at_commit(root, base_commit, unit, base_paths))
+            was = density_at_commit(root, base_commit, unit, base_paths)
+            if mean <= was:
+                inherited.append(
+                    f"{unit}: {mean / 100:.2f} mean header lines, "
+                    f"{ceiling / 100:.2f} allowed, {was / 100:.2f} in the base tree"
+                )
+                continue
+            ceiling = max(ceiling, was)
         if mean > ceiling:
             over.append((unit, ceiling, mean))
 
     failures = []
     for pair in sorted(set(per_pair) | set(baseline)):
+        path, pattern = pair
         now = per_pair.get(pair, 0)
         allowed = baseline.get(pair, 0)
-        if now > allowed:
-            failures.append((pair, allowed, now))
+        if now <= allowed:
+            continue
+        if base_commit:
+            was = counts_in_base(path).get(pattern, 0)
+            if now <= was:
+                inherited.append(
+                    f"{path} [{pattern}]: {now} found, {allowed} allowed, "
+                    f"{was} in the base tree"
+                )
+                continue
+            allowed = max(allowed, was)
+        failures.append((pair, allowed, now))
+
+    grade_failures = []
+    for path, (grade, worst) in sorted(per_grade.items()):
+        allowed_grade = grade_baseline.get(path, NEW_FILE_GRADE)
+        if grade <= allowed_grade:
+            continue
+        if base_commit:
+            was = grade_at_commit(root, base_commit, came_from.get(path, path))
+            if was is not None and grade <= was:
+                inherited.append(
+                    f"{path}: grade {grade / 100:.2f}, "
+                    f"{allowed_grade / 100:.2f} allowed, "
+                    f"{was / 100:.2f} in the base tree"
+                )
+                continue
+            allowed_grade = max(allowed_grade, was or 0)
+        grade_failures.append((path, allowed_grade, grade, worst))
+
+    if inherited:
+        print(
+            "check-prose: drift inherited from the base tree, which this "
+            "change did not cause and does not fail on:"
+        )
+        for line in inherited:
+            print(f"  {line}")
 
     if failures:
         print("check-prose: FAIL -- content-free prose added.\n", file=sys.stderr)
@@ -1152,12 +1241,6 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
-
-    grade_failures = []
-    for path, (grade, worst) in sorted(per_grade.items()):
-        allowed_grade = grade_baseline.get(path, NEW_FILE_GRADE)
-        if grade > allowed_grade:
-            grade_failures.append((path, allowed_grade, grade, worst))
 
     if grade_failures:
         print(

--- a/scripts/test-prose-guard.sh
+++ b/scripts/test-prose-guard.sh
@@ -674,6 +674,112 @@ else
   ok "B3 --absolute still sees inherited drift"
 fi
 
+# ── C: a count and a grade are judged against the base tree too ─────────────
+#
+# The same rule as B, for the other two ratchets. A branch that never opened
+# the drifted file used to fail on it, so the author had to repair somebody
+# else's prose inside their own diff or wait for a separate repair to land.
+# C1 and C5 are the witnesses: both fail before this rule reaches counts and
+# grades. C2 and C6 are the boundary -- adding to the drifted file still
+# fails. C3 keeps `--absolute` strict for the post-merge canary, and C4 keeps
+# an unresolvable base strict, which is the direction an unknown must always
+# take.
+
+# $1 = root, $2 = relative path, $3 = hard sentences, $4 = easy lines. Mixed
+# prose, so a later edit can raise the file's grade by adding hard sentences.
+mixed_doc() {
+  mkdir -p "$(dirname "$1/$2")"
+  : >"$1/$2"
+  i=0
+  while [ "$i" -lt "$3" ]; do
+    printf 'Considerable organizational infrastructure necessitates comprehensive architectural documentation regarding institutional configuration management, alongside verification.\n' >>"$1/$2"
+    i=$((i + 1))
+  done
+  i=0
+  while [ "$i" -lt "$4" ]; do
+    printf 'The cache is keyed by path. A miss is a hard error. The store owns one file.\n' >>"$1/$2"
+    i=$((i + 1))
+  done
+  (cd "$1" && git add -A) >/dev/null 2>&1
+}
+
+r="$(new_root c1)"
+baseline "$r"
+doc "$r" docs/drift.md <<'EOF'
+Two things follow from that, and the second is the hard one.
+EOF
+commit_all "$r"
+mark_as_main "$r"
+doc "$r" docs/unrelated.md <<'EOF'
+The store keys every child table off `executions.id`.
+EOF
+commit_all "$r"
+expect_pass "C1 an inherited count does not fail a branch that did not cause it" "$r"
+if python3 "$SCRIPT" "$r" 2>/dev/null | grep -q 'docs/drift.md'; then
+  ok "C1 the forgiven file is named"
+else
+  no "C1 the forgiven file is named" "the run said nothing about docs/drift.md"
+fi
+
+r="$(new_root c2)"
+baseline "$r"
+doc "$r" docs/drift.md <<'EOF'
+Two things follow from that, and the second is the hard one.
+EOF
+commit_all "$r"
+mark_as_main "$r"
+doc "$r" docs/drift.md <<'EOF'
+Two things follow from that, and the second is the hard one.
+Both halves matter here.
+EOF
+commit_all "$r"
+expect_fail "C2 adding to an already-drifted file still fails" "$r"
+
+r="$(new_root c3)"
+baseline "$r"
+doc "$r" docs/drift.md <<'EOF'
+Two things follow from that, and the second is the hard one.
+EOF
+commit_all "$r"
+mark_as_main "$r"
+doc "$r" docs/unrelated.md <<'EOF'
+The store keys every child table off `executions.id`.
+EOF
+commit_all "$r"
+if python3 "$SCRIPT" --absolute "$r" >/dev/null 2>&1; then
+  no "C3 --absolute still sees an inherited count" "the guard passed"
+else
+  ok "C3 --absolute still sees an inherited count"
+fi
+
+# One commit and no origin/main: nothing resolves as a base, so the whole-tree
+# check is what runs. A shallow clone and a fresh repository land here.
+r="$(new_root c4)"
+baseline "$r"
+doc "$r" docs/drift.md <<'EOF'
+Two things follow from that, and the second is the hard one.
+EOF
+commit_all "$r"
+expect_fail "C4 an unresolvable base holds the whole tree to the baseline" "$r"
+
+r="$(new_root c5)"
+baseline "$r"
+hard_doc "$r" docs/hard.md 8
+commit_all "$r"
+mark_as_main "$r"
+easy_doc "$r" docs/unrelated.md 12
+commit_all "$r"
+expect_pass "C5 an inherited reading grade does not fail an untouched branch" "$r"
+
+r="$(new_root c6)"
+baseline "$r"
+mixed_doc "$r" docs/hard.md 2 12
+commit_all "$r"
+mark_as_main "$r"
+mixed_doc "$r" docs/hard.md 10 12
+commit_all "$r"
+expect_fail "C6 raising an already-hard file's grade still fails" "$r"
+
 # ── G1: plain prose within grade 6 passes ────────────────────────────────────
 r="$(new_root g1)"
 easy_doc "$r" docs/a.md 12


### PR DESCRIPTION
## What and why

`scripts/check-prose.py` holds three ratchets, and only one of them judged the
change rather than the tree. Module-header density already compared a crate's
mean against the base tree; the per-(file, pattern) counts and the per-file
reading grade compared against their baseline alone. So a branch that touched
none of the drifted files still failed `make prose`, and the author had to
repair somebody else's prose inside their own diff — which AGENTS.md forbids for
a shared cell — or land a separate repair first and wait for it. That happened
on 2026-09-06: a pull request holding no Rust at all could not go green until an
unrelated repair merged.

Counts and grades now take the allowance density already had:

    allowed = max(the baseline entry, the same value in the base tree)

The base is the commit `resolve_base_commit` already picks (the merge commit's
first parent in CI, the merge base with `origin/main` locally, `PROSE_BASE_REF`
for a hermetic test). `--absolute` still skips the base entirely, so the
post-merge canary keeps reporting drift that reached `main`. An unresolvable
base — a shallow clone, a fresh repository — resolves to `""` and holds the whole
tree to the baseline, because an unknown must make the check stricter and never
weaker.

Two directions this does not weaken, both pinned by tests:

- A first-time offender still fails. A file the base tree does not hold reads
  back as zero hits and no grade, so it inherits nothing.
- `--update` is untouched: it still refuses to raise a count, a grade or a mean.

Inherited drift is named on the way past (`check-prose: drift inherited from the
base tree…`), so forgiving it is never the same as hiding it. The density
ratchet, which forgave silently before, now reports through the same line.

Exemplar: `scripts/check-file-size.sh` — the same rule, the same base
resolution, and the same fallback (AGENTS.md, "The ratchet judges your change,
not the tree").

## Witness mechanism

Six cases in `scripts/test-prose-guard.sh`, hermetic like its `B` and `S`
siblings — each builds a throwaway git repository, commits a drifted file,
points `refs/remotes/origin/main` at that commit, then commits the branch's own
change on top.

- **C1** (counts) and **C5** (grade) are the witnesses: the base tree is already
  over a ceiling and the branch adds an unrelated file. Both fail on `main`'s
  script — I verified it by running the suite with
  `git show origin/main:scripts/check-prose.py` in place:

      FAIL C1 an inherited count does not fail a branch that did not cause it -- the guard exited non-zero
      FAIL C1 the forgiven file is named -- the run said nothing about docs/drift.md
      FAIL C5 an inherited reading grade does not fail an untouched branch -- the guard exited non-zero

  All six pass with this change (69 passed, 0 failed).
- **C2** and **C6** are the boundary: the same fixtures fail once the diff adds a
  construction to the drifted file, or raises its grade.
- **C3** keeps `--absolute` strict on a tree C1 forgives.
- **C4** is the fallback: one commit, no `origin/main`, nothing resolves as a
  base, and the drifted file fails.

`scripts/test-prose-guard.sh` runs in `guard-self-tests.yml` and as
`make prose-test`.

## Evidence

- `./scripts/test-prose-guard.sh` — 69 passed, 0 failed.
- `python3 scripts/check-prose.py` and `--absolute` — both OK on this branch.
- `make guards-fast`, `shellcheck scripts/test-prose-guard.sh`,
  `make line-citations`, `./scripts/check-file-size.sh` — all green locally.
- CI is the rest of the evidence.

## Docs

CLAUDE.md's "Enforced by `make prose`" paragraph now says all three ratchets
judge the change against the base tree, what `--absolute` does, and that an
unresolvable base makes the check strict. That paragraph is the one the issue's
DoD names: it lives in CLAUDE.md, which imports AGENTS.md.

Tests deleted: None.

Residue issues filed: none — nothing was left behind by this change.

Closes #6244

## Summary by Sourcery

Judge prose ratchets against the branch change and base tree so inherited drift is reported without blocking unrelated work.

Bug Fixes:
- Make prose count and reading-grade ratchets compare changes with the resolved base tree, so inherited violations no longer fail unrelated branches while newly introduced drift still fails.
- Preserve strict whole-tree checking for --absolute and when the base cannot be resolved, including first-time offenders.

Enhancements:
- Report inherited prose drift explicitly, including density, count, and reading-grade violations, while retaining rename-aware base comparisons.

Documentation:
- Document the change-based behavior of all prose ratchets, --absolute semantics, and strict fallback behavior in CLAUDE.md.

Tests:
- Add hermetic guard tests covering inherited drift, newly introduced violations, absolute mode, and unresolved-base fallback.