### PR TITLE
fix(scripts): don't stand a session down for a closed-unmerged PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,10 +383,17 @@ only locally, in a stale worktree, clean, with no remote branch and no PR.
 
 It asks the **pull requests first**, because that is the stronger signal and
 the one the issue itself never shows: a sweep PR can close forty issues at
-once while each of them still reads unassigned, unlabelled and open. Then the
-claim comments, on the red-`main` rules — the tracker is the table so a peer
-in another worktree can see it, a comment carries its author and timestamp, a
-claim lapses so a crashed session cannot hold an issue shut, and every unknown
+once while each of them still reads unassigned, unlabelled and open. A hit
+only blocks while it can actually still be the live work: a `Closes #N` PR
+that is OPEN or MERGED stands the session down; one that is CLOSED unmerged
+is a dead attempt — reported, not blocking, because that is the state where
+the next session most needs to proceed. A `Refs #N` PR — the carrier when a
+fix uses no closing keyword so `dod-check` does not hold an unrelated
+issue's checklist against it — is named too, but only as a weaker signal
+that never blocks by itself. Then the claim comments,
+on the red-`main` rules — the tracker is the table so a peer in another
+worktree can see it, a comment carries its author and timestamp, a claim
+lapses so a crashed session cannot hold an issue shut, and every unknown
 proceeds loudly. `make issue-claim N=5045` asks by hand; `make
 issue-claim-test` covers it, both blocking branches included.
 

--- a/scripts/issue-claim.sh
+++ b/scripts/issue-claim.sh
@@ -180,6 +180,21 @@ fi
 # have caught the collisions this script was filed for: #5246 closed 44 issues
 # in one sweep, and none of them showed a thing on the issue itself.
 
+# Each hit is `<number> <state> <kind>`. `closes` means the body has
+# `Closes #N`. `refs` means it has `Refs #N` but no `Closes #N`. `$issue` is
+# already checked as digits only, so it is safe to put in the jq program
+# below.
+pr_jq='
+  .[]
+  | select(
+      (.body | test("Closes #ISSUE\\b")) or (.body | test("Refs #ISSUE\\b"))
+    )
+  | "\(.number) \(.state) \(
+      if (.body | test("Closes #ISSUE\\b")) then "closes" else "refs" end
+    )"
+'
+pr_jq="${pr_jq//ISSUE/$issue}"
+
 # prs_ok tracks whether this query actually ran, distinct from prs itself
 # being empty. "no PR closes it" is a claim about a list that was read; a
 # query that failed to even ask must never be reported in that shape.
@@ -192,20 +207,53 @@ if [ "$use_fixture" -eq 1 ]; then
     prs="$fixture_prs"
   fi
 elif ! prs="$(gh pr list --state all --limit 100 --json number,state,body \
-  --jq ".[] | select(.body | test(\"Closes #$issue\\\\b\")) | \"\(.number) \(.state)\"" 2>/dev/null)"; then
+  --jq "$pr_jq" 2>/dev/null)"; then
   echo "note: could not list pull requests. Proceeding (fail-open); the claim" >&2
   echo "      check below still runs." >&2
   prs=""
   prs_ok=0
 fi
 
-if [ -n "$prs" ]; then
+# Split the hits by kind. A `refs` hit never blocks: `Refs` is also how an
+# unrelated PR cites this issue. A `closes` hit blocks only when its state
+# is OPEN or MERGED. A CLOSED `closes` hit means a past try died. That is
+# the state where the next session should move, not stop.
+closing_hits=""
+refs_hits=""
+blocking=0
+while IFS=' ' read -r pr_num pr_state pr_kind; do
+  [ -n "$pr_num" ] || continue
+  case "$pr_kind" in
+  refs)
+    refs_hits="$refs_hits$pr_num $pr_state
+"
+    ;;
+  *)
+    # Anything that is not `refs` counts as `closes`, even an unknown third
+    # field. An unknown kind is not proof the hit is safe, so it blocks, the
+    # way every hit did before this split.
+    closing_hits="$closing_hits$pr_num $pr_state
+"
+    case "$pr_state" in
+    CLOSED) : ;;
+    *) blocking=1 ;;
+    esac
+    ;;
+  esac
+done <<EOF
+$prs
+EOF
+
+if [ "$blocking" -eq 1 ]; then
   echo "STAND DOWN  #$issue is already claimed by a pull request." >&2
   echo "" >&2
-  printf '     %s\n' "$prs" >&2
+  printf '     %s\n' "$closing_hits" >&2
   echo "" >&2
   echo "     A MERGED one means the work is done and the issue is stale." >&2
   echo "     An OPEN one means somebody is on it right now." >&2
