### PR TITLE
fix(scripts): guard-trigger-coverage reads job-level if:, not just triggers

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -123,16 +123,13 @@ jobs:
       # The steps above run here because this trigger carries no `paths:`
       # filter at all -- that is what lets them fire on a scripts-only pull
       # request. Nothing enforced that absence except a comment, so this reads
-      # it back: at least one workflow must run each guard it names with an
-      # unfiltered `pull_request:` trigger, or a future edit narrowing this one
-      # would silently reopen the gap (#5448).
-      #
-      # It does not cover the closing-keywords step above, and adding it to
-      # `WATCHED_GUARDS` would read as protection it cannot give: this guard
-      # reads a workflow's *trigger*, and ci.yml's `pull_request:` trigger
-      # carries no `paths:` key either, so that copy alone would satisfy it
-      # while the job-level `if:` still skipped the guard. #6248 is where that
-      # blind spot is tracked.
+      # it back: at least one workflow must run each guard it names from a
+      # job that neither a `paths:` filter nor a `needs.*.outputs.*`-gated
+      # `if:` can skip, or a future edit narrowing this one would silently
+      # reopen the gap (#5448, #6248). `check-closing-keywords.py` above is
+      # covered by this job's own unconditional invocation even though its
+      # `ci.yml` copy sits inside the `changes`-gated `check` job -- the
+      # guard reads that job condition now, not just the trigger.
       - name: each guard above still runs with no paths filter somewhere
         if: ${{ !cancelled() }}
         run: python3 ./scripts/check-guard-trigger-coverage.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,11 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + gate-parity
                          #   + schema-tier-parity (a -schema step runs at the
                          #     same rung as its base step; #5139)
-                         #   + guard-trigger-coverage (prose, hue-separation
-                         #     and transcript-surfaces each run with no
-                         #     paths: filter in at least one workflow)
+                         #   + guard-trigger-coverage (prose, hue-separation,
+                         #     transcript-surfaces and closing-keywords each
+                         #     run, in some workflow, from a job neither a
+                         #     paths: filter nor a needs.*.outputs.*-gated
+                         #     if: can skip)
                          #   + priority-scheme (the issue priority scheme is
                          #     stated once, in SCR-005, and the triage guard's
                          #     regex covers exactly the levels it names)
@@ -209,12 +211,19 @@ says nothing about which files reach it, so a `paths:` filter narrowing
 `guard-self-tests.yml`'s `pull_request:` trigger to `docs/**` would still read
 as green, and the three steps would run nowhere for a scripts-only pull
 request. Nothing held that absence in place except a comment.
