### PR TITLE
fix(stella-cli): probe delete capability instead of guessing uid==0

### DIFF
--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -797,6 +797,49 @@ fn remove_uninstalls_every_tier_that_holds_the_name() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// Checks whether a directory at `mode` really blocks a delete inside it,
+/// in this process, instead of guessing from the uid.
+///
+/// Root can unlink through a read-only parent no matter the mode bit. A
+/// bare `uid == 0` check would guess wrong here, and wrong the other way on
+/// a container or a platform where a non-root uid can also override the
+/// bit. This tries the real delete on a throwaway directory instead, so it
+/// agrees with what the caller below is about to see. `mode` is a
+/// parameter, not a fixed `0o555`, so the test below can call this same
+/// function with a mode it can pass without root.
+#[cfg(unix)]
+fn write_protection_is_enforced_at(root: &Path, mode: u32) -> bool {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let probe_dir = root.join("write-protection-probe");
+    std::fs::create_dir_all(&probe_dir).expect("probe directory");
+    let probe_file = probe_dir.join("victim");
+    std::fs::write(&probe_file, b"probe").expect("probe file");
+    std::fs::set_permissions(&probe_dir, std::fs::Permissions::from_mode(mode))
+        .expect("set the probe directory's mode");
+
+    let blocked = std::fs::remove_file(&probe_file).is_err();
+
+    // Restore before the caller's own cleanup runs, so a locked-down probe
+    // directory never strands the harness.
+    std::fs::set_permissions(&probe_dir, std::fs::Permissions::from_mode(0o755))
+        .expect("restore the probe directory");
+    let _ = std::fs::remove_dir_all(&probe_dir);
+
+    blocked
+}
+
+/// The mode the test below uses for its read-only tier — one constant so
+/// the probe and the tier always mean the same thing by "read-only".
+#[cfg(unix)]
+const READ_ONLY_TIER_MODE: u32 = 0o555;
+
+/// Checks with [`READ_ONLY_TIER_MODE`], the mode the test below uses.
+#[cfg(unix)]
+fn write_protection_is_enforced(root: &Path) -> bool {
+    write_protection_is_enforced_at(root, READ_ONLY_TIER_MODE)
+}
+
 /// **Witness (#4302).** A project tier that will not delete must not stop the
 /// user tier from being read.
 ///
