### PR TITLE
feat(stella-cli): serve the claim and the three work verbs over the driver channel

### DIFF
--- a/crates/stella-cli/src/driver_plugin.rs
+++ b/crates/stella-cli/src/driver_plugin.rs
@@ -26,11 +26,12 @@
 //!
 //! # What a session does today
 //!
-//! [`capabilities::HostDriverCapabilities`] serves the tracker read and answers
-//! `unsupported` for the rest, so a driver's ask for an unbuilt verb degrades
-//! rather than dying. This module does not paper over that: the refusals are
-//! printed, in the driver's own vocabulary and under the plugin's own name, so
-//! an operator sees exactly which asks this build could not serve and for whom.
+//! [`capabilities::HostDriverCapabilities`] serves the tracker read, the
+//! cooperative claim and the three `work` verbs, and answers `unsupported` for
+//! the rest, so a driver's ask for an unbuilt verb degrades rather than dying.
+//! This module does not paper over the rest: the refusals are printed, in the
+//! driver's own vocabulary and under the plugin's own name, so an operator sees
+//! exactly which asks this build could not serve and for whom.
 //!
 //! Scheduling is absent. One invocation opens one session and
 //! reports what the driver said to do next; who re-opens it after a
@@ -58,6 +59,7 @@ use crate::plugin_cmd::roster::PluginRoster;
 
 pub(crate) mod capabilities;
 pub(crate) mod session_log;
+pub(crate) mod work;
 
 /// An installed driver, bound to the process the host will start.
 ///