+  echo "     A CLOSED one only blocks here because an OPEN or MERGED hit is" >&2
+  echo "     listed with it. It may be the first, dead try at the same fix," >&2
+  echo "     so read it too." >&2
   echo "" >&2
   echo "     Read its diff before writing anything. Sometimes yours covers" >&2
   echo "     something theirs missed and belongs on top of \`main\`; more often" >&2
@@ -213,6 +261,20 @@ if [ -n "$prs" ]; then
   echo "     once and show nothing on any of them, which is why this asks the" >&2
   echo "     PRs rather than the issue." >&2
   exit 1
+fi
+
+if [ -n "$closing_hits" ]; then
+  echo "note: the pull request(s) that close #$issue were closed, not merged." >&2
+  echo "      That is a dead try, not a live claim. Read them, then proceed." >&2
+  printf '     %s\n' "$closing_hits" >&2
+fi
+
+if [ -n "$refs_hits" ]; then
+  echo "note: a pull request refs #$issue but does not close it. That is a" >&2
+  echo "      weaker signal, not a claim by itself. Read it before you write:" >&2
+  echo "      the live fix can sit in a Refs-only PR while the one that would" >&2
+  echo "      close the issue is dead." >&2
+  printf '     %s\n' "$refs_hits" >&2
 fi
 
 if [ "$use_fixture" -eq 1 ]; then
@@ -281,7 +343,7 @@ if [ "$mode" = "check" ]; then
   if [ "$prs_ok" -eq 0 ]; then
     proceed "ok  proceed (PR list unreadable)"
   fi
-  proceed "ok  #$issue is unclaimed — no PR closes it and no live claim holds it."
+  proceed "ok  #$issue is unclaimed — nothing open or merged closes it, and no live claim holds it."
 fi
 
 body="$marker $me

--- a/scripts/test-issue-claim.sh
+++ b/scripts/test-issue-claim.sh
@@ -71,16 +71,49 @@ want "a fresh claim by somebody else stands this session down" \
 # shows. #5246 closed forty-four issues in one sweep with nothing on any of
 # them.
 want "an OPEN pull request closing the issue stands this session down" \
-  expect-block "5246 OPEN" check "ada" "" "5246 OPEN"
+  expect-block "5246 OPEN" check "ada" "" "5246 OPEN closes"
 
 want "and so does a MERGED one — the work is already done" \
-  expect-block "5246 MERGED" check "ada" "" "5246 MERGED"
+  expect-block "5246 MERGED" check "ada" "" "5246 MERGED closes"
 
 # The PR check runs FIRST and on its own: a claim-free issue with a live PR
 # must still block, or the stronger signal would be reachable only when the
 # weaker one happened to be absent too.
 want "a PR blocks even with no claim comments at all" \
-  expect-block "already claimed by a pull request" check "ada" "" "5246 OPEN"
+  expect-block "already claimed by a pull request" check "ada" "" "5246 OPEN closes"
+
+# ── closed-unmerged and refs-only pull requests must not block ───────────────
+
+# A pull request that was closed, not merged, is dead. It is not proof the
+# work is done or in progress. A PR closed as superseded minutes after it
+# opened is this exact shape. It must not stand a session down. That is the
+# state where the next session should move, not stop.
+want "a closed-unmerged closing pull request does not stand this session down" \
+  expect-proceed "1234 CLOSED" check "ada" "" "1234 CLOSED closes"
+
+# A closed hit next to an OPEN hit still blocks: the OPEN hit is live. Both
+# get named, each with its own state, so the closed one can be read as a
+# past, dead try at the same fix.
+out="$("$SCRIPT" check 5045 \
+  --fixture-login ada --fixture-claims "" \
+  --fixture-prs "1234 CLOSED closes
+1235 OPEN closes" 2>&1)"
+rc=$?
+case "$rc,$out" in
+1,*"1234 CLOSED"*"1235 OPEN"*)
+  ok "a closed-unmerged hit and an open one both get named, each with its own state"
+  ;;
+*)
+  bad "expected exit 1 naming both '1234 CLOSED' and '1235 OPEN', got exit $rc: $out"
+  ;;
+esac
+
+# A pull request can refs an issue without closing it. `dod-check` reads
+# every linked issue's checklist, and a closing keyword would hold an
+# unrelated fix to a checklist that is not its own. So a refs-only hit is a
+# weak signal. It must not block, and it must not stay hidden either.
+want "a Refs-only pull request does not stand this session down, but is named" \
+  expect-proceed "6203 OPEN" check "ada" "" "6203 OPEN refs"
 
 # ── the negative controls: every unknown proceeds ────────────────────────────
 

