### PR TITLE
feat(stella-core): give the steering plane a plugin producer

### DIFF
--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -188,7 +188,10 @@ pub(crate) async fn run_raw_one_shot(
                 .serving(|manifest| {
                     crate::wrapper_plugin::session_host(cfg, manifest, Arc::clone(&sub_agents))
                 })
-                .map_err(crate::failure::CliFailure::from)?,
+                .map_err(crate::failure::CliFailure::from)?
+                // What a plugin puts in front of the model spends the same
+                // allowance this turn's records, skills and frames spend.
+                .with_context_allowance(crate::plugin_steering::allowance(cfg)),
         ),
         None => None,
     };
@@ -621,7 +624,9 @@ pub async fn run_goal_cmd(
                         candidate.as_ref().map(|granted| &granted.grant),
                     )
                 })
-                .map_err(crate::failure::CliFailure::from)?,
+                .map_err(crate::failure::CliFailure::from)?
+                // The same allowance every other steering source spends.
+                .with_context_allowance(crate::plugin_steering::allowance(cfg)),
         ),
         None => None,
     };

--- a/crates/stella-cli/src/agent/goal/goal_wrapped.rs
+++ b/crates/stella-cli/src/agent/goal/goal_wrapped.rs
@@ -156,6 +156,9 @@ impl TurnDriver for GoalRoundDriver<'_, '_> {
         // `TamperWatch::pin_declared` for why re-observing would launder a
         // rewrite from an earlier round.
         self.watch.pin_declared(prelude.witness());
+        // Whatever the steering allowance refused, named where every other
+        // steering source names its cuts.
+        crate::plugin_steering::report_drops(&prelude);
         self.messages.extend(prelude.into_messages());
         // One observer per internal turn, exactly as
         // `crate::wrapper_plugin::RawTurnDriver` builds one per round: `tools`

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -881,7 +881,7 @@ async fn run_task(
     // The second moment of binding (#3882): a plugin's `child_turn` is spent
     // by this attempt's own dispatcher, which needs the provider built above.
     let wrapped = match resolved_wrapper {
-        Some(resolved) => Some(resolved.serving(&invocation_root, sub_agents)?),
+        Some(resolved) => Some(resolved.serving(&invocation_root, sub_agents, &cfg)?),
         None => None,
     };
     let active_rules = rules::enforce_workspace_rules(

--- a/crates/stella-cli/src/fleet_cmd/wrapped.rs
+++ b/crates/stella-cli/src/fleet_cmd/wrapped.rs
@@ -393,6 +393,9 @@ impl TurnDriver for AttemptDriver<'_, '_> {
         // later round's declaration cannot launder an earlier round's rewrite —
         // see `TamperWatch::pin_declared`.
         self.watch.pin_declared(prelude.witness());
+        // Whatever the steering allowance refused, named where every other
+        // steering source names its cuts.
+        crate::plugin_steering::report_drops(&prelude);
         // Invariant 7: `into_messages` hands back user messages, appended
         // after the byte-stable system prefix this conversation opens with.
         self.messages.extend(prelude.into_messages());
@@ -471,7 +474,9 @@ impl ResolvedAttempt {
     /// isolated worktree's, which has none and would answer every recall with
     /// nothing. `child_turn` reaches this attempt's own dispatcher, so the
     /// child runs in the worker's tree with the worker's tool policy and is
-    /// paid for out of the worker's guard.
+    /// paid for out of the worker's guard. `cfg` is what the steering
+    /// allowance is read from, so a plugin's contribution spends the tokens
+    /// this attempt's records, skills and frames spend.
     ///
     /// # Errors
     ///
@@ -482,6 +487,7 @@ impl ResolvedAttempt {
         self,
         invocation_root: &std::path::Path,
         dispatcher: std::sync::Arc<crate::subagent::SessionSubAgents>,
+        cfg: &crate::config::Config,
     ) -> Result<AttemptWrapper, String> {
         // One host per member of the selection, built from that member's own
         // manifest: the child-turn plane reads the manifest's `[roles]` and
@@ -501,7 +507,9 @@ impl ResolvedAttempt {
             )
         })?;
         Ok(AttemptWrapper {
-            bound,
+            // What a plugin puts in front of the model spends the same
+            // allowance this attempt's records, skills and frames spend.
+            bound: bound.with_context_allowance(crate::plugin_steering::allowance(cfg)),
             candidate: self.candidate,
             task: self.task,
         })

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -101,6 +101,9 @@ mod plugin_cmd;
 // Where those routes become dispatches: the session's hook plane, folded
 // once at config assembly (#4417, #3521).
 mod plugin_hooks;
+// The plugin arm of the steering plane. It sets what a plugin may put in
+// front of the model. It names what the allowance cut.
+mod plugin_steering;
 mod scoreboard_cmd;
 mod self_driving_cmd;
 // The `/profile` posture planner (fast · balanced · pro · ultra).

--- a/crates/stella-cli/src/memory/recall.rs
+++ b/crates/stella-cli/src/memory/recall.rs
@@ -1295,8 +1295,9 @@ fn record_section_text(rendered: RenderedChannel) -> Option<String> {
 /// capability change (`crate::tool_lean`), so the advice is to widen what the
 /// session may spend on schemas, or to turn the lever off.
 ///
-/// `None` for a plugin-contributed candidate, which nothing produces yet.
-/// Silence there is the absence of a producer, not a withheld report.
+/// A plugin drop names the plugin and the stage it spoke at, because the
+/// handle is `<plugin>/<stage>` and both halves are things a person can act on.
+/// The remedy is the allowance or the plugin, and never the stage.
 fn drop_message(
     drop: &stella_core::steering::DroppedCandidate,
     still_selected: bool,
@@ -1324,7 +1325,12 @@ fn drop_message(
              is called; raise `context.steering.max_tokens`, or set \
              `context.steering.tools.lean` false to advertise every tool"
         )),
-        SteeringSource::Plugin => None,
+        SteeringSource::Plugin => Some(format!(
+            "a plugin's contribution did not fit what this turn's records, skills and frames \
+             left of the steering allowance, and was not put in front of the model: {handle} \
+             — the plugin still ran; raise `context.steering.max_tokens`, or take the plugin \
+             out of `active_plugins`"
+        )),
     }
 }
 

--- a/crates/stella-cli/src/memory/tests/steering_selection.rs
+++ b/crates/stella-cli/src/memory/tests/steering_selection.rs
@@ -745,9 +745,10 @@ fn every_dropped_source_gets_a_line_with_its_own_remedy() {
             // `crate::tool_lean` produces these: the session's tool
             // allowance, and what it could not afford.
             dropped(SteeringSource::Tool, "bash"),
-            // The plugin arm still has none, and its silence is the absence
-            // of a producer rather than a withheld report.
-            dropped(SteeringSource::Plugin, "stella-research"),
+            // `stella_runtime::wrapper` produces these: text a plugin
+            // offered at one of its stages that the allowance could not
+            // hold. The handle is `<plugin>/<stage>`.
+            dropped(SteeringSource::Plugin, "stella-research/research"),
         ],
     };
 
@@ -756,7 +757,7 @@ fn every_dropped_source_gets_a_line_with_its_own_remedy() {
 
     assert_eq!(
         lines.len(),
-        5,
+        6,
         "one summary for the memory drops, then one line per remaining \
          reportable source: {lines:?}"
     );
@@ -796,8 +797,11 @@ fn every_dropped_source_gets_a_line_with_its_own_remedy() {
          callable, and names the knob that would have advertised it: {joined}"
     );
     assert!(
-        !joined.contains("stella-research"),
-        "no source invents a line it has no producer for: {joined}"
+        lines[5].contains("stella-research/research")
+            && lines[5].contains("the plugin still ran")
+            && lines[5].contains("active_plugins"),
+        "a plugin's cut text names the plugin and the stage, says the plugin \
+         still ran, and names the two knobs that would have kept it: {joined}"
     );
 }
 

--- a/crates/stella-cli/src/plugin_steering.rs
+++ b/crates/stella-cli/src/plugin_steering.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The plugin arm of the steering plane.
+//!
+//! `stella_core::steering::plugins` makes the choice.
+//! `stella_runtime::wrapper` measures. This is the adapter between them. It
+//! reads the allowance a workspace names. It hands that to the dispatcher
+//! that drives the plugins. It names on stderr what the allowance refused.
+//!
+//! It is [`crate::tool_lean`]'s sibling, one source over. The shape is the
+//! same on purpose. Both spend the number `context.steering.max_tokens`
+//! names. Both go through the ledger that number is shared in. Both report
+//! their cuts through `memory::report_steering_drops`, the one writer every
+//! steering source uses.
+//!
+//! # A cut is a cost measure, not a change in what a plugin may do
+//!
+//! A plugin whose text the allowance could not hold still ran. Its scope and
+//! witness lists still stand. What it published still reached the stage after
+//! it. Its `after_turn` is still asked. What it lost is prompt bytes. The drop
+//! report says so, and says how to buy them back.
+
+use stella_core::steering::plugins::ContextAllowance;
+
+use crate::config::Config;
+
+/// What this session may spend on a plugin's text, or `None` when the
+/// workspace has switched the steering plane off.
+///
+/// It reads the settings chain at bind time, as
+/// [`crate::wrapper_plugin::standing_pipeline`] beside it does. A wrapper is
+/// bound once per run, so the answer cannot move under a turn. The ledger it
+/// carries is the session's. So the block a turn renders before the plugins
+/// are asked has already spent from what this hands them.
+pub(crate) fn allowance(cfg: &Config) -> Option<ContextAllowance> {
+    let declared = crate::settings::Settings::load(&cfg.workspace_root)
+        .unwrap_or_default()
+        .plugin_context_budget()?;
+    Some(ContextAllowance::new(
+        declared,
+        std::sync::Arc::clone(&cfg.steering_ledger),
+    ))
+}
+
+/// Name what this round's allowance refused.
+///
+/// It goes through `memory::report_steering_drops`, so a plugin's cut reads
+/// like a record's or a skill's, in the same place and the same shape. It is
+/// silent when nothing was cut, which is every turn a workspace runs inside
+/// its allowance.
+pub(crate) fn report_drops(prelude: &stella_runtime::wrapper::TurnPrelude) {
+    use colored::Colorize;
+
+    // The memory budget this writer takes shapes the recall line alone, and a
+    // set built by the wrapper socket holds plugin drops only.
+    crate::memory::report_steering_drops(prelude.steering(), 0, |message| {
+        eprintln!("  {} {message}", "!".yellow());
+    });
+}

--- a/crates/stella-cli/src/settings/steering.rs
+++ b/crates/stella-cli/src/settings/steering.rs
@@ -90,6 +90,36 @@ impl Settings {
             mcp_max_tokens: steering.tools.mcp_max_tokens,
         })
     }
