### PR TITLE
docs(stella-cli): say what the process-free tool check actually proves

### DIFF
--- a/crates/stella-cli/src/enterprise_telemetry.rs
+++ b/crates/stella-cli/src/enterprise_telemetry.rs
@@ -405,16 +405,15 @@ fn register_verified_credentials(enrollment: &VerifiedEnrollment) {
     ]);
 }
 
-/// Check that every tool the registry offers is one the catalog declares.
+/// Check that every tool on offer is one the catalog lists.
 ///
-/// A name the catalog does not list is a tool nobody here has reviewed, and
-/// that is what this refuses.
+/// A tool the catalog does not list is one nobody here has checked. This
+/// turns those down.
 ///
-/// It does not show that an enrolled host cannot start a program. `bash` is a
-/// catalog row and the agent runs it. What keeps such a host narrow is the
-/// surface gate above, which admits the raw one-shot path alone, plus the
-/// pieces that path never builds: no tool servers, no custom tools, no
-/// wrapper plugin.
+/// This does not prove the agent cannot run a program. It can. `bash` is on
+/// the list. What holds it back sits elsewhere: only `stella run` with no
+/// plugin may run at all, and that path loads no tool servers, no custom
+/// tools, and no plugin.
 pub(crate) fn prove_process_free_surface(workspace_root: &Path) -> Result<(), String> {
     let registry = stella_tools::ToolRegistry::new(workspace_root.to_path_buf());
     let catalog: BTreeSet<&str> = stella_tools::catalog::ALL_NAMES.iter().copied().collect();

--- a/crates/stella-cli/src/enterprise_telemetry.rs
+++ b/crates/stella-cli/src/enterprise_telemetry.rs
@@ -405,12 +405,16 @@ fn register_verified_credentials(enrollment: &VerifiedEnrollment) {
     ]);
 }
 
-/// Prove the built-in tool surface is closed over the declared catalog — the
-/// process-free posture's structural claim. Every advertised tool must be a
-/// catalog row, and no catalog row executes a subprocess: the registry's
-/// dispatchable surface is coordination, session state, and the environment
-/// report, so a registry whose surface equals the catalog cannot spawn.
-/// A stray name would mean a tool this proof has never audited.
+/// Check that every tool the registry offers is one the catalog declares.
+///
+/// A name the catalog does not list is a tool nobody here has reviewed, and
+/// that is what this refuses.
+///
+/// It does not show that an enrolled host cannot start a program. `bash` is a
+/// catalog row and the agent runs it. What keeps such a host narrow is the
+/// surface gate above, which admits the raw one-shot path alone, plus the
+/// pieces that path never builds: no tool servers, no custom tools, no
+/// wrapper plugin.
 pub(crate) fn prove_process_free_surface(workspace_root: &Path) -> Result<(), String> {
     let registry = stella_tools::ToolRegistry::new(workspace_root.to_path_buf());
     let catalog: BTreeSet<&str> = stella_tools::catalog::ALL_NAMES.iter().copied().collect();


### PR DESCRIPTION
## The problem

`prove_process_free_surface` is the check that lets a signed-up machine send
usage counts. Its comment said:

> no catalog row executes a subprocess: the registry's dispatchable surface is
> coordination, session state, and the environment report, so a registry whose
> surface equals the catalog cannot spawn.

All of that is wrong. `bash` is the first row in
`crates/stella-tool-facts/src/catalog.rs`, graded high risk, and
`ToolRegistry::new` adds it to the set this check reads. So the check looks at
a set of tools that holds a shell, and passes.

This is the file someone opens to check the rule that Stella sends nothing on
its own. The comment told that reader the machine cannot run a program before
it may send anything. It runs one on most turns.

## The change

One comment. No code, no names, no behaviour.

It now says what the check proves: every tool on offer is on the catalog list.
It says that this is not a promise about running programs, and names `bash`.
Then it points at what does keep the surface small: only `stella run` with no
plugin may run, and that path loads no tool servers, no custom tools, and no
plugin.

Reading grade of the comment: 3.68, down from 13.73.

## Why the behaviour is fine

`authorize_execution_surface_with` lets `RawOneShot` through and refuses the
other five, and
`process_free_authority_allows_only_the_registry_only_raw_one_shot_surface`
proves it for every one of them. `docs/spec/enterprise-authority-telemetry.md`
already describes this correctly and needs no edit. Only the comment
overclaimed.

## Witness test

None. This is a comment, so there is nothing that fails before and passes
after. `make prose`, `make line-citations` and `cargo fmt --check -p stella-cli`
pass.

Closes #6317
