### PR TITLE
fix(stella-transcript): widen the numbered gutter and pin a collapsed turn

### DIFF
--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -733,9 +733,10 @@ fn push_output_text(line: &mut Vec<Cell>, text: &str, paint: syntax::BodyPaint) 
     // 780 was labelled line 1, because the index is a position in the body and
     // not a position in the file (#4036).
     if paint.numbered {
-        let label = painted
-            .gutter
-            .map_or_else(|| " ".repeat(NUM_COL), |g| format!("{:>4}  ", g.number));
+        let label = painted.gutter.map_or_else(
+            || " ".repeat(NUM_COL),
+            |g| format!("{:>width$}  ", g.number, width = NUM_COL - 2),
+        );
         line.push(Cell::new(label, Color::Faint));
     }
     // Expanded against the running column, before anything measures: a tab is
@@ -756,12 +757,18 @@ fn push_output_text(line: &mut Vec<Cell>, text: &str, paint: syntax::BodyPaint) 
     }
 }
 
-/// Width of the line-number column: four digits and two spaces.
+/// Width of the line-number column: five digits and a two-column gap.
+///
+/// Both arms in [`push_output_text`] build this width from one constant.
+/// The digit field is `NUM_COL - 2`. The empty fallback is `NUM_COL`
+/// spaces. Widening this constant moves both arms together, so one cannot
+/// drift from the other. Five digits fits a file well past 9,999 lines,
+/// and its numbered rows still line up with an unnumbered row beside them.
 ///
 /// A body line without a gutter — the read footer — still pays for it, so the
 /// source above it stays in one straight column instead of stepping left at the
 /// end of every read.
-const NUM_COL: usize = 6;
+const NUM_COL: usize = 7;
 
 /// The grid colour for a token class.
 ///
@@ -1268,5 +1275,33 @@ mod tests {
                 to_plain(std::slice::from_ref(line)),
             );
         }
+    }
+
+    /// A five-digit line number's gutter must match the width of the
+    /// gutter-less footer row beside it. `{:>4}` is a *minimum* width, so a
+    /// fifth digit grows past four columns and the two widths stop
+    /// matching.
+    #[test]
+    fn numbered_gutter_matches_the_footer_width_for_a_five_digit_line_number() {
+        let paint = syntax::BodyPaint {
+            lang: None,
+            numbered: true,
+        };
+        let mut numbered = Vec::new();
+        push_output_text(&mut numbered, "12345\tfn main() {}", paint);
+        let mut footer = Vec::new();
+        push_output_text(&mut footer, "(12345/50000 lines, read 1)", paint);
+
+        let numbered_gutter = numbered[0].width();
+        let footer_gutter = footer[0].width();
+        assert_eq!(
+            numbered_gutter, footer_gutter,
+            "a five-digit numbered gutter ({numbered_gutter} cells) drifted from the \
+             gutter-less footer beside it ({footer_gutter} cells)"
+        );
+        assert_eq!(
+            numbered_gutter, NUM_COL,
+            "the gutter must stay NUM_COL wide"
+        );
     }
 }

--- a/crates/stella-transcript/tests/grid_snapshots.rs
+++ b/crates/stella-transcript/tests/grid_snapshots.rs
@@ -434,6 +434,74 @@ fn grid_snapshots_pin_a_failed_step_open_at_zoom_turns() {
     );
 }
 