+
+    /// What an installed plugin may put in front of the model this session,
+    /// or `None` when the plane is off.
+    ///
+    /// The same number [`Self::tool_advertisement`] hands the tool arm: the
+    /// whole volatile allowance, `context.steering.max_tokens`. A plugin's
+    /// `before_turn` text is volatile context like a record or a recalled
+    /// frame, so it spends the allowance they spend rather than one of its
+    /// own — a second key would be a second budget nobody could weigh against
+    /// the first, which is the defect the plane exists to end.
+    ///
+    /// `None` is the master switch, read exactly as the tool arm reads it: with
+    /// the plane off nothing may be withheld, or turning steering off would
+    /// take a plugin's contribution away instead of a ranking.
+    ///
+    /// It does **not** ask `tools.lean`. That lever is about the tool array,
+    /// and a workspace that sends every schema has said nothing about what a
+    /// third-party plugin may spend.
+    pub fn plugin_context_budget(&self) -> Option<u64> {
+        if !self.steering_enabled() {
+            return None;
+        }
+        Some(
+            self.context
+                .as_ref()
+                .map(|context| context.steering.clone())
+                .unwrap_or_default()
+                .max_tokens,
+        )
+    }
 }
 
 /// The tri-state reading of an environment variable: unset, explicitly on, or
@@ -141,6 +171,32 @@ mod tests {
             }
             other => panic!("the lever is on, so a budget is owed: {other:?}"),
         }