-`guard-trigger-coverage` reads the trigger back: each of the three must run
-with no `paths:`/`paths-ignore:` filter in at least one workflow, so a later
-edit narrowing this one cannot reopen the gap silently. That workflow's
-`gate-steps` job — named `gate steps no other workflow runs` — is now one of
-`main`'s required status checks too,
-added after a red run of it merged into `main` and reddened every open PR.
+`guard-trigger-coverage` reads the trigger back: each watched guard must run,
+in some workflow, from a job with no `paths:`/`paths-ignore:` filter above it
+and no `if:` of its own that reads a `needs.*.outputs.*` value — the second
+half added once a guard reached `ci.yml`'s `check` job, whose own
+`if: needs.changes.outputs.rust != 'false'` skips it for a prose-only diff
+even though `ci.yml`'s trigger carries no `paths:` key at all, because that
+filter moved out of the trigger and into the job so the required contexts
+still report for a skipped job. So a later edit narrowing the trigger, or
+moving a guard into a job gated that way, cannot reopen the gap silently.
+That workflow's `gate-steps` job — named `gate
+steps no other workflow runs` — is now one of `main`'s required status
+checks too, added after a red run of it merged into `main` and reddened
+every open PR.
 
 A fifth workflow, `deck-fit.yml`, owns the decks under
 `website/public/presentations/`. Its measurement — every slide against the

--- a/scripts/check-guard-trigger-coverage.py
+++ b/scripts/check-guard-trigger-coverage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Guard: the three steps `ci.yml`'s required job cannot reach for a
-scripts-only diff still run on one, somewhere.
+"""Guard: the steps `ci.yml`'s required job cannot reach for some diffs
+still run on one, somewhere.
 
 `ci.yml`'s required job skips `prose`, `hue-separation`, and
 `transcript-surfaces` for a diff confined to Rust, scripts, or any path
@@ -8,31 +8,46 @@ outside its own prose carve-out (AGENTS.md names the skip). Today
 `guard-self-tests.yml` runs all three with no `paths:` filter at all, so
 they fire on every pull request no matter which files changed. Nothing kept
 that true except a comment: a future edit could add a `paths:` filter to
-that trigger, or narrow it to `docs/**`, and the three steps would go back to
+that trigger, or narrow it to `docs/**`, and those steps would go back to
 running nowhere for a scripts-only pull request, quietly, because
 `gate-parity` only asks whether a step runs in some workflow, never whether
 that workflow's trigger reaches the files the step reads.
 
-So this checks the trigger, not just the step. For each guard script named
-below, it scans every workflow's `run:` lines for an invocation, then reads
-that workflow's `pull_request:` trigger for a `paths:` or `paths-ignore:`
-key. A guard passes when **at least one** workflow runs it with neither key
-present under `pull_request:` — `hue-separation` runs a second, path-filtered
-copy in `docs-guards.yml` too, and that copy does not have to be
-unconditional for the guard to be satisfied, because the unconditional copy
-in `guard-self-tests.yml` already is.
+So this checks the trigger, not just the step — and not the trigger alone
+either. A job can be skipped for reasons its workflow's trigger never shows:
+`ci.yml`'s `check` job carries `if: needs.changes.outputs.rust != 'false'`,
+reading an output a `changes` job set from the diff, so a step inside it can
+still run nowhere for a prose-only pull request even though `ci.yml`'s own
+`pull_request:` trigger has no `paths:` key at all — that filter moved out of
+the trigger and into the job condition so the required contexts keep
+reporting for a job GitHub skips rather than fails. A guard whose only
+invocation sits in a job gated that way is exactly as uncovered as one
+sitting behind a `paths:` filter — the check has to read both.
 
-Only `pull_request:` is read. `merge_group` triggers admit no `paths:` key at
-all on GitHub Actions, and a `push:` trigger fires after the merge decision
-is already made, so it cannot be what blocks a red result from landing.
+For each guard script named below, this scans every workflow's jobs for an
+invocation, then asks, for the job it sits in: does the workflow's
+`pull_request:` trigger carry a `paths:`/`paths-ignore:` key, and does the
+job's own `if:` read a `needs.*.outputs.*` value? A guard passes when **at
+least one** workflow runs it from a job that neither gate touches —
+`hue-separation` runs a second, path-filtered copy in `docs-guards.yml`, and
+a third inside `ci.yml`'s gated `check` job, and neither has to be
+unconditional for the guard to be satisfied, because the unconditional copy
+in `guard-self-tests.yml`'s `gate-steps` job already is.
+
+Only `pull_request:` is read for the trigger half. `merge_group` triggers
+admit no `paths:` key at all on GitHub Actions, and a `push:` trigger fires
+after the merge decision is already made, so it cannot be what blocks a red
+result from landing.
 
 The YAML reading here is line-based and only correct for the shapes this
 repository's own workflow files use — a mapping `on:` block with each event
 as its own key, or the rare bare scalar/list form that cannot carry a
-`paths:` key in the first place. It is not a general YAML parser, and does
-not try to be one: `scripts/test-guard-trigger-coverage.py` builds a fixture
-workflow in each of those two shapes and runs this guard against it, so
-neither reading is left to a claim in this docstring.
+`paths:` key in the first place; a job-level `if:` read as the one line
+sitting at the job body's own indentation, never a step's. It is not a
+general YAML parser, and does not try to be one:
+`scripts/test-guard-trigger-coverage.py` builds a fixture workflow in each
+of those shapes and runs this guard against it, so no reading is left to a
+claim in this docstring.
 """
 
 from __future__ import annotations
@@ -41,13 +56,14 @@ import re
 import sys
 from pathlib import Path
 
-# The three steps AGENTS.md names as the ones `ci.yml`'s required job
-# structurally cannot run for a prose-only diff. A guard added to that set
-# later joins this list in the same change that documents it there.
+# Steps `ci.yml`'s required job cannot run for a prose-only diff, plus any
+# other guard this check now watches. Add a new guard here and in AGENTS.md
+# in the same change.
 WATCHED_GUARDS = (
     "check-prose.py",
     "check-hue-separation.py",
     "check-transcript-surfaces.py",
+    "check-closing-keywords.py",
 )
 
 WORKFLOWS_DIR = "workflows"
@@ -178,6 +194,101 @@ def pull_request_is_unconditional(lines: list[str]) -> bool | None:
     return None
 
 
+def parse_jobs(lines: list[str]) -> dict[str, list[str]]:
+    """Every job in this workflow's `jobs:` block, mapped to its own lines.
+
+    Splits the block the same way `top_level_block` splits the whole file:
+    the first non-blank, non-comment line under `jobs:` fixes the column
+    every job name sits at, and each job's lines run until the next name at
+    that same column.
+    """
+    found, jobs_block, _ = top_level_block(lines, "jobs")
+    if not found:
+        return {}
+    job_indent: int | None = None
+    for raw in jobs_block:
+        line = raw.rstrip("\n")
+        if _is_blank_or_comment(line):
+            continue
+        job_indent = _indent(line)
+        break
+    if job_indent is None:
+        return {}
+    jobs: dict[str, list[str]] = {}
+    name: str | None = None
+    body: list[str] = []
+    for raw in jobs_block:
+        line = raw.rstrip("\n")
+        if not _is_blank_or_comment(line) and _indent(line) == job_indent:
+            if name is not None:
+                jobs[name] = body
+            m = re.match(r"^[ \t]*([A-Za-z0-9_.-]+):", line)
+            name = m.group(1) if m else None
+            body = []
+            continue
+        if name is not None:
+            body.append(raw)
+    if name is not None:
+        jobs[name] = body
+    return jobs
+
+
+def job_if_expression(job_lines: list[str]) -> str | None:
+    """This job's own `if:` value, or `None`.
+
+    Only a line at the job body's own first indentation counts. A `steps:`
+    list sits at that same column, but each step lives one or more levels
+    deeper as a list item, so a step's `if:` is never read as the job's.
+    """
+    body_indent: int | None = None
+    for raw in job_lines:
+        line = raw.rstrip("\n")
+        if _is_blank_or_comment(line):
+            continue
+        body_indent = _indent(line)
+        break
+    if body_indent is None:
+        return None
+    for raw in job_lines:
+        line = raw.rstrip("\n")
+        if _is_blank_or_comment(line) or _indent(line) != body_indent:
+            continue
+        m = re.match(r"^if:[ \t]*(.*)$", line.strip())
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+# This is the shape `ci.yml`'s `check` job uses. That job runs only when an
+# earlier `changes` job says the diff touches its area, e.g.
+# `if: needs.changes.outputs.rust != 'false'`. A step in that job is not
+# unconditional just because the trigger has no `paths:` key. The job can
+# still skip itself for a diff outside its area.
+_DIFF_GATE_RE = re.compile(r"needs\.[A-Za-z0-9_-]+\.outputs\.[A-Za-z0-9_-]+")
+
+
+def job_diff_gate(job_lines: list[str]) -> str | None:
+    """This job's own `if:` text, when it reads a `needs.*.outputs.*` value.
+
+    `None` when the job has no `if:`, or one that cannot vary with which
+    files a diff touches (`github.event_name == 'pull_request'`, say).
+    """
+    expr = job_if_expression(job_lines)
+    if expr and _DIFF_GATE_RE.search(expr):
+        return expr
+    return None
+
+
+# guard -> list of (workflow name, job name, status, gate expression).
+# status is one of:
+#   "ok"     -- unfiltered trigger, job not diff-gated: this covers it.
+#   "paths"  -- the trigger itself carries paths:/paths-ignore:.
+#   "gated"  -- the trigger is unfiltered, but the job's own `if:` reads a
+#               needs.*.outputs.* value. See the shape above.
+#   "no_pr"  -- the workflow never triggers on pull_request at all.
+Runner = tuple[str, str, str, str | None]
+
+
 def main(argv: list[str]) -> int:
     # `--manifest-dir DIR` points the whole check at a fixture tree instead of
     # the real repository, the same convention `check-file-size.sh` and
@@ -193,18 +304,25 @@ def main(argv: list[str]) -> int:
         )
         return 1
 
-    # guard -> list of (workflow name, unconditional | None)
-    coverage: dict[str, list[tuple[str, bool | None]]] = {g: [] for g in WATCHED_GUARDS}
+    coverage: dict[str, list[Runner]] = {g: [] for g in WATCHED_GUARDS}
 
     for wf_path in sorted(workflows_dir.glob("*.yml")):
         lines = wf_path.read_text(encoding="utf-8").splitlines(keepends=True)
-        commands = extract_run_commands(lines)
-        guards_here = [g for g in WATCHED_GUARDS if any(g in cmd for cmd in commands)]
-        if not guards_here:
-            continue
-        unconditional = pull_request_is_unconditional(lines)
-        for g in guards_here:
-            coverage[g].append((wf_path.name, unconditional))
+        trigger_unconditional = pull_request_is_unconditional(lines)
+        for job_name, job_lines in parse_jobs(lines).items():
+            commands = extract_run_commands(job_lines)
+            guards_here = [g for g in WATCHED_GUARDS if any(g in cmd for cmd in commands)]
+            if not guards_here:
+                continue
+            if trigger_unconditional is None:
+                status, gate = "no_pr", None
+            elif trigger_unconditional is False:
+                status, gate = "paths", None
+            else:
+                gate = job_diff_gate(job_lines)
+                status = "gated" if gate else "ok"
+            for g in guards_here:
+                coverage[g].append((wf_path.name, job_name, status, gate))
 
     fail = False
     lines_out: list[str] = []
@@ -214,15 +332,20 @@ def main(argv: list[str]) -> int:
             fail = True
             lines_out.append(f"  {guard}: no workflow runs it at all.")
             continue
-        if any(ok is True for _name, ok in runners):
+        if any(status == "ok" for _wf, _job, status, _gate in runners):
             continue
         fail = True
-        detail = ", ".join(
-            f"{name} ({'no pull_request trigger' if u is None else 'paths-restricted'})"
-            for name, u in runners
-        )
+        parts = []
+        for wf, job, status, gate in runners:
+            if status == "no_pr":
+                parts.append(f"{wf} (no pull_request trigger)")
+            elif status == "paths":
+                parts.append(f"{wf} (paths-restricted)")
+            else:  # "gated"
+                parts.append(f"{wf}:{job} (job `{job}` skipped when `if: {gate}` is false)")
+        detail = ", ".join(parts)
         lines_out.append(
-            f"  {guard}: every workflow that runs it restricts pull_request by path: {detail}."
+            f"  {guard}: every invocation is filtered or conditionally skipped: {detail}."
         )
 
     if fail:
@@ -230,8 +353,9 @@ def main(argv: list[str]) -> int:
         for line in lines_out:
             print(line)
         print(
-            "  Add or restore an unfiltered `pull_request:` trigger in the workflow that "
-            "runs the guard, so it fires on every pull request regardless of which paths changed."
+            "  Add or restore an invocation that runs from an unfiltered `pull_request:` "
+            "trigger, in a job whose own `if:` cannot read a `needs.*.outputs.*` value, so "
+            "the guard fires on every pull request regardless of which paths changed."
         )
         return 1
 

--- a/scripts/test-guard-trigger-coverage.py
+++ b/scripts/test-guard-trigger-coverage.py
@@ -10,6 +10,7 @@ repository. Not part of `make gate`; run it with
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 import tempfile
@@ -17,6 +18,15 @@ from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 GUARD = HERE / "check-guard-trigger-coverage.py"
+
+# Import the guard as a module. Do not copy its watched-guard list here.
+# A fixture for "every guard but this one" then tracks `WATCHED_GUARDS` on
+# its own. Adding a fifth guard must not break every old fixture.
+_spec = importlib.util.spec_from_file_location("check_guard_trigger_coverage", GUARD)
+assert _spec is not None and _spec.loader is not None
+_guard_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_guard_module)
+WATCHED_GUARDS: tuple[str, ...] = _guard_module.WATCHED_GUARDS
 
 pass_count = 0
 fail_count = 0
@@ -34,6 +44,26 @@ def workflow(pull_request_body: str, run_line: str) -> str:
         "      - name: a step\n"
         f"        run: {run_line}\n"
     )
+
+
+def other_guard_steps(primary: str) -> str:
+    """Extra `run:` steps invoking every watched guard except `primary`.
+
+    A fixture that only wants to exercise `primary`'s own condition must
+    still give every other watched guard *some* unconditional invocation,
+    or it fails for the unrelated reason that a guard added later has no
+    invocation anywhere in the fixture at all.
+    """
+    return "".join(
+        f"      - name: {g}\n        run: python3 ./scripts/{g}\n"
+        for g in WATCHED_GUARDS
+        if g != primary
+    )
+
+
+def all_guard_steps() -> str:
+    """One `run:` step per watched guard, in declaration order."""
+    return "".join(f"      - name: {g}\n        run: python3 ./scripts/{g}\n" for g in WATCHED_GUARDS)
 
 
 def fixture(name: str, workflows: dict[str, str]) -> Path:
@@ -69,14 +99,13 @@ def expect(name: str, root: Path, want_rc: int, needle: str = "") -> None:
     pass_count += 1
 
 
-# ── T1  an unfiltered trigger for all three watched guards passes. ──────────
+# ── T1  an unfiltered trigger for every watched guard passes. ───────────────
 root = fixture(
     "unfiltered",
     {
         "guards.yml": (
             workflow("\n  merge_group:", "python3 ./scripts/check-prose.py")
-            + "      - name: hue\n        run: python3 ./scripts/check-hue-separation.py\n"
-            + "      - name: transcript\n        run: python3 ./scripts/check-transcript-surfaces.py\n"
+            + other_guard_steps("check-prose.py")
         )
     },
 )
@@ -97,7 +126,7 @@ expect(
     "T2 a paths: filter on the only runner fails",
     root,
     1,
-    "check-prose.py: every workflow that runs it restricts",
+    "check-prose.py: every invocation is filtered or conditionally skipped:",
 )
 
 # ── T3  paths-ignore: is caught the same way. ────────────────────────────────
@@ -115,7 +144,7 @@ expect(
     "T3 a paths-ignore: filter on the only runner fails",
     root,
     1,
-    "check-prose.py: every workflow that runs it restricts",
+    "check-prose.py: every invocation is filtered or conditionally skipped:",
 )
 
 # ── T4  one filtered copy plus one unfiltered copy still passes. ────────────
@@ -127,8 +156,7 @@ root = fixture(
         ),
         "unfiltered.yml": (
             workflow("\n  merge_group:", "python3 ./scripts/check-hue-separation.py")
-            + "      - name: prose\n        run: python3 ./scripts/check-prose.py\n"
-            + "      - name: transcript\n        run: python3 ./scripts/check-transcript-surfaces.py\n"
+            + other_guard_steps("check-hue-separation.py")
         ),
     },
 )
@@ -146,10 +174,7 @@ root = fixture(
             "jobs:\n"
             "  guards:\n"
             "    runs-on: ubuntu-latest\n"
-            "    steps:\n"
-            "      - name: prose\n        run: python3 ./scripts/check-prose.py\n"
-            "      - name: hue\n        run: python3 ./scripts/check-hue-separation.py\n"
-            "      - name: transcript\n        run: python3 ./scripts/check-transcript-surfaces.py\n"
+            "    steps:\n" + all_guard_steps()
         )
     },
 )
@@ -220,14 +245,67 @@ root = fixture(
             "jobs:\n"
             "  guards:\n"
             "    runs-on: ubuntu-latest\n"
-            "    steps:\n"
-            "      - name: prose\n        run: python3 ./scripts/check-prose.py\n"
-            "      - name: hue\n        run: python3 ./scripts/check-hue-separation.py\n"
-            "      - name: transcript\n        run: python3 ./scripts/check-transcript-surfaces.py\n"
+            "    steps:\n" + all_guard_steps()
         )
     },
 )
 expect("T8 the bare flow form of on: counts as unfiltered coverage", root, 0)
+
+# ── T9  a guard reachable only through a gated job fails. ───────────────────
+# This holds even when the trigger has no `paths:` key. It is the shape
+# `ci.yml`'s `check` job uses.
+root = fixture(
+    "job_gated",
+    {
+        "ci.yml": (
+            "name: fixture\n"
+            "on:\n"
+            "  pull_request:\n"
+            "jobs:\n"
+            "  changes:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    outputs:\n"
+            "      rust: ${{ steps.filter.outputs.rust }}\n"
+            "    steps:\n"
+            "      - id: filter\n"
+            '        run: echo "rust=true" >> "$GITHUB_OUTPUT"\n'
+            "  check:\n"
+            "    needs: changes\n"
+            "    if: ${{ !cancelled() && needs.changes.outputs.rust != 'false' }}\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n" + all_guard_steps()
+        )
+    },
+)
+expect(
+    "T9 a guard reachable only through a needs.changes.outputs-gated job fails",
+    root,
+    1,
+    "check-prose.py: every invocation is filtered or conditionally skipped:",
+)
+
+# ── T10  a job if: unrelated to the diff still counts as coverage. ──────────
+# Only a `needs.*.outputs.*` gate is a gap the guard should refuse.
+root = fixture(
+    "job_ungated",
+    {
+        "guards.yml": (
+            "name: fixture\n"
+            "on:\n"
+            "  pull_request:\n"
+            "jobs:\n"
+            "  guards:\n"
+            "    if: ${{ !cancelled() && github.event_name == 'pull_request' }}\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n" + all_guard_steps()
+        )
+    },
+)
+expect(
+    "T10 a job if: unrelated to needs.*.outputs.* still counts as unconditional",
+    root,
+    0,
+)
 
 print()
 print(f"test-guard-trigger-coverage: {pass_count} passed, {fail_count} failed")


### PR DESCRIPTION
## What / why

`scripts/check-guard-trigger-coverage.py` asked only whether a workflow's
`pull_request:` trigger carried a `paths:`/`paths-ignore:` key. It never
looked at whether the *job* a guard's `run:` line sits in can itself skip
the guard.

`ci.yml`'s `check` job carries `if: needs.changes.outputs.rust != 'false'`
(the #1892 shape: the `paths:` filter moved out of the trigger and into a
job condition so the required contexts still report for a skipped job).
`ci.yml`'s own `pull_request:` trigger has no `paths:` key at all, so a
guard whose only invocation sat inside that gated `check` job satisfied the
old check while actually running nowhere for a prose-only diff -- exactly
the failure mode `guard-trigger-coverage` exists to catch. That is why
`check-closing-keywords.py` (added to `ci.yml`'s `check` job and to
`guard-self-tests.yml`'s `gate-steps` job in #6228) was deliberately kept
out of `WATCHED_GUARDS`, with a comment pointing at this issue.

## The fix

`scripts/check-guard-trigger-coverage.py` now:
- Parses each workflow's `jobs:` block (`parse_jobs`) instead of scanning
  the whole file for `run:` lines.
- Reads a job's own `if:` (`job_if_expression`), distinguishing it from a
  step's `if:` by indentation.
- Flags a job as diff-gated (`job_diff_gate`) when its `if:` reads a
  `needs.*.outputs.*` value -- the shape a `changes` job's output-based
  skip uses.
- Reports a guard as covered only when at least one invocation sits in a
  job that neither a `paths:`-filtered trigger nor a diff-gated `if:` can
  skip.

`check-closing-keywords.py` joins `WATCHED_GUARDS`: the check can now tell
its `guard-self-tests.yml` copy (genuinely unconditional -- the `gate-steps`
job carries no job-level `if:` at all) from its `ci.yml` copy (inside the
gated `check` job), so it reports the guard as covered by the first without
being fooled by the second. The stale comment in `guard-self-tests.yml`
deferring to this issue is removed and replaced with a comment explaining
the new coverage.

`AGENTS.md`'s `guard-trigger-coverage` description is updated in both
places (the `make gate` step list and the `guard-self-tests.yml` narrative)
to say what the guard actually reads now.

## Witness

`scripts/test-guard-trigger-coverage.py` gained two fixtures:
- **T9**: a `ci.yml`-shaped fixture with a `changes` job and a `check` job
  gated on `needs.changes.outputs.rust != 'false'`, running all four
  watched guards. Fails on the new code (exit 1, naming the job and its
  `if:`); the pre-fix script reports `OK` (exit 0) against the exact same
  fixture, which is the bug this issue names.
- **T10**: a job whose `if:` references `github.event_name` (not a
  `needs.*.outputs.*` value) still counts as unconditional coverage --
  only a diff-derived gate is a gap.

Checked directly, the artisanal way:
```
$ python3 /tmp/old-check-guard-trigger-coverage.py --manifest-dir <T9 fixture>
check-guard-trigger-coverage: OK -- 3 guard(s) each run unconditionally ...

$ python3 scripts/check-guard-trigger-coverage.py --manifest-dir <T9 fixture>
check-guard-trigger-coverage: FAIL -- a scripts-only pull request would not run:
  check-prose.py: every invocation is filtered or conditionally skipped: ci.yml:check (job `check` skipped when `if: ...needs.changes.outputs.rust != 'false'` is false).
  ...
```

All 10 cases in `scripts/test-guard-trigger-coverage.py` pass; the real
guard against this repository's own `.github/workflows/` still reports
`OK` for all four watched guards (the `ci.yml` copies of `hue-separation`
and `closing-keywords` are now correctly classified as "gated" rather than
"ok", but each still has a genuinely unconditional copy elsewhere, so the
overall result is unchanged for the pre-existing three and newly correct
for the fourth).

Exemplar: this mirrors the existing line-based, `--manifest-dir`-driven
self-test pattern `check-file-size.sh` / `check-lockfile-sync.sh` and this
same script already used for the trigger half.

## Tests deleted

None.

## Residue

None noticed beyond what's already tracked -- no new follow-up filed.

Closes #6248

## Summary by Sourcery

Ensure guard trigger coverage detects invocations that can be skipped by diff-derived job conditions as well as path-filtered pull request triggers.

New Features:
- Extend guard trigger coverage checks to recognize job-level diff-based conditions and include the closing-keywords guard.

Bug Fixes:
- Prevent guards in jobs gated by needs.*.outputs.* conditions from being incorrectly treated as unconditionally covered.

Enhancements:
- Parse workflow jobs and report whether each guard invocation is path-filtered, job-gated, or genuinely unconditional.

Documentation:
- Update guard coverage documentation and workflow comments to describe trigger and job-level filtering checks.

Tests:
- Add fixtures covering diff-gated jobs and unrelated job conditions, while keeping coverage fixtures synchronized with the watched guard list.