### PR TITLE
docs(policy): fix over file — fix what you find in the PR, file only what cannot ride it

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,16 +35,18 @@ Stella's definition of done is a test that **fails on the old code and passes on
 - [ ] `Closes #N` appears **both** above and as a commit trailer — squash builds
       the commit body from commit messages, so the description alone won't carry it
 
-## Nothing left behind
+## Fix over file
 
-Anything you noticed and did not fix — a bug, a missing test, dead or unwired
-code, the logical next step of this work — is a GitHub issue before this merges,
-written as a handoff a fresh agent could execute (AGENTS.md § "Nothing left
-behind"). The gate catches the residue (a `TODO` with no issue number); it
-cannot catch what only you saw.
+A defect you saw while making this change is fixed in this PR, even when it
+is off-topic. Name each extra fix below. File an issue only when a fix could
+not ride this PR: it needs a maintainer call, a rig or spend, or more than
+one session. File it only if fixing it moves a pillar: stability,
+reliability, maintainability, innovation, efficiency, or performance
+(AGENTS.md § "Fix over file"). The gate catches a `TODO` with no issue
+number. It cannot catch what only you saw.
 
-- [ ] Filed: #___, #___ — **or**
-- [ ] There is nothing: everything I noticed is fixed in this PR
+- [ ] Extra fixes in this PR: ___ — **or** none
+- [ ] Filed, with the reason a fix could not ride this PR: #___ — **or** nothing was deferred
 
 ## Ground-rule check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1039,40 +1039,53 @@ not a `make gate` step: locally there is no second tree to compare.
 
 ---
 
-## Nothing left behind — every finding becomes a fix or a GitHub issue
+## Fix over file — a finding is fixed in the PR, and filed only when it cannot be
 
 The standing rule for every session, human or agent, and the companion to the
-witness-test contract above: work is not finished while anything you noticed
+witness-test contract above: work is not finished while a defect you noticed
 lives only in your head, a chat transcript, or a worktree that is about to be
-deleted.
+deleted. The durable place for a finding is the fix itself, and the issue
+tracker is the fallback, not the default.
 
-- **Fix what you can inside the change you are already making.** A bug you can
-  fix safely within your current scope gets fixed, not filed.
-- **Everything else becomes a GitHub issue before you finish** — a bug you saw
-  and did not fix, a defect you worked around, a missing test, an idea worth
-  keeping, dead or unwired code you noticed, and the logical next step of the
-  work you just completed. If your change ships scaffolding that something else
-  must later wire up, file the issue for that wiring in the same PR — unwired
-  code with no tracking issue is exactly the failure mode this rule exists to
-  prevent.
-- **Write every issue as a handoff.** Assume the reader is a fresh agent with
-  none of your session's context: state the problem, the files involved (paths,
-  not descriptions), how to reproduce or verify, the constraints you already
-  discovered (gates, invariants, related PRs and issues), and what "done" looks
-  like. A one-line issue that needs your memory to interpret is a note to
-  yourself, not a handoff.
+- **Fix it in the PR you are already making.** A defect you can fix gets
+  fixed, whether or not it is what the PR set out to do. Two unrelated fixes in
+  one PR is fine; say what each one is in the description so a reviewer can
+  read them apart. A PR that ships scaffolding wires it up in the same change
+  rather than filing the wiring for later.
+- **Defer to an issue only when a fix cannot responsibly ride the PR.** Three cases:
+  it needs a decision only the maintainer can make; it needs a rig, a
+  credential, or real spend; or it is larger than the session, so a partial
+  fix would leave the tree worse than the defect. Say which case applies in
+  the issue.
+- **Log nothing that does not eat at a pillar.** An issue earns its place
+  only if fixing it moves at least one of stability, reliability,
+  maintainability, innovation, efficiency, or performance, and the issue
+  names which. These are not issues: an open design question with no defect
+  behind it (decide it in the PR, or record the decision as an ADR); a
+  record of a choice already in effect; a measurement or bench run that
+  cannot change a decision; a test for a path nothing reaches; bookkeeping
+  about the tracker itself; and a follow-up the PR that would file it has
+  already made moot.
+- **Write every issue you do file as a handoff.** Assume the reader is a
+  fresh agent with none of your session's context: state the problem, the
+  files involved (paths, not descriptions), how to reproduce or verify, the
+  constraints you already discovered (gates, invariants, related PRs and
+  issues), which pillar it moves, and what "done" looks like. A one-line
+  issue that needs your memory to interpret is a note to yourself, not a
+  handoff.
 - **Search before filing** (`gh issue list`, `gh search issues`) and link
   related issues instead of duplicating them. Reference the issues you filed