+    }
+
+    /// **Witness.** A plugin's contribution is held to the allowance the
+    /// settings name — the same one the block and the tool array spend.
+    #[test]
+    fn a_plugin_is_held_to_the_allowance_the_settings_name() {
+        let settings = from_json(r#"{"context":{"steering":{"max_tokens":900}}}"#);
+        assert_eq!(settings.plugin_context_budget(), Some(900));
+    }
+
+    /// The master switch settles it here too. With the plane off nothing may
+    /// be withheld, so a plugin's contribution is not budgeted at all.
+    #[test]
+    fn the_plane_being_off_budgets_no_plugin_contribution() {
+        let settings = from_json(r#"{"context":{"steering":{"enabled":false}}}"#);
+        assert_eq!(settings.plugin_context_budget(), None);
+    }
+
+    /// The tool lever is about the tool array. A workspace that sends every
+    /// schema has said nothing about what a plugin may spend.
+    #[test]
+    fn the_tool_lever_does_not_decide_what_a_plugin_may_spend() {
+        let settings =
+            from_json(r#"{"context":{"steering":{"max_tokens":700,"tools":{"lean":false}}}}"#);
+        assert_eq!(settings.tool_advertisement(), ToolAdvertisement::Full);
+        assert_eq!(settings.plugin_context_budget(), Some(700));
     }
 
     /// The master switch settles it. With the plane off, no tool may be held

--- a/crates/stella-cli/src/wrapper_plugin.rs
+++ b/crates/stella-cli/src/wrapper_plugin.rs
@@ -442,6 +442,23 @@ impl BoundWrapper {
         self.dispatch.variant()
     }
 
+    /// Hold this wrapper's text to the session's steering allowance. With the
+    /// plane off there is no ceiling to hold it to.
+    ///
+    /// Every door that binds a wrapper calls it, right after
+    /// [`ResolvedWrapper::serving`]. So a plugin's text buys from the same
+    /// tokens the turn's records, skills and frames bought from.
+    #[must_use]
+    pub(crate) fn with_context_allowance(
+        mut self,
+        allowance: Option<stella_core::steering::plugins::ContextAllowance>,
+    ) -> Self {
+        if let Some(allowance) = allowance {
+            self.dispatch = self.dispatch.with_context_allowance(allowance);
+        }
+        self
+    }
+
     /// Every child turn this host ran on the plugin's behalf, in order.
     ///
     /// Empty both when the plugin never asked and when no plane was installed;
@@ -1042,6 +1059,9 @@ impl TurnDriver for RawTurnDriver<'_> {
         // declare more as it learns more; already-pinned artifacts keep their
         // first baseline, so a later round cannot launder an earlier rewrite.
         self.watch.pin_declared(prelude.witness());
+        // Whatever the steering allowance refused, named where every other
+        // steering source names its cuts.
+        crate::plugin_steering::report_drops(&prelude);
         // Invariant 7, at the one call site that spends it: `into_messages`
         // hands back user messages, and they are appended *after* the
         // byte-stable system prefix the conversation already opens with.

--- a/crates/stella-core/src/steering.rs
+++ b/crates/stella-core/src/steering.rs
@@ -38,6 +38,7 @@
 use std::collections::BTreeMap;
 
 pub mod ledger;
+pub mod plugins;
 pub mod tools;
 
 /// What is happening in this turn, as a selector needs to see it.
@@ -80,11 +81,6 @@ pub struct TurnSignal<'a> {
 }
 
 /// Which plane a candidate came from.
-///
-/// `Plugin` is declared now and produced by nothing yet: #3246
-/// sequences plugins last, and the whole cost of a fifth source arriving
-/// later is whether this enum and [`SteeringSet`] anticipated it. A case
-/// costs nothing today and a second seam costs a migration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SteeringSource {
     /// A context record — a rule, fact, or directive (`.stella/rules/`).
@@ -95,7 +91,8 @@ pub enum SteeringSource {
     Skill,
     /// A tool schema competing for advertisement space.
     Tool,
-    /// A plugin-contributed candidate. Nothing produces one yet (#3246).
+    /// Context an installed plugin contributed at one of its declared stages.
+    /// See [`plugins`] for the producer.
     Plugin,
 }
 
@@ -152,7 +149,14 @@ fn source_rank(source: SteeringSource) -> u8 {
         SteeringSource::Tool => 1,
         SteeringSource::Skill => 2,
         SteeringSource::Memory => 3,
-        // Last until #3246 gives it an authority story.
+        // Last. It sits below every source this repository publishes. A
+        // plugin is code from outside that a person switched on. A record, a
+        // skill and a frame are this workspace's own. Let a plugin outrank a
+        // record and a `must` rule loses its seat to a package author. That
+        // is a governance failure, not a ranking nit. It sits below `Tool`
+        // for the same reason one rung down. A tool the model cannot see is
+        // one it will not pick. So a chatty plugin must not hide the working
+        // surface.
         SteeringSource::Plugin => 4,
     }
 }

--- a/crates/stella-core/src/steering/plugins.rs
+++ b/crates/stella-core/src/steering/plugins.rs
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What a plugin adds to the prompt, as a steering-plane source.
+//!
+//! # Why this is here
+//!
+//! [`SteeringSource::Plugin`] had a rank and a tag. It had no producer. A
+//! plugin that is switched on answers `before_turn` with text. The host puts
+//! that text in front of the model. Nothing priced it. Nothing ranked it.
+//! Nothing said what became of it. So the one source from outside this
+//! repository was the one source the shared budget could not see.
+//!
+//! This module is the producer. It has the shape [`super::tools`] has. The
+//! choice is made here, over owned data. The measuring and the socket work
+//! stay in the layer above (AGENTS.md #2).
+//!
+//! # The cost is measured
+//!
+//! A manifest could have named a token figure per stage. That number would be
+//! the plugin pricing itself. A plugin that names too small a number wins
+//! budget it never paid for. Then the plane prices a claim, not a cost. So
+//! [`PluginContribution::est_tokens`] is measured over the exact text. The
+//! host that holds the text does the measuring.
+//!
+//! # A plugin that says nothing costs nothing
+//!
+//! A stage with no text is not a candidate. Nor is it a candidate that costs
+//! zero. A row for a plugin that added nothing reads as text somebody could
+//! go and find.
+
+use std::sync::Arc;
+
+use super::ledger::SteeringLedger;
+use super::{SteeringCandidate, SteeringSet, SteeringSource, pack_to_budget};
+
+/// What one plugin said at one stage, and what it costs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginContribution {
+    /// The plugin's own name. It is the word a person writes in
+    /// `active_plugins`, and the word they take out again. Never the
+    /// `[wrapper] id`. A drop report is read by whoever can act on it.
+    pub plugin: String,
+    /// The stage this text was added at.
+    pub stage: String,
+    /// What sending it costs, measured over the exact text.
+    pub est_tokens: u64,
+}
+
+impl PluginContribution {
+    /// What this row is called on the plane.
+    ///
+    /// The stage is always part of it. That holds even for a plugin that
+    /// speaks at one stage. A handle is what a receipt joins on. So it may
+    /// not mean two things on two turns.
+    #[must_use]
+    pub fn handle(&self) -> String {
+        format!("{}/{}", self.plugin, self.stage)
+    }
+}
+
+/// One candidate per row, with its cost and its rank.
+///
+/// A `score` means something only inside one source, as
+/// [`SteeringCandidate::score`] says. Here it is cheapness. The row that costs
+/// less sorts first. That is the rule [`super::tools::tool_candidates`] uses
+/// inside a group. Nothing here reads the prompt. What a plugin has to say is
+/// the plugin's call. A host that ranked it against the goal would be adding a
+/// view nobody asked for.
+#[must_use]
+pub fn plugin_candidates(contributions: &[PluginContribution]) -> Vec<SteeringCandidate> {
+    contributions
+        .iter()
+        .map(|contribution| {
+            let est_tokens = contribution.est_tokens;
+            SteeringCandidate {
+                source: SteeringSource::Plugin,
+                handle: contribution.handle(),
+                score: 1.0 / (1.0 + est_tokens as f64),
+                why: format!(
+                    "the \"{}\" plugin added {est_tokens} tokens at the {} stage",
+                    contribution.plugin, contribution.stage
+                ),
+                est_tokens,
+            }
+        })
+        .collect()
+}
+
+/// What a turn may still spend on a plugin's text.
+///
+/// A handle on the one shared cell, not a number of its own. Records, skills
+/// and recalled frames spend this allowance first. The tool list takes what is
+/// left. So a plugin that adds eight thousand tokens has to be visible to
+/// both. Else "the block is too big" is a question no one piece of code can
+/// answer.
+#[derive(Debug, Clone)]
+pub struct ContextAllowance {
+    /// The whole volatile allowance the session declares.
+    declared: u64,
+    /// What the open turn has spent of it, and what the tool list settled.
+    ledger: Arc<SteeringLedger>,
+}
+
+impl ContextAllowance {
+    /// An allowance of `declared` tokens, spent against `ledger`.
+    #[must_use]
+    pub fn new(declared: u64, ledger: Arc<SteeringLedger>) -> Self {
+        Self { declared, ledger }
+    }
+
+    /// What is left for this round.
+    ///
+    /// The sum saturates. A block already past the allowance leaves nothing. A
+    /// subtraction that wrapped would hand a plugin the whole budget at the one
+    /// moment there is none.
+    #[must_use]
+    pub fn remaining(&self) -> u64 {
+        self.declared.saturating_sub(self.ledger.spent())
+    }
+
+    /// Note what this round took.
+    ///
+    /// Charged after the pack. So what is noted is what reached the prompt, not
+    /// what was offered. A later round of the turn then sees less left. That is
+    /// right: the text piles up in one chat.
+    pub fn spend(&self, tokens: u64) {
+        self.ledger.spend(tokens);
+    }
+}
+
+/// What the plane decided about one round.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContributedContext {
+    /// What fit, in the order it arrived.
+    ///
+    /// Arrival order, not pack order. The messages go to the model in the stage
+    /// order the members agreed on. A sort here would make the prompt turn on
+    /// what each stage cost.
+    pub kept: Vec<PluginContribution>,
+    /// What was kept and what was cut, for the drop report.
+    pub steering: SteeringSet,
+}
+
+/// Fit `contributions` into `budget_tokens`, and name what did not fit.
+///
+/// One [`pack_to_budget`] call, which is the point. A plugin's text and a
+/// published record are priced in one unit by one packer. So the order between
+/// them is the plane's fixed one. It is not an accident of which layer ran
+/// first.
+#[must_use]
+pub fn contribute(
+    contributions: Vec<PluginContribution>,
+    budget_tokens: u64,
+) -> ContributedContext {
+    let steering = pack_to_budget(plugin_candidates(&contributions), budget_tokens);
+    let kept = contributions
+        .into_iter()
+        .filter(|contribution| {
+            let handle = contribution.handle();
+            steering
+                .selected
+                .iter()
+                .any(|candidate| candidate.handle == handle)
+        })
+        .collect();
+    ContributedContext { kept, steering }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contribution(plugin: &str, stage: &str, est_tokens: u64) -> PluginContribution {
+        PluginContribution {
+            plugin: plugin.to_string(),
+            stage: stage.to_string(),
+            est_tokens,
+        }
+    }
+
+    /// **The witness.** Text the allowance cannot hold is cut and named. Every
+    /// row lands in one list or the other.
+    #[test]
+    fn a_contribution_the_allowance_cannot_afford_is_withheld_and_named() {
+        let offered = vec![
+            contribution("stella-research", "research", 100),
+            contribution("stella-plan", "plan", 900),
+        ];
+
+        let decided = contribute(offered, 500);
+
+        assert_eq!(decided.kept.len(), 1, "{:?}", decided.kept);
+        assert_eq!(decided.kept[0].plugin, "stella-research");
+        assert_eq!(decided.steering.dropped.len(), 1);
+        assert_eq!(decided.steering.dropped[0].handle, "stella-plan/plan");
+        assert_eq!(
+            decided.steering.dropped[0].source,
+            SteeringSource::Plugin,
+            "the drop arrives on the plane as a plugin drop"
+        );
+        assert_eq!(
+            decided.steering.selected.len() + decided.steering.dropped.len(),
+            2,
+            "every row is either selected or dropped, never lost"
+        );
+    }
+
+    /// An allowance that covers it all cuts nothing. That is what makes a wide
+    /// budget the same as no budget.
+    #[test]
+    fn an_allowance_that_covers_everything_withholds_nothing() {
+        let offered = vec![
+            contribution("a", "research", 100),
+            contribution("b", "plan", 900),
+        ];
+
+        let decided = contribute(offered.clone(), u64::MAX);
+
+        assert_eq!(decided.kept, offered);
+        assert!(decided.steering.dropped.is_empty());
+    }
+
+    /// What lives keeps the order it arrived in. This is prompt text. A filter
+    /// that also sorted would move the block between two turns that said the
+    /// same thing.
+    #[test]
+    fn withholding_a_contribution_does_not_reorder_the_rest() {
+        let offered = vec![
+            contribution("expensive", "research", 400),
+            contribution("cheap", "plan", 10),
+            contribution("middling", "review", 100),
+        ];
+
+        let kept: Vec<String> = contribute(offered, 120)
+            .kept
+            .into_iter()
+            .map(|contribution| contribution.plugin)
+            .collect();
+
+        assert_eq!(kept, vec!["cheap".to_string(), "middling".to_string()]);
+    }
+
+    /// A handle names the plugin and the stage. So one plugin at two stages is
+    /// two rows a receipt can tell apart.
+    #[test]
+    fn one_plugin_at_two_stages_is_two_handles() {
+        let candidates = plugin_candidates(&[
+            contribution("vera", "witness", 10),
+            contribution("vera", "verify", 20),
+        ]);
+
+        assert_eq!(candidates[0].handle, "vera/witness");
+        assert_eq!(candidates[1].handle, "vera/verify");
+        assert!(
+            candidates[0].why.contains("10") && candidates[0].why.contains("vera"),
+            "the why names the plugin and what it costs: {}",
+            candidates[0].why
+        );
+    }
+
+    /// **The witness for the shared cell.** What the block spent is gone from
+    /// what a plugin may add. What the plugin adds is gone from what the tool
+    /// list is settled against.
+    #[test]
+    fn a_contribution_spends_the_same_allowance_the_block_does() {
+        let ledger = Arc::new(SteeringLedger::new());
+        ledger.open_turn();
+        ledger.spend(400);
+        let allowance = ContextAllowance::new(1_000, Arc::clone(&ledger));
+
+        assert_eq!(allowance.remaining(), 600);
+
+        let decided = contribute(vec![contribution("vera", "witness", 250)], 600);
+        allowance.spend(decided.steering.est_tokens());
+
+        assert_eq!(allowance.remaining(), 350);
+        assert_eq!(
+            ledger.spent(),
+            650,
+            "the block and the plugin share one cell"
+        );
+    }
+
+    /// A block past the allowance leaves nothing. It does not wrap back around
+    /// to the whole budget.
+    #[test]
+    fn a_block_over_the_allowance_leaves_a_plugin_nothing() {
+        let ledger = Arc::new(SteeringLedger::new());
+        ledger.spend(u64::MAX);
+
+        assert_eq!(
+            ContextAllowance::new(1_000, ledger).remaining(),
+            0,
+            "the remainder saturates at nothing"
+        );
+    }
+}

