### PR TITLE
fix(stella-context): flag a stale-anchor backlog and pin a whole-file label

### DIFF
--- a/crates/stella-cli/src/memory/anchor_scan.rs
+++ b/crates/stella-cli/src/memory/anchor_scan.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use colored::Colorize;
-use stella_context::{Clock, ContextStore, SystemClock};
+use stella_context::{AnchorView, Clock, ContextStore, SystemClock};
 
 /// Time cap for the auto sweep at mount. Each anchor costs one file
 /// check, and a slow disk — not a long list — is what could make that
@@ -54,6 +54,46 @@ fn open_context_store(workspace_root: &Path) -> Result<Option<ContextStore>, Str
         .map_err(|e| format!("cannot open context store: {e}"))
 }
 
+/// How many of `anchors` a pass at `budget` could reach, one file check
+/// each, oldest first — the same order [`ContextStore::open_anchors`]
+/// returns and [`scan_stale_anchors_at_mount`] walks. Read-only, so
+/// `stella memory validate` can report real throughput without touching
+/// the store.
+struct ScanCapacity {
+    /// How many anchors were open when the pass started.
+    total: usize,
+    /// How many of them the pass reached before its deadline.
+    examined: usize,
+}
+
+impl ScanCapacity {
+    /// True when the backlog beat the budget. New anchors sit last in the
+    /// walk, so a workspace adding them fast enough never reaches them.
+    fn is_falling_behind(&self) -> bool {
+        self.examined < self.total
+    }
+}
+
+fn mount_scan_capacity(
+    anchors: &[AnchorView],
+    workspace_root: &Path,
+    budget: Duration,
+) -> ScanCapacity {
+    let deadline = Instant::now() + budget;
+    let mut examined = 0usize;
+    for a in anchors {
+        if Instant::now() >= deadline {
+            break;
+        }
+        let _ = workspace_root.join(&a.path).exists();
+        examined += 1;
+    }
+    ScanCapacity {
+        total: anchors.len(),
+        examined,
+    }
+}
+
 /// Walk the open `observed_in` anchors and report — or end — the ones whose
 /// file has left the tree.
 ///
@@ -74,6 +114,19 @@ pub(crate) fn scan_stale_anchors(workspace_root: &Path, end_stale: bool) -> Resu
         .map_err(|e| format!("cannot read anchors: {e}"))?;
     if anchors.is_empty() {
         return Ok(());
+    }
+
+    let capacity = mount_scan_capacity(&anchors, workspace_root, MOUNT_SCAN_BUDGET);
+    if capacity.is_falling_behind() {
+        println!(
+            "\n  {} the mount sweep can check only {}/{} open anchor(s) in one pass \
+             at the current {}ms budget — the newest may never be reached; run \
+             `stella memory validate --end-stale` to catch up.",
+            "⚠".yellow(),
+            capacity.examined,
+            capacity.total,
+            MOUNT_SCAN_BUDGET.as_millis()
+        );
     }
 
     let stale: Vec<StaleAnchor> = anchors
@@ -333,5 +386,79 @@ mod tests {
             1,
             "the anchor is untouched when the budget is already spent"
         );