--- a/scripts/test-issue-claim.sh
+++ b/scripts/test-issue-claim.sh
@@ -94,17 +94,22 @@ want "a closed-unmerged closing pull request does not stand this session down" \
 # A closed hit next to an OPEN hit still blocks: the OPEN hit is live. Both
 # get named, each with its own state, so the closed one can be read as a
 # past, dead try at the same fix.
+#
+# The report must also say why the closed one is in the list, or a reader
+# takes it for a second live claim. Naming both states is not enough to tell
+# this run from the pre-fix one, which blocked on any hit and printed the
+# same two lines; the explanation is what only this version writes.
 out="$("$SCRIPT" check 5045 \
   --fixture-login ada --fixture-claims "" \
   --fixture-prs "1234 CLOSED closes
 1235 OPEN closes" 2>&1)"
 rc=$?
 case "$rc,$out" in
-1,*"1234 CLOSED"*"1235 OPEN"*)
-  ok "a closed-unmerged hit and an open one both get named, each with its own state"
+1,*"1234 CLOSED"*"1235 OPEN"*"only blocks here because an OPEN or MERGED hit is"*)
+  ok "a closed-unmerged hit and an open one both get named, and the closed one is explained"
   ;;
 *)
-  bad "expected exit 1 naming both '1234 CLOSED' and '1235 OPEN', got exit $rc: $out"
+  bad "expected exit 1 naming both '1234 CLOSED' and '1235 OPEN' and explaining the closed hit, got exit $rc: $out"
   ;;
 esac
 


### PR DESCRIPTION
## What

`scripts/issue-claim.sh check <n>` treated any PR that referenced the
issue as a live claim, so it stood a session down for a PR that was
closed without merging -- the one state where the work is neither done
nor in progress, and where the next session most needs to proceed, not
stop. It also matched only `Closes #N`, so a PR that deliberately used
`Refs #N` (because `dod-check` reads every linked issue's checklist,
and a `Closes` there would hold an unrelated fix to it) was invisible.

## Why

Working #6193, the check stood a session down for #6200 -- closed as
superseded minutes after opening -- while the live carrier, #6203, used
`Refs #6193` on purpose and never showed up at all. The check inverted
twice on one issue.

## The fix

`scripts/issue-claim.sh`'s `gh pr list` query now tags each hit with a
third field, `closes` or `refs`, alongside its number and state. The
verdict:

- a `closes` hit that is OPEN or MERGED still blocks (unchanged).
- a `closes` hit that is CLOSED does not block -- it is reported as a
  dead attempt, and the check proceeds.
- a `refs` hit never blocks -- it is reported as a weaker signal, since
  `Refs` is also how an unrelated PR cites context.
- a mix (e.g. one CLOSED hit and one OPEN hit) still blocks, and both
  are named with their own state.

`AGENTS.md`'s `scripts/issue-claim.sh` paragraph is updated to describe
the split verdict.

## Witness

`scripts/test-issue-claim.sh` adds three cases (plus the fixture
format everywhere else moves from `<number> <state>` to
`<number> <state> <kind>`):

- a closed-unmerged closing PR: exit 0, PR named.
- a closed-unmerged PR alongside an OPEN one: exit 1, both named, each
  with its own state.
- a refs-only PR: exit 0, PR named as a weaker signal.

Verified fail on the pre-fix script by stashing only `scripts/issue-claim.sh`
and re-running the suite against the new tests: 2 of 23 cases red (the
closed-unmerged case and the refs-only case), the rest green. Restoring
the fix turns the suite fully green (23/23).

## Local checks run

- `./scripts/test-issue-claim.sh` -- 23/23 passing.
- `shellcheck scripts/issue-claim.sh scripts/test-issue-claim.sh` -- clean.
- `make guards-fast` -- clean (includes `check-prose`, `check-line-citations`,
  `check-file-size`, `cargo fmt --check`).

Tests deleted: None.

Residue issues filed: None -- this PR is confined to the one script and
its test file, matching the issue's own "no new file" constraint.

Closes #6223

## Summary by Sourcery

Refine issue claim checks so only live closing pull requests stand sessions down while dead attempts and reference-only PRs are reported without blocking.

Bug Fixes:
- Prevent closed-unmerged pull requests from incorrectly blocking issue claims while continuing to block for open or merged closing pull requests.
- Recognize and report Refs-only pull requests as weaker signals without treating them as active claims.

Enhancements:
- Clarify issue-claim guidance and diagnostics for dead closing attempts, active claims, and weaker references.

Documentation:
- Document the updated pull-request claim verdicts in AGENTS.md.

Tests:
- Expand issue-claim coverage for closed-unmerged PRs, mixed closed and open PRs, and Refs-only PRs.