--- a/crates/stella-runtime/src/wrapper.rs
+++ b/crates/stella-runtime/src/wrapper.rs
@@ -82,6 +82,7 @@ mod arbitration;
 mod candidate_fanout;
 mod child_turn;
 mod compose;
+mod contribution;
 mod dispatch;
 mod driver_call;
 mod driver_subprocess;

--- a/crates/stella-runtime/src/wrapper/contribution.rs
+++ b/crates/stella-runtime/src/wrapper/contribution.rs
@@ -1,0 +1,191 @@
+//! What a plugin's text costs, and how much of it a turn can afford.
+//!
+//! `stella_core::steering::plugins` ranks and packs. This measures. The split
+//! is the one every steering source keeps. The engine holds no I/O and no
+//! rendering. So the number comes from the layer that holds the messages
+//! (AGENTS.md #2).
+//!
+//! # It measures the text that reaches the model
+//!
+//! Each admitted `before_turn` answer becomes user messages. The cost is the
+//! sum over their bodies. So the ledger and the prompt cannot drift. What is
+//! charged is what is sent.
+//!
+//! # A refusal here cuts bytes, never a dispatch
+//!
+//! Text the allowance cannot hold is left out of the prompt and named in the
+//! drop report. The plugin still ran. Its scope and witness lists still stand.
+//! What it published still reaches the next stage. This is a budget on what
+//! goes in front of the model, and on nothing else.
+
+use stella_core::steering::SteeringSet;
+use stella_core::steering::plugins::{ContextAllowance, PluginContribution, contribute};
+use stella_plugin::StageName;
+use stella_protocol::completion::CompletionMessage;
+
+/// One member's answer at one stage: what it said, and what saying it costs.
+pub(crate) struct StageContribution {
+    contribution: PluginContribution,
+    messages: Vec<CompletionMessage>,
+}
+
+impl StageContribution {
+    /// Price `messages` as what `plugin` said at `stage`.
+    ///
+    /// `None` for an answer with no message. A plugin that put nothing in
+    /// front of the model is not a row that costs zero. It is not a row.
+    pub(crate) fn measured(
+        plugin: &str,
+        stage: &StageName,
+        messages: Vec<CompletionMessage>,
+    ) -> Option<Self> {
+        if messages.is_empty() {
+            return None;
+        }
+        let est_tokens = messages
+            .iter()
+            .map(|message| stella_protocol::estimate_tokens(&message.content))
+            .sum();
+        Some(Self {
+            contribution: PluginContribution {
+                plugin: plugin.to_string(),
+                stage: stage.to_string(),
+                est_tokens,
+            },
+            messages,
+        })
+    }
+}
+
+/// Fit a round's text into what the turn can still afford, and charge the
+/// allowance for what got through.
+///
+/// `None` is a host that named no ceiling. Everything is kept, nothing is cut,
+/// and the plane still reports what each plugin said. Unmeasured is not the
+/// same as unbounded. The record is what tells the two apart.
+///
+/// What lives keeps arrival order, which is the stage order the members agreed
+/// on. The pack's own order decides only who is cut.
+pub(crate) fn afford(
+    gathered: Vec<StageContribution>,
+    allowance: Option<&ContextAllowance>,
+) -> (Vec<CompletionMessage>, SteeringSet) {
+    let budget = allowance.map_or(u64::MAX, ContextAllowance::remaining);
+    let decided = contribute(
+        gathered
+            .iter()
+            .map(|stage| stage.contribution.clone())
+            .collect(),
+        budget,
+    );
+    let kept: Vec<CompletionMessage> = gathered
+        .into_iter()
+        .filter(|stage| decided.kept.contains(&stage.contribution))
+        .flat_map(|stage| stage.messages)
+        .collect();
+    if let Some(allowance) = allowance {
+        allowance.spend(decided.steering.est_tokens());
+    }
+    (kept, decided.steering)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use stella_core::steering::SteeringSource;
+    use stella_core::steering::ledger::SteeringLedger;
+
+    use super::*;
+
+    fn said(plugin: &str, word: &str, text: &str) -> StageContribution {
+        StageContribution::measured(
+            plugin,
+            &StageName::new(word),
+            vec![CompletionMessage::user(text)],
+        )
+        .expect("a message is a contribution")
+    }
+
+    /// A stage that said nothing is not a row on the plane.
+    #[test]
+    fn an_answer_with_no_message_is_no_contribution() {
+        assert!(
+            StageContribution::measured("quiet", &StageName::new("plan"), Vec::new()).is_none()
+        );
+    }
+
+    /// **The witness.** Text over what the turn has left is kept out of the
+    /// prompt and named in the drop report.
+    #[test]
+    fn a_contribution_over_the_allowance_is_withheld_and_named() {
+        let ledger = Arc::new(SteeringLedger::new());
+        let allowance = ContextAllowance::new(4, Arc::clone(&ledger));
+
+        let (messages, steering) = afford(
+            vec![said("chatty", "research", &"word ".repeat(200))],
+            Some(&allowance),
+        );
+
+        assert!(messages.is_empty(), "nothing reached the prompt");
+        assert_eq!(steering.dropped.len(), 1);
+        assert_eq!(steering.dropped[0].handle, "chatty/research");
+        assert_eq!(steering.dropped[0].source, SteeringSource::Plugin);
+        assert_eq!(ledger.spent(), 0, "and nothing was charged for it");
+    }
+
+    /// Text the allowance holds reaches the prompt. It is charged to the one
+    /// cell the block and the tool list meet in.
+    #[test]
+    fn an_affordable_contribution_reaches_the_prompt_and_is_charged() {
+        let ledger = Arc::new(SteeringLedger::new());
+        let allowance = ContextAllowance::new(10_000, Arc::clone(&ledger));
+
+        let (messages, steering) = afford(
+            vec![said("vera", "witness", "run the test")],
+            Some(&allowance),
+        );
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(steering.selected.len(), 1);
+        assert_eq!(steering.selected[0].handle, "vera/witness");
+        assert_eq!(ledger.spent(), steering.est_tokens());
+        assert!(ledger.spent() > 0, "the text cost something");
+    }
+
+    /// No allowance keeps it all and still reports it. An unmeasured ceiling
+    /// is not an unbounded one, and the record is what tells them apart.
+    #[test]
+    fn no_allowance_keeps_everything_and_still_reports_it() {
+        let (messages, steering) = afford(
+            vec![
+                said("a", "research", "one"),
+                said("b", "plan", &"word ".repeat(400)),
+            ],
+            None,
+        );
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(steering.selected.len(), 2);
+        assert!(steering.dropped.is_empty());
+    }
+
+    /// What lives keeps arrival order, which is the stage order the members
+    /// agreed on. Prompt bytes may not turn on what a stage cost.
+    #[test]
+    fn the_survivors_keep_the_stage_order() {
+        let ledger = Arc::new(SteeringLedger::new());
+        let allowance = ContextAllowance::new(40, Arc::clone(&ledger));
+
+        let (messages, _) = afford(
+            vec![
+                said("first", "research", "aaaa bbbb cccc"),
+                said("second", "plan", "dddd"),
+            ],
+            Some(&allowance),
+        );
+
+        let text: Vec<&str> = messages.iter().map(|m| m.content.as_str()).collect();
+        assert_eq!(text, vec!["aaaa bbbb cccc", "dddd"]);
+    }
+}