+/// `suite_run_with_a_failure`'s first turn kept open, minus the failure —
+/// the same shape with a passing step and an answer instead of `None`.
+fn suite_run_without_a_failure() -> Run {
+    run(
+        "loop-detect-suite",
+        vec![
+            Turn {
+                name: "run-suite".to_string(),
+                prompt: "run the loop-detect suite".to_string(),
+                prose: Vec::new(),
+                notes: Vec::new(),
+                steps: vec![step(
+                    bash(
+                        "cargo test -p stella-core loop_detect",
+                        &["running 4 tests", "test result: ok. 4 passed; 0 failed"],
+                        Status::Ok,
+                    ),
+                    0,
+                )],
+                answer: Some("The suite passes; nothing to fix.".to_string()),
+                status: Status::Ok,
+                duration_ms: 3_400,
+            },
+            Turn {
+                name: "add-a-test".to_string(),
+                prompt: "add one more case".to_string(),
+                prose: Vec::new(),
+                notes: Vec::new(),
+                steps: vec![step(
+                    bash(
+                        "cargo test -p stella-core loop_detect",
+                        &["running 5 tests", "test result: ok. 5 passed; 0 failed"],
+                        Status::Ok,
+                    ),
+                    0,
+                )],
+                answer: Some("Added the new case; the suite still passes.".to_string()),
+                status: Status::Ok,
+                duration_ms: 2_100,
+            },
+        ],
+    )
+}
+
+/// A turn that is not the run's last and has no failing step, collapsed at
+/// `Zoom::Turns`. Neither existing `Zoom::Turns` golden covers it —
+/// `grid_snapshots_pin_a_mixed_turn_at_zoom_turns` renders a single-turn run,
+/// so `fold.rs`'s `default_open` keeps its only turn open through
+/// `is_last_turn` regardless of collapsing; `failed_step_pinned_open` above
+/// uses a non-last turn but pins it open with `Status::pins_open`, which
+/// golden shows the *escape* from collapsing, not collapsing itself. This
+/// fixture has two turns, the first finished `Status::Ok` with no failing
+/// step, so nothing pins it open and the header actually collapses.
+#[test]
+fn grid_snapshots_pin_a_collapsed_turn_header_at_zoom_turns() {
+    let r = suite_run_without_a_failure();
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Turns);
+    let frame = grid::to_plain(&grid::render_turn_lines(&r, &state, 0, W));
+    assert_golden(
+        "collapsed_turn_at_zoom_turns",
+        "the first of two turns, neither failing — Zoom::Turns collapses it, \
+         unlike failed_step_pinned_open where a failure pins it open",
+        W,
+        &frame,
+    );
+}
+
 // ──────────────────────── a note with detail, one without ─────────────────
 
 fn notes_run() -> Run {

--- a/crates/stella-transcript/tests/snapshots/grid/collapsed_turn_at_zoom_turns.txt
+++ b/crates/stella-transcript/tests/snapshots/grid/collapsed_turn_at_zoom_turns.txt
@@ -1,0 +1,8 @@
+# grid golden · collapsed_turn_at_zoom_turns
+# the first of two turns, neither failing — Zoom::Turns collapses it, unlike failed_step_pinned_open where a failure pins it open
+# width 100 · rendered through grid::to_plain, styling stripped
+# regenerate: BLESS=1 cargo test -p stella-transcript --test grid_snapshots
+
+╭─ run-suite ▸ "run the loop-detect suite" ────────────────────────────────────────────────────── ─╮
+│ …
+╰─ ✓ done ───────────────────────────────────────────────── [1 steps] [0:03] [4.0k→120] [$0.0006] ─╯


### PR DESCRIPTION
## Members

- #5968 — `grid.rs`'s numbered-line gutter spelled its width twice: `NUM_COL` and a literal `{:>4}` plus two literal spaces. `{:>4}` is a *minimum* width, so a five-digit line number rendered 7 columns beside an unnumbered row's 6, misaligning every numbered row in a file past 9,999 lines (`crates/stella-store/src/tests.rs` and `crates/stella-cli/src/command_deck.rs` are both well past it). Fixed by building both arms from `NUM_COL` alone and widening `NUM_COL` to 7 so a five-digit number still fits. **Witness**: `grid::tests::numbered_gutter_matches_the_footer_width_for_a_five_digit_line_number` compares a numbered row's gutter width against a gutter-less footer row's beside it. Verified by construction: reverting just the two changed lines back to `{:>4}` + `NUM_COL = 6` reproduces the old bug and the test fails with `7 cells` vs `6 cells`; restoring the fix passes.

- #5961 — No golden pinned a turn collapsed at `Zoom::Turns`. The two cases that looked like they covered it did not: `grid_snapshots_pin_a_mixed_turn_at_zoom_turns` renders a single-turn run, so `fold.rs`'s `default_open` keeps the only turn open through `is_last_turn` regardless of collapsing; `failed_step_pinned_open` uses a non-last turn but pins it open through `Status::pins_open`, which shows the *escape* from collapsing, not collapsing itself. Added a ninth case, `grid_snapshots_pin_a_collapsed_turn_header_at_zoom_turns`, built from a new two-turn fixture (`suite_run_with_a_failure`'s shape with the failure taken off), rendered through `render_turn_lines(&r, &state, 0, W)` at `Zoom::Turns`. Blessed and read — the golden is 3 lines (`╭─ … ▸ "…"`, `│ …`, `╰─ …`), genuinely shorter than the 8-line open frame beside it in `failed_step_pinned_open.txt`.

## Tests deleted

None.

Closes #6305

## Summary by Sourcery

Fix transcript gutter alignment for large files and cover collapsed turn rendering at Turns zoom.

Bug Fixes:
- Keep numbered transcript gutters aligned for five-digit line numbers by deriving their width from a widened shared column constant.

Enhancements:
- Add coverage for collapsed non-final turns at Turns zoom with a golden snapshot.

Tests:
- Add a regression test comparing five-digit numbered gutters with footer gutters.
- Add a golden snapshot test for a genuinely collapsed turn header at Turns zoom.