### PR TITLE
fix(stella-autonomy): delete the superseded rank_defects/priority_rank export

### DIFF
--- a/crates/stella-autonomy/README.md
+++ b/crates/stella-autonomy/README.md
@@ -78,7 +78,7 @@ the CLI does — so the dashboard and the terminal cannot disagree.
 
 | File | What it holds |
 |---|---|
-| [`src/lib.rs`](src/lib.rs) | The dedup digest, the `AimdLimits`/`Calibration`/`calibrate` controller, the `Lens`/`Tooling`/`LENSES` aperture ladder and `advance`, `CycleRecord`/`dry_streak`, the `Supply`/`Demand`/`Floors`/`CyclePlan`/`plan_cycle` governor, `Metrics`/`metrics`/`starved`, `QueueIssue`/`rank_defects` (superseded by `priority::triage` — see that module), and `Liveness`/`liveness`/`RunRow`/`fold_runs`. |
+| [`src/lib.rs`](src/lib.rs) | The dedup digest, the `AimdLimits`/`Calibration`/`calibrate` controller, the `Lens`/`Tooling`/`LENSES` aperture ladder and `advance`, `CycleRecord`/`dry_streak`, the `Supply`/`Demand`/`Floors`/`CyclePlan`/`plan_cycle` governor, `Metrics`/`metrics`/`starved`, `QueueIssue` (ranked by `priority::triage` — see that module), and `Liveness`/`liveness`/`RunRow`/`fold_runs`. |
 | [`src/step.rs`](src/step.rs) | The top-level loop machine: `LoopState`/`LoopObservation`/`step`, the `Unblock` remedies for a broken base, and the `Blocked` reasons. |
 | [`src/deliver.rs`](src/deliver.rs) | The per-PR delivery machine: `PrState`/`Observation`/`deliver_next`, the fix/rebase ceilings, and the escalation reasons. |
 | [`src/doctrine.rs`](src/doctrine.rs) | The policy knobs a human sets: `Doctrine`, `ForeignBreakage`, contention policy and `contention_verdict`. |

--- a/crates/stella-autonomy/src/convention.rs
+++ b/crates/stella-autonomy/src/convention.rs
@@ -10,7 +10,7 @@
 //! # The defect this exists to prevent
 //!
 //! It is a feedback loop, and it is specific to *this* repository's
-//! automation. [`crate::rank_defects`] counts an issue as a defect if it
+//! automation. [`crate::priority::triage`] counts an issue as a defect if it
 //! carries `bug` **or** `triage` — an untriaged issue is a defect nobody has
 //! classified yet. Meanwhile `.github/workflows/issue-triage.yml` adds
 //! `triage` to any issue opened without one of its `TYPE_LABELS`
@@ -40,7 +40,7 @@
 //! This crate depends on no other workspace crate, which is what lets
 //! `stella-observatory` link its folds without linking the machinery it
 //! observes. So [`conform`] takes borrowed label text rather than a
-//! `stella_protocol::Issue`, exactly as [`crate::rank_defects`] keeps its own
+//! `stella_protocol::Issue`, exactly as [`crate::priority::triage`] keeps its own
 //! [`crate::QueueIssue`] input type for the same reason, and the one mapping
 //! from a tracker's shape into this one lives in the caller.
 