--- a/crates/stella-runtime/src/wrapper/dispatch.rs
+++ b/crates/stella-runtime/src/wrapper/dispatch.rs
@@ -72,6 +72,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use stella_core::ports::Clock;
+use stella_core::steering::SteeringSet;
+use stella_core::steering::plugins::ContextAllowance;
 use stella_plugin::{
     AfterTurnRequest, BeforeTurnRequest, CandidateGrant, Continuation, EvidenceProvenance,
     EvidenceSet, FlipObservation, LoopGrant, ObservedEvidence, Outcome, PROTOCOL_VERSION,
@@ -126,6 +128,7 @@ pub struct TurnPrelude {
     role: Option<String>,
     scope: Vec<String>,
     witness: Vec<String>,
+    steering: SteeringSet,
 }
 
 impl TurnPrelude {
@@ -174,6 +177,18 @@ impl TurnPrelude {
     #[must_use]
     pub fn witness(&self) -> &[String] {
         &self.witness
+    }
+
+    /// What the steering plane decided about this round. It holds one row per
+    /// plugin per stage, priced over the text below. What the turn's allowance
+    /// could not hold sits in `dropped`.
+    ///
+    /// A host reports it through the writer every steering source uses. So a
+    /// cut text reaches the operator by name. It is a record and not a second
+    /// choice. The messages here are already the ones that fit.
+    #[must_use]
+    pub fn steering(&self) -> &SteeringSet {
+        &self.steering
     }
 
     /// The contributions, as the volatile messages they are.
@@ -313,6 +328,13 @@ pub struct WrapperDispatch {
     /// cannot hold. See `super::compose::Composition::hold_grant`.
     hold_grant: LoopGrant,
     host_max_holds: u32,
+    /// What this session may still spend on a plugin's text. `None` is a host
+    /// that named no ceiling.
+    ///
+    /// A handle on the session's steering ledger, not a number. The block a
+    /// turn has drawn spends the same allowance, and the tool list takes what
+    /// is left.
+    context: Option<ContextAllowance>,
     /// Where a stamp's two times come from. A port rather than a call to the
     /// system clock, so a test can pin both numbers and read the whole record
     /// back byte for byte.
@@ -540,6 +562,7 @@ impl WrapperDispatch {
             rule: composition.rule,
             hold_grant: composition.hold_grant,
             host_max_holds: DEFAULT_HOST_MAX_HOLDS,
+            context: None,
             clock: Arc::new(HostClock),
         })
     }
@@ -549,6 +572,18 @@ impl WrapperDispatch {
     #[must_use]
     pub fn with_host_max_holds(mut self, holds: u32) -> Self {
         self.host_max_holds = holds;
+        self
+    }
+
+    /// Hold this session's plugin text to `allowance`.
+    ///
+    /// Without it, text is measured and reported and never cut. That is what a
+    /// host that named no allowance is owed. With it, what a plugin puts in
+    /// front of the model buys from the same tokens this turn's records,
+    /// skills and frames bought from.
+    #[must_use]
+    pub fn with_context_allowance(mut self, allowance: ContextAllowance) -> Self {
+        self.context = Some(allowance);
         self
     }
 
@@ -796,8 +831,14 @@ impl WrapperDispatch {
             role: None,
             scope: Vec::new(),
             witness: Vec::new(),
+            steering: SteeringSet::default(),
         };
 
+        // What each member said at each stage, priced over the exact messages.
+        // Gathered rather than appended as it arrives. The allowance is
+        // decided over the whole round. Packing each answer as it lands would
+        // let the first stage spend it all and hide that the last was cut.
+        let mut contributions: Vec<super::contribution::StageContribution> = Vec::new();
         let mut published: Vec<PublishedSignal> = Vec::new();
         // Stage-major, then member within a stage: a later stage must see what
         // an earlier one published *from every member*, which is the whole
@@ -880,9 +921,24 @@ impl WrapperDispatch {
                     }
                 }
                 published.extend(admitted.published().iter().copied());
-                prelude.messages.extend(admitted.into_messages());
+                // The plugin's own name, not the `[wrapper] id`. A drop report
+                // is read by whoever can act on it. What they act on is the
+                // word in `active_plugins`.
+                contributions.extend(super::contribution::StageContribution::measured(
+                    &member.manifest.name,
+                    stage,
+                    admitted.into_messages(),
+                ));
             }
         }