@@ -812,6 +855,10 @@ fn remove_uninstalls_every_tier_that_holds_the_name() {
 /// read-only tier is what actually makes `remove_dir_all` fail on the child.
 /// Unix only: `chmod` is the portable way to arrange this, and Windows
 /// permissions do not reproduce it.
+///
+/// **Skips when the check above finds the mode bit does not hold**, such as
+/// under root: the setup below cannot work in that process, and running it
+/// anyway would report a false failure in `remove`.
 #[cfg(unix)]
 #[test]
 fn a_project_tier_that_will_not_delete_does_not_strand_the_user_copy() {
@@ -821,6 +868,17 @@ fn a_project_tier_that_will_not_delete_does_not_strand_the_user_copy() {
     let _restore =
         crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT", "STELLA_PROJECT_HOOKS"]);
     let root = temp_root("undeletable-project-tier");
+
+    if !write_protection_is_enforced(&root) {
+        eprintln!(
+            "skipping a_project_tier_that_will_not_delete_does_not_strand_the_user_copy: \
+             this process can delete through a read-only directory, so a 0o555 tier cannot \
+             be made undeletable here"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+        return;
+    }
+
     let home = root.join("home");
     let _paths = crate::paths::test_user_home(home.clone());
     let source = package(&root, "vera");
@@ -870,6 +928,26 @@ fn a_project_tier_that_will_not_delete_does_not_strand_the_user_copy() {
             .all(|route| route.plugin != "vera"),
         "and it must stop dispatching from the user tier: {:?}",
         after.hook_routes()
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// The check the sibling test gates on must test the delete, not guess an
+/// answer from the mode bit.
+///
+/// A directory that does not restrict writes must never come back
+/// "blocked". This runs on every uid and needs no root, since it never
+/// claims a mode bit is enforced — it only claims one is not.
+#[cfg(unix)]
+#[test]
+fn write_protection_probe_does_not_report_blocked_when_the_delete_would_succeed() {
+    let root = temp_root("write-protection-probe-negative");
+
+    assert!(
+        !write_protection_is_enforced_at(&root, 0o755),
+        "a 0o755 directory does not stop the delete the probe attempts, so the probe must \
+         say so rather than trusting the mode bit it never actually tested"
     );
 
     let _ = std::fs::remove_dir_all(&root);


### PR DESCRIPTION
## What & why

Batch fix for #6302 (testing, 1 member).

**#5670 — `a_project_tier_that_will_not_delete_does_not_strand_the_user_copy` fails deterministically when the suite runs as root.**

The test makes a project tier read-only (`0o555`) and asserts `remove()` reports the delete failure rather than swallowing it (the #4302 witness). Root holds `CAP_DAC_OVERRIDE` and deletes through a `0o555` parent regardless of the mode bit, so the assumed failure never happens, `expect_err` panics, and the failure reads as a `remove` regression when nothing is wrong with it. CI runs on a non-root runner so this is invisible there; it surfaces only when an agent session runs the suite as root (e.g. inside a container).

Fix: gate the test on a **probed** delete capability instead of a bare `uid == 0` check, per the issue's "Suggested shapes" and the folded #6016 refinement. `write_protection_is_enforced_at(root, mode)` (`crates/stella-cli/src/plugin_cmd/tests.rs`) creates a throwaway directory in the same temp root, `chmod`s it to `mode`, and attempts a real unlink of a file inside it — the skip is keyed off whether that unlink actually failed, not off who is asking. A bare uid check gets this wrong in both directions the issue names: it would report "blocked" for root running with `CAP_DAC_OVERRIDE` dropped, and "not blocked" on a hypothetical platform where a non-root uid can also override the bit.

When the probe finds the mode bit does not hold, the test prints why (naming the cause in the same doc comment a future reader would need, per the issue's DoD) and returns rather than panicking on a false failure.

### Witness

`write_protection_probe_does_not_report_blocked_when_the_delete_would_succeed` calls the same probed function, `write_protection_is_enforced_at`, with a `0o755` (writable) directory and asserts it reports "not blocked". Against the pre-fix tree this does not compile at all — the function did not exist — and, more to the point, it pins the exact defect class the issue names: a capability check that answers "blocked" without ever testing a delete.

A literal fail-then-pass root run is not reproducible in this session: neither this development machine nor CI runs as root (the issue's own text: "CI runs on a non-root runner, so this is invisible there"), so there is no environment here that can demonstrate the original panic and then its absence. What is verified instead:

- `write_protection_probe_does_not_report_blocked_when_the_delete_would_succeed` is a deterministic negative control on the exact probe function the fix gates on, runnable (and run) as any uid.
- A targeted local run of the crate's plugin_cmd test module confirms the #4302 witness (`a_project_tier_that_will_not_delete_does_not_strand_the_user_copy`) is unchanged and still green for a normal, non-root user — 39 passed, 0 failed — so the probe adds a skip path without weakening the regression coverage it guards.
- `make guards-fast` is green, including `check-prose` (no new content-free constructions) and `check-file-size` (`plugin_cmd/tests.rs` sits nowhere near the 1500-line ceiling and is not a god file).

Closes #5670

## The witness

Stella's definition of done is a test that fails on the old code and passes on the new.

- [x] This PR includes a witness test (fails on the pre-fix code — the gated function does not exist — and pins the defect class the issue names)

An actual root fail-then-pass demonstration is not available in this session or in CI — see "Witness" above for why, and what was verified instead.

## The gate

- [x] `cargo fmt --check`
- [ ] clippy across the workspace — CI's job; this laptop does not build or test the workspace (house rule)
- [ ] the full test suite — CI's job; a targeted run scoped to the touched module was run locally (39 passed, 0 failed)
- [x] Docs updated where behavior/flags changed — none needed; this is test-only, and the new skip condition is documented in the test's own doc comments
- [ ] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: none — the batch has one member and it rides this PR
- [x] Filed: nothing deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- N/A — no new cross-boundary types

## Anything reviewers should know?

- #5670 had a duplicate, #6016, already merged into it as a comment before this batch was filed; its "probe the capability, never the uid" refinement is what this PR implements.
- The negative-control witness needed the probe helper parameterized on `mode: u32` so a non-root test could exercise the exact function the real test gates on, rather than duplicating its logic. `write_protection_is_enforced(root)`, used by the real test, is a thin wrapper fixing `mode` to the `0o555` the tier actually uses.

## Summary by Sourcery

Gate the read-only project-tier regression test on an actual delete-capability probe instead of assuming protection from the process UID.

Bug Fixes:
- Prevent the read-only project-tier regression test from producing false failures when the process can delete through a protected directory.
- Add a regression test verifying delete capability is probed rather than inferred from directory mode or user identity.

Enhancements:
- Use an actual delete-capability probe to determine whether write protection is enforced in the current process, with clear skip diagnostics when it is not.

Tests:
- Add coverage for the delete-capability probe using a writable directory as a deterministic negative control.