### PR TITLE
fix(stella-cli): ask the authorization gate about a plugin lane's seams

### DIFF
--- a/crates/stella-cli/src/plugin_authz.rs
+++ b/crates/stella-cli/src/plugin_authz.rs
@@ -76,6 +76,12 @@
 //! [`AuthzDecision::Allow`] — "this rule has no objection" — and never about a
 //! principal it was not built for. That keeps it composable with the gates a
 //! session already binds: this one can only ever *narrow*.
+//!
+//! # The other half of the plane
+//!
+//! A tool call is one of the two things a plugin holds authority over. The
+//! other is a **lane seam**, and [`lanes`] is where the session's gate is
+//! asked about one.
 
 use std::collections::BTreeMap;
 
@@ -88,6 +94,8 @@ use stella_plugin::{Capability, RiskLevel};
 use stella_protocol::ToolContract;
 
 use crate::plugin_cmd::roster::PluginRoster;
+
+pub(crate) mod lanes;
 
 /// The name every rule in this plane reports itself under.
 const GATE_NAME: &str = "plugin-capability";

--- a/crates/stella-cli/src/plugin_authz/lanes.rs
+++ b/crates/stella-cli/src/plugin_authz/lanes.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The gate's say over what a plugin lane holds
+//! (`doc:turn-lane-assembly` §9.8).
+//!
+//! `granted = requested ∩ authorized` has three answers. This module is the
+//! third one.
+//!
+//! The first is the rung a person took at install
+//! ([`stella_plugin::ConsentedGrade`]). The second is the operator's own
+//! `lanes.custom.<id>.capabilities` ceiling. Both are limits a person
+//! agreed to. Neither is a rule a deployment writes.
+//!
+//! The third is the session's [`AuthzGate`]. It is asked here, as
+//! [`Principal::Plugin`]. That case names this exact caller.
+//!
+//! # Why it lives in `stella-cli`
+//!
+//! [`AuthzGate`] and [`Principal`] belong to `stella-core`.
+//! [`LaneCapability`] belongs to `stella-protocol`. [`LaneGrant`] belongs to
+//! `stella-plugin`. The host is the only place all three are in scope.
+//! [`crate::plugin_authz`] makes the same case for the tool half.
+//!
+//! # It narrows a grant; it cannot build one
+//!
+//! [`narrowed_by_gate`] takes a grant the host already worked out. It can
+//! only take seams away. There is no code path that puts one back. So a gate
+//! that says yes to everything leaves the rung and the ceiling where they
+//! were.
+//!
+//! # A failure refuses
+//!
+//! `Ok(Deny)` is a decision. `Err(AuthzEvalError)` is the lack of one. The
+//! store was down, or a rule would not compile. The seam is withheld either
+//! way. That is the fail-closed rule `stella_core::ports::authz` states in
+//! its own docs.
+//!
+//! [`AuthzDecision::RequireApproval`] withholds too. Nobody is at the
+//! keyboard while a manifest is read. An ask that reaches no one would be a
+//! grant.
+
+use std::collections::BTreeMap;
+
+use stella_core::ports::{AuthzDecision, AuthzGate, LaneSeam, Principal};
+use stella_plugin::LaneGrant;
+use stella_protocol::LaneCapability;
+
+/// A lane grant after the session's gate has had its say.
+///
+/// The grant and the gate's refusals are kept apart. So a report can tell a
+/// seam the rung withheld from a seam the gate withheld. They read the same
+/// in [`LaneGrant::withheld`]. Only the gate's reason is one a plugin author
+/// can act on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GatedLaneGrant {
+    /// The grant, narrowed to what the gate allowed.
+    pub(crate) grant: LaneGrant,
+    /// Each seam the gate took away, and the reason it gave.
+    pub(crate) refused: BTreeMap<LaneCapability, String>,
+}
+
+/// Ask `gate` about every seam `grant` holds. Drop the ones it refuses.
+///
+/// `plugin` is the manifest name. That is the whole of
+/// [`Principal::Plugin`]'s payload. The lane id rides in the [`LaneSeam`]
+/// instead, because one plugin can ship several lanes. A gate that could not
+/// tell them apart would have to answer for the plugin as a whole.
+pub(crate) fn narrowed_by_gate(
+    grant: &LaneGrant,
+    gate: &dyn AuthzGate,
+    plugin: &str,
+) -> GatedLaneGrant {
+    let principal = Principal::Plugin(plugin.to_string());
+    let mut granted = grant.granted.clone();
+    let mut refused = BTreeMap::new();
+
+    for capability in &grant.granted {
+        let seam = LaneSeam::new(grant.lane.clone(), *capability);
+        let reason = match gate.check_lane(&seam, &principal) {
+            Ok(AuthzDecision::Allow) => continue,
+            Ok(AuthzDecision::Deny { reason }) => reason,
+            // No one is here to answer while a manifest is read, so an ask
+            // nobody can settle is a seam nobody granted.
+            Ok(AuthzDecision::RequireApproval { reason }) => {
+                format!("{reason} — and no one is here to answer")
+            }
+            Err(error) => error.to_string(),
+        };
+        granted.remove(capability);
+        refused.insert(*capability, reason);
+    }
+
+    GatedLaneGrant {
+        grant: LaneGrant {
+            lane: grant.lane.clone(),
+            requested: grant.requested.clone(),
+            granted,
+        },
+        refused,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/stella-cli/src/plugin_authz/lanes/tests.rs
+++ b/crates/stella-cli/src/plugin_authz/lanes/tests.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! Tests for [`super::narrowed_by_gate`]. It is the gate's say over what a
+//! plugin lane holds.
+//!
+//! Each test here fails on the old tree. Nothing there asked a gate about a
+//! lane seam. `AuthzGate::check_lane` did not exist to ask.
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+
+use serde_json::Value;
+use stella_core::ports::{
+    AuthzDecision, AuthzEvalError, AuthzGate, LaneSeam, NoAuthz, Principal, RiskCeiling,
+};
+use stella_plugin::{Capability, LaneGrant};
+use stella_protocol::{LaneCapability, LaneId, RiskLevel, ToolContract};
+
+use super::narrowed_by_gate;
+use crate::plugin_authz::{PluginCapabilityGate, PluginGates};
+
+const PLUGIN: &str = "acme";
+const LANE: &str = "acme.replay";
+
+/// The grant the rung and the ceiling already settled. The lane asked for
+/// three seams. It holds two.
+fn resolved_grant() -> LaneGrant {
+    LaneGrant {
+        lane: LaneId::new(LANE),
+        requested: BTreeSet::from([
+            LaneCapability::Bus,
+            LaneCapability::Steering,
+            LaneCapability::Gate,
+        ]),
+        granted: BTreeSet::from([LaneCapability::Bus, LaneCapability::Steering]),
+    }
+}
+
+/// A gate that answers the way a test tells it to. It also writes down what
+/// it was asked. So a witness can check the question, not just the answer.
+struct FixtureGate {
+    answer: fn(&LaneSeam) -> Result<AuthzDecision, AuthzEvalError>,
+    asked: Mutex<Vec<(String, Principal)>>,
+}
+
+impl FixtureGate {
+    fn new(answer: fn(&LaneSeam) -> Result<AuthzDecision, AuthzEvalError>) -> Self {
+        Self {
+            answer,
+            asked: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Every question this gate was put, in order.
+    fn asked(&self) -> Vec<(String, Principal)> {
+        self.asked.lock().expect("no test poisons the lock").clone()
+    }
+}
+
+impl AuthzGate for FixtureGate {
+    fn name(&self) -> &'static str {
+        "fixture"
+    }
+
+    fn check(
+        &self,
+        _contract: &ToolContract,
+        _principal: &Principal,
+        _input: &Value,
+    ) -> Result<AuthzDecision, AuthzEvalError> {
+        Ok(AuthzDecision::Allow)
+    }
+
+    fn check_lane(
+        &self,
+        seam: &LaneSeam,
+        principal: &Principal,
+    ) -> Result<AuthzDecision, AuthzEvalError> {
+        self.asked
+            .lock()
+            .expect("no test poisons the lock")
+            .push((seam.label(), principal.clone()));
+        (self.answer)(seam)
+    }
+}
+
+/// **The witness for the gate's say.** A gate refuses `bus` for this plugin.
+/// The seam drops out of the grant. The ask does not change.
+#[test]
+fn a_gate_that_refuses_a_seam_takes_it_out_of_the_grant() {
+    let gate = FixtureGate::new(|seam| {
+        if seam.capability == LaneCapability::Bus {
+            Ok(AuthzDecision::Deny {
+                reason: "the watching seam is off in this deployment".into(),
+            })
+        } else {
+            Ok(AuthzDecision::Allow)
+        }
+    });
+
+    let gated = narrowed_by_gate(&resolved_grant(), &gate, PLUGIN);
+
+    assert_eq!(
+        gated.grant.granted,
+        BTreeSet::from([LaneCapability::Steering]),
+        "the refused seam is gone and nothing else moved"
+    );
+    assert_eq!(
+        gated.grant.requested,
+        resolved_grant().requested,
+        "what the manifest asked for is kept as written"
+    );
+    assert_eq!(
+        gated.refused.keys().copied().collect::<Vec<_>>(),
+        vec![LaneCapability::Bus],
+        "the gate's refusal is reported apart from the rung's"
+    );
+    assert!(
+        gated.refused[&LaneCapability::Bus].contains("off in this deployment"),
+        "the gate's own reason reaches the report"
+    );
+}
+
+/// **The witness for who is asked about.** The gate is asked as
+/// [`Principal::Plugin`]. The name it carries is the manifest name. The seam
+/// names the lane's own id.
+#[test]
+fn the_gate_is_asked_about_the_plugin_and_the_lane() {
+    let gate = FixtureGate::new(|_| Ok(AuthzDecision::Allow));
+    narrowed_by_gate(&resolved_grant(), &gate, PLUGIN);
+
+    let asked = gate.asked();
+    assert_eq!(asked.len(), 2, "one question per seam the lane holds");
+    for (_, principal) in &asked {
+        assert_eq!(
+            principal,
+            &Principal::Plugin(PLUGIN.to_string()),
+            "a lane seam is asked for as the plugin, never as the host"
+        );
+    }
+    assert_eq!(
+        asked
+            .iter()
+            .map(|(seam, _)| seam.as_str())
+            .collect::<Vec<_>>(),
+        vec!["acme.replay:bus", "acme.replay:steering"],
+        "each question names the lane that asked, and only the seams that \
+         cleared the rung are asked about"
+    );
+}
+
+/// **The witness for the fail-closed rule.** A gate that cannot decide holds
+/// the seam back. It never grants one.
+#[test]
+fn a_gate_that_cannot_evaluate_withholds_the_seam() {
+    let gate = FixtureGate::new(|_| {
+        Err(AuthzEvalError::new(
+            "fixture",
+            "the policy store is unreachable",
+        ))
+    });
+
+    let gated = narrowed_by_gate(&resolved_grant(), &gate, PLUGIN);
+
+    assert!(
+        gated.grant.granted.is_empty(),
+        "no decision is not a yes: {:?}",
+        gated.grant.granted
+    );
+    assert_eq!(
+        gated.grant.withheld(),
+        resolved_grant().requested,
+        "everything asked for is withheld, the rung's own seam included"
+    );
+    assert!(
+        gated.refused[&LaneCapability::Bus].contains("could not evaluate"),
+        "the reason says it could not tell, not that it refused"
+    );
+}
+
+/// An ask nobody can answer is held back too. No one is at the keyboard
+/// while a manifest is read.
+#[test]
+fn an_approval_nobody_can_answer_withholds_the_seam() {
+    let gate = FixtureGate::new(|_| {
+        Ok(AuthzDecision::RequireApproval {
+            reason: "an operator has to allow this lane".into(),
+        })
+    });
+
+    let gated = narrowed_by_gate(&resolved_grant(), &gate, PLUGIN);
+
+    assert!(gated.grant.granted.is_empty());
+    assert!(
+        gated.refused[&LaneCapability::Steering].contains("no one is here to answer"),
+        "the report says why the ask could not be put to anyone"
+    );
+}
+
+/// **The witness for "the gate can only narrow".** A gate says yes to
+/// everything. It still cannot hand back a seam the rung held back.
+#[test]
+fn a_permissive_gate_cannot_widen_the_grant() {
+    let ceiling = RiskCeiling::new(RiskLevel::Destructive);
+    let gates: [&dyn AuthzGate; 2] = [&NoAuthz, &ceiling];
+
+    for gate in gates {
+        let gated = narrowed_by_gate(&resolved_grant(), gate, PLUGIN);
+
+        assert_eq!(
+            gated.grant,
+            resolved_grant(),
+            "a gate with no opinion about lane seams leaves the grant alone"
+        );
+        assert!(gated.refused.is_empty());
+        assert!(
+            gated.grant.withheld().contains(&LaneCapability::Gate),
+            "the seam the rung withheld stays withheld"
+        );
+    }
+}
+
+/// The gate this host really binds keeps the default too. So a workspace
+/// with plugins reports what it always did.
+#[test]
+fn a_tool_rule_has_no_opinion_about_a_lane_seam() {
+    let installed = PluginGates {
+        rules: vec![PluginCapabilityGate::accepted(
+            PLUGIN,
+            &[Capability {
+                tool: "bash".into(),
+                risk: RiskLevel::High,
+                purpose: "runs the lane".into(),
+                scope: Vec::new(),
+            }],
+        )],
+    };
+
+    let gated = narrowed_by_gate(&resolved_grant(), &installed, PLUGIN);
+
+    assert_eq!(
+        gated.grant,
+        resolved_grant(),
+        "a rule built from a tool list does not answer for a seam"
+    );
+    assert!(gated.refused.is_empty());
+}

--- a/crates/stella-cli/src/plugin_cmd/doctor.rs
+++ b/crates/stella-cli/src/plugin_cmd/doctor.rs
@@ -16,15 +16,25 @@
 //!
 //! # It reports; it changes nothing
 //!
-//! Every line comes from the manifests on disk and from the merged settings.
-//! Nothing is written. No process starts. No grant moves.
+//! Every line comes from the manifests on disk, from the merged settings, and
+//! from the gate this session would bind. Nothing is written. No process
+//! starts. No grant moves.
+//!
+//! # Three authorities, reported apart
+//!
+//! A seam has to clear three things. The rung a person took at install. The
+//! operator's `lanes.custom` ceiling. The session's [`AuthzGate`]. Each one
+//! can only take a seam away. The report names which one did. Only the
+//! gate's reason is one a plugin author can act on.
 
 use std::path::Path;
 
+use stella_core::ports::AuthzGate;
 use stella_plugin::{ConsentedGrade, LaneAuthority, PluginManifest};
 use stella_protocol::{LaneCapability, LaneId};
 
 use super::roster::PluginRoster;
+use crate::plugin_authz::lanes::narrowed_by_gate;
 use crate::settings::{LaneCeiling, LaneSettings, Settings};
 
 /// What a lane may hold on this machine: the rung a person accepted at
@@ -69,8 +79,12 @@ pub(super) fn doctor(workspace_root: &Path, settings: &Settings) -> Result<(), S
         println!("no plugins installed — add one with `stella plugin install <dir>`");
         return Ok(());
     }
+    // The same gate a session binds, read once here: `check_lane` is pure over
+    // what it prefetched, so the roster read happens now and the report asks a
+    // value.
+    let gate = crate::agent::tool_stack::session_gate(workspace_root);
     for plugin in roster.plugins() {
-        for line in lane_lines(&plugin.manifest, settings.lanes.as_ref()) {
+        for line in lane_lines(&plugin.manifest, settings.lanes.as_ref(), gate.as_ref()) {
             println!("{line}");
         }
     }
@@ -81,7 +95,11 @@ pub(super) fn doctor(workspace_root: &Path, settings: &Settings) -> Result<(), S
 ///
 /// Pure, and kept apart from the printing. What it says is what a test needs
 /// to read. A function that also opened directories could not have one.
-fn lane_lines(manifest: &PluginManifest, ceilings: Option<&LaneSettings>) -> Vec<String> {
+fn lane_lines(
+    manifest: &PluginManifest,
+    ceilings: Option<&LaneSettings>,
+    gate: &dyn AuthzGate,
+) -> Vec<String> {
     let mut lines = vec![manifest.name.clone()];
     let lanes = match manifest.declared_lanes() {
         Ok(lanes) => lanes,
@@ -103,7 +121,9 @@ fn lane_lines(manifest: &PluginManifest, ceilings: Option<&LaneSettings>) -> Vec
     for lane in lanes {
         let ceiling = ceilings.and_then(|settings| settings.ceiling(lane.id()));
         let authority = HostLaneAuthority { grade, ceiling };
-        let grant = lane.grant(&authority);
+        let consented = lane.grant(&authority);
+        let gated = narrowed_by_gate(&consented, gate, &manifest.name);
+        let grant = &gated.grant;
 
         lines.push(format!(
             "  lane `{}` — {}, resumed by {}",
@@ -114,13 +134,27 @@ fn lane_lines(manifest: &PluginManifest, ceilings: Option<&LaneSettings>) -> Vec
         lines.push(format!("    asks for: {}", say(grant.requested.iter())));
         lines.push(format!("    holds:    {}", say(grant.granted.iter())));
 
-        let withheld = grant.withheld();
+        let withheld: Vec<LaneCapability> = grant
+            .withheld()
+            .into_iter()
+            .filter(|capability| !gated.refused.contains_key(capability))
+            .collect();
         if !withheld.is_empty() {
             lines.push(format!(
                 "    withheld: {} — above the `{}` rung accepted at install, or \
                  outside this workspace's `lanes.custom` ceiling",
                 say(withheld.iter()),
                 manifest.loop_grant.participation
+            ));
+        }
+
+        // A gate's refusal is not the rung being too low. It is a rule an
+        // operator wrote. Its reason is the one part of the report a plugin
+        // author can act on.
+        for (capability, reason) in &gated.refused {
+            lines.push(format!(
+                "    refused:  {capability} — `{}` says: {reason}",
+                gate.name()
             ));
         }
 
@@ -162,7 +196,9 @@ fn say<'a>(capabilities: impl Iterator<Item = &'a LaneCapability>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use stella_core::ports::{AuthzDecision, AuthzEvalError, LaneSeam, NoAuthz, Principal};
     use stella_plugin::Participation;
+    use stella_protocol::ToolContract;
 
     const REPLAY: &str = r#"
         name = "acme"
@@ -181,9 +217,45 @@ mod tests {
     }
 
     fn report(text: &str, settings: &str) -> String {
+        report_under(text, settings, &NoAuthz)
+    }
+
+    /// The same report, under a gate a test supplies.
+    fn report_under(text: &str, settings: &str, gate: &dyn AuthzGate) -> String {
         let ceilings: LaneSettings =
             serde_json::from_str(settings).expect("the lane settings parse");
-        lane_lines(&manifest(text), Some(&ceilings)).join("\n")
+        lane_lines(&manifest(text), Some(&ceilings), gate).join("\n")
+    }
+
+    /// A gate that refuses the watching seam and allows the rest.
+    struct NoBus;
+
+    impl AuthzGate for NoBus {
+        fn name(&self) -> &'static str {
+            "no-bus"
+        }
+
+        fn check(
+            &self,
+            _contract: &ToolContract,
+            _principal: &Principal,
+            _input: &serde_json::Value,
+        ) -> Result<AuthzDecision, AuthzEvalError> {
+            Ok(AuthzDecision::Allow)
+        }
+
+        fn check_lane(
+            &self,
+            seam: &LaneSeam,
+            principal: &Principal,
+        ) -> Result<AuthzDecision, AuthzEvalError> {
+            if seam.capability == LaneCapability::Bus {
+                return Ok(AuthzDecision::Deny {
+                    reason: format!("{} may not watch the bus", principal.label()),
+                });
+            }
+            Ok(AuthzDecision::Allow)
+        }
     }
 
     /// **The witness for the report.** A seam nobody answered for is named.
@@ -257,7 +329,7 @@ mod tests {
     /// "the command found nothing".
     #[test]
     fn a_plugin_with_no_lane_says_so() {
-        let printed = lane_lines(&manifest("name = \"acme\"\n"), None).join("\n");
+        let printed = lane_lines(&manifest("name = \"acme\"\n"), None, &NoAuthz).join("\n");
         assert!(printed.contains("ships no lane of its own"), "{printed}");
     }
 
@@ -299,5 +371,35 @@ mod tests {
         let grant = lane.grant(&authority);
         assert_eq!(grant.withheld().len(), 1);
         assert!(grant.withheld().contains(&LaneCapability::Steering));
+    }
+
+    /// **The witness for the gate's line.** A seam the gate refused is
+    /// reported as refused. The gate's own name and reason go with it. The
+    /// old report had no third authority to name.
+    #[test]
+    fn a_seam_the_gate_refuses_is_reported_as_refused() {
+        let printed = report_under(REPLAY, "{}", &NoBus);
+        assert!(printed.contains("holds:    steering"), "{printed}");
+        assert!(
+            printed.contains("refused:  bus — `no-bus` says: plugin:acme may not watch the bus"),
+            "{printed}"
+        );
+        assert!(
+            !printed.contains("withheld: bus"),
+            "a seam the gate refused is not blamed on the rung: {printed}"
+        );
+    }
+
+    /// A gate that keeps the default `check_lane` leaves the report exactly
+    /// where it was, so a deployment whose gate governs only tool calls reads
+    /// what it always read.
+    #[test]
+    fn a_gate_with_no_lane_opinion_changes_no_line() {
+        let tool_only = stella_core::ports::RiskCeiling::new(stella_protocol::RiskLevel::Low);
+        assert_eq!(
+            report_under(REPLAY, "{}", &NoAuthz),
+            report_under(REPLAY, "{}", &tool_only)
+        );
+        assert!(!report(REPLAY, "{}").contains("refused:"));
     }
 }

--- a/crates/stella-cli/src/settings/lanes.rs
+++ b/crates/stella-cli/src/settings/lanes.rs
@@ -3,10 +3,11 @@
 //!
 //! A manifest **asks** for the turn-loop seams its lane wants. The host
 //! decides what it holds: `granted = requested ∩ authorized`. The rung a
-//! person accepted at install is one half of what is authorized, and
-//! `stella-plugin` reads that half on its own. This block is the other: it is
-//! where an operator writes the seams a lane may hold on this machine or in
-//! this workspace.
+//! person accepted at install is one third of what is authorized, and
+//! `stella-plugin` reads that third on its own. This block is the second: it
+//! is where an operator writes the seams a lane may hold on this machine or in
+//! this workspace. The session's `AuthzGate` is the third
+//! (`crate::plugin_authz::lanes`, §9.8), and it is asked after both.
 //!
 //! # Why it nests under a named key
 //!

--- a/crates/stella-core/src/ports.rs
+++ b/crates/stella-core/src/ports.rs
@@ -10,7 +10,7 @@ use stella_protocol::{Provider, ToolOutput, ToolSchema};
 
 pub use authz::{
     AuthzContribution, AuthzDecision, AuthzEvalError, AuthzEvaluation, AuthzGate, AuthzRuleTrace,
-    AuthzTrace, NoAuthz, Principal, RiskCeiling,
+    AuthzTrace, LaneSeam, NoAuthz, Principal, RiskCeiling,
 };
 
 /// Executes one tool call. Implemented by `stella-tools::ToolRegistry` (and

--- a/crates/stella-core/src/ports/authz.rs
+++ b/crates/stella-core/src/ports/authz.rs
@@ -47,7 +47,7 @@
 //! would be a second place for the order to be wrong.
 
 use serde_json::Value;
-use stella_protocol::{RiskLevel, ToolContract};
+use stella_protocol::{LaneCapability, LaneId, RiskLevel, ToolContract};
 
 use crate::bus::HookDecision;
 use crate::hooks::decision::{GateVerdict, OperatorPosture, resolve_precedence};
@@ -259,6 +259,46 @@ impl std::fmt::Display for AuthzEvalError {
 
 impl std::error::Error for AuthzEvalError {}
 
+/// One seam of the turn loop, on one lane — what [`AuthzGate::check_lane`] is
+/// asked about.
+///
+/// A lane seam is not a tool call, and this type is what keeps it from having
+/// to pretend to be one. A [`ToolContract`] carries a name the model reads, an
+/// input schema, and a provenance grade; a seam has none of those. Dressing a
+/// seam as a contract would also hand every tool rule an opinion it was never
+/// written to hold: a rule built from an accepted `[[capabilities]]` list
+/// refuses any tool absent from that list, so a seam wearing a tool's clothes
+/// would lose every lane in the tree its every seam.
+///
+/// The lane id and the seam name are both [`stella_protocol`]'s, which is
+/// what keeps this crate unaware that plugins exist: a lane id is a string a
+/// loader validated, and
+/// [`LaneCapability`] is the one table the engine's own seam struct is held to
+/// (`driver::capabilities`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaneSeam {
+    /// The lane asking to hold the seam.
+    pub lane: LaneId,
+    /// The seam, carrying the grade the table gives it.
+    pub capability: LaneCapability,
+}
+
+impl LaneSeam {
+    /// The seam `capability`, on lane `lane`.
+    #[must_use]
+    pub fn new(lane: LaneId, capability: LaneCapability) -> Self {
+        Self { lane, capability }
+    }
+
+    /// A short stable label for audit lines and refusal reasons — never
+    /// parsed, only displayed. An identifier, never content, which is what
+    /// every string on this plane is held to (AGENTS.md #3).
+    #[must_use]
+    pub fn label(&self) -> String {
+        format!("{}:{}", self.lane.as_str(), self.capability.as_str())
+    }
+}
+
 /// The pluggable authorization port: one question, asked once per call,
 /// before the tool runs.
 ///
@@ -302,6 +342,33 @@ pub trait AuthzGate: Send + Sync {
             let trace = AuthzTrace::single(self.name(), &decision);
             AuthzEvaluation { decision, trace }
         })
+    }
+
+    /// Decide whether `principal` may hold `seam`.
+    ///
+    /// The second question, because a lane seam is not a tool call — see
+    /// [`LaneSeam`] for why it is not asked as one. A host asks it once per
+    /// requested seam while it resolves `granted = requested ∩ authorized`,
+    /// after the rung a person accepted at install and after the operator's
+    /// own ceiling. So a gate here can only ever **narrow**: it is asked
+    /// about seams that already cleared both, and its answer can drop one
+    /// and add none.
+    ///
+    /// The default is [`AuthzDecision::Allow`] — *this gate has no opinion
+    /// about lane seams* — the same answer every rule on this plane already
+    /// gives when it is asked about something it was not built for. A gate
+    /// written for tool calls therefore leaves a lane grant where the
+    /// consent rung and the operator ceiling left it, and governing a lane
+    /// is an override somebody types.
+    ///
+    /// `Err` is the absence of a decision and never a soft one, exactly as
+    /// [`Self::check`] has it: the host withholds the seam.
+    fn check_lane(
+        &self,
+        _seam: &LaneSeam,
+        _principal: &Principal,
+    ) -> Result<AuthzDecision, AuthzEvalError> {
+        Ok(AuthzDecision::Allow)
     }
 }
 
@@ -828,5 +895,30 @@ mod tests {
             }
             other => panic!("expected an ask, got {other:?}"),
         }
+    }
+
+    /// **The witness for the second question.** A gate written for
+    /// tool calls answers a lane seam with the default — it has no opinion —
+    /// so binding one cannot cost a lane a seam nobody wrote a rule about.
+    #[test]
+    fn a_gate_written_for_tool_calls_has_no_opinion_about_a_lane_seam() {
+        let seam = LaneSeam::new(
+            stella_protocol::LaneId::new("acme.replay"),
+            LaneCapability::Gate,
+        );
+        let principal = Principal::Plugin("acme".into());
+
+        let ceiling = RiskCeiling::new(RiskLevel::Low);
+        let gates: [&dyn AuthzGate; 2] = [&NoAuthz, &ceiling];
+
+        for gate in gates {
+            assert_eq!(
+                gate.check_lane(&seam, &principal),
+                Ok(AuthzDecision::Allow),
+                "`{}` answered a lane seam it was never asked to govern",
+                gate.name()
+            );
+        }
+        assert_eq!(seam.label(), "acme.replay:gate");
     }
 }

--- a/crates/stella-plugin/README.md
+++ b/crates/stella-plugin/README.md
@@ -217,7 +217,8 @@ before it crosses.
   out of the seam list (`participation_for`) rather than written beside it,
   and `granted = requested ∩ authorized` is kept as two sets so a lane that
   asked for more than it holds still shows the ask. `ConsentedGrade` is the
-  authority this crate can answer on its own; a host with a gate wraps it.
+  authority this crate can answer on its own; a host with a gate narrows the
+  grant afterwards and this crate never learns the gate exists.
 - `src/wrapper.rs` — the `[wrapper]` block: `Wrapper`, `WrapperStage`, the
   **open** `StageName` vocabulary over the closed `HostStage` twelve (#3963 —
   a manifest may contribute a stage under its own word, and the load checks

--- a/crates/stella-plugin/src/lanes.rs
+++ b/crates/stella-plugin/src/lanes.rs
@@ -39,7 +39,9 @@
 //! asked for more than it holds. [`LaneAuthority`] is the second half, and
 //! the answer this crate can give on its own is [`ConsentedGrade`]: a lane
 //! may hold a seam whose risk sits at or under the rung a human accepted at
-//! install. A host with a real gate composes a stricter one on top.
+//! install. A host with a real gate narrows the grant this hands back — it
+//! never widens it, and this crate stays unaware that a gate exists
+//! (`stella_cli::plugin_authz::lanes`, `doc:turn-lane-assembly` §9.8).
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/docs/spec/turn-lane-assembly.md
+++ b/docs/spec/turn-lane-assembly.md
@@ -499,20 +499,15 @@ granted = requested ∩ authorized(principal, capability)
 ```
 
 `requested` comes from the manifest. `authorized` is the authority vocabulary
-of #2716 — `ToolContract` / `AuthzGate` / `Principal` / `RiskLevel`. It has
-**zero code in the tree** (`rg -n "struct ToolContract|trait AuthzGate|enum
-RiskLevel|struct Principal" crates/` → 0 hits, verified in #3246 §2), so it is
-greenfield rather than half-built. It was closed `NOT_PLANNED` as tool-surface
-governance and **reopened on 2026-08-14 as the authority plane plugin lanes
-need** — this section is the mission tie that reopened it.
+of #2716 — `ToolContract` / `AuthzGate` / `Principal` / `RiskLevel`. It had
+**zero code in the tree** when this section was written (verified in #3246
+§2), so it was greenfield rather than half-built. It was closed `NOT_PLANNED`
+as tool-surface governance and **reopened on 2026-08-14 as the authority plane
+plugin lanes need** — this section is the mission tie that reopened it.
 
-So: a plugin lane is designable today, and **safely grantable only after
-#2716**. Until that vocabulary exists, a paid plugin and a hostile one hold
-identical authority over the turn loop, and a `Plugin` row in the lane matrix
-is a record of an intention rather than of a permission. The matrix should
-carry both columns from the start — `requested` and `granted` — so that the
-day #2716 lands, the enforcement point already has a place to write its answer
-instead of needing a schema change.
+The vocabulary landed, the two columns landed, and the gate is now asked about
+the second one. §9.8 is the shape of the question a gate is asked about a
+seam, and it is the answer this section left open.
 
 ### 9.5 The borrow question, and why `stella-serve` already answers it
 
@@ -584,6 +579,64 @@ thing that looks like a style choice and is not:
   `flatten` reads correctly and quietly drops project-scope overrides. That is
   a silent capability drop arriving through the config plane instead of the
   assembly plane, and §3 is a document about how expensive those are to find.
+
+### 9.8 What the gate is asked about a seam — decided
+
+§9.4 left `authorized` as a name with no code behind it. The authority
+vocabulary landed, and so did the split between what a manifest asks for and
+what a host grants. This is the shape of the question that joins them.
+
+`AuthzGate::check` takes a `ToolContract`. A lane seam is not a tool call, so
+one of three things had to happen: dress the seam as a contract, define a
+second port, or give the gate a second question. **The gate got a second
+question.**
+
+```rust
+// stella-core, ports::authz
+pub struct LaneSeam { pub lane: LaneId, pub capability: LaneCapability }
+
+fn check_lane(&self, seam: &LaneSeam, principal: &Principal)
+    -> Result<AuthzDecision, AuthzEvalError> { Ok(AuthzDecision::Allow) }
+```
+
+**Not a fake contract.** A `ToolContract` carries a name the model reads, an
+input schema, and a provenance grade, and a seam has none of them. It would
+also hand every tool rule an opinion nobody wrote: `plugin-capability`
+refuses any tool absent from the list a person accepted at install, so a seam
+wearing a tool's clothes would lose every lane in the tree its every seam,
+on the first run, silently.
+
+**Not a second port.** A host supplies one gate. Two would let a deployment
+implement the tool half and forget the lane half, and nothing would say so.
+
+**The default is `Allow`** — *this gate has no opinion about lane seams*.
+That is the answer every rule on this plane already gives when it is asked
+about something it was not built for, and it is what keeps a deployment whose
+gate governs tool calls reading exactly what it read before.
+
+**Where it is asked.** `stella-cli`'s `plugin_authz::lanes::narrowed_by_gate`,
+beside the tool-side exemplar and for the same reason: `AuthzGate` and
+`Principal` are `stella-core`'s, `LaneCapability` is `stella-protocol`'s,
+`LaneGrant` is `stella-plugin`'s, and the host is the only place all three are
+in scope. `DeclaredLane::grant` is unchanged, so `stella-plugin` never learns
+that `AuthzGate` exists and `stella-core` never learns that plugins do.
+
+**It narrows a grant; it cannot build one.** The function takes the grant the
+consent rung and the operator ceiling already settled and removes from it. So
+"the gate can only narrow" is structural rather than remembered — there is no
+code path that puts a seam back.
+
+**A refusal and a failure both withhold.** `Ok(Deny)` withholds with the
+gate's reason. `Err(AuthzEvalError)` withholds too, which is the fail-closed
+rule `stella_core::ports::authz` states in its own module docs: no decision
+is never a yes. `RequireApproval` withholds as well — nobody is at the
+keyboard while a manifest is read, so an ask that reaches no one would be a
+grant.
+
+**The report keeps the three apart.** `stella plugin doctor` prints a seam the
+rung or the ceiling withheld under `withheld:`, and a seam the gate refused
+under `refused:` with the gate's name and its reason. A plugin author can act
+on the third and on neither of the first two.
 
 ---
 


### PR DESCRIPTION
## What and why

A plugin lane's grant never asked the authorization gate. `granted = requested ∩ authorized` had two answers, and neither was one: `stella_plugin::ConsentedGrade` (the rung a person accepted at install) and `HostLaneAuthority` in `plugin_cmd/doctor.rs` (that rung narrowed by the operator's `lanes.custom.<id>.capabilities` ceiling). Both are limits a person agreed to. A deployment that installs an authorization plane had no say over what a plugin lane holds, even though `Principal::Plugin` names this exact caller and `plugin_authz.rs` already does the same translation for a plugin's tools.

## The shape of the question — the design decision the issue asked for

`AuthzGate::check` takes a `ToolContract`, and a lane seam is not a tool call. The three options the issue named, and why this one:

- **Not a fake `ToolContract`.** `PluginCapabilityGate` denies any tool absent from the accepted `[[capabilities]]` list, so a synthetic `lane:bus` contract would be denied by every plugin gate a session already binds — every lane in the tree would lose every seam on its first run, silently, from a declaration written for a different question.
- **Not a second port.** A host supplies one gate. Two would let a deployment implement the tool half and forget the lane half with nothing to say so.
- **The gate grows a second question**, `stella-core::ports::authz`:

```rust
pub struct LaneSeam { pub lane: LaneId, pub capability: LaneCapability }

fn check_lane(&self, seam: &LaneSeam, principal: &Principal)
    -> Result<AuthzDecision, AuthzEvalError> { Ok(AuthzDecision::Allow) }
```

Both field types are `stella-protocol`'s, which `stella-core` already reads (`driver::capabilities` holds the engine's own seam struct to the same `LaneCapability` table), so no new dependency edge and no plugin awareness in the engine. The default is `Allow` — *this gate has no opinion about lane seams* — the same answer every rule on this plane already gives when asked about something it was not built for, and what keeps `NoAuthz`, `RiskCeiling` and `PluginGates` byte-identical.

Written down in `docs/spec/turn-lane-assembly.md` §9.8, with §9.4's "zero code in the tree" note repointed at the landed vocabulary.

## Where it is asked

`crates/stella-cli/src/plugin_authz/lanes.rs` — beside the exemplar, for the reason `plugin_authz.rs` gives for itself: `AuthzGate`/`Principal` are `stella-core`'s, `LaneCapability` is `stella-protocol`'s, `LaneGrant` is `stella-plugin`'s, and the host is the only place all three are in scope. `DeclaredLane::grant` is untouched, so `stella-plugin` gains no `AuthzGate` or `stella-core` dependency. No new crate. New logic lands in a sibling submodule, not in a god file.

`narrowed_by_gate` takes the grant the host authority already resolved and can only remove from it, so "the gate can only narrow" is structural rather than remembered. `Ok(Deny)` withholds with the gate's reason; `Err(AuthzEvalError)` withholds (the fail-closed rule `ports::authz` states in its own module docs); `RequireApproval` withholds too, because nobody is at the keyboard while a manifest is read and an ask that reaches no one would be a grant.

`stella plugin doctor` binds the session gate (`agent::tool_stack::session_gate`) and prints a gate refusal under `refused:` with the gate's name and reason, apart from the `withheld:` line the rung and the ceiling share — a plugin author can act on the third and on neither of the first two.

## Witness mechanism

Each test fails on `main` **by construction**: `AuthzGate::check_lane` does not exist there, `LaneSeam` does not exist, `narrowed_by_gate` does not exist, and `lane_lines` takes no gate. The file that holds most of them is new, so it cannot compile against the old tree at all.

`cargo test -p stella-cli plugin` (module path `plugin_authz::lanes::tests`):

- `a_gate_that_refuses_a_seam_takes_it_out_of_the_grant` — a fixture gate denies `bus` for `Principal::Plugin("acme")`; the grant loses `bus`, `requested` is unchanged, and the gate's own reason is reported apart from the rung's.
- `the_gate_is_asked_about_the_plugin_and_the_lane` — the fixture records every question: each is `Principal::Plugin("acme")`, and the seams are `acme.replay:bus` / `acme.replay:steering`, so only what cleared the rung is asked about.
- `a_gate_that_cannot_evaluate_withholds_the_seam` — `Err(AuthzEvalError)` withholds everything and the reason says "could not evaluate", not "refused".
- `an_approval_nobody_can_answer_withholds_the_seam`.
- `a_permissive_gate_cannot_widen_the_grant` — `NoAuthz` and `RiskCeiling` leave the grant identical and cannot hand back the seam the rung withheld.
- `a_tool_rule_has_no_opinion_about_a_lane_seam` — a real `PluginGates` built from an accepted `[[capabilities]]` list leaves the grant identical, which is the "byte-identical today" control.
- `plugin_cmd::doctor::tests::a_seam_the_gate_refuses_is_reported_as_refused` and `a_gate_with_no_lane_opinion_changes_no_line`.
- `stella-core`: `ports::authz::tests::a_gate_written_for_tool_calls_has_no_opinion_about_a_lane_seam`.

## Exemplar

`crates/stella-cli/src/plugin_authz.rs` — the tool-side translation this repository already wrote, including its argument for living in the host crate. The defaulted trait method follows `AuthzGate::check_traced`'s own shape: a default that is honest for a gate with nothing extra to say, overridden by a gate that has.

## Tests deleted

None.

## Residue issues filed

None — no defect was found and left unfixed. Two facts a reviewer should know rather than an issue:

- `stella plugin doctor` now reads the roster twice (once for the report, once inside `session_gate`, which loads settings of its own). That is the same gate a session binds rather than a second one built by hand, which is the property worth having; the extra read is two file walks on a report command.
- Nothing else in the tree resolves a plugin lane grant yet — `DeclaredLane::grant` has exactly one caller. When a lane is bound at session start, it goes through `narrowed_by_gate` for the same reason the report does. That wiring is `#3274`'s slice, not a gap this PR opens.

Closes #6242
Refs #6154
Refs #2716
Refs #3274

## Summary by Sourcery

Make plugin lane grants consult the session authorization gate and report its decisions separately from existing consent and operator limits.

New Features:
- Add lane-seam authorization checks to plugin lane grant resolution using the session authorization gate.
- Expose lane-seam authorization through the core authorization interface with plugin and lane context.

Bug Fixes:
- Ensure plugin lane grants honor deployment authorization policies instead of relying only on install consent and operator capability ceilings.
- Fail closed when lane authorization cannot be evaluated or requires unavailable approval.

Enhancements:
- Update plugin diagnostics to distinguish authorization-gate refusals from consent or operator-ceiling withholding.
- Keep lane authorization host-owned so existing plugin and tool authorization gates remain compatible and cannot widen grants.

Documentation:
- Document the lane-seam authorization model and the gate's separate seam-checking question in the turn-lane assembly specification.
- Clarify that plugin lane grants are narrowed by the host authorization gate without adding authorization dependencies to stella-plugin.

Tests:
- Add coverage for lane-seam authorization decisions, principals, fail-closed behavior, approval handling, and the guarantee that gates cannot widen grants.
- Add diagnostic coverage for reporting gate refusals separately from other withheld capabilities and preserving behavior for gates without lane opinions.