+        // One pack over the whole round, through the plane's own budgeter.
+        // What the allowance cannot hold is left out of the prompt and named.
+        // The plugin still ran. What it published still reached the stage
+        // after it.
+        let (messages, steering) =
+            super::contribution::afford(contributions, self.context.as_ref());
+        prelude.messages = messages;
+        prelude.steering = steering;
         prelude
     }
 

--- a/crates/stella-runtime/tests/wrapper_contribution_budget.rs
+++ b/crates/stella-runtime/tests/wrapper_contribution_budget.rs
@@ -1,0 +1,304 @@
+//! A plugin's text reaches the steering plane, costs what it costs, and is
+//! cut when the turn cannot afford it.
+//!
+//! `SteeringSource::Plugin` had a rank and no producer. So a plugin that was
+//! switched on could put any number of tokens in front of the model. Nothing
+//! priced it, ranked it, or said what became of it. These tests drive
+//! `stella_runtime::WrapperDispatch`, which is the shipped sequence. An
+//! in-process plugin sits on one side and a `TurnDriver` that keeps what it is
+//! handed sits on the other.
+//!
+//! They fail before this change for a plain reason. `TurnPrelude` held no
+//! steering record to read. `WrapperDispatch` held no allowance to fit text
+//! into. So the first two tests name methods that did not exist, and the third
+//! had nothing that could cut a message.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use stella_core::steering::SteeringSource;
+use stella_core::steering::ledger::SteeringLedger;
+use stella_core::steering::plugins::ContextAllowance;
+use stella_plugin::{
+    AfterTurnRequest, AfterTurnResponse, BeforeTurnRequest, BeforeTurnResponse, FlipObservation,
+    ObservedEvidence, PROTOCOL_VERSION, PluginManifest, SignalValues, TamperFinding, TurnOutcome,
+    VolatileContext,
+};
+use stella_runtime::wrapper::{
+    DrivenTurn, HostCallChannel, InProcessWrapper, RoundInput, TurnDriver, TurnPrelude,
+    WrapperDispatch, WrapperError, WrapperHandler,
+};
+
+/// A steering-grade plugin that speaks at `research` and nowhere else.
+///
+/// `before_turn_stages` narrows the `before_turn` point to the stages a
+/// manifest names. That is what makes the "an undeclared stage adds no row"
+/// test a claim about the shipped filter. It is not a claim about how this
+/// fixture behaves.
+const RESEARCH_ONLY: &str = r#"
+name = "stella-research"
+description = "grounds the turn before it starts"
+
+[loop]
+participation = "steering"
+points = ["before_turn"]
+before_turn_stages = ["research"]
+
+[wrapper]
+id = "research-v1"
+
+[[wrapper.stages]]
+name = "research"
+
+[[wrapper.stages]]
+name = "execute"
+"#;
+
+/// The same plugin with the stage list taken off. So it is asked at both
+/// stages, and it speaks at both.
+const EVERY_STAGE: &str = r#"
+name = "stella-research"
+description = "grounds the turn before it starts"
+
+[loop]
+participation = "steering"
+points = ["before_turn"]
+
+[wrapper]
+id = "research-v1"
+
+[[wrapper.stages]]
+name = "research"
+
+[[wrapper.stages]]
+name = "execute"
+"#;
+
+fn manifest(text: &str) -> PluginManifest {
+    PluginManifest::from_toml_str(text).expect("the fixture manifest loads")
+}
+
+/// Says one message at every stage it is asked at, sized by `words`.
+struct Contributor {
+    words: usize,
+}
+
+#[async_trait]
+impl WrapperHandler for Contributor {
+    async fn before_turn(
+        &self,
+        request: BeforeTurnRequest,
+        _host: &dyn HostCallChannel,
+    ) -> Result<BeforeTurnResponse, WrapperError> {
+        Ok(BeforeTurnResponse {
+            context: vec![VolatileContext::new(
+                request.stage.as_str(),
+                format!(
+                    "{} {}",
+                    request.stage.as_str(),
+                    "ground ".repeat(self.words)
+                ),
+            )],
+            ..BeforeTurnResponse::empty()
+        })
+    }
+
+    async fn after_turn(
+        &self,
+        _request: AfterTurnRequest,
+        _host: &dyn HostCallChannel,
+    ) -> Result<AfterTurnResponse, WrapperError> {
+        Ok(AfterTurnResponse {
+            protocol_version: PROTOCOL_VERSION,
+            evidence: ObservedEvidence {
+                flip: FlipObservation::NotAttempted,
+                measurements: BTreeMap::new(),
+                detail: None,
+            },
+        })
+    }
+}
+
+/// A host that keeps the one prelude it was handed.
+#[derive(Default)]
+struct Recorder {
+    seen: Option<TurnPrelude>,
+}
+
+#[async_trait(?Send)]
+impl TurnDriver for Recorder {
+    async fn run_turn(&mut self, prelude: TurnPrelude) -> DrivenTurn {
+        self.seen = Some(prelude);
+        DrivenTurn {
+            outcome: TurnOutcome {
+                completed: true,
+                answer: "done".into(),
+                tools: None,
+                changed_files: None,
+            },
+            tamper: TamperFinding::NotChecked,
+        }
+    }
+}
+
+/// The host's pre-turn snapshot. Every field is answered here because
+/// `SignalValues` derives no `Default`. A host must say what it saw.
+fn signals() -> SignalValues {
+    SignalValues {
+        test_command: false,
+        candidates: 0,
+        budget_metered: false,
+        conversational: false,
+        questions: 0,
+        plans: false,
+        verifies: false,
+        wants_witness: false,
+        wants_verifier: false,
+        mutating_actions: 0,
+        diff_lines: 0,
+        witness_authored: false,
+        flip_achieved: false,
+        tests_red: false,
+        tests_green: false,
+    }
+}
+
+fn input() -> RoundInput {
+    RoundInput {
+        goal: "fix the flaky test".into(),
+        signals: signals(),
+        candidate: None,
+    }
+}
+
+fn bind(text: &str, words: usize) -> WrapperDispatch {
+    WrapperDispatch::bind(
+        manifest(text),
+        Arc::new(InProcessWrapper::new(Contributor { words })),
+    )
+    .expect("[wrapper] declared")
+}
+
+async fn drive(dispatch: WrapperDispatch) -> TurnPrelude {
+    let mut recorder = Recorder::default();
+    dispatch
+        .run(input(), &mut recorder)
+        .await
+        .expect("the dispatch ran");
+    recorder.seen.expect("the host was asked to run a turn")
+}
+
+/// **The witness.** Text from a granted stage reaches the plane as a
+/// `SteeringSource::Plugin` row. The row is named for the plugin and the
+/// stage. It is priced over the text that reached the prompt.
+#[tokio::test]
+async fn a_granted_contribution_reaches_the_plane() {
+    let prelude = drive(bind(RESEARCH_ONLY, 4)).await;
+
+    let steering = prelude.steering().clone();
+    assert_eq!(steering.selected.len(), 1, "{:?}", steering.selected);
+    assert_eq!(steering.selected[0].source, SteeringSource::Plugin);
+    assert_eq!(steering.selected[0].handle, "stella-research/research");
+    assert!(steering.dropped.is_empty(), "{:?}", steering.dropped);
+
+    let injected: u64 = prelude
+        .into_messages()
+        .iter()
+        .map(|message| stella_protocol::estimate_tokens(&message.content))
+        .sum();
+    assert_eq!(
+        steering.est_tokens(),
+        injected,
+        "the plane charged exactly what the prompt carries"
+    );
+}
+
+/// A stage the manifest never named adds no row. The filter that stops the
+/// dispatch also stops the cost. So a row is never a claim about a plugin
+/// nobody asked.
+#[tokio::test]
+async fn an_undeclared_stage_produces_no_candidate() {
+    let narrowed = drive(bind(RESEARCH_ONLY, 4)).await;
+    let every = drive(bind(EVERY_STAGE, 4)).await;
+
+    assert_eq!(
+        narrowed.steering().selected.len(),
+        1,
+        "one declared stage, one candidate"
+    );
+    assert_eq!(
+        every.steering().selected.len(),
+        2,
+        "and both stages when the manifest declares both: {:?}",
+        every.steering().selected
+    );
+    assert!(
+        !narrowed
+            .steering()
+            .selected
+            .iter()
+            .any(|candidate| candidate.handle.ends_with("/execute")),
+        "the undeclared stage contributed nothing to cost"
+    );
+}
+
+/// **The witness for the budget.** Text the turn cannot afford is kept out of
+/// the prompt and named in the drop report. The allowance is the one cell the
+/// block has already spent from.
+#[tokio::test]
+async fn a_contribution_over_the_allowance_is_withheld_and_named() {
+    let ledger = Arc::new(SteeringLedger::new());
+    ledger.open_turn();
+    // The turn's records, skills and frames got there first and left ten
+    // tokens, which no contribution below fits in.
+    ledger.spend(990);
+
+    let prelude = drive(
+        bind(EVERY_STAGE, 60)
+            .with_context_allowance(ContextAllowance::new(1_000, Arc::clone(&ledger))),
+    )
+    .await;
+
+    let steering = prelude.steering().clone();
+    assert_eq!(steering.selected.len(), 0, "{:?}", steering.selected);
+    assert_eq!(steering.dropped.len(), 2, "{:?}", steering.dropped);
+    assert!(
+        steering
+            .dropped
+            .iter()
+            .all(|drop| drop.source == SteeringSource::Plugin),
+        "the drops arrive on the plane as plugin drops: {:?}",
+        steering.dropped
+    );
+    assert!(
+        prelude.into_messages().is_empty(),
+        "and nothing the allowance refused reached the prompt"
+    );
+    assert_eq!(ledger.spent(), 990, "nothing was charged for a refusal");
+}
+
+/// A plugin that never asked for `before_turn` is not asked, and costs
+/// nothing. The grant is the gate, one rung above the stage list.
+#[tokio::test]
+async fn a_plugin_that_declared_no_point_contributes_nothing() {
+    const NO_POINTS: &str = r#"
+name = "stella-quiet"
+description = "declares a stage order and answers nothing"
+
+[loop]
+participation = "steering"
+
+[wrapper]
+id = "quiet-v1"
+
+[[wrapper.stages]]
+name = "execute"
+"#;
+
+    let prelude = drive(bind(NO_POINTS, 40)).await;
+
+    assert!(prelude.steering().selected.is_empty());
+    assert!(prelude.steering().dropped.is_empty());
+    assert!(prelude.into_messages().is_empty());
+}