@@ -529,7 +529,7 @@ mod tests {
 
     /// The witness. A filing with no type label is refused *before* it reaches
     /// the tracker, rather than being filed, stamped `triage` by
-    /// `issue-triage.yml`, and read back by `rank_defects` as an untriaged
+    /// `issue-triage.yml`, and read back by `priority::triage` as an untriaged
     /// defect the loop must now triage.
     #[test]
     fn a_filing_that_omits_the_type_axis_is_refused() {

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -2,12 +2,13 @@
 //!
 //! `self-driving` is a cycle: fix a batch of defects, audit what is left, file
 //! what it cannot fix, benchmark against the comparator, ship, and repeat.
-//! Everything a machine can decide without a model lives here, so the model
-//! never has to re-derive it and cannot get it subtly wrong: the AIMD
-//! controller that sizes a cycle to its machine, the aperture ladder that
-//! keeps "no defects" a statement about a lens rather than the code, the
-//! dry-streak oracle that advances the ladder, the digest normalization the
-//! dedup set rests on, and the folds that turn the ledger into evidence.
+//! Everything a machine can decide without a model lives here. The model
+//! never has to re-derive it, and cannot get it subtly wrong. This crate
+//! holds the AIMD controller that sizes a cycle to its machine, the aperture
+//! ladder that keeps "no defects" a statement about a lens rather than the
+//! code, the dry-streak oracle that advances the ladder, the digest
+//! normalization the dedup set rests on, and the folds that turn the ledger
+//! into evidence.
 //!
 //! No I/O: every function here is synchronous over owned data — the same
 //! discipline AGENTS.md #2 requires of `stella-core`, kept here by choice
@@ -246,11 +247,11 @@ pub enum CycleOutcome {
     ResourceFail,
 }
 
-/// One AIMD step. Additive increase on a clean cycle (+2 batch; one more
-/// worktree only after three consecutive clean cycles, because parallelism is
-/// the knob that hurts most when it is wrong), multiplicative decrease on a
-/// resource failure (halve, and drop straight back to serial) — the
-/// controller shape that provably converges instead of oscillating.
+/// One AIMD step. A clean cycle brings additive increase: +2 batch, and one
+/// more worktree only after three clean cycles in a row, because parallelism
+/// is the knob that hurts most when it is wrong. A resource failure brings
+/// multiplicative decrease: halve, and drop straight back to serial. This is
+/// the controller shape that provably converges instead of oscillating.
 pub fn calibrate(cal: &mut Calibration, outcome: CycleOutcome, limits: &AimdLimits) {
     match outcome {
         CycleOutcome::Ok => {
@@ -647,10 +648,10 @@ pub struct CyclePlan {
 /// has right now) x demand (what the queue needs) x calibration (what
 /// previous cycles proved this box survives) -> a tier and concrete knobs.
 ///
-/// The rung order is the contract: floors and contention outrank everything,
-/// including heavy-class hardware; demand overrides supply in exactly one
-/// direction (a P0 is worth a degraded cycle, never a skipped one — it
-/// shrinks the batch to what will fit rather than standing down); and demand
+/// The rung order is the contract. Floors and contention outrank everything,
+/// including heavy-class hardware. Demand overrides supply in exactly one
+/// direction: a P0 is worth a degraded cycle, never a skipped one — it
+/// shrinks the batch to what will fit rather than standing down. Demand
 /// never upgrades the tier or widens the batch.
 pub fn plan_cycle(
     supply: Supply,
@@ -928,45 +929,6 @@ impl QueueIssue {
         self.has_label(ESCALATION_LABEL)
             && !escalation::may_retry(self.escalation.as_ref(), policy, now_unix)
     }
-
-    /// P0 ranks 0, P1 ranks 1, P2 ranks 2, everything else 3 — an aged P1 is
-    /// a worse thing to be carrying than a fresh one, so age only breaks ties
-    /// inside a rank.
-    pub fn priority_rank(&self) -> u8 {
-        ["P0", "P1", "P2"]
-            .iter()
-            .position(|p| self.has_label(p))
-            .map_or(3, |i| i as u8)
-    }
-}
-
-/// Filter to defects and rank them. `bug` and `triage` both count: an
-/// untriaged issue is a defect nobody has classified yet, not a non-defect.
-/// Feature work is excluded — this loop closes defects, and
-/// mixing the two makes the batch unreviewable.
-///
-/// An escalated issue is held back while its cooldown runs, and comes back on
-/// its own once that is over ([`QueueIssue::escalation_holds`]). The record in
-/// its body is how that survives across processes — `spent` in the drive loop
-/// is process-local and cannot.
-pub fn rank_defects(
-    issues: Vec<QueueIssue>,
-    escalation: &escalation::EscalationPolicy,
-    now_unix: i64,
-) -> Vec<QueueIssue> {
-    let mut defects: Vec<QueueIssue> = issues
-        .into_iter()
-        .filter(|i| {
-            (i.has_label("bug") || i.has_label("triage"))
-                && !i.escalation_holds(escalation, now_unix)
-        })
-        .collect();
-    defects.sort_by(|a, b| {
-        a.priority_rank()
-            .cmp(&b.priority_rank())
-            .then_with(|| crate::priority::by_age(&a.created_at, &b.created_at))
-    });
-    defects
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/stella-autonomy/src/step.rs
+++ b/crates/stella-autonomy/src/step.rs
@@ -50,7 +50,7 @@
 //! `stella-protocol`. This crate depends on no workspace crate — that is what
 //! lets `stella-observatory` link its folds without linking the machinery it
 //! observes — so the references here are local newtypes and the caller maps.
-//! Exactly the trade [`crate::rank_defects`] already makes with
+//! Exactly the trade [`crate::priority::triage`] already makes with
 //! [`crate::QueueIssue`].
 
 use serde::{Deserialize, Serialize};

--- a/crates/stella-autonomy/src/tests.rs
+++ b/crates/stella-autonomy/src/tests.rs
@@ -751,33 +751,6 @@ fn starved_reads_the_controller_not_the_ledger() {
 }
 
 // ---------------------------------------------------------------------------
-// queue — ranked P0 > P1 > P2, oldest first inside a rank
-// ---------------------------------------------------------------------------
-
-#[test]
-fn rank_beats_age_across_ranks_triage_counts_and_features_do_not() {
-    let issues: Vec<QueueIssue> = serde_json::from_value(json!([
-        {"number": 101, "title": "fresh P1",  "createdAt": "2026-08-01T00:00:00Z", "url": "u",
-         "labels": [{"name": "bug"}, {"name": "P1"}]},
-        {"number": 102, "title": "aged P1",   "createdAt": "2026-01-01T00:00:00Z", "url": "u",
-         "labels": [{"name": "bug"}, {"name": "P1"}]},
-        {"number": 103, "title": "the P0",    "createdAt": "2026-08-01T00:00:00Z", "url": "u",
-         "labels": [{"name": "bug"}, {"name": "P0"}]},
-        {"number": 104, "title": "untriaged", "createdAt": "2025-01-01T00:00:00Z", "url": "u",
-         "labels": [{"name": "triage"}]},
-        {"number": 105, "title": "a feature", "createdAt": "2025-01-01T00:00:00Z", "url": "u",
-         "labels": [{"name": "enhancement"}]}
-    ]))
-    .expect("fixture parses");
-
-    let ranked: Vec<u64> = rank_defects(issues, &crate::escalation::EscalationPolicy::default(), 0)
-        .iter()
-        .map(|i| i.number)
-        .collect();
-    assert_eq!(ranked, [103, 102, 101, 104]);
-}
-
-// ---------------------------------------------------------------------------
 // the run fold — the status the file cannot state on its own
 // ---------------------------------------------------------------------------
 

--- a/crates/stella-autonomy/src/tests.rs
+++ b/crates/stella-autonomy/src/tests.rs
@@ -751,6 +751,40 @@ fn starved_reads_the_controller_not_the_ledger() {
 }
 
 // ---------------------------------------------------------------------------
+// queue — the superseded ranker must not come back
+// ---------------------------------------------------------------------------
+
+/// The witness for deleting `rank_defects`/`priority_rank`. They reproduced
+/// exactly the bug `priority.rs`'s module docs describe as the reason that
+/// module exists — an issue with no priority label sorted at rank 3, mixed
+/// below every real `P2`, instead of being separated out as unassessed.
+/// They had zero non-test callers once `priority::triage` replaced them,
+/// yet stayed `pub`, so the next reader reaching for the obvious `lib.rs`
+/// export got the wrong semantics back.
+///
+/// The fix *is* the removal, so the witness scans this crate's own source
+/// rather than calling an API — the same technique
+/// `stella-observatory`/`stella-serve`'s
+/// `the_two_copies_of_this_policy_have_not_drifted` already uses to hold a
+/// fact about text rather than about a running value. This fails on the
+/// prior `lib.rs`, which defines both as `pub`, and passes once they are
+/// gone.
+#[test]
+fn rank_defects_and_priority_rank_are_not_a_public_export() {
+    let source = include_str!("lib.rs");
+    assert!(
+        !source.contains("pub fn rank_defects"),
+        "rank_defects must not come back as a public export -- rank a queue \
+         through priority::triage, which does not mis-sort an unranked issue"
+    );
+    assert!(
+        !source.contains("fn priority_rank"),
+        "priority_rank must not come back -- it mapped an unranked issue to \
+         rank 3, indistinguishable from a real P2"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // the run fold — the status the file cannot state on its own
 // ---------------------------------------------------------------------------
 

--- a/crates/stella-protocol/src/issue.rs
+++ b/crates/stella-protocol/src/issue.rs
@@ -33,7 +33,7 @@
 //! - **There is no `priority` field.** Priority is expressed as a label here,
 //!   because that is how the trackers this must span actually carry it, and a
 //!   dedicated field would force every provider to invent a mapping into it.
-//!   Ranking reads labels (`stella_autonomy::rank_defects`).
+//!   Ranking reads labels (`stella_autonomy::priority::triage`).
 //!
 //! # Why the kernel is here and the ranking is not
 //!
@@ -372,7 +372,7 @@ pub trait IssueProvider: Send + Sync {
     ///
     /// **Order decides membership as soon as a backlog outgrows `limit`.**
     /// Ranking is the loop's job and is deterministic
-    /// (`stella_autonomy::rank_defects`). It runs after this read, though, over
+    /// (`stella_autonomy::priority::triage`). It runs after this read, though, over
     /// whatever arrived. A full page is picked by the tracker's own order and
     /// ranked only inside that set. A tracker that hands back the newest issues
     /// first therefore hides the oldest ones from the ranker. An old P0 is the

--- a/docs/spec/backlog-self-driving.md
+++ b/docs/spec/backlog-self-driving.md
@@ -317,7 +317,7 @@ wrongly is worse than not filing at all** — the queue the loop ranks is the
 queue the loop just polluted.
 
 **The defect is a feedback loop, and it is live in this repository today.**
-`rank_defects` counts an issue as a defect if it carries `bug` **or** `triage` —
+`priority::triage` counts an issue as a defect if it carries `bug` **or** `triage` —
 an untriaged issue is a defect nobody has classified yet. Meanwhile
 `.github/workflows/issue-triage.yml` adds `triage` to any issue opened without
 one of its `TYPE_LABELS`, and the comment above that rule names the exact case:
@@ -369,7 +369,7 @@ is decided by whichever label the ranker happens to test first.
 Lands in `crates/stella-autonomy/src/convention.rs` — pure, and over borrowed
 label text rather than a `stella_protocol::Issue`, so the crate keeps the
 no-workspace-dependency property that lets the Observatory link its folds. That
-is the same trade `rank_defects` already makes, and the one mapping from a
+is the same trade `priority::triage` already makes, and the one mapping from a
 tracker's shape into this one lives in the caller.
 
 ### 3.1b Sizing, readiness, and the guard's logins
@@ -948,7 +948,7 @@ The pipeline's discipline, carried forward without relaxation:
 | Decision | Deterministic | Model |
 |---|---|---|
 | How big is this cycle | `plan_cycle` | — |
-| Which issue is next | `rank_defects` over the readiness queue | — |
+| Which issue is next | `priority::triage` over the readiness queue | — |
 | Is this finding new | `finding_digest` | — |
 | What is the next PR action | `deliver next` | — |
 | Has the ladder gone dry | `dry_streak` | — |

--- a/scripts/test-self-driving.sh
+++ b/scripts/test-self-driving.sh
@@ -133,7 +133,7 @@ chmod +x "$STUB_BIN/gh"
 
 # A backlog holding $1 defects, of which $2 carry P0, written to $3.
 #
-# `rank_defects` counts an issue as a defect when it is labelled `bug` or
+# `priority::triage` counts an issue as a defect when it is labelled `bug` or
 # `triage`, and `demand_from` counts P0 off the same list — so a fixture is
 # the honest way to say "the queue holds N, M of them urgent". Numbers are
 # what the governor derives, never what it is told.


### PR DESCRIPTION
## What & why

Batch fix for #6301 (protocol area, 1 member). The member issue below was
already closed as folded into the batch; referenced here for context, not as
a separate closing keyword.

### #5318 — the old defect ranking was still exported and still cited as the live one

`crates/stella-autonomy/src/lib.rs` exported `QueueIssue::priority_rank` and
`rank_defects`, which reproduce exactly the bug `priority.rs`'s module docs
describe as the reason that module exists: an issue with no priority label
sorts at rank 3, mixed in below every `P2`, instead of being separated out as
unassessed. `priority::triage` already replaced both — the CLI's
`self_driving_cmd/backlog.rs` calls `priority::triage`, not `rank_defects` —
so `rank_defects`/`priority_rank` had zero non-test callers and stayed `pub`
purely as the more discoverable, and wrong, `lib.rs` export.

Fix: deleted `priority_rank`/`rank_defects` and their test
(`rank_beats_age_across_ranks_triage_counts_and_features_do_not`, which
exercised the old, wrong sort order — issue 104's untriaged fixture landing
last in the ranked list instead of in `unassessed`). Chased every stale
citation that pointed at `rank_defects` as the live ranking mechanism:

- `crates/stella-protocol/src/issue.rs` module docs and `IssueProvider::list_open`
  doc comment (the two the parent issue named).
- `crates/stella-autonomy/src/convention.rs` module docs (two spots) and a
  test doc comment, which used `[crate::rank_defects]` as an intra-doc link.
- `crates/stella-autonomy/src/step.rs` module docs, same intra-doc link.
- `crates/stella-autonomy/README.md`'s `src/lib.rs` layout row.
- `docs/spec/backlog-self-driving.md` (three live-design citations; left one
  historical "the slice found" narrative sentence alone since it correctly
  describes what existed at that point in time).
- `scripts/test-self-driving.sh`'s fixture-generator comment.

Left alone, on purpose: the handful of remaining `rank_defects`/`priority_rank`
mentions in `priority.rs`'s own module docs and tests, and in
`stella-cli/src/self_driving_cmd/{triage,backlog}.rs`, are all past-tense
("used to be hardcoded in `rank_defects`", "the old `priority_rank` mapped...")
— they explain history accurately and don't claim either function is live.
`crates/stella-tools/tests/fixtures/name_rung_corpus.jsonl` also still lists
`priority_rank`/`rank_defects` as symbols, but that fixture is an explicitly
frozen historical snapshot of the code-graph index (`search_recall.rs`'s
module docs), not a live citation.

## The witness

`rank_defects_and_priority_rank_are_not_a_public_export`
(`crates/stella-autonomy/src/tests.rs`): scans this crate's own `lib.rs`
source and asserts neither `pub fn rank_defects` nor `fn priority_rank`
still exists — the same "hold a fact about text" technique this workspace's
`the_two_copies_of_this_policy_have_not_drifted` test already uses. It fails
on the pre-fix `lib.rs` (confirmed against `origin/main`, which still
defines `pub fn rank_defects`) and passes once the export is gone. A
behavioral witness isn't meaningful here — nothing on the live path changed;
`priority::triage` was already what the CLI called before this PR — so the
witness proves the actual defect (the wrong function staying `pub` and
discoverable) rather than a made-up behavior change.

Separately: deleting the intra-doc links `[crate::rank_defects]` in
`convention.rs`/`step.rs` without repointing them would have broken
`cargo doc -D warnings` (the `doc-warnings`/`doc-warnings-schema` gate steps)
with a `rustdoc::broken_intra_doc_links` error — that's the mechanical check
standing behind the doc-citation half of this fix.

## Extra fix (fix over file)

Also fixed: two long, dense sentences in `stella-autonomy/src/lib.rs`'s
module docs and `plan_cycle`/`calibrate` doc comments tripped the prose
reading-grade ratchet (`make prose`) once the file's total prose shrank —
removing `rank_defects`'s doc comments shifted the file's average sentence
length/syllable ratio just over its 9.56 ceiling (found 9.61). Split three
overlong sentences into shorter ones with plainer punctuation; no wording
was cut, only re-punctuated. `make prose` now passes at the same ceiling.

- [x] Extra fixes in this PR: `stella-autonomy/src/lib.rs` prose-grade fix (above), needed to keep `make guards-fast` green after the deletion — not a separate defect I went looking for.
- [x] Filed: nothing — no fix was deferred; the batch's one member rides this PR in full.

## The gate

- [ ] `cargo fmt --check` — ran `cargo fmt --all` locally, no changes.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — CI (`make check`/`make gate` not run locally per repo policy).
- [ ] `cargo test --workspace` — CI.
- [x] Docs updated where behavior/flags changed (see citations above).
- [ ] CLA signed.
- [x] `Closes #N` appears both above and as a commit trailer.

Tests deleted: `rank_beats_age_across_ranks_triage_counts_and_features_do_not`
(`crates/stella-autonomy/src/tests.rs`) — it exercised the deleted
`rank_defects`, asserting the old, wrong sort order the parent issue names as
the bug (an untriaged issue landing last in the ranked list rather than
separated into `unassessed`). Named here per `check-deleted-tests`.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps.
- [x] No new outbound network calls.
- [x] No new cross-boundary types.

Closes #6301

## Summary by Sourcery

Remove the obsolete defect-ranking exports and update their documentation and regression coverage to enforce `priority::triage` as the sole live ranking path.

Bug Fixes:
- Remove the superseded public defect-ranking APIs so callers use `priority::triage`, which correctly separates unassessed issues instead of mis-ranking them with P2 work.

Enhancements:
- Replace stale references to the deleted ranking APIs across code documentation, specifications, and fixture-generation guidance.
- Add a source-level regression test preventing the obsolete ranking exports from returning.

Documentation:
- Update autonomy, protocol, and self-driving backlog documentation to identify `priority::triage` as the live ranking mechanism.

Tests:
- Replace the test for the obsolete ranking behavior with a regression test verifying that `rank_defects` and `priority_rank` are no longer exported.

Chores:
- Re-punctuate dense autonomy documentation to preserve the prose-quality guard after removing the obsolete API documentation.