+    }
+
+    /// A zero budget models a backlog too big for one pass, no slow disk
+    /// needed. `scan_stale_anchors_at_mount` stays quiet either way, so
+    /// this is the only place the gap shows.
+    #[test]
+    fn mount_scan_capacity_flags_a_backlog_the_budget_cannot_clear() {
+        let root = tempdir().unwrap();
+        let context_db =
+            stella_store::workspace_private_sqlite_path(root.path(), "context.db").unwrap();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let context = stella_context::ContextStore::open(&context_db).unwrap();
+        rt.block_on(async {
+            use stella_context::{ContextDelta, MemoryInput};
+            context
+                .upsert(ContextDelta {
+                    memories: vec![
+                        MemoryInput::reflection("about file one", Vec::<String>::new())
+                            .with_anchors(["src/one.rs"]),
+                        MemoryInput::reflection("about file two", Vec::<String>::new())
+                            .with_anchors(["src/two.rs"]),
+                        MemoryInput::reflection("about file three", Vec::<String>::new())
+                            .with_anchors(["src/three.rs"]),
+                    ],
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+        });
+        let anchors = context.open_anchors().unwrap();
+        assert_eq!(anchors.len(), 3);
+
+        let capacity = mount_scan_capacity(&anchors, root.path(), Duration::ZERO);
+        assert_eq!(capacity.total, 3);
+        assert_eq!(
+            capacity.examined, 0,
+            "a zero budget reaches its deadline before the first check"
+        );
+        assert!(
+            capacity.is_falling_behind(),
+            "3 open anchors against a pass that can examine none is exactly \
+             the falling-behind backlog this signal exists to catch"
+        );
+    }
+
+    /// The other side: a budget that covers the backlog is not falling
+    /// behind, so the report line stays quiet on an ordinary workspace.
+    #[test]
+    fn mount_scan_capacity_is_current_when_the_budget_covers_the_backlog() {
+        let root = tempdir().unwrap();
+        let context_db =
+            stella_store::workspace_private_sqlite_path(root.path(), "context.db").unwrap();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let context = stella_context::ContextStore::open(&context_db).unwrap();
+        rt.block_on(async {
+            use stella_context::{ContextDelta, MemoryInput};
+            context
+                .upsert(ContextDelta {
+                    memories: vec![
+                        MemoryInput::reflection("about file one", Vec::<String>::new())
+                            .with_anchors(["src/one.rs"]),
+                    ],
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+        });
+        let anchors = context.open_anchors().unwrap();
+
+        let capacity = mount_scan_capacity(&anchors, root.path(), Duration::from_secs(1));
+        assert_eq!(capacity.examined, capacity.total);
+        assert!(!capacity.is_falling_behind());
     }
 }

--- a/crates/stella-tools/tests/relevance_calibration.rs
+++ b/crates/stella-tools/tests/relevance_calibration.rs
@@ -174,8 +174,13 @@ const DEPTH: usize = 40;
 /// answer set in this repository, cited at the entry.
 struct Labelled {
     query: &'static str,
-    /// `(path, Some(symbol))` pins one chunk; `(path, None)` accepts any
-    /// chunk of that file, for a query whose answer is a whole file's subject.
+    /// `(path, Some(symbol))` pins one chunk. `(path, None)` accepts every
+    /// chunk of that file. Use `None` only when `basis` names the whole
+    /// file as the subject, the way the 21 `cache_control` sites below do.
+    /// A `None` whose `basis` names one section or one part is a bug:
+    /// `measure` reads the *deepest* labelled candidate, so the loosest
+    /// chunk of that file becomes "the answer" instead of the one `basis`
+    /// names.
     answers: &'static [(&'static str, Option<&'static str>)],
     /// Why these are the answers and nothing else is — read at review time,
     /// and printed with the row so a later reader can re-check the label
@@ -216,10 +221,19 @@ const QUERIES: &[Labelled] = &[
         query: "how does a provider declare which features it supports and how is that checked",
         answers: &[
             ("crates/stella-model/src/provider_parity.rs", None),
-            ("AGENTS.md", None),
+            (
+                "AGENTS.md",
+                Some("AGENTS.md › Architecture: ports, not direct dependencies"),
+            ),
         ],
         basis: "invariant 8's matrix and the invariant that states it — a deliberately broader \
-                answer set, so the tail is measured against something other than a single file",
+                answer set, so the tail is measured against something other than a single file. \
+                Pinned to the architecture section rather than the whole file: rule 8 has no \
+                heading of its own, and `stella_graph::markdown::sections` scopes a section to \
+                the next heading of any level, so every numbered rule from 1 through 12 shares \
+                this one chunk — the finest granularity this harness's per-heading chunking can \
+                name for it. `provider_parity.rs` stays `None`: that whole file is rule 8's \
+                matrix, so nothing narrower fits there",
     },
 ];
 
@@ -627,4 +641,57 @@ async fn print_the_relevant_and_irrelevant_score_distributions() {
     println!("===================================================================\n");
 
     graph.shutdown();
+}
+
+/// Needs no embedding backend, so it runs on every `cargo test` — unlike
+/// [`print_the_relevant_and_irrelevant_score_distributions`] above.
+///
+/// A `(path, None)` label for `AGENTS.md` would let any chunk win, so
+/// `measure` could report the worst-ranked chunk as "the answer" instead
+/// of the one `basis` names. This checks the pinned `Some(breadcrumb)`
+/// against a real section: `stella_graph`'s markdown chunker must produce
+/// it from the real `AGENTS.md`, so it matches something when the harness
+/// runs. A `None` here leaves `entry.1` below with nothing to unwrap,
+/// which fails the test by construction.
+#[test]
+fn the_pinned_agents_md_answer_is_a_real_chunk_the_indexer_produces() {
+    let labelled = QUERIES
+        .iter()
+        .find(|q| q.query.starts_with("how does a provider declare"))
+        .expect("query 4 is still in the table");
+    let entry = labelled
+        .answers
+        .iter()
+        .find(|entry| entry.0 == "AGENTS.md")
+        .expect("query 4 still labels an AGENTS.md answer");
+    let breadcrumb = entry.1.expect(
+        "the AGENTS.md answer must be pinned to one section, not every chunk of the file — a \
+         whole-file None here is exactly the defect this test exists to catch",
+    );
+
+    let root = workspace_root();
+    let db_dir = tempfile::tempdir().expect("tempdir for the index");
+    let graph =
+        CodeGraph::open(&root, &db_dir.path().join("codegraph.db")).expect("open the index");
+    // Index just this one file: no embeddings, no walk of the rest of the
+    // corpus, and fast enough to run on every `cargo test` with no
+    // `#[ignore]`.
+    graph
+        .register_paths(&[root.join("AGENTS.md")])
+        .expect("index AGENTS.md");
+
+    let spans = graph
+        .definition_spans(breadcrumb)
+        .expect("query the symbol table");
+    assert_eq!(
+        spans.len(),
+        1,
+        "{breadcrumb:?} must name exactly one chunk of AGENTS.md — the harness's exact-match \
+         lookup (`chunk.name == symbol`) needs exactly one, got {spans:?}"
+    );
+    assert_eq!(spans[0].path, "AGENTS.md");
+    assert_eq!(
+        spans[0].kind, "section",
+        "the pinned breadcrumb must name a markdown section, not some other symbol kind"
+    );
 }


### PR DESCRIPTION
## Members

- #5782 — Add a warning when the anchor sweep falls behind at session mount.
  **What**: `stella memory validate` now measures how many of the currently
  open anchors the mount sweep's own budget (`MOUNT_SCAN_BUDGET`, 200ms)
  could reach in one pass — `mount_scan_capacity` in
  `crates/stella-cli/src/memory/anchor_scan.rs`, a read-only walk that pays
  the same per-anchor filesystem cost `scan_stale_anchors_at_mount` does —
  and prints a warning line when the backlog outruns it. The mount-time
  sweep itself stays silent by design (per its own doc comment); this adds
  the missing signal to the on-demand `validate` command instead, which the
  issue's own suggested fix names as an acceptable shape.
  **Why**: the sweep always walks anchors oldest-first with a fixed time
  budget, so a workspace adding anchors faster than the sweep can check
  them ends up with a backlog that can never clear — and nothing said so.
  **Witness**: `mount_scan_capacity_flags_a_backlog_the_budget_cannot_clear`
  seeds 3 anchors and measures against a zero-duration budget, asserting
  `is_falling_behind()` is true; `mount_scan_capacity_is_current_when_the_budget_covers_the_backlog`
  is the negative control (a generous budget, not falling behind). Both call
  `mount_scan_capacity`, a function that does not exist on `main`, so
  neither test compiles without this change — that is the fail→pass flip.

- #4811 — A whole-file answer label lets an incidental chunk be reported as
  the calibration answer.
  **What**: `crates/stella-tools/tests/relevance_calibration.rs` query 4's
  `AGENTS.md` answer moves from `(path, None)` to
  `(path, Some("AGENTS.md › Architecture: ports, not direct dependencies"))`
  — the same fix #4808 already applied to query 3. `Labelled::answers`'s
  doc comment now states the general rule: `None` is sound only when
  `basis` itself claims the whole file as the subject.
  **Why**: `basis` names one specific rule ("invariant 8's matrix and the
  invariant that states it"), but `None` admitted every AGENTS.md chunk as
  a correct answer. Since `measure` reads the *deepest* labelled candidate,
  the label would silently start reporting whichever AGENTS.md chunk ranks
  worst as "the answer" the moment one drifts into the ranking window — the
  exact defect #4784 already found and #4808 fixed for query 3.
  **How the breadcrumb was verified**: this harness needs a paid embedding
  backend (`VOYAGE_API_KEY`) and cannot run on this machine, so the exact
  chunk name was derived by reading `stella_graph::markdown::sections`
  rather than by running the harness. That function scopes a markdown
  section to the next heading of *any* level, and AGENTS.md's rule 8 has no
  heading of its own — the enclosing `## Architecture: ports, not direct
  dependencies` section (which holds all twelve numbered rules) has no
  subheading before the next `##`, so it is one chunk. This is independently
  confirmed by `tests/chunk_retrieval_witnesses.rs`'s own module doc, which
  names this exact heading and states the same "ten invariants in one
  chunk" property for the same reason.
  **Witness**: `the_pinned_agents_md_answer_is_a_real_chunk_the_indexer_produces`
  needs no embedding backend — it indexes the real `AGENTS.md` alone via
  `CodeGraph::register_paths` (one file, no embeddings) and asserts the
  pinned breadcrumb names exactly one chunk of kind `section`. It fails to
  compile against the old `(path, None)` label, since `entry.1` has nothing
  to `.expect()`.

## Could not ride

- #6263 (already listed on the batch issue, not a member here) —
  unrelated compile break against context-graph-protocol HEAD.

## Tests deleted

None.

Closes #6290

## Summary by Sourcery

Surface mount-sweep backlogs during validation and make the AGENTS.md calibration answer use a precise section label.

New Features:
- Add a validation warning when the mount-time anchor sweep cannot examine all open anchors within its budget.

Bug Fixes:
- Pin the AGENTS.md relevance-calibration answer to the specific architecture section instead of accepting any chunk from the file.

Enhancements:
- Clarify answer-labeling guidance so whole-file labels are used only when the answer basis covers the entire file.

Tests:
- Add coverage for detecting anchor-scan backlogs and for verifying that the pinned AGENTS.md label resolves to a real indexed section.