### PR DESCRIPTION
## What and why

`SteeringSource::Plugin` was an arm of the steering plane with a rank, a tag and
no producer. An installed plugin's `before_turn` text goes straight in front of
the model, so the one source that comes from outside this repository was the one
source the shared budget could not see: nothing priced it, nothing ranked it,
and `drop_message` returned `None` for it, so even a candidate that arrived drew
no report.

This is the join.

- **`crates/stella-core/src/steering/plugins.rs`** (new, pure — invariant 2).
  Mirrors `steering/tools.rs`: `PluginContribution { plugin, stage, est_tokens }`,
  `plugin_candidates`, and `contribute(contributions, budget)`, which packs
  through the one shared `pack_to_budget`. Beside them `ContextAllowance` reads
  what a turn has left off `steering::ledger::SteeringLedger` and charges what
  the text took — the same cell records, skills, frames and the tool array
  already meet in.
- **`crates/stella-runtime/src/wrapper/contribution.rs`** (new sibling). Measures
  each admitted `before_turn` answer over the exact messages it would inject,
  then fits the round into what the turn can still afford.
  `dispatch::open_round` calls it once per round, over the round as a whole, so
  a first stage cannot spend everything and hide that the last was cut.
- **`TurnPrelude::steering`** carries the plane's record, and
  `WrapperDispatch::with_context_allowance` carries the ceiling — beside
  `with_host_max_holds`, the same shape.
