### PR TITLE
fix(stella-cli,stella-fleet): do not read a slug's hash as an issue number

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd/contention.rs
+++ b/crates/stella-cli/src/self_driving_cmd/contention.rs
@@ -132,6 +132,11 @@ fn gather(root: &Path, key: &str, own_root: Option<&Path>) -> Contention {
 ///
 /// A match counts only where neither neighbouring character is a digit, which
 /// is what makes `i-43` a mention and `i-4300` not one.
+///
+/// The rule holds only over text somebody wrote. It cannot tell that part of a
+/// name is a hash. There the neighbours are hex letters, so every number is
+/// spelled sooner or later by accident. Callers reading a slug cut that suffix
+/// off with [`stella_fleet::strip_slug_hash`] first.
 #[must_use]
 fn names_issue(text: &str, key: &str) -> bool {
     if key.is_empty() {
@@ -164,7 +169,14 @@ pub(crate) fn branches_naming(ls_remote: &str, key: &str) -> Vec<String> {
         // reported that name as its evidence.
         .filter_map(|line| line.split("refs/heads/").nth(1))
         .map(str::trim)
-        .filter(|name| names_issue(name, key))
+        // The stem, not the hash on the end of it. That suffix is sixteen hex
+        // characters of FNV-1a, and hex is mostly letters, so `names_issue`'s
+        // digit-neighbour rule lets a number inside one through: issue 18
+        // matched the `18` in issue 11's branch `stella/11-8fdade18d3a4de74`
+        // and was deferred on every pass for hours, because a deferral writes
+        // no `spent` entry. The evidence string keeps the whole name — an
+        // operator looking for the branch needs the one git will show them.
+        .filter(|name| names_issue(stella_fleet::strip_slug_hash(name), key))
         .map(str::to_owned)
         .collect()
 }
@@ -189,8 +201,11 @@ pub(super) fn worktrees_naming(porcelain: &str, key: &str, own_root: Option<&Pat
         // checkouts out differently must still be seen, and a false negative
         // here is two loops on one issue where a false positive is only a
         // deferral. [`names_issue`] removes the part that was simply wrong —
-        // #43 matching a worktree for #4300.
-        .filter(|path| names_issue(path, key))
+        // #43 matching a worktree for #4300 — and `strip_slug_hash` the part
+        // that was wrong for the same reason one directory further down: a
+        // worktree's leaf is a slug, so the hash sits on the end of the path
+        // and answers for any number that happens to fall inside it.
+        .filter(|path| names_issue(stella_fleet::strip_slug_hash(path), key))
         .filter(|path| own_root.is_none_or(|own| !Path::new(path).starts_with(own)))
         .map(str::to_owned)
         .collect()
@@ -293,12 +308,11 @@ pub(super) fn ledger_claims(root: &Path, key: &str) -> Vec<String> {
 /// for the same reason: **contention is other people.** Now that this loop
 /// mints the claims it also reads, a probe that counted its own would be the
 /// #4300 shape again through the authoritative signal — the loop deferring
-/// forever on evidence only it produces. The candidate filter in `drive`
-/// already keeps a claimed or spent key out of the queue, so this is not
-/// reachable today; it is here because "the loop never defers on its own
-/// lease" should be a property of this function rather than a coincidence of
-/// a filter two modules away, and because it is the half of #4309 that a
-/// later change to that filter would silently take back.
+/// forever on evidence only it produces. Nothing reaches that today: the
+/// candidate filter in `drive` keeps a claimed or spent key out of the queue.
+/// It is here so "the loop never defers on its own lease" is a property of
+/// this function, not a lucky side effect of a filter two modules away that a
+/// later edit could take back.
 ///
 /// It is the *owner string* that is compared, not liveness: a crashed run of
 /// this loop had a different pid, so its lapsing lease is somebody else's
@@ -553,6 +567,66 @@ mod tests {
         assert!(
             branches_naming(out, "7").is_empty(),
             "no branch here names issue 7"
+        );
+    }
+
+    /// The hash on a slug is not a name, and must not be searched as one.
+    ///
+    /// The live one. `stella/11-8fdade18d3a4de74` is issue 11's branch on
+    /// `macanderson/rainforest`, left behind when its pull request merged. The
+    /// `18` inside its hash has a letter on each side, so the digit-neighbour
+    /// rule passed it and issue 18 — the only claimable issue in that repo —
+    /// read as somebody else's work. A deferral writes no `spent` entry, so
+    /// the next pass asked the same question and got the same answer, for
+    /// hours.
+    #[test]
+    fn a_hash_that_happens_to_contain_the_key_is_not_a_branch_naming_it() {
+        let out = "5e998e0dacbae5481cea564051a52acbbd0570ff\t\
+                   refs/heads/stella/11-8fdade18d3a4de74\n";
+
+        assert!(
+            branches_naming(out, "18").is_empty(),
+            "this branch is issue 11's; the 18 is inside its hash"
+        );
+        // The control: the branch still answers for the issue it is named for.
+        assert_eq!(
+            branches_naming(out, "11"),
+            vec!["stella/11-8fdade18d3a4de74"],
+            "and the evidence keeps the whole name, hash included"
+        );
+    }
+
+    /// The same collision one directory down, where a worktree path ends in a
+    /// slug and every leftover of a run carries nearly the same digits.
+    #[test]
+    fn a_hash_in_a_worktree_path_is_not_that_path_naming_the_key() {
+        let porcelain = "worktree /repo/.stella/private/self-driving/11-8fdade18d3a4de74\n";
+
+        assert!(
+            worktrees_naming(porcelain, "18", None).is_empty(),
+            "this worktree is issue 11's"
+        );
+        assert_eq!(worktrees_naming(porcelain, "11", None).len(), 1);
+    }
+
+    /// A name nobody generated keeps matching exactly as it did.
+    ///
+    /// The fix is a narrower scan, not a rule about what a branch may be
+    /// called: a human's checkout and a preserved branch mint no slug, so
+    /// stripping a hash must not stop either of them counting.
+    #[test]
+    fn stripping_the_hash_does_not_stop_a_human_or_preserved_branch_matching() {
+        let out = "abc\trefs/heads/wip-43-preserved\n\
+                   def\trefs/heads/fix-43\n\
+                   012\trefs/heads/stella/43-8fdade18d3a4de74\n";
+
+        assert_eq!(
+            branches_naming(out, "43"),
+            vec!["wip-43-preserved", "fix-43", "stella/43-8fdade18d3a4de74"]
+        );
+        assert!(
+            worktrees_naming("worktree /home/dev/checkouts/issue-43\n", "43", None).len() == 1,
+            "a person's checkout is still a peer"
         );
     }
 

--- a/crates/stella-fleet/src/git.rs
+++ b/crates/stella-fleet/src/git.rs
@@ -281,6 +281,59 @@ fn short_hash(s: &str) -> String {
     format!("{hash:016x}")
 }
 
+/// How many hex chars [`short_hash`] writes, and therefore how long the
+/// discriminator on the tail of a slug is.
+const SLUG_HASH_HEX_LEN: usize = 16;
+
+/// `name` without the `short_hash` discriminator `worktree_slug` appends, or
+/// `name` unchanged when it does not end in one.
+///
+/// A slug is a stem somebody can read plus a hash nobody can. Only the stem
+/// carries meaning, so a reader asking what a branch or directory is *about*
+/// must ask the stem — and the hash is where FNV-1a put sixteen characters that
+/// answer nothing and match anything.
+///
+/// The self-driving loop reads these names to see whether a peer is already
+/// working an issue, matching the number as a substring and refusing a match
+/// only when a digit sits beside it. Hex is mostly letters, so issue 18 matched
+/// the `18` inside issue 11's branch `stella/11-8fdade18d3a4de74` and was
+/// deferred on every pass for hours. No wait clears that: the hash covers
+/// `run_scope` + task id, ids in one run differ only in the tail, and FNV-1a
+/// barely moves its high bytes for such inputs — so every slug a run mints
+/// carries nearly the same digits, and some issue number always collides.
+///
+/// This lives beside `short_hash` and `worktree_slug` for the reason
+/// [`crate::issue_claim_key`] gives: a reader that re-derives the shape of what
+/// a writer produced is a shared cell in two files, and it drifts.
+///
+/// Callers pass whole paths as well as bare names, so the match is anchored on
+/// the end rather than on a path component. Indexed as bytes, never split by
+/// `char`: either may hold any UTF-8, and an offset counted back from the end
+/// would land mid-character and panic. It is used only after the byte there is
+/// confirmed to be `-`, which is ASCII and therefore a boundary.
+#[must_use]
+pub fn strip_slug_hash(name: &str) -> &str {
+    let bytes = name.as_bytes();
+    let Some(stem) = bytes.len().checked_sub(SLUG_HASH_HEX_LEN + 1) else {
+        return name;
+    };
+    // A stem of its own is required, so a name that is nothing but a hash keeps
+    // it rather than stripping away to nothing.
+    if stem == 0 || bytes[stem] != b'-' {
+        return name;
+    }
+    // `short_hash`'s exact alphabet, not `is_ascii_hexdigit`: it writes
+    // lowercase, and a name matching only in uppercase is somebody else's.
+    if bytes[stem + 1..]
+        .iter()
+        .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        &name[..stem]
+    } else {
+        name
+    }
+}
+
 /// How much of the human-readable stem a slug keeps before its hash suffix.
 /// The slug is a single filesystem name *and* a branch component, and one path
 /// component maxes out at 255 bytes on ext4/APFS — a plan free-texting its task
@@ -807,6 +860,48 @@ mod tests {
         assert_ne!(a, c);
         // Deterministic across calls.
         assert_eq!(a, worktree_slug("run", "fix/the thing"));
+    }
+
+    /// The parser and the minter agree, on whatever the minter produces.
+    ///
+    /// Stated as a round trip rather than against a literal, because the thing
+    /// that would break a reader is the hash width changing here and nobody
+    /// noticing there.
+    #[test]
+    fn stripping_a_minted_slug_returns_the_stem_it_was_built_from() {
+        for id in ["t1", "fix/the thing", &"refactor ".repeat(40)] {
+            let slug = worktree_slug("run", id);
+            let stem = strip_slug_hash(&slug);
+            assert_ne!(stem, slug, "{slug} ends in a hash");
+            assert_eq!(
+                slug,
+                format!("{stem}-{}", short_hash(&format!("run\u{1f}{id}")))
+            );
+        }
+    }
+
+    /// It strips a discriminator, and nothing that merely resembles one.
+    #[test]
+    fn strip_slug_hash_leaves_every_other_name_alone() {
+        // No suffix at all, and one too short to be a full digest.
+        assert_eq!(strip_slug_hash("stella/43-fix"), "stella/43-fix");
+        assert_eq!(strip_slug_hash("wip-43-preserved"), "wip-43-preserved");
+        assert_eq!(strip_slug_hash("t1-8fdade18d3a4de7"), "t1-8fdade18d3a4de7");
+        // Hex, but not the lowercase `short_hash` writes.
+        assert_eq!(
+            strip_slug_hash("t1-8FDADE18D3A4DE74"),
+            "t1-8FDADE18D3A4DE74"
+        );
+        // Sixteen hex chars, but no stem left over to be a name.
+        assert_eq!(strip_slug_hash("-8fdade18d3a4de74"), "-8fdade18d3a4de74");
+        // A whole path, because that is what the worktree probe passes.
+        assert_eq!(
+            strip_slug_hash("/repo/.stella/private/self-driving/11-8fdade18d3a4de74"),
+            "/repo/.stella/private/self-driving/11"
+        );
+        // Multi-byte input must not panic on a byte offset counted from the end.
+        assert_eq!(strip_slug_hash("résumé"), "résumé");
+        assert_eq!(strip_slug_hash("æ-8fdade18d3a4de74"), "æ");
     }
 
     #[test]

--- a/crates/stella-fleet/src/lib.rs
+++ b/crates/stella-fleet/src/lib.rs
@@ -90,7 +90,7 @@ pub use gc::{
 };
 pub use git::{
     GitCli, GitError, GitOutput, RemoveOptions, RemoveOutcome, SystemGitCli, Worktree,
-    WorktreeEntry, WorktreeError, WorktreeManager,
+    WorktreeEntry, WorktreeError, WorktreeManager, strip_slug_hash,
 };
 pub use ledger::{
     AttemptFinish, AttemptId, AttemptStart, CommitRecord, Ledger, LedgerError, RunRecord,


### PR DESCRIPTION
Closes #6309

## What was wrong

The self-driving loop asks whether a peer is already working an issue before it
claims one. Two of the signals it reads are the names of remote branches and the
paths of local worktrees. It matches the issue number as a substring and refuses
a match only when a digit sits on either side — right for text a person wrote,
wrong for the sixteen hex characters a slug ends with. Hex is mostly letters, so
a number that falls inside a hash reads as a name.

On `macanderson/rainforest`, issue 18 matched the `18` inside issue 11's
leftover branch `stella/11-8fdade18d3a4de74` (issue 11 is closed, its PR merged,
the branch never deleted). Issue 18 was the only claimable issue in that
repository, so the loop deferred it and waited, every pass:

```
deferred 18 — somebody else is already on it (remote branch: stella/11-8fdade18d3a4de74)
waiting — the queue offers nothing this run has not already taken (1 deferred ...)
```

A deferral writes no `spent` entry, by design, so nothing recovers: the next
pass re-reads the queue, re-runs the probe, and defers again. It sat there for
hours with nothing reporting a problem.

It is not a coincidence that can be waited out. The hash is FNV-1a over the run
scope plus the task id, ids within a run differ only in the tail, and FNV-1a
barely moves its high bytes for such inputs. Every slug that repository ever
minted carries the same pattern — `8fdadf18…`, `8fdae118…`, `8fd04d18…`,
`8fd3d318…` — so some issue number always collides.

## The fix

`strip_slug_hash` takes the discriminator off before the match, at both call
sites (`branches_naming` and `worktrees_naming`). It lives in `stella-fleet`
beside `short_hash`/`worktree_slug`, for the reason `issue_claim_key`'s own doc
comment gives: a reader that re-derives the shape of what a writer produced is a
shared cell in two files, and it drifts.

This narrows the scan; it does not rule on what a branch may be called. A
human's `fix-43`, the `wip-43-preserved` branch, and a fleet worktree outside
the loop's own root mint no slug and keep matching exactly as before — there is
a test asserting that.

`prs_naming` and `claims_naming` were never affected: one requires a literal `#`
before the number, the other compares claim keys exactly.

## Witness

`a_hash_that_happens_to_contain_the_key_is_not_a_branch_naming_it` and
`a_hash_in_a_worktree_path_is_not_that_path_naming_the_key`, both in
`contention.rs`'s test module, built on the exact live string. Verified the
fail→pass flip by reverting only the two call sites and re-running:

```
a_hash_that_happens_to_contain_the_key_is_not_a_branch_naming_it ... FAILED
    panicked: this branch is issue 11's; the 18 is inside its hash
a_hash_in_a_worktree_path_is_not_that_path_naming_the_key ... FAILED
    panicked: this worktree is issue 11's
test result: FAILED. 17 passed; 2 failed
```

With the fix restored: `19 passed; 0 failed`. The control
(`stripping_the_hash_does_not_stop_a_human_or_preserved_branch_matching`) passes
both ways, which is the point of it.

`stripping_a_minted_slug_returns_the_stem_it_was_built_from` in
`stella-fleet/src/git.rs` states the parser/minter agreement as a round trip
rather than against a literal, so changing the hash width here cannot silently
break the reader there.

## Verification

Narrow, per SCR-001 — CI's `make gate` is the authoritative check.

- `cargo test -p stella-fleet slug` — 6 passed
- `cargo test -p stella-cli --bin stella self_driving_cmd` — 250 passed
- `cargo test -p stella-cli --bin stella command_deck::start_work` — 20 passed
  (`branches_naming` is `pub(crate)`; the deck reads it too)
- `make guards-fast` — green, prose and line-citations included
- `make lint CARGO_SCOPE="-p stella-fleet -p stella-cli"` — clean
- `make doc-warnings CARGO_SCOPE="-p stella-fleet -p stella-cli"` — clean

## Notes for review

- No deleted tests.
- No new dependency, no new crate. Two existing crates change; neither file is
  grandfathered and both stay well under the 1500-line ceiling.
- No `#[allow]` added. Rustdoc first rejected the public doc for linking private
  `short_hash`/`worktree_slug`; those are plain backticks now rather than a
  suppression.
- The evidence string a deferral records still carries the whole branch name,
  hash included — an operator looking for the branch needs the name git shows
  them. Only the matching is narrowed.

## Summary by Sourcery

Ignore generated slug hash suffixes when detecting contention so the self-driving loop only matches the meaningful name portion.

Bug Fixes:
- Prevent issue numbers embedded in generated slug hashes from being mistaken for active work in remote branches and worktree paths, avoiding repeated false deferrals by the self-driving loop.

Enhancements:
- Centralize slug-hash parsing in stella-fleet and preserve matching for human-named or non-slug branches and worktrees.

Tests:
- Add coverage for hash collisions in branch and worktree names, preserved matching behavior, and slug parser/minter round trips.