@@ -213,11 +215,11 @@ pub(crate) fn bind_installed(
 
 /// [`bind_installed`], with the environment lookup supplied.
 ///
-/// The seam exists for the reason [`stella_plugin::Runtime::child_env`] takes
-/// a lookup rather than reading the environment itself: what the socket
-/// withholds from a child is decided by the *names* a manifest declared, and a
-/// test that had to set `ANTHROPIC_API_KEY` in the test process to prove the
-/// withholding would be mutating global state every other test shares.
+/// The seam is here for the reason [`stella_plugin::Runtime::child_env`] takes
+/// a lookup. What the socket keeps from a child is decided by the *names* a
+/// manifest declared. A test that had to set `ANTHROPIC_API_KEY` in its own
+/// process to prove that would be writing global state every other test
+/// shares.
 fn bind_with(
     roster: &PluginRoster,
     name: &str,

--- a/crates/stella-cli/src/driver_plugin/capabilities.rs
+++ b/crates/stella-cli/src/driver_plugin/capabilities.rs
@@ -16,26 +16,41 @@
 //! That is the point of the two names. What you read at install and what the
 //! loop may do are one thing here.
 //!
-//! # One verb, and the rest say so
+//! # What is served, and what says so
 //!
-//! The host serves `backlog_next`. It reads the queue through
-//! [`IssueProvider`], in the order `self_driving_cmd::ready` folds.
+//! The host serves `backlog_next` — the queue, read through [`IssueProvider`]
+//! in the order `self_driving_cmd::ready` folds — `backlog_claim`, and the
+//! three `work` verbs.
 //!
 //! Each other verb answers [`HostCallRefusal::Unsupported`] and names its
 //! family. That is a stated gap, not a silence. The match below covers every
 //! verb, so a new one is a build error here.
+//!
+//! # An ask carries its own verb's arguments and nobody else's
+//!
+//! [`DriverArgs`] has one member per verb that reads one, and an ask naming
+//! `work_start` while carrying a `backlog_claim` table is two claims about
+//! what the driver wants. [`mismatched_args`] refuses that rather than reading
+//! one and dropping the other — the rule `DriverMessage`'s own envelope
+//! applies to `point` against `call`, one layer in.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
 
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_core::ports::{AuthzDecision, AuthzGate, Principal};
 use stella_plugin::{
-    BacklogEntry, BacklogPage, DriverCall, DriverOk, HostCallFailure, HostCallRefusal,
+    BacklogEntry, BacklogPage, ClaimReport, DriverArgs, DriverCall, DriverOk, HostCallFailure,
+    HostCallRefusal, UnitArgs,
 };
 use stella_protocol::issue::{Issue, IssueProvider};
 use stella_runtime::wrapper::DriverCapabilities;
 use stella_tools::registry::Tool;
 
+use super::work::WorkSlot;
 use crate::plugin_authz::PluginGates;
+use crate::self_driving_cmd::claim::Claim;
 use crate::self_driving_cmd::config::LoopConfig;
 
 /// How many ranked issues one `backlog_next` answer carries.
@@ -61,6 +76,18 @@ pub(crate) struct HostDriverCapabilities {
     /// This workspace's own loop settings: the label names, and the rule that
     /// says which issue is ready.
     config: LoopConfig,
+    /// The workspace this session drives — where a worktree is cut and where
+    /// the lease ledger lives.
+    root: PathBuf,
+    /// The one unit of work this session may hold.
+    work: WorkSlot,
+    /// The lease this session holds while it works a unit.
+    ///
+    /// Held for the length of the session rather than the call, because that
+    /// is what a lease is: dropping it releases the key, so a claim that lived
+    /// only as long as `perform` would be free again before the turn it exists
+    /// to protect had started.
+    lease: Mutex<Option<crate::self_driving_cmd::claim::Lease>>,
 }
 
 impl HostDriverCapabilities {
@@ -70,12 +97,17 @@ impl HostDriverCapabilities {
         gates: Option<PluginGates>,
         issues: Box<dyn IssueProvider>,
         config: LoopConfig,
+        root: PathBuf,
+        work: WorkSlot,
     ) -> Self {
         Self {
             principal: Principal::Plugin(plugin.to_string()),
             gates,
             issues,
             config,
+            root,
+            work,
+            lease: Mutex::new(None),
         }
     }
 
@@ -143,8 +175,166 @@ impl HostDriverCapabilities {
             backlog: Some(BacklogPage {
                 issues: ready.iter().take(BACKLOG_PAGE).map(entry).collect(),
             }),
+            ..DriverOk::default()
         })
     }
+
+    /// The cooperative lease — `backlog_claim`.
+    ///
+    /// Over the `dispatch_claims` table in `.stella/private/fleet.db`, which is
+    /// the same table `stella self-driving drive` claims through, so a driver
+    /// session and a hand-started loop against one clone can see each other.
+    ///
+    /// A ledger that cannot answer is **not** a peer holding the key. It fails
+    /// open, like every other contention probe: `held` is true with no holder
+    /// named, and the reason is in [`Claim::Unavailable`]'s own words — a loop
+    /// meant to run for days cannot treat a local I/O error as somebody else's
+    /// work.
+    ///
+    /// It does not ask [`Self::may_shell`], because nothing here shells out.
+    /// The lease is a row this process writes into the workspace's own ledger,
+    /// so `[driver] calls` is the whole gate on it. Demanding `bash` for a
+    /// local write would be asking a human to grant a power this never uses.
+    fn backlog_claim(&self, unit: &UnitArgs) -> Result<DriverOk, HostCallFailure> {
+        let key = named_unit(unit)?;
+        let taken = crate::self_driving_cmd::claim::acquire(&self.root, key);
+        let report = match taken {
+            Claim::Granted(lease) => {
+                *self
+                    .lease
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(lease);
+                ClaimReport {
+                    issue: key.to_string(),
+                    held: true,
+                    holder: String::new(),
+                }
+            }
+            Claim::HeldBy(who) => ClaimReport {
+                issue: key.to_string(),
+                held: false,
+                holder: who,
+            },
+            Claim::Unavailable => ClaimReport {
+                issue: key.to_string(),
+                held: true,
+                holder: String::new(),
+            },
+        };
+        Ok(DriverOk {
+            claim: Some(report),
+            ..DriverOk::default()
+        })
+    }
+
+    /// One unit of backlog through the turn loop — `work_start`.
+    ///
+    /// The issue is resolved through the port before anything is cut, so a key
+    /// no tracker knows is a refusal rather than an empty worktree. Reading it
+    /// spends the shell the same way [`Self::backlog_next`] does, so it is held
+    /// to the same grant.
+    async fn work_start(&self, unit: &UnitArgs) -> Result<DriverOk, HostCallFailure> {
+        let key = named_unit(unit)?;
+        self.may_shell()?;
+        let issue = self
+            .issues
+            .get(&stella_protocol::issue::IssueKey::from(key))
+            .await
+            .map_err(|error| {
+                HostCallFailure::new(
+                    HostCallRefusal::Failed,
+                    format!("this host could not read issue {key}: {error}"),
+                )
+            })?;
+        let report = self.work.start(&issue).await?;
+        Ok(DriverOk {
+            work: Some(report),
+            ..DriverOk::default()
+        })
+    }
+}
+
+/// The key an ask named, or a refusal that says it named none.
+///
+/// A blank key is refused rather than guessed at. There is exactly one
+/// plausible guess — the top of the queue — and it is the wrong one: what to
+/// work is the driver's decision, and a host that picks for it has taken the
+/// judgement the channel exists to leave with the plugin.
+fn named_unit(unit: &UnitArgs) -> Result<&str, HostCallFailure> {
+    let key = unit.issue.trim();
+    if key.is_empty() {
+        return Err(HostCallFailure::new(
+            HostCallRefusal::Failed,
+            "this ask names no issue, and this host does not choose one for a driver — send the \
+             `key` a `backlog_next` answer gave you",
+        ));
+    }
+    Ok(key)
+}
+
+/// Refuse an ask that carries arguments for a verb that reads none.
+///
+/// A dropped table is a driver believing it said something the host never
+/// heard, which is the failure the message envelope refuses one layer out.
+fn no_args(call: DriverCall, args: Option<&DriverArgs>) -> Result<(), HostCallFailure> {
+    let named = args.map(DriverArgs::tables).unwrap_or_default();
+    if named.is_empty() {
+        return Ok(());
+    }
+    Err(HostCallFailure::new(
+        HostCallRefusal::Failed,
+        format!(
+            "\"{call}\" reads no arguments, and this ask carries the arguments of {}",
+            describe(&named)
+        ),
+    ))
+}
+
+/// The refusal for an ask whose table is not the one its verb reads.
+///
+/// Unreachable behind [`table_for`], which has already established that the
+/// table names this verb and no other. Written as a value rather than an
+/// `expect` because AGENTS.md #5 makes no exception for "I checked earlier".
+fn no_table(call: DriverCall) -> HostCallFailure {
+    HostCallFailure::new(
+        HostCallRefusal::Failed,
+        format!("\"{call}\" reads an argument table of its own name, and this ask carries none"),
+    )
+}
+
+/// The ask's table, once it is established that it names `call` and nothing
+/// else.
+fn table_for(call: DriverCall, args: Option<&DriverArgs>) -> Result<&DriverArgs, HostCallFailure> {
+    let args = args.ok_or_else(|| {
+        HostCallFailure::new(
+            HostCallRefusal::Failed,
+            format!("\"{call}\" reads arguments, and this ask carries none"),
+        )
+    })?;
+    let named = args.tables();
+    if named != vec![call] {
+        return Err(HostCallFailure::new(
+            HostCallRefusal::Failed,
+            format!(
+                "this ask names \"{call}\" and carries the arguments of {}; an ask carries the \
+                 table of the verb it names and nothing else",
+                describe(&named)
+            ),
+        ));
+    }
+    Ok(args)
+}
+
+/// How a mismatched table is named in a refusal.
+fn describe(named: &[DriverCall]) -> String {
+    if named.is_empty() {
+        return "no verb".to_string();
+    }
+    named
+        .iter()
+        .map(|call| format!("\"{call}\""))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// One tracker record, as the channel carries it. No body: [`BacklogEntry`]
@@ -164,16 +354,56 @@ fn entry(issue: &Issue) -> BacklogEntry {
 
 #[async_trait]
 impl DriverCapabilities for HostDriverCapabilities {
-    async fn perform(&self, call: DriverCall) -> Result<DriverOk, HostCallFailure> {
+    async fn perform(
+        &self,
+        call: DriverCall,
+        args: Option<DriverArgs>,
+    ) -> Result<DriverOk, HostCallFailure> {
         match call {
             DriverCall::BacklogNext => self.backlog_next().await,
-            DriverCall::BacklogClaim
-            | DriverCall::BacklogFile
+            DriverCall::BacklogClaim => {
+                let table = table_for(call, args.as_ref())?;
+                let unit = table.backlog_claim.as_ref().ok_or_else(|| no_table(call))?;
+                self.backlog_claim(unit)
+            }
+            DriverCall::WorkStart => {
+                let table = table_for(call, args.as_ref())?;
+                let unit = table.work_start.as_ref().ok_or_else(|| no_table(call))?;
+                self.work_start(unit).await
+            }
+            // No arguments, and none accepted: the session holds one unit, so
+            // there is nothing for a key here to name that the session does not
+            // already know. An ask that sent one would be describing a
+            // different unit from the one this would report on.
+            DriverCall::WorkStatus => {
+                no_args(call, args.as_ref())?;
+                Ok(DriverOk {
+                    work: Some(self.work.status()),
+                    ..DriverOk::default()
+                })
+            }
+            DriverCall::WorkAbandon => {
+                let table = table_for(call, args.as_ref())?;
+                let reason = table
+                    .work_abandon
+                    .as_ref()
+                    .map(|abandon| abandon.reason.trim())
+                    .filter(|reason| !reason.is_empty())
+                    .ok_or_else(|| {
+                        HostCallFailure::new(
+                            HostCallRefusal::Failed,
+                            "abandoning a unit records why, and this ask gives no reason — a \
+                             release with nothing said about it teaches the next cycle nothing",
+                        )
+                    })?;
+                Ok(DriverOk {
+                    work: Some(self.work.abandon(reason).await?),
+                    ..DriverOk::default()
+                })
+            }
+            DriverCall::BacklogFile
             | DriverCall::BacklogClose
             | DriverCall::BacklogLink
-            | DriverCall::WorkStart
-            | DriverCall::WorkStatus
-            | DriverCall::WorkAbandon
             | DriverCall::DeliverOpen
             | DriverCall::DeliverObserve
             | DriverCall::DeliverNext
@@ -186,8 +416,8 @@ impl DriverCapabilities for HostDriverCapabilities {
             | DriverCall::CurateAccept => Err(HostCallFailure::new(
                 HostCallRefusal::Unsupported,
                 format!(
-                    "this host does not perform \"{call}\" yet; the {} capabilities are still \
-                     unbuilt",
+                    "this host does not perform \"{call}\" yet; the rest of the {} family is \
+                     still unbuilt",
                     call.family()
                 ),
             )),

--- a/crates/stella-cli/src/driver_plugin/capabilities.rs
+++ b/crates/stella-cli/src/driver_plugin/capabilities.rs
@@ -30,9 +30,10 @@
 //!
 //! [`DriverArgs`] has one member per verb that reads one, and an ask naming
 //! `work_start` while carrying a `backlog_claim` table is two claims about
-//! what the driver wants. [`mismatched_args`] refuses that rather than reading
-//! one and dropping the other — the rule `DriverMessage`'s own envelope
-//! applies to `point` against `call`, one layer in.
+//! what the driver wants. [`table_for`] refuses that rather than reading one
+//! and dropping the other, and [`no_args`] refuses a table sent to a verb that
+//! reads none — the rule `DriverMessage`'s own envelope applies to `point`
+//! against `call`, one layer in.
 
 use std::path::PathBuf;
 use std::sync::Mutex;

--- a/crates/stella-cli/src/driver_plugin/tests.rs
+++ b/crates/stella-cli/src/driver_plugin/tests.rs
@@ -963,6 +963,15 @@ async fn a_claim_is_granted_when_free_and_names_the_holder_when_it_is_not() {
     assert!(!taken.held, "{taken:?}");
     assert!(taken.holder.contains("peer:9001"), "{taken:?}");
     drop(peer);
+
+    // A claim that names nothing is refused rather than pointed at the top of
+    // the queue: which unit to take is the driver's decision.
+    let blank = host(workspace.path().to_path_buf())
+        .perform(DriverCall::BacklogClaim, claim_on("  "))
+        .await
+        .expect_err("a blank key names no unit");
+    assert_eq!(blank.refusal, HostCallRefusal::Failed);
+    assert!(blank.detail.contains("names no issue"), "{blank}");
 }
 
 /// Working a unit reads the tracker, so it is held to the same grant the read

--- a/crates/stella-cli/src/driver_plugin/tests.rs
+++ b/crates/stella-cli/src/driver_plugin/tests.rs
@@ -12,6 +12,7 @@
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::Mutex;
 
 use stella_plugin::PluginManifest;
 
@@ -265,15 +266,85 @@ fn opening_a_session_spawns_the_resolved_program_and_reports_what_it_was() {
 
 use async_trait::async_trait;
 use stella_core::ports::Principal;
-use stella_plugin::{DriverCall, HostCallRefusal};
+use stella_plugin::{AbandonArgs, DriverArgs, DriverCall, HostCallRefusal, UnitArgs, WorkState};
 use stella_protocol::issue::{
     Issue, IssueClass, IssueDraft, IssueError, IssueKey, IssueLabel, IssueProvider, IssueState,
 };
 use stella_runtime::wrapper::{DriverCapabilities, NoDriverCapabilities};
 
 use super::capabilities::HostDriverCapabilities;
+use super::work::{WorkRunner, WorkSlot};
 use crate::plugin_authz::PluginGates;
 use crate::self_driving_cmd::config::LoopConfig;
+use crate::self_driving_cmd::work::WorkOutcome;
+
+/// A worker that answers from memory, so no test here spends a model call or
+/// cuts a checkout.
+///
+/// The seam is [`WorkRunner`] and nothing below it, so what these tests drive
+/// is the shipping slot, the shipping refusals and the shipping report.
+struct FixtureWorker {
+    /// What one unit comes back as.
+    outcome: WorkOutcome,
+    /// Every path a release was asked for, in order.
+    released: Mutex<Vec<PathBuf>>,
+}
+
+impl FixtureWorker {
+    fn answering(outcome: WorkOutcome) -> Self {
+        Self {
+            outcome,
+            released: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl WorkRunner for FixtureWorker {
+    async fn run(&self, _issue: &Issue) -> Result<WorkOutcome, String> {
+        Ok(self.outcome.clone())
+    }
+
+    async fn release(&self, path: &std::path::Path) -> Result<(), String> {
+        self.released
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(path.to_path_buf());
+        Ok(())
+    }
+}
+
+/// A unit that left a change on a branch.
+fn changed() -> WorkOutcome {
+    WorkOutcome::Changed {
+        branch: "stella/41".into(),
+        path: PathBuf::from("/tmp/self-driving/41"),
+        stat: " 1 file changed, 2 insertions(+)".into(),
+    }
+}
+
+/// The one-issue tracker, one worker, and the slot over it.
+fn capabilities_working(manifest: &str, outcome: WorkOutcome) -> HostDriverCapabilities {
+    let roster = roster(vec![installed(manifest, "/opt/pkgs/selfdriving")]);
+    HostDriverCapabilities::new(
+        "stella-selfdriving",
+        PluginGates::from_roster(&roster),
+        Box::new(one_open_issue()),
+        LoopConfig::default(),
+        PathBuf::from("/tmp/stella-driver-test"),
+        WorkSlot::new(Box::new(FixtureWorker::answering(outcome))),
+    )
+}
+
+/// The arguments a `work_start` ask carries for issue 41.
+fn work_on(key: &str) -> Option<DriverArgs> {
+    Some(DriverArgs {
+        work_start: Some(UnitArgs {
+            issue: key.to_string(),
+        }),
+        ..DriverArgs::default()
+    })
+}
 
 /// For the gate tests above, which are about what a grant admits rather than
 /// what runs behind it.
@@ -371,6 +442,8 @@ fn capabilities_for(manifest: &str, tracker: FixtureTracker) -> HostDriverCapabi
         PluginGates::from_roster(&roster),
         Box::new(tracker),
         LoopConfig::default(),
+        PathBuf::from("/tmp/stella-driver-test"),
+        WorkSlot::new(Box::new(FixtureWorker::answering(changed()))),
     )
 }
 
@@ -427,7 +500,7 @@ async fn a_served_call_is_attributed_to_the_plugin_and_held_to_its_grant() {
     );
 
     let ok = granted
-        .perform(DriverCall::BacklogNext)
+        .perform(DriverCall::BacklogNext, None)
         .await
         .expect("a granted plugin is served the queue");
     let page = ok.backlog.expect("a served read carries its page");
@@ -436,7 +509,7 @@ async fn a_served_call_is_attributed_to_the_plugin_and_held_to_its_grant() {
     assert_eq!(page.issues[0].labels, ["bug", "P1"]);
 
     let refused = capabilities_for(GRANTS_NO_SHELL, one_open_issue())
-        .perform(DriverCall::BacklogNext)
+        .perform(DriverCall::BacklogNext, None)
         .await
         .expect_err("a plugin that was not granted the shell is refused the read");
     assert_eq!(refused.refusal, HostCallRefusal::Forbidden);
@@ -450,7 +523,7 @@ async fn a_served_call_is_attributed_to_the_plugin_and_held_to_its_grant() {
 #[tokio::test]
 async fn an_unbuilt_verb_names_its_family() {
     let refused = capabilities_for(GRANTS_BASH, FixtureTracker { open: Vec::new() })
-        .perform(DriverCall::DeliverMerge)
+        .perform(DriverCall::DeliverMerge, None)
         .await
         .expect_err("nothing here serves a merge");
     assert_eq!(refused.refusal, HostCallRefusal::Unsupported);
@@ -488,6 +561,11 @@ fn the_shipped_package_names_a_program_stella_starts() {
 }
 
 /// One session against the shipped program, under `grant`.
+///
+/// The workspace root is a temporary directory, because `backlog_claim` writes
+/// a lease into `.stella/private/fleet.db` under it — a test that pointed this
+/// at the repository would leave a ledger row behind and would race every other
+/// test doing the same.
 #[cfg(unix)]
 fn drive_shipped_program(grant: &str) -> (Result<DriveNext, String>, Vec<String>) {
     let installed = InstalledPlugin {
@@ -497,6 +575,7 @@ fn drive_shipped_program(grant: &str) -> (Result<DriveNext, String>, Vec<String>
         consent: crate::plugin_cmd::receipt::ConsentState::Receipted,
         panel_grant: crate::plugin_cmd::panel_grant::PanelGrantState::Undecided,
     };
+    let workspace = tempfile::tempdir().expect("a temporary workspace");
     let roster = roster(vec![installed]);
     let bound = bind_with(&roster, "stella-selfdriving", &mut |_| {}, &mut path_only)
         .expect("binds to the shipped program")
@@ -505,6 +584,8 @@ fn drive_shipped_program(grant: &str) -> (Result<DriveNext, String>, Vec<String>
             PluginGates::from_roster(&roster),
             Box::new(one_open_issue()),
             LoopConfig::default(),
+            workspace.path().to_path_buf(),
+            WorkSlot::new(Box::new(FixtureWorker::answering(changed()))),
         )));
     let next = bound.open("drive-test");
     (next, bound.refusals())
@@ -513,14 +594,16 @@ fn drive_shipped_program(grant: &str) -> (Result<DriveNext, String>, Vec<String>
 /// **The end-to-end witness.** The shipped program, through the real
 /// transport, twice.
 ///
-/// With `backlog_next` declared, the read is served and the program gets as far
-/// as asking to claim the issue it found. With it omitted, the host refuses the
-/// ask `undeclared`, the session **keeps running**, and the program still ends
-/// it with a `next` rather than dying — the property that makes a refusal a
-/// value the loop reads instead of a crash.
+/// With `backlog_next` and `backlog_claim` declared, both are served and the
+/// program gets as far as asking to work the issue it claimed — which this
+/// grant does not declare, so the loop stops there and says which ask it was.
+/// With the read omitted, the host refuses the first ask `undeclared`, the
+/// session **keeps running**, and the program still ends it with a `next`
+/// rather than dying — the property that makes a refusal a value the loop reads
+/// instead of a crash.
 ///
 /// The package must name a program for either arm to run at all, and the host
-/// must serve the verb for the first arm to reach the claim.
+/// must serve both verbs for the first arm to reach the work.
 #[cfg(unix)]
 #[test]
 fn the_shipped_program_is_served_what_it_declared_and_refused_what_it_did_not() {
@@ -559,10 +642,12 @@ env = ["PATH"]
     let (served, served_refusals) = drive_shipped_program(DECLARES_THE_READ);
     match served.expect("the session ended with a next") {
         DriveNext::Halt { reason } => {
-            // The read was served, so the program reached the claim — which
-            // this host does not serve, and which it says rather than guessing.
+            // The read and the claim were both served, so the program reached
+            // the work — which this grant does not declare, and which it says
+            // rather than guessing.
             assert!(reason.contains("41"), "{reason}");
-            assert!(reason.contains("backlog_claim"), "{reason}");
+            assert!(reason.contains("work_start"), "{reason}");
+            assert!(reason.contains("undeclared"), "{reason}");
         }
         DriveNext::Sleep { secs } => {
             panic!("the queue was not empty, yet the driver slept {secs}s");
@@ -571,7 +656,7 @@ env = ["PATH"]
     assert!(
         served_refusals
             .iter()
-            .all(|line| !line.contains("backlog_next")),
+            .all(|line| !line.contains("backlog_next") && !line.contains("backlog_claim")),
         "a declared, served call must not be refused: {served_refusals:?}"
     );
 
@@ -591,4 +676,317 @@ env = ["PATH"]
         .unwrap_or_else(|| panic!("the refusal must be reported: {refusals:?}"));
     assert!(named.contains("stella-selfdriving"), "{named}");
     assert!(named.contains("undeclared"), "{named}");
+}
+
+// ---------------------------------------------------------------------------
+// The work verbs
+// ---------------------------------------------------------------------------
+
+/// A manifest that grants `bash` and declares the three work verbs beside the
+/// read, which is what the shipped package declares.
+const GRANTS_WORK: &str = r#"
+name = "stella-selfdriving"
+[loop]
+participation = "none"
+[[capabilities]]
+tool = "bash"
+risk = "destructive"
+purpose = "read the defect queue and work an issue"
+[driver]
+calls = ["backlog_next", "work_start", "work_status", "work_abandon"]
+[driver.process]
+argv = ["/bin/sh"]
+timeout_secs = 5
+"#;
+
+/// **The witness.** `work_start` runs a unit and reports what the tree holds.
+///
+/// Nothing weaker can pass it: without a served verb there is no `work` member
+/// to read, and without an argument table there is no way to say which unit.
+#[tokio::test]
+async fn work_start_runs_a_unit_and_reports_what_the_tree_holds() {
+    let host = capabilities_working(GRANTS_WORK, changed());
+
+    let ok = host
+        .perform(DriverCall::WorkStart, work_on("41"))
+        .await
+        .expect("a granted plugin is served the work");
+    let report = ok.work.expect("a served work ask carries its report");
+    assert_eq!(report.issue, "41");
+    assert_eq!(report.state, WorkState::Changed);
+    assert_eq!(report.branch, "stella/41");
+    assert!(report.stat.contains("1 file changed"), "{report:?}");
+}
+
+/// A turn that changed nothing is a real answer, not a failure, and it carries
+/// the turn's own last word — which is the only thing that tells "nothing to do
+/// here" from "the money ran out before it started".
+#[tokio::test]
+async fn a_unit_that_changed_nothing_is_not_a_failure() {
+    let host = capabilities_working(
+        GRANTS_WORK,
+        WorkOutcome::NoChange {
+            why: "this was already fixed on the base".into(),
+        },
+    );
+    let report = host
+        .perform(DriverCall::WorkStart, work_on("41"))
+        .await
+        .expect("a unit that changed nothing still answers")
+        .work
+        .expect("with a report");
+    assert_eq!(report.state, WorkState::NoChange);
+    assert!(report.detail.contains("already fixed"), "{report:?}");
+    assert!(report.branch.is_empty(), "{report:?}");
+}
+
+/// The slot answers `idle` before anything is started, so a driver can tell an
+/// empty session from a host that did not perform the call.
+#[tokio::test]
+async fn work_status_is_idle_before_a_unit_is_started() {
+    let host = capabilities_working(GRANTS_WORK, changed());
+    let report = host
+        .perform(DriverCall::WorkStatus, None)
+        .await
+        .expect("status is served with no unit held")
+        .work
+        .expect("with a report");
+    assert_eq!(report.state, WorkState::Idle);
+    assert!(report.issue.is_empty(), "{report:?}");
+}
+
+/// Starting, reading, and giving the unit back — the session's whole slot, in
+/// the order a cycle uses it.
+#[tokio::test]
+async fn a_unit_is_held_until_it_is_abandoned() {
+    let host = capabilities_working(GRANTS_WORK, changed());
+
+    host.perform(DriverCall::WorkStart, work_on("41"))
+        .await
+        .expect("the unit starts");
+
+    let held = host
+        .perform(DriverCall::WorkStatus, None)
+        .await
+        .expect("status is served")
+        .work
+        .expect("with a report");
+    assert_eq!(held.state, WorkState::Changed);
+    assert_eq!(held.issue, "41");
+
+    // A second unit while one is held is refused rather than queued: two
+    // worktrees under one session are two claims it cannot release apart.
+    let refused = host
+        .perform(DriverCall::WorkStart, work_on("41"))
+        .await
+        .expect_err("a session works one unit at a time");
+    assert_eq!(refused.refusal, HostCallRefusal::Unavailable);
+    assert!(refused.detail.contains("stella/41"), "{refused}");
+
+    let given_back = host
+        .perform(
+            DriverCall::WorkAbandon,
+            Some(DriverArgs {
+                work_abandon: Some(AbandonArgs {
+                    reason: "the base moved under it".into(),
+                }),
+                ..DriverArgs::default()
+            }),
+        )
+        .await
+        .expect("the unit is given back")
+        .work
+        .expect("with a report");
+    assert_eq!(given_back.state, WorkState::Idle);
+    assert!(
+        given_back.detail.contains("the base moved"),
+        "{given_back:?}"
+    );
+
+    let after = host
+        .perform(DriverCall::WorkStatus, None)
+        .await
+        .expect("status is served")
+        .work
+        .expect("with a report");
+    assert_eq!(after.state, WorkState::Idle);
+}
+
+/// A `work_start` that names no issue is refused with a reason. The one
+/// plausible guess — the top of the queue — is the wrong one, because what to
+/// work is the driver's decision.
+#[tokio::test]
+async fn a_work_ask_that_names_no_issue_is_refused_rather_than_guessed_at() {
+    let host = capabilities_working(GRANTS_WORK, changed());
+
+    let no_table = host
+        .perform(DriverCall::WorkStart, None)
+        .await
+        .expect_err("an ask with no arguments cannot name a unit");
+    assert_eq!(no_table.refusal, HostCallRefusal::Failed);
+
+    let blank = host
+        .perform(DriverCall::WorkStart, work_on("   "))
+        .await
+        .expect_err("a blank key names no unit either");
+    assert_eq!(blank.refusal, HostCallRefusal::Failed);
+    assert!(blank.detail.contains("names no issue"), "{blank}");
+}
+
+/// An ask carries the table of the verb it names and nothing else. Reading one
+/// and dropping the other would leave a driver believing it said something the
+/// host never heard.
+#[tokio::test]
+async fn an_ask_carrying_another_verbs_arguments_is_refused() {
+    let host = capabilities_working(GRANTS_WORK, changed());
+
+    let crossed = host
+        .perform(
+            DriverCall::WorkStart,
+            Some(DriverArgs {
+                backlog_claim: Some(UnitArgs { issue: "41".into() }),
+                ..DriverArgs::default()
+            }),
+        )
+        .await
+        .expect_err("a claim table does not answer a work ask");
+    assert_eq!(crossed.refusal, HostCallRefusal::Failed);
+    assert!(crossed.detail.contains("backlog_claim"), "{crossed}");
+
+    let unread = host
+        .perform(DriverCall::WorkStatus, work_on("41"))
+        .await
+        .expect_err("work_status reads no arguments");
+    assert_eq!(unread.refusal, HostCallRefusal::Failed);
+    assert!(unread.detail.contains("work_start"), "{unread}");
+}
+
+/// Abandoning records why. A release with nothing said about it teaches the
+/// next cycle nothing, so a blank reason is refused rather than accepted.
+#[tokio::test]
+async fn abandoning_a_unit_without_a_reason_is_refused() {
+    let host = capabilities_working(GRANTS_WORK, changed());
+    host.perform(DriverCall::WorkStart, work_on("41"))
+        .await
+        .expect("the unit starts");
+
+    let refused = host
+        .perform(
+            DriverCall::WorkAbandon,
+            Some(DriverArgs {
+                work_abandon: Some(AbandonArgs {
+                    reason: "  ".into(),
+                }),
+                ..DriverArgs::default()
+            }),
+        )
+        .await
+        .expect_err("a release says why");
+    assert_eq!(refused.refusal, HostCallRefusal::Failed);
+    assert!(refused.detail.contains("no reason"), "{refused}");
+}
+
+/// Abandoning nothing is a refusal, not a success that released nothing: a
+/// driver that lost track of its own slot is told so.
+#[tokio::test]
+async fn abandoning_an_empty_slot_is_refused() {
+    let host = capabilities_working(GRANTS_WORK, changed());
+    let refused = host
+        .perform(
+            DriverCall::WorkAbandon,
+            Some(DriverArgs {
+                work_abandon: Some(AbandonArgs {
+                    reason: "stopping".into(),
+                }),
+                ..DriverArgs::default()
+            }),
+        )
+        .await
+        .expect_err("there is nothing to abandon");
+    assert_eq!(refused.refusal, HostCallRefusal::Unavailable);
+}
+
+/// **The claim witness.** The lease is real, and a peer that holds it is named.
+///
+/// Both directions over one workspace: a free key is granted, and a key a peer
+/// already leased comes back `held: false` with the holder's own string. The
+/// grant is what makes the second answer usable — a loop told only "no" cannot
+/// tell a peer from a broken ledger, and those call for opposite responses.
+#[tokio::test]
+async fn a_claim_is_granted_when_free_and_names_the_holder_when_it_is_not() {
+    let workspace = tempfile::tempdir().expect("a temporary workspace");
+    let roster = roster(vec![installed(GRANTS_WORK, "/opt/pkgs/selfdriving")]);
+    let claim_on = |key: &str| {
+        Some(DriverArgs {
+            backlog_claim: Some(UnitArgs {
+                issue: key.to_string(),
+            }),
+            ..DriverArgs::default()
+        })
+    };
+    let host = |root: PathBuf| {
+        HostDriverCapabilities::new(
+            "stella-selfdriving",
+            PluginGates::from_roster(&roster),
+            Box::new(one_open_issue()),
+            LoopConfig::default(),
+            root,
+            WorkSlot::new(Box::new(FixtureWorker::answering(changed()))),
+        )
+    };
+
+    let free = host(workspace.path().to_path_buf())
+        .perform(DriverCall::BacklogClaim, claim_on("41"))
+        .await
+        .expect("a free key is granted")
+        .claim
+        .expect("a served claim carries its report");
+    assert_eq!(free.issue, "41");
+    assert!(free.held, "{free:?}");
+    assert!(free.holder.is_empty(), "{free:?}");
+
+    // A peer takes the key and keeps it: the lease releases when it drops, so
+    // it has to outlive the ask.
+    let peer = crate::self_driving_cmd::claim::acquire_as(workspace.path(), "42", "peer:9001");
+    assert!(
+        matches!(peer, crate::self_driving_cmd::claim::Claim::Granted(_)),
+        "the peer must actually hold it for this to test anything"
+    );
+
+    let taken = host(workspace.path().to_path_buf())
+        .perform(DriverCall::BacklogClaim, claim_on("42"))
+        .await
+        .expect("a held key still answers")
+        .claim
+        .expect("with a report");
+    assert_eq!(taken.issue, "42");
+    assert!(!taken.held, "{taken:?}");
+    assert!(taken.holder.contains("peer:9001"), "{taken:?}");
+    drop(peer);
+}
+
+/// Working a unit reads the tracker, so it is held to the same grant the read
+/// is: a plugin that was not granted the shell gets neither.
+#[tokio::test]
+async fn a_work_ask_is_held_to_the_grant_the_read_is() {
+    const NO_SHELL: &str = r#"
+name = "stella-selfdriving"
+[loop]
+participation = "none"
+[[capabilities]]
+tool = "write_file"
+risk = "medium"
+purpose = "remember what a cycle learned"
+[driver]
+calls = ["work_start"]
+[driver.process]
+argv = ["/bin/sh"]
+timeout_secs = 5
+"#;
+    let refused = capabilities_working(NO_SHELL, changed())
+        .perform(DriverCall::WorkStart, work_on("41"))
+        .await
+        .expect_err("a plugin that was not granted the shell is refused the work");
+    assert_eq!(refused.refusal, HostCallRefusal::Forbidden);
+    assert!(refused.detail.contains("stella-selfdriving"), "{refused}");
 }

--- a/crates/stella-cli/src/driver_plugin/work.rs
+++ b/crates/stella-cli/src/driver_plugin/work.rs
@@ -38,8 +38,9 @@
 //! # Why the turn runs on a blocking thread
 //!
 //! `work::start` builds its own tokio runtime and calls `block_on`. But
-//! [`super::capabilities::HostDriverCapabilities::perform`] is already inside
-//! the session's runtime, so a straight call would panic.
+//! [`stella_runtime::wrapper::DriverCapabilities::perform`], which
+//! [`super::capabilities::HostDriverCapabilities`] implements, is already
+//! inside the session's runtime, so a straight call would panic.
 //! [`tokio::task::spawn_blocking`] moves the work to a thread with no runtime
 //! on it. That is what the inner `block_on` needs.
 //!

--- a/crates/stella-cli/src/driver_plugin/work.rs
+++ b/crates/stella-cli/src/driver_plugin/work.rs
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The one unit of work a driver session may hold, and what runs it.
+//!
+//! `doc:backlog-self-driving` §3.2. The `work` verbs are the only part of the
+//! loop that changes a file. The rest ranks, decides, or reports.
+//!
+//! # One unit, held by the session
+//!
+//! A driver asks `work_start` with an issue key. It gets a report back. The
+//! session keeps that unit. So `work_status` and `work_abandon` need no key of
+//! their own. They act on the one the session holds.
+//!
+//! A second `work_start` while a unit holds a change is turned down, not
+//! queued. Two checkouts under one session would be two claims. The loop could
+//! not give back one without the other. Which unit to work is the driver's
+//! call.
+//!
+//! # It runs the turn Stella already runs
+//!
+//! [`self_driving_cmd::work::start`](crate::self_driving_cmd::work::start) is
+//! the whole of it. It is the path `stella self-driving` takes. It cuts a
+//! checkout outside the fleet's own space. It quotes the issue as data. It
+//! spends one bounded `stella run`. Then it reads the tree, not what the turn
+//! said about it. Serving the verb here changes who asks. It changes nothing
+//! about what runs.
+//!
+//! # Why not `child_turn`
+//!
+//! The wrapper socket has a capability that spends a model call for a plugin.
+//! It is the wrong one here. `stella_runtime::wrapper::child_turn` builds every
+//! child through `SubAgentSpec::read_only`. The turn sits behind
+//! `ReadOnlyTools`. It cannot write a file. Its own module states that as a
+//! promise. A work unit is the case that promise rules out. Widening it would
+//! hand a write to every plugin that holds a read.
+//!
+//! # Why the turn runs on a blocking thread
+//!
+//! `work::start` builds its own tokio runtime and calls `block_on`. But
+//! [`super::capabilities::HostDriverCapabilities::perform`] is already inside
+//! the session's runtime, so a straight call would panic.
+//! [`tokio::task::spawn_blocking`] moves the work to a thread with no runtime
+//! on it. That is what the inner `block_on` needs.
+//!
+//! # The port
+//!
+//! [`WorkRunner`] lets a test drive the verb with no model call. It is the one
+//! seam. The slot, the refusals and the report all sit above it. So a test
+//! here tests the code that ships.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use stella_plugin::{HostCallFailure, HostCallRefusal, WorkReport, WorkState};
+use stella_protocol::issue::Issue;
+
+use crate::self_driving_cmd::budget::RunBudget;
+use crate::self_driving_cmd::config::LoopConfig;
+use crate::self_driving_cmd::work::WorkOutcome;
+
+/// What works a unit, behind a port.
+///
+/// Two verbs, not one. Running a turn and giving a checkout back fail for
+/// different reasons, and a caller branches on both.
+#[async_trait]
+pub(crate) trait WorkRunner: Send + Sync {
+    /// Run `issue` to a diff, or say why it did not get there.
+    async fn run(&self, issue: &Issue) -> Result<WorkOutcome, String>;
+
+    /// Release the checkout at `path`, keeping whatever it committed.
+    async fn release(&self, path: &Path) -> Result<(), String>;
+}
+
+/// The shipping runner: the loop's own `work start`, on a blocking thread.
+pub(crate) struct SpawnedWorkRunner {
+    /// The workspace the loop was started in.
+    root: PathBuf,
+    /// This workspace's own loop settings — the branch prefix, the commit
+    /// signature, and which worker runs the turn.
+    config: LoopConfig,
+    /// The session's ceiling, and what has gone against it.
+    ///
+    /// Behind a lock. A driver may send two asks at once, and a budget that
+    /// two turns both read as full is no budget. The lock is never held across
+    /// an `await`: the value is copied out, spent, and put back.
+    budget: Mutex<RunBudget>,
+}
+
+impl SpawnedWorkRunner {
+    /// A runner over one workspace, under `budget`.
+    pub(crate) fn new(root: PathBuf, config: LoopConfig, budget: RunBudget) -> Self {
+        Self {
+            root,
+            config,
+            budget: Mutex::new(budget),
+        }
+    }
+
+    /// The session's budget, as it stands.
+    ///
+    /// A poisoned lock is read through, not passed on. This is
+    /// `DriverCallGate::refusals`'s rule. Losing the number because some other
+    /// ask panicked is the silence the channel refuses. It is also AGENTS.md
+    /// rule 5's line on an `unwrap` over runtime state.
+    fn budget_now(&self) -> RunBudget {
+        self.budget
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Fold what a finished turn spent back into the session's budget.
+    fn settle(&self, spent: RunBudget) {
+        *self
+            .budget
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = spent;
+    }
+}
+
+#[async_trait]
+impl WorkRunner for SpawnedWorkRunner {
+    async fn run(&self, issue: &Issue) -> Result<WorkOutcome, String> {
+        let root = self.root.clone();
+        let config = self.config.clone();
+        let issue = issue.clone();
+        let mut budget = self.budget_now();
+
+        let (outcome, budget) = tokio::task::spawn_blocking(move || {
+            let outcome = crate::self_driving_cmd::work::start(
+                &root,
+                &issue,
+                &mut budget,
+                &config.attribution,
+                &config.worker,
+            );
+            (outcome, budget)
+        })
+        .await
+        .map_err(|error| format!("the work unit's thread did not finish: {error}"))?;
+
+        // Settled whichever way the turn went. A turn that stopped early
+        // still spent. Charging only the wins would let a run of failures
+        // spend with no bound. That is `RunBudget::record`'s own argument, one
+        // level up.
+        self.settle(budget);
+        outcome
+    }
+
+    async fn release(&self, path: &Path) -> Result<(), String> {
+        let root = self.root.clone();
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || crate::self_driving_cmd::work::release(&root, &path))
+            .await
+            .map_err(|error| format!("the release did not finish: {error}"))?
+    }
+}
+
+/// The unit a session holds, if it holds one.
+#[derive(Debug, Clone, Default)]
+struct Held {
+    /// The tracker key.
+    issue: String,
+    /// Where the unit stands.
+    state: WorkState,
+    /// The branch the work sits on, when the tree holds a change.
+    branch: String,
+    /// What `git` said the turn left behind.
+    stat: String,
+    /// The checkout, so a release has something to remove.
+    path: Option<PathBuf>,
+    /// What the turn said, or why it did not finish.
+    detail: String,
+}
+
+impl Held {
+    /// What the driver reads.
+    fn report(&self) -> WorkReport {
+        WorkReport {
+            issue: self.issue.clone(),
+            state: self.state,
+            branch: self.branch.clone(),
+            stat: self.stat.clone(),
+            detail: self.detail.clone(),
+        }
+    }
+}
+
+/// The session's work slot: nothing, or one unit.
+///
+/// A `Mutex`, not a `RwLock`: every step here writes. It is never held across
+/// an `await`. The turn runs outside it, and the slot is read and written
+/// around that.
+pub(crate) struct WorkSlot {
+    held: Mutex<Option<Held>>,
+    runner: Box<dyn WorkRunner>,
+}
+
+impl WorkSlot {
+    /// An empty slot over `runner`.
+    pub(crate) fn new(runner: Box<dyn WorkRunner>) -> Self {
+        Self {
+            held: Mutex::new(None),
+            runner,
+        }
+    }
+
+    /// Read the slot.
+    fn peek(&self) -> Option<Held> {
+        self.held
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Write the slot.
+    fn put(&self, unit: Option<Held>) {
+        *self
+            .held
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = unit;
+    }
+
+    /// `work_start` — run `issue` and keep what came of it.
+    ///
+    /// A unit that changed nothing, or that did not finish, is written over.
+    /// There is no checkout to lose and no branch to deliver, so holding the
+    /// slot shut would only stop the loop working the next issue.
+    ///
+    /// # Errors
+    ///
+    /// [`HostCallRefusal::Unavailable`] when the session holds a unit that left
+    /// a change. Abandoning that one clears it. [`HostCallRefusal::Failed`]
+    /// when the turn could not be run at all.
+    pub(crate) async fn start(&self, issue: &Issue) -> Result<WorkReport, HostCallFailure> {
+        if let Some(held) = self.peek()
+            && held.state == WorkState::Changed
+        {
+            return Err(HostCallFailure::new(
+                HostCallRefusal::Unavailable,
+                format!(
+                    "this session already holds {} on branch {}; a driver works one unit at a \
+                     time, so deliver it or ask for `work_abandon` before starting another",
+                    held.issue, held.branch
+                ),
+            ));
+        }
+
+        let outcome = self.runner.run(issue).await.map_err(|reason| {
+            HostCallFailure::new(
+                HostCallRefusal::Failed,
+                format!("{}: {reason}", issue.key.as_str()),
+            )
+        })?;
+
+        let unit = match outcome {
+            WorkOutcome::Changed { branch, path, stat } => Held {
+                issue: issue.key.as_str().to_string(),
+                state: WorkState::Changed,
+                branch,
+                stat,
+                path: Some(path),
+                detail: String::new(),
+            },
+            // Not an error, and not an empty answer. An issue the loop
+            // cannot act on is a real outcome. The turn's last word is the
+            // only thing that tells "nothing to do here" from "the money ran
+            // out first".
+            WorkOutcome::NoChange { why } => Held {
+                issue: issue.key.as_str().to_string(),
+                state: WorkState::NoChange,
+                detail: why,
+                ..Held::default()
+            },
+            WorkOutcome::Failed { reason } => Held {
+                issue: issue.key.as_str().to_string(),
+                state: WorkState::Failed,
+                detail: reason,
+                ..Held::default()
+            },
+        };
+        let report = unit.report();
+        self.put(Some(unit));
+        Ok(report)
+    }
+
+    /// `work_status` — what the session holds.
+    ///
+    /// [`WorkState::Idle`] before a unit is started, and after one is given
+    /// back. A verb that answered nothing would leave a driver unable to tell
+    /// an empty slot from a host that did not do the call.
+    pub(crate) fn status(&self) -> WorkReport {
+        self.peek().map(|held| held.report()).unwrap_or_default()
+    }
+
+    /// `work_abandon` — give the unit back, saying why.
+    ///
+    /// The checkout goes. The branch stays. A turn that committed keeps its
+    /// work, so this is safe to reach for. It frees disk. It throws nothing
+    /// away.
+    ///
+    /// # Errors
+    ///
+    /// [`HostCallRefusal::Unavailable`] when the session holds nothing. A
+    /// driver that lost track is told so, rather than handed a success that
+    /// freed nothing.
+    pub(crate) async fn abandon(&self, reason: &str) -> Result<WorkReport, HostCallFailure> {
+        let held = self.peek().ok_or_else(|| {
+            HostCallFailure::new(
+                HostCallRefusal::Unavailable,
+                "this session holds no unit of work, so there is nothing to abandon",
+            )
+        })?;
+
+        // Reported, never fatal. A checkout that will not go is something
+        // the operator must know: it will collide with the next attempt at
+        // this issue. It is still no reason to keep the slot full.
+        let released = match &held.path {
+            Some(path) => self.runner.release(path).await,
+            None => Ok(()),
+        };
+        self.put(None);
+
+        let mut report = held.report();
+        report.state = WorkState::Idle;
+        report.detail = match released {
+            Ok(()) => reason.to_string(),
+            Err(error) => format!("{reason} — and the checkout would not release: {error}"),
+        };
+        Ok(report)
+    }
+}

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -631,7 +631,7 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             // Reads plugin manifests and copies/removes local directories. No
             // plugin process is started here — install is a consent
             // transaction, not an execution.
-            return plugin_cmd::run_plugin(cmd).map_err(failure::CliFailure::from);
+            return plugin_cmd::run_plugin(cmd, &cli.globals).map_err(failure::CliFailure::from);
         }
         // Reads context-record TOML and the tree, and appends to the local
         // lifecycle ledger on the review actions (Phase 3, #714). `propose

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -631,7 +631,8 @@ fn run(cli: Cli, loaded_env: &env_files::Loaded) -> Result<(), failure::CliFailu
             // Reads plugin manifests and copies/removes local directories. No
             // plugin process is started here — install is a consent
             // transaction, not an execution.
-            return plugin_cmd::run_plugin(cmd).map_err(failure::CliFailure::from);
+            return plugin_cmd::run_plugin(cmd, cli.globals.spend_limit)
+                .map_err(failure::CliFailure::from);
         }
         // Reads context-record TOML and the tree, and appends to the local
         // lifecycle ledger on the review actions (Phase 3, #714). `propose

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -202,6 +202,12 @@ fn session_id() -> String {
 /// Before this returns, the plugin, the refusals, and the ending are all
 /// written down through [`crate::driver_plugin::session_log::record`].
 ///
+/// `flags` is what a work turn inherits. A driver that asks for `work_start`
+/// spends the operator's provider budget, and `--spend-limit` is the ceiling
+/// on it. It is the session-wide flag, not one this verb defines: a second
+/// flag of that name would collide with the global clap propagates into every
+/// subcommand, which is what `no_subcommand_flag_reuses_a_global_name` refuses.
+///
 /// # Errors
 ///
 /// Whatever [`crate::driver_plugin::bind_installed`] refuses, or the session's

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -132,18 +132,16 @@ pub enum PluginCmd {
     ///
     /// One session per invocation: what re-opens it after a `sleep` is the
     /// loop the driver is describing, not this verb (#3599 B2).
+    /// The ceiling on what this session may spend is the session-wide
+    /// `--spend-limit` global, not a flag of this verb's own. `--spend-limit`
+    /// is declared `global = true` on [`crate::cli::GlobalArgs`], so clap
+    /// already propagates it into `stella plugin drive`; redefining it here
+    /// would collide with that slot rather than shadow it, which is what
+    /// `no_subcommand_flag_reuses_a_global_name` refuses.
     Drive {
         /// The plugin's `name`, as `stella plugin list` prints it.
         #[arg(value_name = "NAME")]
         name: String,
-        /// The most this session may spend on the turns it asks for, in USD.
-        ///
-        /// A driver that asks for `work_start` spends your provider budget,
-        /// and this is the ceiling. Omitted means observed mode — spend is
-        /// still summed and reported, and nothing is refused, which is what
-        /// `stella self-driving` does with the same flag absent.
-        #[arg(long, value_name = "USD")]
-        spend_limit: Option<f64>,
     },
 }
 
@@ -167,7 +165,13 @@ impl From<ScopeArg> for PluginScope {
 }
 
 /// Run `stella plugin <cmd>`. Offline: local files only, no API key.
-pub fn run_plugin(cmd: &PluginCmd) -> Result<(), String> {
+///
+/// `spend_limit` is the session-wide `--spend-limit` global, read off
+/// [`crate::cli::GlobalArgs`] by the caller and passed down rather than
+/// redeclared on `drive` — see [`PluginCmd::Drive`]. `None` is observed mode:
+/// spend is still summed and reported, and nothing is refused, which is what
+/// `stella self-driving` does with the same flag absent.
+pub fn run_plugin(cmd: &PluginCmd, spend_limit: Option<f64>) -> Result<(), String> {
     let root =
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
     let settings = Settings::load(&root).unwrap_or_default();
@@ -181,7 +185,7 @@ pub fn run_plugin(cmd: &PluginCmd) -> Result<(), String> {
             decide_panel(&root, name, panel_answer(*allow, *deny), &settings)
         }
         PluginCmd::Remove { name } => remove(&root, name),
-        PluginCmd::Drive { name, spend_limit } => drive(&root, name, *spend_limit),
+        PluginCmd::Drive { name } => drive(&root, name, spend_limit),
     }
 }
 

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -136,6 +136,14 @@ pub enum PluginCmd {
         /// The plugin's `name`, as `stella plugin list` prints it.
         #[arg(value_name = "NAME")]
         name: String,
+        /// The most this session may spend on the turns it asks for, in USD.
+        ///
+        /// A driver that asks for `work_start` spends your provider budget,
+        /// and this is the ceiling. Omitted means observed mode — spend is
+        /// still summed and reported, and nothing is refused, which is what
+        /// `stella self-driving` does with the same flag absent.
+        #[arg(long, value_name = "USD")]
+        spend_limit: Option<f64>,
     },
 }
 
@@ -173,7 +181,7 @@ pub fn run_plugin(cmd: &PluginCmd) -> Result<(), String> {
             decide_panel(&root, name, panel_answer(*allow, *deny), &settings)
         }
         PluginCmd::Remove { name } => remove(&root, name),
-        PluginCmd::Drive { name } => drive(&root, name),
+        PluginCmd::Drive { name, spend_limit } => drive(&root, name, *spend_limit),
     }
 }
 
@@ -202,7 +210,7 @@ fn session_id() -> String {
 /// Whatever [`crate::driver_plugin::bind_installed`] refuses, or the session's
 /// own failure — a driver that could not be started, timed out, died, or ended
 /// without saying what should happen next.
-fn drive(workspace_root: &Path, name: &str) -> Result<(), String> {
+fn drive(workspace_root: &Path, name: &str, spend_limit: Option<f64>) -> Result<(), String> {
     let name = checked_name(name)?;
     let mut warn = |line: String| eprintln!("  ! {line}");
     let resolved = crate::driver_plugin::resolve(workspace_root, name, &mut warn)?;
@@ -215,24 +223,48 @@ fn drive(workspace_root: &Path, name: &str) -> Result<(), String> {
     // The capabilities are built here rather than inside the binder because
     // this is where the workspace is: the tracker adapter and the loop's own
     // configuration are both facts about the directory `stella` was run in.
+    let config = crate::self_driving_cmd::config::load(workspace_root);
+    // The ceiling the operator named, in the shape a child turn takes it: a
+    // run's cap, narrowed per turn to what is left of it, never handed down
+    // whole, which is `RunBudget`'s own rule.
+    let budget = crate::self_driving_cmd::budget::RunBudget::new(
+        crate::self_driving_cmd::turn_flags::TurnFlags {
+            spend_limit,
+            ..Default::default()
+        },
+    );
     let capabilities = Box::new(
         crate::driver_plugin::capabilities::HostDriverCapabilities::new(
             name,
             resolved.gates().cloned(),
             Box::new(crate::issue_provider::GhIssueProvider),
-            crate::self_driving_cmd::config::load(workspace_root),
+            config.clone(),
+            workspace_root.to_path_buf(),
+            crate::driver_plugin::work::WorkSlot::new(Box::new(
+                crate::driver_plugin::work::SpawnedWorkRunner::new(
+                    workspace_root.to_path_buf(),
+                    config,
+                    budget,
+                ),
+            )),
         ),
     );
     let bound = resolved.serving(capabilities);
-    // Said before the session rather than inferred from the refusals after it:
-    // this host serves the tracker read and nothing else yet, so an operator
-    // should learn which asks will degrade from the host rather than from a
-    // driver's own halt message.
+    // Said before the session rather than inferred from the refusals after it,
+    // so an operator learns which asks will degrade from the host rather than
+    // from a driver's own halt message.
     if bound.offers_calls() {
         println!(
-            "  this build serves `backlog_next`; every other capability this session asks for \
-             will be refused as unsupported"
+            "  this build serves `backlog_next`, `backlog_claim`, `work_start`, `work_status` \
+             and `work_abandon`; every other capability this session asks for will be refused \
+             as unsupported"
         );
+        if spend_limit.is_none() {
+            println!(
+                "  no --spend-limit was given, so a turn this session asks for spends until it \
+                 finishes"
+            );
+        }
     }
     let next = bound.open(&session);
     let refusals = bound.refusals();

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -60,6 +60,7 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::self_driving_cmd::turn_flags::TurnFlags;
 use crate::settings::{Settings, Toggle};
 
 pub(crate) mod configure;
@@ -136,14 +137,6 @@ pub enum PluginCmd {
         /// The plugin's `name`, as `stella plugin list` prints it.
         #[arg(value_name = "NAME")]
         name: String,
-        /// The most this session may spend on the turns it asks for, in USD.
-        ///
-        /// A driver that asks for `work_start` spends your provider budget,
-        /// and this is the ceiling. Omitted means observed mode — spend is
-        /// still summed and reported, and nothing is refused, which is what
-        /// `stella self-driving` does with the same flag absent.
-        #[arg(long, value_name = "USD")]
-        spend_limit: Option<f64>,
     },
 }
 
@@ -167,7 +160,7 @@ impl From<ScopeArg> for PluginScope {
 }
 
 /// Run `stella plugin <cmd>`. Offline: local files only, no API key.
-pub fn run_plugin(cmd: &PluginCmd) -> Result<(), String> {
+pub(crate) fn run_plugin(cmd: &PluginCmd, globals: &crate::cli::GlobalArgs) -> Result<(), String> {
     let root =
         std::env::current_dir().map_err(|e| format!("cannot determine workspace root: {e}"))?;
     let settings = Settings::load(&root).unwrap_or_default();
@@ -181,7 +174,11 @@ pub fn run_plugin(cmd: &PluginCmd) -> Result<(), String> {
             decide_panel(&root, name, panel_answer(*allow, *deny), &settings)
         }
         PluginCmd::Remove { name } => remove(&root, name),
-        PluginCmd::Drive { name, spend_limit } => drive(&root, name, *spend_limit),
+        // The session-wide flags, in the form a child turn takes them. A
+        // driver that asks for `work_start` spends the operator's provider
+        // budget, and `--spend-limit` is what bounds it — the same flag, read
+        // from the same place, as every other turn this binary runs.
+        PluginCmd::Drive { name } => drive(&root, name, TurnFlags::from_globals(globals)?),
     }
 }
 
@@ -210,7 +207,7 @@ fn session_id() -> String {
 /// Whatever [`crate::driver_plugin::bind_installed`] refuses, or the session's
 /// own failure — a driver that could not be started, timed out, died, or ended
 /// without saying what should happen next.
-fn drive(workspace_root: &Path, name: &str, spend_limit: Option<f64>) -> Result<(), String> {
+fn drive(workspace_root: &Path, name: &str, flags: TurnFlags) -> Result<(), String> {
     let name = checked_name(name)?;
     let mut warn = |line: String| eprintln!("  ! {line}");
     let resolved = crate::driver_plugin::resolve(workspace_root, name, &mut warn)?;
@@ -224,15 +221,10 @@ fn drive(workspace_root: &Path, name: &str, spend_limit: Option<f64>) -> Result<
     // this is where the workspace is: the tracker adapter and the loop's own
     // configuration are both facts about the directory `stella` was run in.
     let config = crate::self_driving_cmd::config::load(workspace_root);
-    // The ceiling the operator named, in the shape a child turn takes it: a
-    // run's cap, narrowed per turn to what is left of it, never handed down
-    // whole, which is `RunBudget`'s own rule.
-    let budget = crate::self_driving_cmd::budget::RunBudget::new(
-        crate::self_driving_cmd::turn_flags::TurnFlags {
-            spend_limit,
-            ..Default::default()
-        },
-    );
+    // The ceiling the operator named, narrowed per turn to what is left of it
+    // rather than handed down whole, which is `RunBudget`'s own rule.
+    let capped = flags.spend_limit.is_some();
+    let budget = crate::self_driving_cmd::budget::RunBudget::new(flags);
     let capabilities = Box::new(
         crate::driver_plugin::capabilities::HostDriverCapabilities::new(
             name,
@@ -259,7 +251,7 @@ fn drive(workspace_root: &Path, name: &str, spend_limit: Option<f64>) -> Result<
              and `work_abandon`; every other capability this session asks for will be refused \
              as unsupported"
         );
-        if spend_limit.is_none() {
+        if !capped {
             println!(
                 "  no --spend-limit was given, so a turn this session asks for spends until it \
                  finishes"

--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -1167,7 +1167,7 @@ fn a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended() 
         "nothing recorded before any session ran"
     );
 
-    drive(&root, "watcher").expect("a session that sleeps is not an error");
+    drive(&root, "watcher", None).expect("a session that sleeps is not an error");
 
     let sessions = crate::driver_plugin::session_log::read_sessions(&root);
     assert_eq!(sessions.len(), 1, "{sessions:?}");

--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -1167,7 +1167,9 @@ fn a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended() 
         "nothing recorded before any session ran"
     );
 
-    drive(&root, "watcher", None).expect("a session that sleeps is not an error");
+    // No ceiling and no routing: this fixture asks for no capability, so it
+    // spends nothing and there is nothing for a ceiling to bound.
+    drive(&root, "watcher", TurnFlags::default()).expect("a session that sleeps is not an error");
 
     let sessions = crate::driver_plugin::session_log::read_sessions(&root);
     assert_eq!(sessions.len(), 1, "{sessions:?}");

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -15,7 +15,7 @@
 
 mod audit;
 mod backlog;
-mod budget;
+pub(crate) mod budget;
 pub(crate) mod claim;
 mod claim_mirror;
 mod claude_worker;
@@ -53,7 +53,7 @@ mod supply;
 mod surface;
 mod triage;
 pub(crate) mod turn_flags;
-mod work;
+pub(crate) mod work;
 
 use std::collections::BTreeMap;
 use std::process::Command;

--- a/crates/stella-cli/src/self_driving_cmd/budget.rs
+++ b/crates/stella-cli/src/self_driving_cmd/budget.rs
@@ -74,7 +74,7 @@ use super::turn_flags::TurnFlags;
 /// describes: spend is still summed, so the loop can report what a run cost,
 /// and nothing is ever refused.
 #[derive(Debug, Clone)]
-pub(super) struct RunBudget {
+pub(crate) struct RunBudget {
     /// The flags every child turn inherits, ceiling included.
     flags: TurnFlags,
     /// Turns whose summary could not be read, and which were therefore
@@ -90,7 +90,7 @@ pub(super) struct RunBudget {
 /// ends the run and reports *budget reached*, while the same condition inside a
 /// work unit defers that issue. A message would make both read the prose.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(super) struct Exhausted {
+pub(crate) struct Exhausted {
     /// The run's ceiling.
     pub cap: f64,
     /// What it had already spent when the turn was refused.
@@ -109,7 +109,7 @@ impl std::fmt::Display for Exhausted {
 
 impl RunBudget {
     /// A budget over the flags this invocation parsed.
-    pub(super) fn new(flags: TurnFlags) -> Self {
+    pub(crate) fn new(flags: TurnFlags) -> Self {
         Self {
             flags,
             spent: 0.0,
@@ -118,12 +118,12 @@ impl RunBudget {
     }
 
     /// The run's ceiling, when one was set.
-    pub(super) fn cap(&self) -> Option<f64> {
+    pub(crate) fn cap(&self) -> Option<f64> {
         self.flags.spend_limit
     }
 
     /// What this run's turns have reported spending.
-    pub(super) fn spent(&self) -> f64 {
+    pub(crate) fn spent(&self) -> f64 {
         self.spent
     }
 

--- a/crates/stella-cli/src/self_driving_cmd/claim.rs
+++ b/crates/stella-cli/src/self_driving_cmd/claim.rs
@@ -147,7 +147,7 @@ impl Drop for Lease {
 ///
 /// Every failure is [`Claim::Unavailable`] rather than an error: see that
 /// variant for why a probe that cannot answer must not defer.
-pub(super) fn acquire(root: &Path, key: &str) -> Claim {
+pub(crate) fn acquire(root: &Path, key: &str) -> Claim {
     acquire_as(root, key, &owner())
 }
 

--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -108,9 +108,47 @@ pub(super) fn worktrees_root(root: &Path) -> PathBuf {
     root.join(WORKTREES_DIR)
 }
 
+/// Give a checkout back, keeping whatever it committed.
+///
+/// The checkout goes; the branch stays. `git worktree remove` deletes no
+/// branch, so a turn that committed keeps its work and only the disk is
+/// reclaimed — which is what makes this safe for a driver to reach for
+/// mid-cycle. The prune afterwards is what stops a removal that half-finished
+/// from making the next attempt at the same issue collide with a registration
+/// pointing at nothing.
+///
+/// Refuses to touch anything outside [`worktrees_root`]. A driver names the
+/// path it is releasing, and a path is the one argument that can name somebody
+/// else's checkout; the loop's own namespace is the whole of what it may
+/// reclaim (`stella fleet gc`'s rule, at the other door).
+///
+/// # Errors
+///
+/// A message a user can act on: the path is not this loop's, or git would not
+/// remove it.
+pub(crate) fn release(root: &Path, path: &Path) -> Result<(), String> {
+    if !path.starts_with(worktrees_root(root)) {
+        return Err(format!(
+            "{} is not under this loop's own worktrees, so nothing here will remove it",
+            path.display()
+        ));
+    }
+    let target = path.to_string_lossy().to_string();
+    // The tree decides, not the exit code. [`super::state::git`] answers `None`
+    // for empty stdout as well as for failure, and a successful `worktree
+    // remove` prints nothing — the trap [`tree_change`] documents, at this
+    // door. So the removal is judged by whether the checkout is gone.
+    let _ = super::state::git(root, &["worktree", "remove", &target, "--force"]);
+    let _ = super::state::git(root, &["worktree", "prune"]);
+    if path.exists() {
+        return Err(format!("git would not release the checkout at {target}"));
+    }
+    Ok(())
+}
+
 /// What one unit of work did, measured from the tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum WorkOutcome {
+pub(crate) enum WorkOutcome {
     /// The turn left changes on the branch.
     Changed {
         /// The branch holding them, for `deliver` to push.
@@ -640,7 +678,7 @@ pub(super) struct Worktree {
 /// issue through the port, cut a worktree outside the fleet's namespace, run a
 /// real `stella run` inside it with the issue quoted as data, then read the
 /// tree.
-pub(super) fn start(
+pub(crate) fn start(
     root: &Path,
     issue: &Issue,
     budget: &mut RunBudget,

--- a/crates/stella-cli/src/tests.rs
+++ b/crates/stella-cli/src/tests.rs
@@ -19,7 +19,7 @@ use super::term_policy::{
     PlainReason, animation_disabled, deck_decision, dumb_terminal, truthy_env,
 };
 use super::{
-    AuthCmd, Cli, Command, OutputFormat, TelemetryCmd, error_summary_json, fleet_verbs,
+    AuthCmd, Cli, Command, OutputFormat, TelemetryCmd, error_summary_json, fleet_verbs, plugin_cmd,
     query_format,
 };
 
@@ -547,6 +547,35 @@ fn fleet_claims_parses_as_a_verb_and_defaults_to_the_live_listing() {
             assert_eq!(tasks, vec!["claims are stale, audit them".to_string()]);
         }
         _ => panic!("expected the fleet subcommand"),
+    }
+}
+
+/// `stella plugin drive <name> --spend-limit <usd>` still parses, and binds
+/// the session-wide global rather than a flag of `drive`'s own.
+///
+/// `drive` declared its own `--spend-limit` when the verb landed, which
+/// collided with the global of that name and reddened
+/// [`no_subcommand_flag_reuses_a_global_name`]. Reading the propagated global
+/// is the fix. The invocation `website/content/docs/commands/plugin.mdx`
+/// documents is unchanged by it, and this pins that, so restoring the local
+/// flag fails both tests rather than only the collision one.
+#[test]
+fn plugin_drive_reads_the_session_wide_spend_limit() {
+    let cli = Cli::try_parse_from([
+        "stella",
+        "plugin",
+        "drive",
+        "selfdriving",
+        "--spend-limit",
+        "25",
+    ])
+    .expect("the documented `plugin drive --spend-limit` invocation must parse");
+    assert_eq!(cli.globals.spend_limit, Some(25.0));
+    match cli.command {
+        Some(Command::Plugin {
+            cmd: plugin_cmd::PluginCmd::Drive { ref name },
+        }) => assert_eq!(name, "selfdriving"),
+        _ => panic!("expected the parse to bind `plugin drive selfdriving`"),
     }
 }
 

--- a/crates/stella-plugin/src/driver.rs
+++ b/crates/stella-plugin/src/driver.rs
@@ -51,10 +51,11 @@
 //! be pinning a wire contract to behaviour no host code can typecheck against,
 //! and every one of them would change at the phase that implemented it.
 //!
-//! So no call carries arguments today — no served verb reads one — and
-//! [`DriverOk`] carries one optional member per verb the host reports on, of
-//! which [`BacklogPage`] is the first. Every member is omitted when absent, so
-//! a verb that reports nothing still answers `{}`.
+//! So [`DriverArgs`] and [`DriverOk`] each carry one optional member per verb
+//! that reads or reports one, and nothing for the rest. Every member is
+//! omitted when absent, so a verb that reads nothing sends no `args` key and a
+//! verb that reports nothing still answers `{}` — the bytes a driver written
+//! against B0 already sends and reads.
 //!
 //! What this pins independently of any of that is the part consent depends on:
 //! which capabilities exist, which of them a driver declared, and what happens
@@ -435,6 +436,8 @@ struct DriverEnvelope {
     call: Option<DriverCall>,
     #[serde(default)]
     id: Option<u32>,
+    #[serde(default)]
+    args: Option<DriverArgs>,
 }
 
 impl DriverEnvelope {
@@ -445,10 +448,10 @@ impl DriverEnvelope {
                  `call` (a capability ask), never both",
             )),
             (Some(DrivePoint::Drive), None) => {
-                if self.id.is_some() {
+                if self.id.is_some() || self.args.is_some() {
                     return Err(E::custom(
-                        "a session response carries `point` and `body` only; `id` belongs to a \
-                         capability ask",
+                        "a session response carries `point` and `body` only; `id` and `args` \
+                         belong to a capability ask",
                     ));
                 }
                 let body = self
@@ -466,7 +469,11 @@ impl DriverEnvelope {
                 let id = self
                     .id
                     .ok_or_else(|| E::custom("a capability ask must carry `id`"))?;
-                Ok(DriverMessage::Call(DriverCallRequest { id, call }))
+                Ok(DriverMessage::Call(DriverCallRequest {
+                    id,
+                    call,
+                    args: self.args,
+                }))
             }
             (None, None) => Err(E::custom(
                 "a driver message must carry either `point` (a session response) or `call` (a \
@@ -616,14 +623,22 @@ pub enum DriveNext {
 /// pipelines two asks needs to tell the answers apart, and a number the host
 /// assigned would arrive too late to be useful.
 ///
-/// There is no `args` key, and its absence is checked rather than tolerated —
-/// see this module's header. The verb that needs arguments brings them.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+/// The `args` key is the verb's own table and nothing else — see
+/// [`DriverArgs`]. An ask for a verb that reads no arguments omits it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DriverCallRequest {
     /// What the driver calls this ask, echoed on the answer.
     pub id: u32,
     /// Which capability.
     pub call: DriverCall,
+    /// What the ask is about, for a verb that reads one.
+    ///
+    /// Omitted for a verb that reads none, which is what every ask written
+    /// against B0 sends. A table naming a verb other than [`Self::call`] is a
+    /// refusal rather than a value the host quietly drops — see
+    /// [`DriverArgs::tables`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args: Option<DriverArgs>,
 }
 
 impl<'de> Deserialize<'de> for DriverCallRequest {
@@ -733,6 +748,88 @@ pub enum DriverCallOutcome {
     Err(HostCallFailure),
 }
 
+/// What a capability ask is **about** — one member per verb that reads one.
+///
+/// The mirror of [`DriverOk`], on the way in. Every member is omitted when
+/// absent, so a verb that reads nothing sends no table at all and the bytes an
+/// ask written against B0 sends are unchanged. The table denies unknown
+/// fields, so an argument this contract does not have is a decode error on the
+/// host's side rather than a value silently dropped.
+///
+/// **A table names exactly the verb the ask names.** [`Self::tables`] is what
+/// a host checks that with: an ask carrying `work_start` arguments under a
+/// `work_status` call is two claims about what the driver wants, and believing
+/// one of them quietly is the failure [`DriverMessage`]'s own envelope refuses
+/// one layer out.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DriverArgs {
+    /// Which unit [`DriverCall::BacklogClaim`] should take the lease on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backlog_claim: Option<UnitArgs>,
+    /// Which unit [`DriverCall::WorkStart`] should work.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_start: Option<UnitArgs>,
+    /// Why [`DriverCall::WorkAbandon`] is releasing the session's unit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_abandon: Option<AbandonArgs>,
+}
+
+impl DriverArgs {
+    /// Every verb this table carries arguments for, in declaration order.
+    ///
+    /// Written over an exhaustive destructure rather than a field-by-field
+    /// read, so a member added to [`DriverArgs`] without a case here is
+    /// `E0027` — the compiler enforcing totality, the way
+    /// [`crate::wire_corpus`] does for the enums on this wire.
+    #[must_use]
+    pub fn tables(&self) -> Vec<DriverCall> {
+        let Self {
+            backlog_claim,
+            work_start,
+            work_abandon,
+        } = self;
+        let mut named = Vec::new();
+        if backlog_claim.is_some() {
+            named.push(DriverCall::BacklogClaim);
+        }
+        if work_start.is_some() {
+            named.push(DriverCall::WorkStart);
+        }
+        if work_abandon.is_some() {
+            named.push(DriverCall::WorkAbandon);
+        }
+        named
+    }
+}
+
+/// The unit of backlog an ask is about.
+///
+/// The tracker's own key, as [`BacklogEntry::key`] spelled it. Opaque to the
+/// driver, which hands back what the host handed it and never parses it — a
+/// second tracker spells its keys `STELLA-42` and the loop's policy must not
+/// have an opinion about that.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UnitArgs {
+    /// The tracker key.
+    pub issue: String,
+}
+
+/// Why a unit is being released.
+///
+/// A sentence rather than a code, because the audience is a human reading the
+/// loop's ledger afterwards. A release with no reason is the silence
+/// `doc:backlog-self-driving` §3.7 refuses at the session's own terminal, one
+/// level down: a loop that gives an issue back without saying why teaches
+/// nobody anything.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AbandonArgs {
+    /// What a human reads in the ledger.
+    pub reason: String,
+}
+
 /// What a successful capability ask returned.
 ///
 /// One member per verb the host performs, and nothing for the verbs it does
@@ -757,6 +854,16 @@ pub struct DriverOk {
     /// facts, and a loop branches on both.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backlog: Option<BacklogPage>,
+    /// What [`DriverCall::BacklogClaim`] answered with: who holds the unit
+    /// now.
+    ///
+    /// Absent for every other verb, on [`Self::backlog`]'s terms.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim: Option<ClaimReport>,
+    /// What the three `work` verbs answered with: the session's unit, and what
+    /// the tree holds for it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work: Option<WorkReport>,
 }
 
 /// The ranked queue one [`DriverCall::BacklogNext`] read produced.
@@ -799,6 +906,71 @@ pub struct BacklogEntry {
     /// address.
     #[serde(default)]
     pub url: String,
+}
+
+/// Who holds a unit of backlog, after [`DriverCall::BacklogClaim`] asked.
+///
+/// Three answers, and they are different facts a loop branches on: the ask
+/// took the lease, a live peer already holds it, or the ledger could not say.
+/// The third is not the second — an unopenable ledger is not a peer, and a
+/// loop that read it as one would stop working on its own crash — so
+/// [`Self::holder`] is empty exactly when nobody was named.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClaimReport {
+    /// The unit the ask named, echoed so a pipelined driver can join it.
+    pub issue: String,
+    /// Whether this session now holds the lease.
+    pub held: bool,
+    /// Who holds it instead, or empty when nobody was named — either because
+    /// this session took it, or because the ledger could not answer.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub holder: String,
+}
+
+/// The session's unit of work, as the three `work` verbs report it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkReport {
+    /// The unit, or empty when the session holds none.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub issue: String,
+    /// Where the unit stands.
+    pub state: WorkState,
+    /// The branch the work sits on, for `deliver` to push. Empty unless the
+    /// tree holds a change.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub branch: String,
+    /// The summary line `git` printed for what the turn left behind. Empty
+    /// unless the tree holds a change.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stat: String,
+    /// What the turn said, or why the unit did not finish. Empty when there is
+    /// nothing to add.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub detail: String,
+}
+
+/// Where a unit of work stands.
+///
+/// [`Self::NoChange`] is **not** a failure and the two are separate cases for
+/// that reason: an issue the loop cannot act on is a real answer, and folding
+/// it into failure is how a loop learns to report noise
+/// (`crates/stella-cli/src/self_driving_cmd/work.rs` argues it at the door
+/// that produces it).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkState {
+    /// This session holds no unit. The answer to a `work_status` asked before
+    /// anything was started, and after a `work_abandon`.
+    #[default]
+    Idle,
+    /// The turn ran and left a change on the branch.
+    Changed,
+    /// The turn ran and changed nothing.
+    NoChange,
+    /// The turn did not complete.
+    Failed,
 }
 
 #[cfg(test)]
@@ -876,13 +1048,108 @@ mod tests {
         assert!(err.to_string().contains("never both"), "{err}");
     }
 
+    /// An argument this contract does not have is a decode error, not a value
+    /// the host reads past. The key `args` exists now; `limit` does not, and
+    /// `deny_unknown_fields` on [`DriverArgs`] is what says so.
     #[test]
-    fn a_capability_ask_may_not_carry_arguments_yet() {
-        // `args` is not a key of this contract at B0, and the envelope denies
-        // it rather than ignoring it — a driver written against a later phase's
-        // arguments must fail loudly against a host that has none.
+    fn a_capability_ask_may_not_carry_an_argument_this_contract_lacks() {
         let err = serde_json::from_str::<DriverCallRequest>(
             r#"{"call":"backlog_next","id":1,"args":{"limit":5}}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("limit"), "{err}");
+    }
+
+    /// An ask for a verb that reads nothing still sends the B0 bytes: no
+    /// `args` key at all, in either direction.
+    #[test]
+    fn an_ask_that_reads_nothing_carries_no_args_key() {
+        let ask = DriverCallRequest {
+            id: 1,
+            call: DriverCall::BacklogNext,
+            args: None,
+        };
+        let json = serde_json::to_string(&ask).expect("an ask serializes");
+        assert_eq!(json, r#"{"id":1,"call":"backlog_next"}"#);
+        assert_eq!(
+            serde_json::from_str::<DriverCallRequest>(&json).expect("and reads back"),
+            ask
+        );
+    }
+
+    /// A table names the verbs it carries arguments for, so a host can refuse
+    /// an ask whose table and whose verb disagree instead of reading one of
+    /// them and dropping the other.
+    #[test]
+    fn an_argument_table_names_the_verbs_it_is_for() {
+        assert!(DriverArgs::default().tables().is_empty());
+
+        let one = DriverArgs {
+            work_start: Some(UnitArgs { issue: "41".into() }),
+            ..DriverArgs::default()
+        };
+        assert_eq!(one.tables(), vec![DriverCall::WorkStart]);
+
+        let two = DriverArgs {
+            backlog_claim: Some(UnitArgs { issue: "41".into() }),
+            work_abandon: Some(AbandonArgs {
+                reason: "the base moved".into(),
+            }),
+            ..DriverArgs::default()
+        };
+        assert_eq!(
+            two.tables(),
+            vec![DriverCall::BacklogClaim, DriverCall::WorkAbandon]
+        );
+    }
+
+    /// The work verbs' arguments and their report survive the wire, and the
+    /// ask still round-trips through the shared envelope.
+    #[test]
+    fn a_work_ask_and_its_report_round_trip() {
+        let ask = DriverMessage::Call(DriverCallRequest {
+            id: 3,
+            call: DriverCall::WorkStart,
+            args: Some(DriverArgs {
+                work_start: Some(UnitArgs { issue: "41".into() }),
+                ..DriverArgs::default()
+            }),
+        });
+        let json = serde_json::to_string(&ask).expect("a work ask serializes");
+        assert_eq!(
+            json,
+            r#"{"id":3,"call":"work_start","args":{"work_start":{"issue":"41"}}}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<DriverMessage>(&json).expect("and reads back"),
+            ask
+        );
+
+        let answered = DriverCallResponse::ok(
+            3,
+            DriverOk {
+                work: Some(WorkReport {
+                    issue: "41".into(),
+                    state: WorkState::Changed,
+                    branch: "stella/41".into(),
+                    stat: " 2 files changed".into(),
+                    detail: String::new(),
+                }),
+                ..DriverOk::default()
+            },
+        );
+        let json = serde_json::to_string(&answered).expect("a work report serializes");
+        let back: DriverCallResponse = serde_json::from_str(&json).expect("and reads back");
+        assert_eq!(back, answered);
+    }
+
+    /// A session response may not carry an argument table: `args` belongs to
+    /// an ask, and a message claiming both is the contradiction the envelope
+    /// exists to refuse.
+    #[test]
+    fn a_session_response_may_not_carry_arguments() {
+        let err = serde_json::from_str::<DriverMessage>(
+            r#"{"point":"drive","body":{"next":{"sleep":{"secs":1}}},"args":{}}"#,
         )
         .unwrap_err();
         assert!(err.to_string().contains("args"), "{err}");
@@ -893,6 +1160,7 @@ mod tests {
         let ask = DriverMessage::Call(DriverCallRequest {
             id: 1,
             call: DriverCall::BacklogNext,
+            args: None,
         });
         let json = serde_json::to_string(&ask).expect("an ask serializes");
         assert_eq!(json, r#"{"id":1,"call":"backlog_next"}"#);
@@ -973,6 +1241,7 @@ mod tests {
                         },
                     ],
                 }),
+                ..DriverOk::default()
             },
         );
         let json = serde_json::to_string(&answered).expect("a backlog page serializes");

--- a/crates/stella-plugin/src/driver.rs
+++ b/crates/stella-plugin/src/driver.rs
@@ -780,8 +780,10 @@ impl DriverArgs {
     ///
     /// Written over an exhaustive destructure rather than a field-by-field
     /// read, so a member added to [`DriverArgs`] without a case here is
-    /// `E0027` — the compiler enforcing totality, the way
-    /// [`crate::wire_corpus`] does for the enums on this wire.
+    /// `E0027` — the compiler enforcing totality, the way `wire_corpus` does
+    /// for the enums on this wire. Named rather than linked: that module is
+    /// behind the `schema` feature and this one is not, so a default-features
+    /// `cargo doc` cannot resolve a link to it.
     #[must_use]
     pub fn tables(&self) -> Vec<DriverCall> {
         let Self {

--- a/crates/stella-plugin/src/lib.rs
+++ b/crates/stella-plugin/src/lib.rs
@@ -152,9 +152,10 @@ pub use consent::{
     Capability, PANEL_GRANT_ASK, RiskLevel, consent_text, highest_risk, panel_handshake_text,
 };
 pub use driver::{
-    BacklogEntry, BacklogPage, DriveNext, DrivePoint, DriveRequest, DriveResponse, DriveSession,
-    DriverCall, DriverCallOutcome, DriverCallRequest, DriverCallResponse, DriverFamily,
-    DriverGrant, DriverMessage, DriverOk,
+    AbandonArgs, BacklogEntry, BacklogPage, ClaimReport, DriveNext, DrivePoint, DriveRequest,
+    DriveResponse, DriveSession, DriverArgs, DriverCall, DriverCallOutcome, DriverCallRequest,
+    DriverCallResponse, DriverFamily, DriverGrant, DriverMessage, DriverOk, UnitArgs, WorkReport,
+    WorkState,
 };
 pub use error::ManifestError;
 pub use evidence::{CheckOutcome, MeasurementRule, OracleCheck, UnmetCheck};

--- a/crates/stella-plugin/src/wire_corpus.rs
+++ b/crates/stella-plugin/src/wire_corpus.rs
@@ -78,17 +78,18 @@ use serde_json::{Value, json};
 use stella_protocol::candidate::CandidateHandle;
 
 use crate::{
-    AdoptCandidateArgs, AdoptCandidateResult, AfterTurnRequest, AfterTurnResponse, BacklogEntry,
-    BacklogPage, BeforeTurnRequest, BeforeTurnResponse, CandidateFanoutArgs, CandidateFanoutResult,
-    CandidateGrant, ChildTurnArgs, ChildTurnResult, DriveNext, DriveRequest, DriveResponse,
-    DriverCall, DriverCallRequest, DriverCallResponse, DriverOk, FanoutCandidate, FlipObservation,
-    HostCall, HostCallArgs, HostCallFailure, HostCallOk, HostCallRefusal, HostCallRequest,
-    HostCallResponse, HostStage, ObservedEvidence, PROTOCOL_VERSION, PanelDenial, PanelEmphasis,
-    PanelFrame, PanelInk, PanelLease, PanelLine, PanelPaint, PanelPatch, PanelPoint, PanelRect,
-    PanelRequest, PanelResponse, PanelSpan, PanelStyle, PanelSurface, PanelText, PublishedSignal,
-    RecallArgs, RecallFrame, RecallResult, RunTestArgs, Signal, SignalKind, SignalValue, StageName,
-    TestBaseline, TestPlan, TestRunResult, TurnOutcome, VolatileContext, WrapperPoint,
-    WrapperRequest, WrapperResponse,
+    AbandonArgs, AdoptCandidateArgs, AdoptCandidateResult, AfterTurnRequest, AfterTurnResponse,
+    BacklogEntry, BacklogPage, BeforeTurnRequest, BeforeTurnResponse, CandidateFanoutArgs,
+    CandidateFanoutResult, CandidateGrant, ChildTurnArgs, ChildTurnResult, ClaimReport, DriveNext,
+    DriveRequest, DriveResponse, DriverArgs, DriverCall, DriverCallRequest, DriverCallResponse,
+    DriverOk, FanoutCandidate, FlipObservation, HostCall, HostCallArgs, HostCallFailure,
+    HostCallOk, HostCallRefusal, HostCallRequest, HostCallResponse, HostStage, ObservedEvidence,
+    PROTOCOL_VERSION, PanelDenial, PanelEmphasis, PanelFrame, PanelInk, PanelLease, PanelLine,
+    PanelPaint, PanelPatch, PanelPoint, PanelRect, PanelRequest, PanelResponse, PanelSpan,
+    PanelStyle, PanelSurface, PanelText, PublishedSignal, RecallArgs, RecallFrame, RecallResult,
+    RunTestArgs, Signal, SignalKind, SignalValue, StageName, TestBaseline, TestPlan, TestRunResult,
+    TurnOutcome, UnitArgs, VolatileContext, WorkReport, WorkState, WrapperPoint, WrapperRequest,
+    WrapperResponse,
 };
 
 /// The committed artifact's filename.
@@ -306,19 +307,66 @@ fn driver_session() -> Result<Value, serde_json::Error> {
     ]))
 }
 
-/// A capability ask, in the one shape it has at B0.
+/// A capability ask, in both of its shapes.
 ///
-/// No `args` key, and no `full`/`minimal` pair, because the request carries no
-/// optional member — the arguments land with the verb that needs them, and an
-/// `args` appearing here later is exactly the diff that should be reviewed.
+/// `args` is the request's one optional member, so the pair is what makes a
+/// change between required and optional a diff here: `backlog_next` reads no
+/// arguments and sends no key, and `work_start` names the unit it is about.
+/// A table for each remaining verb that reads one, because each is a separate
+/// wire contract a driver author writes against.
 fn driver_calls() -> Result<Value, serde_json::Error> {
-    Ok(Value::Array(vec![case(
-        "backlog_next",
-        &DriverCallRequest {
-            id: 1,
-            call: DriverCall::BacklogNext,
-        },
-    )?]))
+    Ok(Value::Array(vec![
+        case(
+            "backlog_next",
+            &DriverCallRequest {
+                id: 1,
+                call: DriverCall::BacklogNext,
+                args: None,
+            },
+        )?,
+        case(
+            "backlog_claim",
+            &DriverCallRequest {
+                id: 2,
+                call: DriverCall::BacklogClaim,
+                args: Some(DriverArgs {
+                    backlog_claim: Some(UnitArgs {
+                        issue: "1234".into(),
+                    }),
+                    work_start: None,
+                    work_abandon: None,
+                }),
+            },
+        )?,
+        case(
+            "work_start",
+            &DriverCallRequest {
+                id: 3,
+                call: DriverCall::WorkStart,
+                args: Some(DriverArgs {
+                    backlog_claim: None,
+                    work_start: Some(UnitArgs {
+                        issue: "1234".into(),
+                    }),
+                    work_abandon: None,
+                }),
+            },
+        )?,
+        case(
+            "work_abandon",
+            &DriverCallRequest {
+                id: 4,
+                call: DriverCall::WorkAbandon,
+                args: Some(DriverArgs {
+                    backlog_claim: None,
+                    work_start: None,
+                    work_abandon: Some(AbandonArgs {
+                        reason: "the base moved under it".into(),
+                    }),
+                }),
+            },
+        )?,
+    ]))
 }
 
 /// The host's answers to those asks.
@@ -328,8 +376,8 @@ fn driver_results() -> Result<Value, serde_json::Error> {
         // it is still the bytes every driver written against B0 reads: every
         // member of `DriverOk` is omitted when absent.
         case("ok/empty", &DriverCallResponse::ok(1, DriverOk::default()))?,
-        // The one verb this host serves. A member appearing here is a wire
-        // change, which is what the corpus exists to put on the screen.
+        // One case per verb this host reports on. A member appearing here is a
+        // wire change, which is what the corpus exists to put on the screen.
         case(
             "ok/backlog",
             &DriverCallResponse::ok(
@@ -343,6 +391,53 @@ fn driver_results() -> Result<Value, serde_json::Error> {
                             url: "https://example.invalid/1234".into(),
                         }],
                     }),
+                    claim: None,
+                    work: None,
+                },
+            ),
+        )?,
+        case(
+            "ok/claim",
+            &DriverCallResponse::ok(
+                5,
+                DriverOk {
+                    backlog: None,
+                    claim: Some(ClaimReport {
+                        issue: "1234".into(),
+                        held: false,
+                        holder: "self-driving:8412".into(),
+                    }),
+                    work: None,
+                },
+            ),
+        )?,
+        case(
+            "ok/work",
+            &DriverCallResponse::ok(
+                6,
+                DriverOk {
+                    backlog: None,
+                    claim: None,
+                    work: Some(WorkReport {
+                        issue: "1234".into(),
+                        state: WorkState::Changed,
+                        branch: "stella/1234".into(),
+                        stat: " 2 files changed, 31 insertions(+)".into(),
+                        detail: String::new(),
+                    }),
+                },
+            ),
+        )?,
+        // The emptiest legal report: a slot with nothing in it. Every optional
+        // member is omitted, so `state` alone is what a driver reads.
+        case(
+            "ok/work/idle",
+            &DriverCallResponse::ok(
+                7,
+                DriverOk {
+                    backlog: None,
+                    claim: None,
+                    work: Some(WorkReport::default()),
                 },
             ),
         )?,

--- a/crates/stella-runtime/src/wrapper/driver_call.rs
+++ b/crates/stella-runtime/src/wrapper/driver_call.rs
@@ -48,7 +48,8 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use async_trait::async_trait;
 use stella_plugin::{
-    DriverCall, DriverCallOutcome, DriverGrant, DriverOk, HostCallFailure, HostCallRefusal,
+    DriverArgs, DriverCall, DriverCallOutcome, DriverGrant, DriverOk, HostCallFailure,
+    HostCallRefusal,
 };
 
 /// The host's own ceiling on capability asks per driver session, when a caller
@@ -71,15 +72,21 @@ pub const DEFAULT_DRIVER_MAX_CALLS: u32 = 128;
 /// [`HostCallRefusal::Unsupported`] for the rest.
 ///
 /// This is the port the *gate* calls **after** it has checked the grant, so an
-/// implementor is never the thing that decides whether a driver may ask. It
-/// still takes no arguments: no served verb needs one yet, and
-/// `stella_plugin::driver` states the rule both halves follow — an argument
-/// table lands with the verb that reads it. The result already carries what a
-/// served verb reports ([`DriverOk`]).
+/// implementor is never the thing that decides whether a driver may ask.
+///
+/// The arguments arrive as the driver sent them, and `None` is what a verb
+/// that reads none is asked with. Whether a table is the *right* one for the
+/// verb is the implementor's answer, not the gate's: the gate decides what a
+/// plugin may ask for, and what a well-formed ask looks like is a property of
+/// the verb. [`DriverArgs::tables`] is what an implementor checks it with.
 #[async_trait]
 pub trait DriverCapabilities: Send + Sync {
-    /// Perform `call`, or say why not.
-    async fn perform(&self, call: DriverCall) -> Result<DriverOk, HostCallFailure>;
+    /// Perform `call` with `args`, or say why not.
+    async fn perform(
+        &self,
+        call: DriverCall,
+        args: Option<DriverArgs>,
+    ) -> Result<DriverOk, HostCallFailure>;
 }
 
 /// A host that implements no driver capability yet.
@@ -93,7 +100,11 @@ pub struct NoDriverCapabilities;
 
 #[async_trait]
 impl DriverCapabilities for NoDriverCapabilities {
-    async fn perform(&self, call: DriverCall) -> Result<DriverOk, HostCallFailure> {
+    async fn perform(
+        &self,
+        call: DriverCall,
+        _args: Option<DriverArgs>,
+    ) -> Result<DriverOk, HostCallFailure> {
         Err(HostCallFailure::new(
             HostCallRefusal::Unsupported,
             format!(
@@ -270,7 +281,7 @@ impl DriverSession<'_> {
     ///
     /// Infallible by construction: a refusal is a [`DriverCallOutcome::Err`]
     /// value the driver reads, never an error that ends the session.
-    pub async fn call(&self, call: DriverCall) -> DriverCallOutcome {
+    pub async fn call(&self, call: DriverCall, args: Option<DriverArgs>) -> DriverCallOutcome {
         // The grant first, and before anything is spent: an undeclared call
         // costs the driver nothing from an allowance it was never entitled to
         // use.
@@ -302,7 +313,7 @@ impl DriverSession<'_> {
             return DriverCallOutcome::Err(failure);
         }
 
-        match self.gate.capabilities.perform(call).await {
+        match self.gate.capabilities.perform(call, args).await {
             Ok(ok) => DriverCallOutcome::Ok(ok),
             Err(failure) => {
                 self.gate.record(call, &failure);
@@ -322,7 +333,11 @@ mod tests {
 
     #[async_trait]
     impl DriverCapabilities for Serves {
-        async fn perform(&self, _call: DriverCall) -> Result<DriverOk, HostCallFailure> {
+        async fn perform(
+            &self,
+            _call: DriverCall,
+            _args: Option<DriverArgs>,
+        ) -> Result<DriverOk, HostCallFailure> {
             Ok(DriverOk::default())
         }
     }
@@ -349,7 +364,7 @@ mod tests {
         );
         let session = gate.open();
 
-        let refused = session.call(DriverCall::DeliverMerge).await;
+        let refused = session.call(DriverCall::DeliverMerge, None).await;
         match refused {
             DriverCallOutcome::Err(failure) => {
                 assert_eq!(failure.refusal, HostCallRefusal::Undeclared);
@@ -364,7 +379,7 @@ mod tests {
         // And the session is still alive and still able to be served — the
         // half that makes the refusal a value rather than a death.
         assert_eq!(
-            session.call(DriverCall::BacklogNext).await,
+            session.call(DriverCall::BacklogNext, None).await,
             DriverCallOutcome::Ok(DriverOk::default())
         );
         assert_eq!(session.spent(), 1);
@@ -388,11 +403,11 @@ mod tests {
         let session = gate.open();
         for _ in 0..4 {
             assert!(matches!(
-                session.call(DriverCall::BacklogNext).await,
+                session.call(DriverCall::BacklogNext, None).await,
                 DriverCallOutcome::Ok(_)
             ));
         }
-        match session.call(DriverCall::BacklogNext).await {
+        match session.call(DriverCall::BacklogNext, None).await {
             DriverCallOutcome::Err(failure) => {
                 assert_eq!(failure.refusal, HostCallRefusal::AllowanceSpent);
             }
@@ -410,7 +425,7 @@ mod tests {
         for _ in 0..3 {
             let session = gate.open();
             assert!(matches!(
-                session.call(DriverCall::SweepAudit).await,
+                session.call(DriverCall::SweepAudit, None).await,
                 DriverCallOutcome::Ok(_)
             ));
         }
@@ -424,7 +439,7 @@ mod tests {
             DEFAULT_DRIVER_MAX_CALLS,
             Box::new(NoDriverCapabilities),
         );
-        match gate.open().call(DriverCall::WorkStart).await {
+        match gate.open().call(DriverCall::WorkStart, None).await {
             DriverCallOutcome::Err(failure) => {
                 assert_eq!(failure.refusal, HostCallRefusal::Unsupported);
                 // The gap names the family and the epic, so a driver author

--- a/crates/stella-runtime/src/wrapper/driver_subprocess.rs
+++ b/crates/stella-runtime/src/wrapper/driver_subprocess.rs
@@ -650,7 +650,7 @@ impl SubprocessDriver {
                             });
                         };
                         let outcome = match session {
-                            Some(session) => session.call(ask.call).await,
+                            Some(session) => session.call(ask.call, ask.args).await,
                             // Unreachable: `frames` is `Some` only when a session
                             // was opened. Written as a value rather than an
                             // `expect`, because AGENTS.md #5 makes no exception

--- a/crates/stella-runtime/tests/driver_socket.rs
+++ b/crates/stella-runtime/tests/driver_socket.rs
@@ -26,8 +26,8 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use stella_plugin::{
-    DriveNext, DriveRequest, DriverCall, DriverGrant, DriverOk, HostCallFailure, HostCallRefusal,
-    PluginManifest,
+    DriveNext, DriveRequest, DriverArgs, DriverCall, DriverGrant, DriverOk, HostCallFailure,
+    HostCallRefusal, PluginManifest,
 };
 use stella_runtime::wrapper::{
     DEFAULT_DRIVER_MAX_CALLS, DriverCallGate, DriverCapabilities, DriverError, MAX_SLEEP_SECS,
@@ -56,7 +56,11 @@ struct Serves;
 
 #[async_trait]
 impl DriverCapabilities for Serves {
-    async fn perform(&self, _call: DriverCall) -> Result<DriverOk, HostCallFailure> {
+    async fn perform(
+        &self,
+        _call: DriverCall,
+        _args: Option<DriverArgs>,
+    ) -> Result<DriverOk, HostCallFailure> {
         Ok(DriverOk::default())
     }
 }

--- a/docs/wire/wrapper.wire.json
+++ b/docs/wire/wrapper.wire.json
@@ -6,6 +6,42 @@
         "call": "backlog_next",
         "id": 1
       }
+    },
+    {
+      "case": "backlog_claim",
+      "message": {
+        "args": {
+          "backlog_claim": {
+            "issue": "1234"
+          }
+        },
+        "call": "backlog_claim",
+        "id": 2
+      }
+    },
+    {
+      "case": "work_start",
+      "message": {
+        "args": {
+          "work_start": {
+            "issue": "1234"
+          }
+        },
+        "call": "work_start",
+        "id": 3
+      }
+    },
+    {
+      "case": "work_abandon",
+      "message": {
+        "args": {
+          "work_abandon": {
+            "reason": "the base moved under it"
+          }
+        },
+        "call": "work_abandon",
+        "id": 4
+      }
     }
   ],
   "driver_results": [
@@ -35,6 +71,44 @@
           }
         },
         "result": 4
+      }
+    },
+    {
+      "case": "ok/claim",
+      "message": {
+        "ok": {
+          "claim": {
+            "held": false,
+            "holder": "self-driving:8412",
+            "issue": "1234"
+          }
+        },
+        "result": 5
+      }
+    },
+    {
+      "case": "ok/work",
+      "message": {
+        "ok": {
+          "work": {
+            "branch": "stella/1234",
+            "issue": "1234",
+            "stat": " 2 files changed, 31 insertions(+)",
+            "state": "changed"
+          }
+        },
+        "result": 6
+      }
+    },
+    {
+      "case": "ok/work/idle",
+      "message": {
+        "ok": {
+          "work": {
+            "state": "idle"
+          }
+        },
+        "result": 7
       }
     },
     {

--- a/plugins/stella-selfdriving/README.md
+++ b/plugins/stella-selfdriving/README.md
@@ -36,24 +36,32 @@ grant be *expressible* and *showable before install* — which the manifest is.
 time, and a `next` that ends the session. It holds no forge token, no provider
 key and no worktree. Every capability it needs, it asks Stella for.
 
-One cycle today: read the ranked queue (`backlog_next`), and if there is work
-at the top of it, ask to claim it (`backlog_claim`). The claim is refused,
-because no host serves it yet, and the program stops rather than working an
-issue it cannot know is unclaimed. Two loops taking one issue is what a claim
-prevents, and proceeding without one would trade a correct refusal for a
-silent race.
+One cycle today: read the ranked queue (`backlog_next`), claim the top of it
+(`backlog_claim`), and ask Stella to work that issue (`work_start`) in a
+checkout of its own. It will not work an issue it cannot know is unclaimed —
+two loops taking one issue is what a claim prevents, and proceeding without one
+would trade a correct refusal for a silent race.
+
+The cycle ends at the diff. No host serves `deliver_open` yet. So the `halt`
+names the branch the work sits on. A person, or the shell script, opens the
+pull request.
 
 ## The grant binds
 
 An ask outside `[driver] calls` comes back `err` with `refusal: "undeclared"`
 and the session keeps going. That is the channel's own gate.
 
-The tracker read goes through a second one. Stella performs it as
+The tracker read and the work go through a second one. Stella performs each as
 `Principal::Plugin("stella-selfdriving")`, and asks the rule
 `crates/stella-cli/src/plugin_authz.rs` built out of the `[[capabilities]]`
 list you accepted at install whether that principal was granted `bash` — the
-capability that shells out to `gh`. A manifest without it is refused the read,
-and the refusal names the plugin.
+capability that shells out to `gh`. A manifest without it is refused both, and
+the refusal names the plugin.
+
+A `work_start` spends your provider budget. You set the ceiling:
+`stella plugin drive stella-selfdriving --spend-limit 25`. With no ceiling,
+spend is added up and reported, and nothing is refused. That is what
+`stella self-driving` does with the same flag absent.
 
 ## What this is not
 
@@ -61,11 +69,11 @@ and the refusal names the plugin.
 working driver and is deliberately untouched: §10's rule is that the shell
 driver is not deleted until its replacement is proven.
 
-What has moved onto the channel: reading the ranked defect queue. What has
-not: the claim, the worktree, the turn, the pull request, the merge, the
-benchmark, the `brew` upgrade, the `~/.zshrc` line and the daemon. All of
-those are still the shell script's, running as you, which is why the
-`[[capabilities]]` list still declares them.
+What has moved onto the channel: reading the ranked defect queue, the
+cooperative claim, and the worktree and the turn behind `work_start`. What has
+not: the pull request, the merge, the sweep, the benchmark, the `brew` upgrade,
+the `~/.zshrc` line and the daemon. All of those are still the shell script's,
+running as you, which is why the `[[capabilities]]` list still declares them.
 
 ## What keeps it honest
 
@@ -76,9 +84,10 @@ it. A power the loop drops must leave the grant; a power the grant drops must
 leave the loop.
 
 `crates/stella-cli/src/driver_plugin/tests.rs` drives `main.py` through the
-real transport twice: once with the shipped grant, where the queue read is
-served, and once with a grant that omits `backlog_next`, where the host refuses
-it and the session still ends with a `next` instead of a crash.
+real transport twice. Once with a grant that carries the read and the claim:
+both are served, and the program gets as far as asking for the work. Once with
+a grant that omits `backlog_next`: the host refuses it, and the session still
+ends with a `next` rather than a crash.
 
 The consent check is an enumeration, so it catches drift in a power somebody
 already thought of. A driver that grew a capability nobody listed would pass

--- a/plugins/stella-selfdriving/main.py
+++ b/plugins/stella-selfdriving/main.py
@@ -14,8 +14,10 @@ do it, and says what should happen next:
     host   {"point": "drive", "body": {"session": "cycle-7"}}
  -> plugin {"call": "backlog_next", "id": 1}
  -> host   {"result": 1, "ok": {"backlog": {"issues": [...]}}}
- -> plugin {"call": "backlog_claim", "id": 2}
- -> host   {"result": 2, "err": {"refusal": "unsupported", "detail": "..."}}
+ -> plugin {"call": "backlog_claim", "id": 2, "args": {...}}
+ -> host   {"result": 2, "ok": {"claim": {"issue": "41", "held": true}}}
+ -> plugin {"call": "work_start", "id": 3, "args": {...}}
+ -> host   {"result": 3, "ok": {"work": {"state": "changed", ...}}}
  -> plugin {"point": "drive", "body": {"next": {"halt": {"reason": "..."}}}}
 
 One JSON message per line, both ways. `crates/stella-plugin/src/driver.rs` is
@@ -33,33 +35,47 @@ say so. Never to go get the thing some other way.
 
 # What a cycle does now
 
-The host serves `backlog_next`. Nothing else is built yet. So a cycle reads the
-ranked queue. If there is work at the top, it asks to claim it.
+The host serves `backlog_next`, `backlog_claim` and the three `work` verbs. So
+a cycle reads the ranked queue, claims the top of it, and asks Stella to work
+that one issue in a checkout of its own.
 
-The claim is turned down today. This program stops there. It will not work an
-issue it cannot know is free. Two loops on one issue is what a claim is for,
-and going ahead without one would trade a good refusal for a quiet race.
+It will not work an issue it cannot know is free. Two loops on one issue is
+what a claim is for, and going ahead without one would trade a good refusal for
+a quiet race.
 
-So a cycle ends in a `halt` that names what the host would not do. It becomes a
-real loop once `work` and `deliver` are served. Nothing in this file changes
-shape for that. Only the stage it reaches before it stops.
+A cycle ends at the diff, because nothing serves `deliver_open` yet. So the
+`halt` names the branch the work is sitting on, and a person or the shell
+script takes it from there. Nothing in this file changes shape for that. Only
+the stage it reaches before it stops.
+
+# Arguments
+
+An ask that is about a unit of work carries that unit:
+
+    {"call": "work_start", "id": 3, "args": {"work_start": {"issue": "41"}}}
+
+The table is named for the verb that reads it, and an ask carries its own
+verb's table and no other. A verb that reads nothing sends no `args` key.
 
 # `scripts/self-driving.sh` still exists
 
 That shell script is the working driver. It holds the powers this package's
 `[[capabilities]]` list names — `bash`, `write_file`, `process_spawn` — as
 you, straight out. This program holds none of them. It asks. The shell script
-stays until this one can do what it does, which is §10's own rule.
+stays until this one can do what it does, which is §10's own rule. What has
+moved across so far is the queue read, the claim, and the work; the pull
+request, the merge and the sweep are still the shell script's.
 """
 
 import json
 import sys
 
-# The verbs a cycle asks for, in the order it needs them. Both are on
+# The verbs a cycle asks for, in the order it needs them. Every one is on
 # `plugin.toml`'s `[driver] calls`. An ask that is not on that list would be
 # turned down, and writing one here would be a bug, not a test of the gate.
 BACKLOG_NEXT = "backlog_next"
 BACKLOG_CLAIM = "backlog_claim"
+WORK_START = "work_start"
 
 # How long to wait for the next cycle when there is nothing to do. Fifteen
 # minutes is the shell driver's own idle pause. The host clamps it either way,
@@ -76,8 +92,8 @@ class Channel:
         self._next_id = 1
         self.refusals = []
 
-    def ask(self, call):
-        """Ask the host for `call`.
+    def ask(self, call, args=None):
+        """Ask the host for `call`, with `args` when the verb reads them.
 
         Returns the `ok` table, or `None` when the host refused. A refusal is
         recorded and returned as an absence: it is an answer this program reads
@@ -85,7 +101,10 @@ class Channel:
         """
         request_id = self._next_id
         self._next_id += 1
-        self._write({"call": call, "id": request_id})
+        message = {"call": call, "id": request_id}
+        if args is not None:
+            message["args"] = args
+        self._write(message)
         answer = self._read("an answer to %s" % call)
         if answer.get("result") != request_id:
             fail("the host answered %r with result %r" % (call, answer.get("result")))
@@ -152,16 +171,26 @@ def queue_of(ok):
     return page.get("issues") or []
 
 
+def refused_halt(channel, said):
+    """Stop, naming the ask the host would not perform.
+
+    `said` is what this cycle was doing when it asked, so the reason a person
+    reads says which stage the loop got to, not only which verb came back.
+    """
+    call, refusal, detail = channel.refusals[-1]
+    return {"halt": {"reason": "%s: %s was refused (%s): %s" % (said, call, refusal, detail)}}
+
+
+def report_of(ok):
+    """The unit a served `work` verb answered with."""
+    return (ok or {}).get("work") or {}
+
+
 def cycle(channel):
     """One cycle's decision, as the `next` it ends with."""
     served = channel.ask(BACKLOG_NEXT)
     if served is None:
-        call, refusal, detail = channel.refusals[-1]
-        return {
-            "halt": {
-                "reason": "%s was refused (%s): %s" % (call, refusal, detail)
-            }
-        }
+        return refused_halt(channel, "reading the queue")
 
     issues = queue_of(served)
     if not issues:
@@ -172,24 +201,45 @@ def cycle(channel):
     title = top.get("title", "")
     sys.stderr.write("stella-selfdriving: next is %s %s\n" % (key, title))
 
-    if channel.ask(BACKLOG_CLAIM) is None:
-        call, refusal, detail = channel.refusals[-1]
+    claimed = channel.ask(BACKLOG_CLAIM, {"backlog_claim": {"issue": key}})
+    if claimed is None:
+        return refused_halt(
+            channel,
+            "%s is ready, and this loop does not work an issue it cannot claim, "
+            "because two loops taking one issue is what the claim prevents" % key,
+        )
+
+    claim = (claimed or {}).get("claim") or {}
+    if not claim.get("held"):
+        holder = claim.get("holder") or "another worker"
+        sys.stderr.write("stella-selfdriving: %s is held by %s\n" % (key, holder))
+        return {"sleep": {"secs": IDLE_SECS}}
+
+    worked = channel.ask(WORK_START, {"work_start": {"issue": key}})
+    if worked is None:
+        return refused_halt(channel, "%s is claimed" % key)
+
+    report = report_of(worked)
+    state = report.get("state")
+    if state == "changed":
         return {
             "halt": {
                 "reason": (
-                    "%s is ready, and %s was refused (%s): %s — this loop does not "
-                    "work an issue it cannot claim, because two loops taking one "
-                    "issue is what the claim prevents" % (key, call, refusal, detail)
+                    "%s is worked: %s on branch %s. No host serves `deliver_open` "
+                    "yet, so the branch is where this cycle stops"
+                    % (key, report.get("stat", "a change"), report.get("branch", "?"))
                 )
             }
         }
-
+    if state == "no_change":
+        return {
+            "halt": {
+                "reason": "%s needed no change: %s" % (key, report.get("detail", ""))
+            }
+        }
     return {
         "halt": {
-            "reason": (
-                "%s is claimed, and no host serves `work_start` yet — "
-                "scripts/self-driving.sh is still the driver that works an issue" % key
-            )
+            "reason": "%s did not finish: %s" % (key, report.get("detail", state))
         }
     }
 

--- a/plugins/stella-selfdriving/plugin.toml
+++ b/plugins/stella-selfdriving/plugin.toml
@@ -113,13 +113,16 @@ scope = [
 # in-turn influence: `participation = "none"` above stays the honest answer,
 # because this plugin still never runs inside a turn. It starts them.
 #
-# ONE OF THESE IS SERVED. `backlog_next` reads the tracker through the same
-# `IssueProvider` port the `stella self-driving` verbs use. Every other verb
-# below returns `unsupported` until the phase that builds it lands, and the
-# loop degrades rather than dying. They are all declared now because a grant is
-# a consent document: a user should read the whole shape of what this loop will
-# be permitted to do before any of it works, rather than discover it one silent
-# widening at a time.
+# FIVE OF THESE ARE SERVED. `backlog_next` reads the tracker through the same
+# `IssueProvider` port the `stella self-driving` verbs use. `backlog_claim`
+# takes the same lease `stella self-driving drive` takes. The three `work`
+# verbs run one issue through one bounded `stella run`, in a checkout of its
+# own.
+#
+# Every other verb below comes back `unsupported` until the phase that builds
+# it lands. The loop degrades; it does not die. All of them are declared now
+# because a grant is a consent document. Read the whole shape of what this loop
+# may do before any of it works.
 #
 # WHAT IS DELIBERATELY ABSENT, and why each is a decision rather than an
 # oversight:
@@ -191,10 +194,13 @@ calls = [
 # and this block is where its process is named.
 [driver.process]
 argv = ["python3", "${plugin_dir}/main.py"]
-# One session is a decision, not a cycle of work: the program reads the queue,
-# asks, and says what should happen next. A minute is a backstop against a
-# child that hangs before writing anything, not a work budget.
-timeout_secs = 60
+# A session now includes the work, because `work_start` is served. The host
+# cuts a checkout and runs one turn in it while this program waits. A turn on a
+# real issue takes minutes. A one-minute backstop would have killed every
+# session that got as far as doing something. An hour is a backstop against a
+# child that wedges. It is not a work budget: `stella plugin drive
+# --spend-limit` is the number that decides what a session may cost.
+timeout_secs = 3600
 # Default-deny, and `PATH` is the whole list — it is here so the host can find
 # `python3`. This program reaches for no file, no forge token and no provider
 # key: everything it needs, it asks for above, and the socket withholds a model

--- a/website/content/docs/commands/plugin.mdx
+++ b/website/content/docs/commands/plugin.mdx
@@ -202,7 +202,15 @@ Drivers use `[driver.process]` instead of `[runtime]`, because these are two dif
 
 **A `[driver]` block with no `[driver.process]` is just a description, not a working program.** It shows what a driver like this would ask for, but stella doesn't start anything. The plugin `plugins/stella-selfdriving` works this way, and the install prompt tells you so directly.
 
-Every action a driver asks for is done **by stella itself**, not by the plugin. The plugin never holds its own API keys or tokens. Right now, every action returns `unsupported`, so any driver session that asks for something is told no, and it explains why. More actions will work over time. Also note: running `stella plugin drive` only opens one session. Something else, the loop itself, is what reopens a session after it goes to sleep.
+Every action a driver asks for is done **by stella itself**, not by the plugin. The plugin never holds its own API keys or tokens. Right now stella performs five of them: `backlog_next` reads the ranked defect queue, `backlog_claim` takes a lease on one issue, and `work_start` / `work_status` / `work_abandon` run one issue through a turn in a checkout of its own. Every other action returns `unsupported`, so a driver that asks for one is told no, and it explains why. More actions will work over time. Also note: running `stella plugin drive` only opens one session. Something else, the loop itself, is what reopens a session after it goes to sleep.
+
+`work_start` spends money, so give it a ceiling:
+
+```bash
+stella plugin drive selfdriving --spend-limit 25
+```
+
+The number is the whole session's cap in US dollars, and each turn gets what is left of it. With no `--spend-limit`, spend is added up and reported and nothing is refused.
 
 ## Scopes
 

--- a/website/content/docs/commands/plugin.mdx
+++ b/website/content/docs/commands/plugin.mdx
@@ -210,7 +210,7 @@ Every action a driver asks for is done **by stella itself**, not by the plugin. 
 stella plugin drive selfdriving --spend-limit 25
 ```
 
-The number is the whole session's cap in US dollars, and each turn gets what is left of it. With no `--spend-limit`, spend is added up and reported and nothing is refused.
+`--spend-limit` is the session-wide flag, so it works before or after the command name. The number is the whole session's cap in US dollars, and each turn gets what is left of it. With no `--spend-limit`, spend is added up and reported and nothing is refused.
 
 ## Scopes
 


### PR DESCRIPTION
## What and why

The driver channel served one verb. `crates/stella-cli/src/driver_plugin/capabilities.rs` answered `HostCallRefusal::Unsupported` for everything after `backlog_next`, so the self-driving plugin could read the ranked queue and do nothing with what it read. `plugins/stella-selfdriving/main.py` halted at the claim, and `scripts/self-driving.sh` still held the work, running as the operator.

Two things blocked it, and this PR builds both.

**An ask could not name its unit.** A call was `{"call": ..., "id": N}` and nothing else, pinned by `a_capability_ask_may_not_carry_arguments_yet`. `DriverArgs` is the table beside `DriverOk`: one member per verb that reads one, `deny_unknown_fields`, every member omitted when absent — so an ask for a verb that reads nothing still sends the bytes a driver written against B0 sends. **An ask carries the table of the verb it names and no other**, checked with `DriverArgs::tables`; reading one table and dropping another would leave a driver believing it said something the host never heard, which is the contradiction `DriverMessage`'s own envelope refuses one layer out.

**`work::start` blocks.** It builds its own current-thread tokio runtime and calls `block_on`, and `perform` already runs inside the driver session's runtime, so a straight call would panic. `tokio::task::spawn_blocking` moves it to a thread with no runtime on it — `#6118`'s "reachable without a nested `block_on`" constraint, settled.

Served now: `backlog_claim`, over the same `dispatch_claims` lease `stella self-driving drive` takes, held for the session; and `work_start` / `work_status` / `work_abandon`, running one issue through one bounded `stella run` in a checkout of its own and reporting what the tree holds rather than what the turn said.

## A deviation from the design pointer, and why

The pointer said to dispatch the work through `child_turn`. The code says otherwise: `crates/stella-runtime/src/wrapper/child_turn.rs` builds every child through `SubAgentSpec::read_only`, so the turn runs behind `ReadOnlyTools` and **cannot write a file**. Its own module states that as a guarantee. A work unit writes code, so widening it would turn a read-only capability into a write one for every plugin that holds it.

What ships instead is `crate::self_driving_cmd::work::start` — the path `stella self-driving` already takes, which cuts a worktree outside the fleet's namespace, quotes the issue as data, and spends one bounded `stella run`. That is Stella's own binary, not an external coding agent: the `WorkerKind::Claude` arm is the external one, and the default is `WorkerKind::Stella`. `crates/stella-cli/src/driver_plugin/work.rs`'s header carries the whole argument.

The pointer also said the budget comes from the manifest's declared cap. There is no dollar cap in a manifest — `[driver] max_calls` is a call count. `stella plugin drive --spend-limit` is the operator's own ceiling instead, in the shape a child turn takes it: a run's cap, narrowed per turn to what is left of it, which is `RunBudget`'s rule.

## Witness mechanism

Every one of these fails on the old code by construction, because `perform` answered `Unsupported` for the verb and the request type had no `args` to send a unit in:

- `work_start_runs_a_unit_and_reports_what_the_tree_holds` — the served verb and its report.
- `a_unit_that_changed_nothing_is_not_a_failure` — `NoChange` carries the turn's last word and is not folded into failure.
- `work_status_is_idle_before_a_unit_is_started`, `a_unit_is_held_until_it_is_abandoned` — the session slot, start → status → refuse a second → abandon → idle.
- `a_work_ask_that_names_no_issue_is_refused_rather_than_guessed_at`, `an_ask_carrying_another_verbs_arguments_is_refused`, `abandoning_a_unit_without_a_reason_is_refused`, `abandoning_an_empty_slot_is_refused` — the four refusals, each with its code.
- `a_work_ask_is_held_to_the_grant_the_read_is` — served as `Principal::Plugin`, held to the install-time rule.
- `a_claim_is_granted_when_free_and_names_the_holder_when_it_is_not` — a real lease in a real ledger, both directions, with a peer holding the second key.
- `the_shipped_program_is_served_what_it_declared_and_refused_what_it_did_not` — `main.py` through the real transport, now reaching `work_start`.
- In `stella-plugin`: `an_argument_table_names_the_verbs_it_is_for`, `a_work_ask_and_its_report_round_trip`, `an_ask_that_reads_nothing_carries_no_args_key`, `a_session_response_may_not_carry_arguments`, `a_capability_ask_may_not_carry_an_argument_this_contract_lacks`.

The seam a test uses is `WorkRunner`, and only that: the slot, the refusals and the report all sit above it, so these test the code that ships rather than a second copy of it.

## Exemplar

`crates/stella-plugin/src/host_call.rs` — the same apparatus in the wrapper socket's dispatch context. `DriverArgs` copies `HostCallArgs`'s shape, and the refusal vocabulary is shared rather than mirrored.

## Tests deleted

`a_capability_ask_may_not_carry_arguments_yet` (`crates/stella-plugin/src/driver.rs`). Its claim was that no verb takes arguments yet, which is exactly what this change retires. `a_capability_ask_may_not_carry_an_argument_this_contract_lacks` replaces it and keeps the property that still holds: an argument key this contract does not have is a decode error, not a value read past.

## Wire contract

`docs/wire/wrapper.wire.json` gains the four ask cases and three result cases. The file was regenerated to match `wire_corpus.rs` byte for byte; a round-trip check confirmed the committed file is identical under the same pretty-printer settings before the edit, so `make wire-schema` in CI is the evidence.

Closes #6260
Closes #6256
Refs #6118
Refs #3599

## Remaining work filed

None new beyond what already stands: `#6118` still tracks the `deliver` family, `#6183` the `sweep` verbs, `#6209` the `curate` verbs, and `#6119` the corpus decode gap. The gaps this change leaves are listed in the follow-ups section of my final report.

## Summary by Sourcery

Enable driver sessions to claim backlog issues and execute bounded work units through the driver channel.

New Features:
- Serve cooperative backlog claiming and the work lifecycle over the driver channel, allowing the self-driving plugin to run one issue and report its resulting tree state.

Bug Fixes:
- Preserve driver session operation when capabilities are refused and prevent nested runtime execution while running work units.

Enhancements:
- Extend driver messages with validated, verb-specific argument tables and claim/work result reports.
- Track one claimed work unit per session, including status, abandonment, lease lifetime, checkout cleanup, and bounded session spending.
- Run driver work through Stella's existing self-driving workflow and update the plugin to stop at the resulting diff until delivery is supported.

Documentation:
- Update wire, plugin, command, and self-driving documentation for the new driver capabilities, argument contract, and spending limit.

Tests:
- Add end-to-end, transport, wire round-trip, capability validation, claim, work lifecycle, authorization, and spending-limit parsing coverage.