- **`crates/stella-cli`** wires it. `Settings::plugin_context_budget` reads the
  allowance `context.steering.max_tokens` already declares, so there is no new
  settings key and no second budget. The three doors that bind a wrapper set it
  (`agent::goal` twice, `fleet_cmd`), the three turn drivers report the drops
  through `memory::report_steering_drops`, and `drop_message`'s plugin arm names
  the plugin, the stage and the remedy.

Exemplar: `crates/stella-core/src/steering/tools.rs` and
`crates/stella-cli/src/tool_lean.rs` — the tool arm of the same plane, landed in
#6057. The producer/adapter split, the `advertise`-shaped packing entry point,
and the "a withheld candidate is a cost measure, never a capability change"
contract are copied from them deliberately.

## Where this departs from the design pointer, and why

The maintainer pointer asked for a producer over the active plugin set, one
candidate per declared `[[wrapper.stages]]` entry, with `est_tokens` from "the
stage's declared prompt contribution (the `before_turn` contribution size, or the
manifest's declared budget)".

There is no declared budget in the manifest today, and adding one would let a
plugin set its own price: a number declared too small wins budget it never paid
for, and the plane would be pricing a claim instead of a cost. The issue's own
item 1 asks for the honest number — "`est_tokens` measured over the exact text
that would be injected". So the producer sits where that text exists, at the
point the contribution arrives, and the active set still decides membership,
because a plugin that is not switched on is never dispatched.

The pointer also put `Plugin` above `Tool` in the precedence. `source_rank`
keeps it last, and the comment now argues it: a tool the model cannot see is one
it will not pick, so a plugin able to evict a built-in schema is the governance
failure the issue names one rung up. It is also inert in the shipped path — tool
schemas are packed by their own `advertise` call against what the block left, so
`Plugin` and `Tool` never meet in one sort.

## Witness mechanism

Each of these fails on `main` by construction, because the methods they name did
not exist and nothing could produce or cut a plugin candidate.

- `crates/stella-runtime/tests/wrapper_contribution_budget.rs` drives the shipped
  `WrapperDispatch` with an in-process plugin and a recording `TurnDriver`:
  - `a_granted_contribution_reaches_the_plane` — a granted stage's text becomes a
    `SteeringSource::Plugin` row named `stella-research/research`, priced at
    exactly what the prompt carries. Fails on `main`: `TurnPrelude::steering`
    did not exist.
  - `an_undeclared_stage_produces_no_candidate` — the `before_turn_stages`
    narrowing that stops the dispatch also stops the cost, checked against the
    same fixture with the narrowing taken off.
  - `a_contribution_over_the_allowance_is_withheld_and_named` — a block that
    already spent 990 of a 1000-token allowance leaves nothing, both stages are
    cut, nothing reaches the prompt, and nothing is charged. Fails on `main`:
    `WrapperDispatch::with_context_allowance` did not exist.
  - `a_plugin_that_declared_no_point_contributes_nothing` — the grant is the
    gate, one rung above the stage list.
- `steering/plugins.rs`'s own units cover the pack: what does not fit is dropped
  and named, the survivors keep arrival order, a wide budget cuts nothing, and
  the block's spend and the plugin's spend land in one ledger cell.
- `wrapper/contribution.rs`'s units cover the measuring: an answer with no
  message is no row, an affordable one is charged, a refused one is not.
- `settings/steering.rs` gains three units for `plugin_context_budget`,
  including the one that keeps `tools.lean` from deciding it.

Verification: CI on this branch. No workspace build was run on the maintainer's
laptop (CLAUDE.md, "CI builds and tests; this laptop does not"). Locally:
`cargo fmt --all` and `make guards-fast` are green, and `make line-citations`,
`make dead-code-allows` and `./scripts/check-file-size.sh` pass.

## Tests deleted

None.

## Definition of done

- [x] A production adapter emits `SteeringSource::Plugin` candidates from an
      installed plugin's granted contribution points.
- [x] A contribution from a point the manifest did not declare never becomes a
      candidate.
- [x] `drop_message`'s plugin arm names the plugin and the remedy instead of
      returning `None`.
- [x] `source_rank`'s comment for `Plugin` states the decided precedence and its
      reason.
- [x] A witness test that fails on the old code.

Closes #6112

## Remaining work filed

See the comment below for the issues this session opened.

## Summary by Sourcery

Integrate installed plugin context into the shared steering budget so contributions are measured, ranked, packed, and reported consistently with other steering sources.

New Features:
- Add plugin contributions as a first-class steering-plane source, producing one budgeted candidate per granted plugin stage.
- Measure admitted plugin context over the exact messages injected into the prompt and enforce the shared steering allowance across each turn.
- Expose plugin steering decisions and actionable drop reports naming the plugin and stage.],
- bug_fixes relevantes? irrelevant? no need? Wait schema requires bug_fixes array. Use []
- bug_fixes
- enhancements
- build
- ci
- deployment
- docs
- tests
- chores
- overview

Enhancements:
- Keep plugin contributions below workspace-owned steering sources and tool advertisements in the defined precedence order.
- Share plugin spending with the existing steering ledger and reuse the established steering packing and reporting behavior.

Tests:
- Add core, runtime, CLI settings, and end-to-end wrapper coverage for plugin contribution measurement, budget enforcement, stage gating, ordering, ledger charging, and drop reporting.