-  from your PR description so the residue of the work is auditable.
+  from your PR description so what was deferred, and why, is auditable.
 
-The judgment half of this rule — did you notice something and not file it —
-is not mechanically decidable, and the PR template asks a human. Its most
-common *residue* is checked: `left-behind` (`scripts/check-left-behind.sh`)
-fails the gate on a `TODO`/`FIXME`/`XXX`/`HACK` in code that names no issue,
-because a marker with no `#1234` beside it is by definition a thing left
-behind with no handoff (#1454). A marker that names an issue is tracked work
-and passes. The fix is always to file the issue and reference it — never to
-delete the marker, and never to add a baseline entry: that baseline started
+The judgment half of this rule — did you notice a defect and neither fix nor
+file it — is not mechanically decidable, and the PR template asks a human.
+Its most common *residue* is checked: `left-behind`
+(`scripts/check-left-behind.sh`) fails the gate on a `TODO`/`FIXME`/`XXX`/
+`HACK` in code that names no issue, because a marker with no `#1234` beside
+it is by definition a thing left behind with no handoff (#1454). A marker
+that names an issue is tracked work and passes. The fix is to fix the thing
+the marker names; failing that, file the issue and reference it — never
+delete the marker, and never add a baseline entry: that baseline started
 empty and is meant to stay empty.
 
 ---
@@ -1613,10 +1626,13 @@ macanderson org repos.
   finishing it links it with `Refs #N` rather than `Closes #N`: `Refs`
   does not close, so the merge gate does not hold that PR against the
   issue's DoD. A PR may carry both, and is gated only on what it closes.
-- **[SCR-004](docs/scr/SCR-004-residue-becomes-issues.md) — Residue:**
-  Before declaring any task complete, file a GitHub issue for every
-  follow-up, tech-debt item, or logical next step you noticed. Apply ONLY
-  the `triage` label.
+- **[SCR-004](docs/scr/SCR-004-residue-becomes-issues.md) — Fix over
+  file:** Fix what you notice in the PR you are making; two unrelated fixes
+  in one PR is fine. File an issue only when a fix cannot responsibly ride
+  the PR (a maintainer decision, a rig or spend, or work larger than the
+  session), and only when fixing it moves stability, reliability,
+  maintainability, innovation, efficiency, or performance. Apply ONLY the
+  `triage` label.
 - **[SCR-005](docs/scr/SCR-005-triage-separation-of-duties.md) — Triage
   separation of duties:** Never apply a priority or size label —
   a dedicated triage agent owns sizing and priority; a guard workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,14 +208,22 @@
   entirely. It was restored because an agent that cannot read a file, search,
   or run a command is not an agent; the lesson kept is the single-purpose
   discipline, not the count.
-- **Nothing left behind.** Every bug, defect, idea, missing test, piece of
-  unwired code, or logical next step you notice and do not fix inside your
-  current change MUST be filed as a GitHub issue before you finish — written
-  as a handoff a fresh agent could execute without your session's context
-  (problem, file paths, repro/verify steps, constraints, definition of done).
-  Search for an existing issue first; link, don't duplicate. The full policy
-  is AGENTS.md § "Nothing left behind — every finding becomes a fix or a
-  GitHub issue". Never end a turn with untracked half-finished work.
+- **Fix over file.** A defect you notice while working gets fixed in the PR
+  you are already making. Two unrelated fixes in one PR is fine; a fix
+  deferred to an issue is not, unless it truly cannot ride the PR: it needs a
+  decision only the maintainer can make, it needs a rig or spend, or it is
+  larger than the session. Only then file it, as a handoff a fresh agent
+  could execute (problem, file paths, repro, constraints, definition of done),
+  after searching for an existing issue.
+
+  **File nothing that does not eat at a pillar.** An issue earns its place
+  only if fixing it moves stability, reliability, maintainability,
+  innovation, efficiency, or performance. An open design question with no
+  defect behind it, a record of a choice already in effect, a measurement
+  that cannot change a decision, a test for a path nothing reaches, or
+  tracker bookkeeping is not an issue — decide it in the PR, or drop it. The
+  full policy is AGENTS.md § "Fix over file". Never end a turn with
+  untracked half-finished work.
 - **An issue you file carries the `triage` label and nothing else.** SCR-004
   and SCR-005 (AGENTS.md's standing-decisions block) hold sizing and priority
   for a dedicated triage agent, and `triage-guard` strips a creator-applied
@@ -252,7 +260,7 @@
   - **Answer it** when it does not belong: deliberately out of scope,
     deferred into a filed issue, or a misreading of the diff. Post a PR
     comment naming the row and the reason, and file the follow-up issue
-    where one is owed ("Nothing left behind" above). Sourcery's verdict is
+    where one is owed ("Fix over file" above). Sourcery's verdict is
     a claim like any other review comment and can be wrong about your diff —
     the rebuttal still goes on the PR, where the next reviewer finds it.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -687,7 +687,7 @@
     "scr/004-residue-becomes-issues": {
       "path": "docs/scr/SCR-004-residue-becomes-issues.md",
       "status": "living",
-      "title": "File all residue as issues before declaring done"
+      "title": "Fix what you find; file only what cannot ride the PR"
     },
     "scr/005-triage-separation-of-duties": {
       "path": "docs/scr/SCR-005-triage-separation-of-duties.md",

--- a/docs/playbooks/tool-removal.md
+++ b/docs/playbooks/tool-removal.md
@@ -98,9 +98,9 @@ git ls-files -z | xargs -0 rg -l --fixed-strings '<tool_name>'
 Every remaining hit is either (a) updated or deleted, (b) a record that must
 stay as recorded (an issue postmortem, archived bench data, a trace fixture),
 or (c) a defect. There is no fourth category — in particular, prose docs do
-not get "removed in ..." notes: delete the sentence, don't memorialize it. Anything discovered that cannot be
-fixed in the same change is filed as a GitHub issue before finishing
-(AGENTS.md § "Nothing left behind").
+not get "removed in ..." notes: delete the sentence, don't memorialize it. Fix what you find in the same
+change. File an issue only for what cannot ride it (AGENTS.md § "Fix over
+file").
 
 ### 10. Gates
 

--- a/docs/scr/SCR-004-residue-becomes-issues.md
+++ b/docs/scr/SCR-004-residue-becomes-issues.md
@@ -1,35 +1,64 @@
 ---
 id: scr/004-residue-becomes-issues
-title: File all residue as issues before declaring done
+title: Fix what you find; file only what cannot ride the PR
 status: living
-origin: "north-star requirement: nothing evaporates in a chat transcript"
+origin: "north-star requirement: nothing evaporates in a chat transcript — and nothing is logged that does not earn its place"
 trigger: the end of every completed task
 autonomy: L1
-enforcement: AGENTS.md standing-decisions block (imported by CLAUDE.md); end-of-task checklist in SCR-003; target L3 — a sweep agent auditing merged PRs for unfiled residue
+enforcement: AGENTS.md standing-decisions block (imported by CLAUDE.md); end-of-task checklist in SCR-003; PR template "Fix over file" section; target L3 — a sweep agent auditing merged PRs for deferred findings that could have ridden them
 ---
 
 ## Directive
 
-Every completed task ends with a residue sweep: anything noticed but not
-done — follow-ups, tech debt, ideas, flaky behavior, doc gaps — is filed as
-a GitHub issue before the task is declared complete. A task that ends
-without its residue filed is not done, even if the code is merged.
+A defect noticed while doing a task is fixed inside the task's own pull
+request. Two unrelated fixes in one pull request is fine. A finding is filed
+as a GitHub issue only when a fix cannot responsibly ride the pull request:
+it needs a decision only the maintainer can make, it needs a rig, a
+credential or real spend, or it is larger than the session. And it is filed
+only when fixing it would move at least one of six pillars: stability,
+reliability, maintainability, innovation, efficiency, or performance. A task
+that ends with a deferrable, pillar-moving finding neither fixed nor filed is
+not done, even if the code is merged.
 
 ## Rationale
 
 The backlog stays alive only if observations survive the session that made
-them. Chat transcripts are write-only memory; issues are the durable store
-the triage agent (SCR-005) can order and the next session can pick up.
+them, and chat transcripts are write-only memory. But an issue is not free:
+it is read by the triage agent (SCR-005), ranked, dispatched, and re-read by
+the session that picks it up. Between 2026-09-02 and 2026-09-06, 300 fixes
+filed about 360 follow-ups, and a read of the result found a large share
+were open questions, records of choices already in effect, and measurements
+that could not change a decision. None of those moves a pillar, and each one
+costs a future session the time to discover that. The cheapest place to
+settle a finding is the pull request that found it.
 
 ## How an agent complies
 
-- At end of task, list everything noticed but not done, however small.
-- File each item as its own issue using the task template
-  (`.github/ISSUE_TEMPLATE/task.yml`), with context linking back to the
-  origin task and a concrete DoD.
-- Apply ONLY the `triage` label — never a priority or size (SCR-005).
+- When you notice a defect, fix it now, in the branch you are on. Name each
+  extra fix in the pull request description so a reviewer can read them
+  apart.
+- If a fix genuinely cannot ride the pull request, file one issue with the
+  task template (`.github/ISSUE_TEMPLATE/task.yml`): the problem, the file
+  paths, how to reproduce, the constraints you found, which of the three
+  cases stopped you fixing it, which pillar it moves, and a concrete
+  definition of done. Apply ONLY the `triage` label (SCR-005).
+- Do not file an open design question (decide it in the pull request, or
+  write an ADR under `docs/adr/`), a record of a choice already in effect, a
+  measurement that cannot change a decision, a test for a path nothing
+  reaches, bookkeeping about the tracker, or a follow-up your own change has
+  made moot.
+
+## Scope, and when this rule changes
+
+This directive is written for the period with zero customers, when tracing
+a production outage back to the change that caused it is not yet a concern.
+It trades a one-fix-per-pull-request history for speed, on purpose. The
+maintainer decided that on 2026-09-06 and said the rule will be adjusted
+once customers exist: at that point a pull request goes back to carrying
+one change, so an outage can be bisected to one merge, and the deferral
+cases above narrow. Revisit this section before the first paying customer.
 
 ## Exceptions
 
-None. A task with zero residue states that explicitly ("no residue") in its
-final report, so silence is never ambiguous.
+None. A task with nothing deferred states that explicitly ("nothing was
+deferred") in its final report, so silence is never ambiguous.

--- a/docs/spec/remote-sandboxes.md
+++ b/docs/spec/remote-sandboxes.md
@@ -236,7 +236,7 @@ shell through `Bash::confined_to`. That file and the rest of
 (#3852); `ToolRegistry::new(root)` is the whole constructor today, and
 nothing left in the tree can say which tree is graded, because nothing
 declares one. Porting the 1,456 lines back would land a boundary that
-never arms, which is the unwired code AGENTS.md § "Nothing left behind"
+never arms, which is the unwired code AGENTS.md § "Fix over file"
 exists to stop. A host that later mounts a graded tree it does not want
 written may reopen this: the claim here is that per-command confinement
 is the wrong layer for it, not that the two regressions above were

--- a/scripts/check-left-behind.sh
+++ b/scripts/check-left-behind.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Guard: a deferral marker in code must name the issue that tracks it.
-# See #1454, and AGENTS.md § "Nothing left behind".
+# See #1454, and AGENTS.md § "Fix over file".
 #
 # AGENTS.md and CLAUDE.md require that anything noticed and not fixed inside the
 # current change becomes a GitHub issue written as a handoff. That is the right
@@ -170,7 +170,7 @@ report="$(
 if [ -n "$report" ]; then
   echo "check-left-behind: FAILED" >&2
   echo "$report" | awk '
-    /^NEW$/      { print ""; print "These files carry a TODO/FIXME/XXX/HACK that names no issue."; print ""; print "The fix is to FILE THE ISSUE and reference it — not to delete the marker,"; print "and not to add a baseline entry. Write it as a handoff a fresh agent could"; print "execute: the problem, the file paths, how to verify, what done looks like"; print "(AGENTS.md, \"Nothing left behind\"). Then:"; print ""; print "    // TODO(#1234): the thing you deferred"; print ""; print "A marker that names an issue is tracked work and passes this guard."; next }
+    /^NEW$/      { print ""; print "These files carry a TODO/FIXME/XXX/HACK that names no issue."; print ""; print "The fix is to FIX THE THING the marker names. Failing that, file the issue"; print "and reference it — never delete the marker, never add a baseline entry. Write"; print "it as a handoff a fresh agent could execute: the problem, the file paths, how"; print "to verify, what done looks like (AGENTS.md, \"Fix over file\"). Then:"; print ""; print "    // TODO(#1234): the thing you deferred"; print ""; print "A marker that names an issue is tracked work and passes this guard."; next }
     /^GREW$/     { print ""; print "These files gained untracked markers beyond their baseline count. Same fix:"; print "file the issue and reference it."; next }
     /^OBSOLETE$/ { print ""; print "Obsolete baseline entries — the markers are gone or now reference an issue."; print "Run \"make left-behind-update\": an exemption must not outlive the problem it"; print "covered, or the file is free to accumulate again."; next }
     { print }

--- a/scripts/self-driving/commands/self-driving.md
+++ b/scripts/self-driving/commands/self-driving.md
@@ -32,9 +32,11 @@ needs must end up on disk or in GitHub before you finish.**
 
 Three rules override everything below.
 
-1. **Nothing left behind.** Every defect you notice and do not fix becomes a
-   GitHub issue *before this cycle ends*, written as a handoff a fresh agent can
-   execute. See `/self-driving:tickets`.
+1. **Fix over file.** Every defect you notice gets fixed in this cycle's PR,
+   even when it is off-topic. File an issue only when a fix cannot ride the
+   PR. File it only if fixing it moves a pillar: stability, reliability,
+   maintainability, innovation, efficiency, or performance. See
+   `/self-driving:tickets`.
 2. **Verified done, not claimed done.** Every behaviour fix ships with a witness
    test that fails on `main` and passes with the change. No witness, no merge —
    label the PR `needs-witness` and say so.
@@ -129,8 +131,8 @@ Phase 4 with what you learned.
 ## Phase 3 — Audit through the current lens
 
 The open aperture is `$SELF_DRIVING_APERTURE`. Audit the **post-fix** tree, and audit
-it *through that lens specifically* — the point of the ladder is that each lens
-sees what the others structurally cannot:
+it *through that lens specifically*. The point of the ladder is that each lens
+sees what the others cannot:
 
 | Aperture | The question it asks | How you look (#1549) |
 |---|---|---|

--- a/scripts/self-driving/commands/self-driving/tickets.md
+++ b/scripts/self-driving/commands/self-driving/tickets.md
@@ -3,32 +3,37 @@ description: File everything this cycle could not fix as GitHub issues written a
 argument-hint: "[--dry-run]"
 ---
 
-# self-driving:tickets — nothing left behind
+# self-driving:tickets — fix over file
 
-The rule from AGENTS.md, and the one phase of the cycle that has no skip
-condition:
+The rule from AGENTS.md § "Fix over file", and the one phase of the cycle
+that has no skip condition:
 
-> Work is not finished while anything you noticed lives only in your head, a chat
-> transcript, or a worktree that is about to be deleted.
+> A defect you can fix gets fixed in the PR you are already making. File it
+> only when a fix cannot responsibly ride the PR, and only when fixing it
+> moves a pillar.
 
-A cycle that fixed twenty defects and filed nothing about the six it could not
-fix has **destroyed information**. The worktree gets deleted, the context window
-resets, and those six findings are gone.
+A cycle that fixed twenty defects and filed nothing about the six it truly
+could not fix has **destroyed information**. The worktree gets deleted, the
+context window resets, and those six findings are gone. A cycle that filed
+twenty questions has wasted the next cycle's time instead.
 
 ---
 
 ## What gets filed
 
-Everything you noticed and did not fix:
+Only a finding that meets both tests:
 
-- a bug you saw and worked around
-- a defect you fixed only partially, and what is left
-- a missing test
-- dead or unwired code
-- **the logical next step of the work you just did** — if this cycle shipped
-  scaffolding something else must wire up, that wiring is an issue, filed in the
-  same breath as the PR
-- an idea worth keeping
+1. **A fix could not ride the PR** — it needs a decision only the maintainer
+   can make, it needs a rig, a credential or real spend, or it is larger than
+   the cycle. Say which in the issue. A defect you could have fixed is fixed,
+   not filed, even when it is unrelated to the PR's title.
+2. **Fixing it moves a pillar** — stability, reliability, maintainability,
+   innovation, efficiency, or performance. Name which.
+
+Do not file an open design question (decide it in the PR, or write an ADR), a
+record of a choice already in effect, a measurement that cannot change a
+decision, a test for a path nothing reaches, tracker bookkeeping, or a
+follow-up your own change has made moot.
 
 ## The handoff format
 


### PR DESCRIPTION
The maintainer's directive of 2026-09-06: **fix over file**. A defect noticed while working is fixed in the PR that found it, even when unrelated to the title, and two unrelated fixes in one PR is fine. An issue is filed only when a fix cannot responsibly ride the PR (a maintainer decision, a rig or spend, or work larger than the session), and only when fixing it moves stability, reliability, maintainability, innovation, efficiency, or performance. Open design questions, records of choices already in effect, measurements that cannot change a decision, tests for unreachable paths, tracker bookkeeping, and moot follow-ups are not issues.

Why: between 2026-09-02 and 2026-09-06, 300 fixes filed about 360 follow-ups under the old "nothing left behind → file it" reflex, and a read of the result found a large share carried no defect. Each one costs the next session the time to discover that.

Scope, written into SCR-004 itself: this holds for the zero-customer period, when tracing a production outage to one merge does not yet matter. The maintainer said it will be tightened once customers exist; the SCR says to revisit before the first paying customer.

Changed, all prose: CLAUDE.md's hard rule; AGENTS.md § "Fix over file" (renamed from "Nothing left behind", with every citation retargeted) and its SCR-004 summary line; `docs/scr/SCR-004-residue-becomes-issues.md`; the PR template's section; the two self-driving command prompts; the `left-behind` guard's remedy text; two doc citations; `docs/manifest.json` regenerated. `make guards-fast` and `check-prose.py` are green.

No witness test: a policy change; the guards that read these files are the check.

Tests deleted: None

## Summary by Sourcery

Adopt the maintainer’s “fix over file” directive consistently across project policy and workflow documentation.

Enhancements:
- Replace the broad “nothing left behind” policy with a “fix over file” policy that prioritizes resolving defects in the current PR and limits issue filing to actionable, pillar-moving work that cannot responsibly ride it.
- Align contributor guidance, self-driving prompts, pull request templates, guards, and cross-references with the revised policy, including explicit deferral criteria and customer-stage scope.
- Update SCR-004 to document the rationale, compliance process, exclusions, and planned review before the first paying customer.

Documentation:
- Regenerate the documentation manifest for the renamed SCR-004 policy.