### PR TITLE
fix(stella-plugin): split panel.rs and refuse a bidi-flipped plugin name

### DIFF
--- a/crates/stella-plugin/README.md
+++ b/crates/stella-plugin/README.md
@@ -293,8 +293,9 @@ before it crosses.
   origin, so a frame cannot name a cell of Stella's own chrome.
 - `src/drawable.rs` — the two rules behind that first one, and the argument for
   where each line sits: what a screen runs (`Cc`), and what reorders the text
-  after it (the bidi `char`s). `PanelText::new` asks both; a plugin's `name`
-  asks the first.
+  after it (the bidi `char`s). `PanelText::new` and `validate_plugin_name`
+  both ask each rule in turn, because a plugin's name is chrome Stella prints
+  under its own border, not a leased rectangle the host clips.
 - `src/seat.rs` — `seat_key`, the one place a `<plugin>/<role>` seat key is
   built (`doc:roleless-core` §8.4). The host joins the two halves; a plugin
   sends only its bare role name, so no plugin can name a seat another plugin

--- a/crates/stella-plugin/src/drawable.rs
+++ b/crates/stella-plugin/src/drawable.rs
@@ -74,21 +74,31 @@ pub(crate) fn first_bidi_control(text: &str) -> Option<(usize, char)> {
 /// Here, not in `manifest.rs`, so it sits by the rule it shares with
 /// [`crate::PanelText::new`].
 ///
-/// It asks [`first_control_character`] and not [`first_bidi_control`]. A name
-/// with `U+202E` is the same trick one door over. To bar it adds a case to the
-/// public [`ManifestError`], which is its own change.
+/// It refuses both hazards [`crate::PanelText::new`] refuses: a control
+/// `char` first, since that is the worse of the two, and then a bidi one — a
+/// name carrying `U+202E` or its kin can render in an order its bytes do not
+/// have, the Trojan Source shape (`CVE-2021-42574`), and this string sits in
+/// Stella's own chrome rather than a leased rectangle the host clips.
 ///
 /// # Errors
 ///
-/// [`ManifestError::NameNotDrawable`], naming the `char` and where it sits.
+/// [`ManifestError::NameNotDrawable`] for a control `char`,
+/// [`ManifestError::NameCarriesBidiControl`] for a bidi one. Each names the
+/// `char` and where it sits.
 pub(crate) fn validate_plugin_name(name: &str) -> Result<(), ManifestError> {
-    match first_control_character(name) {
-        Some((index, found)) => Err(ManifestError::NameNotDrawable {
+    if let Some((index, found)) = first_control_character(name) {
+        return Err(ManifestError::NameNotDrawable {
             index,
             code: found as u32,
-        }),
-        None => Ok(()),
+        });
     }
+    if let Some((index, found)) = first_bidi_control(name) {
+        return Err(ManifestError::NameCarriesBidiControl {
+            index,
+            code: found as u32,
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -140,5 +150,42 @@ mod tests {
             Err(ManifestError::NameNotDrawable { index: 1, code: 27 })
         ));
         assert!(validate_plugin_name("vera").is_ok());
+    }
+
+    /// `validate_plugin_name` asks [`first_bidi_control`] as well as
+    /// [`first_control_character`], refusing every one of the twelve
+    /// [`BIDI_CONTROLS`] and none of the joiners a script legitimately needs.
+    /// Fails on a build where that second ask is missing: a name carrying
+    /// `U+202E` loads and renders reordered under Stella's own border.
+    #[test]
+    fn a_name_that_reorders_itself_with_a_bidi_control_is_refused_by_position() {
+        for hazard in BIDI_CONTROLS {
+            assert!(
+                matches!(
+                    validate_plugin_name(&format!("gates {hazard}neerg")),
+                    Err(ManifestError::NameCarriesBidiControl {
+                        index: 6,
+                        code
+                    }) if code == *hazard as u32
+                ),
+                "U+{:04X} loaded, or was refused by the wrong rule",
+                *hazard as u32
+            );
+        }
+        assert!(matches!(
+            validate_plugin_name("✦\u{202e}"),
+            Err(ManifestError::NameCarriesBidiControl {
+                index: 1,
+                code: 0x202e
+            })
+        ));
+        // The joiners stay allowed — the control-character rule above is what
+        // bars an escape, not this one.
+        for kept in ['\u{200c}', '\u{200d}'] {
+            assert!(
+                validate_plugin_name(&format!("gates{kept}status")).is_ok(),
+                "{kept:?} is a joiner and should load"
+            );
+        }
     }
 }

--- a/crates/stella-plugin/src/error.rs
+++ b/crates/stella-plugin/src/error.rs
@@ -671,6 +671,26 @@ pub enum ManifestError {
         code: u32,
     },
 
+    /// The manifest's `name` carried a bidi formatting character.
+    ///
+    /// Its own case, not a reused [`Self::NameNotDrawable`]: the two refusals
+    /// ask different things, and a message telling an author to look for an
+    /// escape sequence that is not in their name wastes their time. `U+202E`
+    /// and its kin flip the text after them, so a name can render in an order
+    /// its bytes do not have — the Trojan Source shape (`CVE-2021-42574`) —
+    /// under Stella's own border, next to the consent prompt a person reads
+    /// to decide whether to trust the plugin at all.
+    #[error(
+        "manifest name carries the bidi formatting character U+{code:04X} at position {index}: \
+         it reorders the name after it, so Stella's chrome would read one way and mean another"
+    )]
+    NameCarriesBidiControl {
+        /// Which character of the name, counted in `char`s from zero.
+        index: usize,
+        /// The Unicode scalar value that was refused.
+        code: u32,
+    },
+
     /// The manifest's `name` carried a `/`.
     ///
     /// The host joins the name to a role name to build the seat key a user

--- a/crates/stella-plugin/src/panel.rs
+++ b/crates/stella-plugin/src/panel.rs
@@ -9,16 +9,17 @@
 //! Some of that section's rules are held by the types, not by a host's care.
 //! That is why this is a contract at all:
 //!
-//! - **A panel never emits an escape sequence, and never flips its own text.**
-//!   [`PanelText`] wraps a private `String` whose only constructor turns away
-//!   every control `char` and every bidi one, so `\x1b[2J` and `U+202E` are
-//!   both decode errors on the frame that carries them. The host draws the
+//! - **A panel never emits an escape sequence, and never flips its own text**.
+//!   [`PanelText`] wraps a private `String`. Its only constructor turns away
+//!   every control `char` and every bidi one. `\x1b[2J` and `U+202E` are both
+//!   decode errors on the frame that carries them. The host draws the
 //!   border, the title and every escape byte the terminal ever sees.
-//! - **A panel cannot address a cell it was not leased.** [`PanelRect`] carries
-//!   an extent and no origin, so the coordinates a plugin writes are its own
-//!   rectangle's; there is no number it could put in a frame that names a cell
-//!   of Stella's chrome. [`PanelFrame::fits`] refuses one that starts or runs
-//!   past the lease's own edge, naming the row and column that did it.
+//! - **A panel cannot address a cell it was not leased**. [`PanelRect`]
+//!   carries an extent and no origin. The coordinates a plugin writes are
+//!   its own rectangle's. There is no number it could put in a frame that
+//!   names a cell of Stella's chrome. [`PanelFrame::fits`] refuses one that
+//!   starts or runs past the lease's own edge, naming the row and column
+//!   that did it.
 //!
 //! The `[panel]` block is the consent half: [`PanelGrant`], whose `denies` list
 //! must name every [`PanelDenial`] before the manifest loads, so the two limits
@@ -35,6 +36,12 @@ use crate::drawable::{first_bidi_control, first_control_character};
 use crate::error::ManifestError;
 use crate::runtime::{ProcessBlock, Runtime};
 use crate::wire::PROTOCOL_VERSION;
+
+mod error;
+#[cfg(test)]
+mod tests;
+
+pub use error::{PanelOverflow, PanelRefusal, PanelTextError};
 
 /// What a `[panel]` block gives up, and must say it gives up.
 ///
@@ -207,10 +214,10 @@ pub struct PanelGrant {
     /// editing mistake rather than an emphasis, as `[panel] denies`'s is
     /// ([`ManifestError::PanelDuplicateSurface`]).
     ///
-    /// A set rather than one kind because the three placements are independent
-    /// — a plugin may reasonably want a settings pane and a `/name` popup and
-    /// no transcript block — and because the consent prompt reads better as a
-    /// list of what appears on screen than as three separate blocks.
+    /// A set, not one kind. The three placements are independent — a plugin
+    /// may reasonably want a settings pane and a `/name` popup and no
+    /// transcript block. The consent prompt also reads better as a list of
+    /// what appears on screen than as three separate blocks.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub surfaces: Vec<PanelSurface>,
     /// The bare slash name this panel's popup opens under, without the leading
@@ -324,14 +331,15 @@ impl PanelGrant {
     /// one legal without crossing to another module, and a host that assembles
     /// a grant in Rust can ask the same question the parser asks.
     ///
-    /// Two rules are the ones every other block has — a repeated entry is an
-    /// editing mistake rather than an emphasis, and a declared process is held
-    /// to [`Runtime`]'s rules under its own block name. The rest belong to this
-    /// block alone: the denial set is Stella's, so a block may not name a
-    /// subset of it and call the result a narrower panel
-    /// (`design/tui-v2/SPEC.md` §12's handshake); a panel names at least one
-    /// place it draws; and a slash name is checked for the shape the host will
-    /// have to register (#5203).
+    /// Two rules are the ones every other block has. A repeated entry is an
+    /// editing mistake, not an emphasis. A declared process is held to
+    /// [`Runtime`]'s rules under its own block name.
+    ///
+    /// Three rules belong to this block alone. The denial set is Stella's, so
+    /// a block cannot name a subset of it and call the result a narrower
+    /// panel (`design/tui-v2/SPEC.md` §12's handshake). A panel must name at
+    /// least one place it draws. A slash name is checked for the shape the
+    /// host will have to register (#5203).
     ///
     /// **Where it draws is asked before what it gives up**, because a block
     /// naming no surface is unfinished rather than over-permissive, and telling
@@ -558,47 +566,13 @@ impl PanelLease {
     }
 }
 
-/// Why a host will not draw a frame it was handed.
-///
-/// Two routing cases and the geometry, because a frame can be wrong in ways
-/// that have nothing to do with its size: a plugin drawing three surfaces can
-/// answer the wrong lease, and one that fell behind can answer a tick the host
-/// has already replaced.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum PanelRefusal {
-    /// The frame answers a different panel than the one leased.
-    #[error("a panel frame for the \"{answered}\" surface answers a \"{leased}\" lease")]
-    Surface {
-        /// The surface the lease was for.
-        leased: PanelSurface,
-        /// The surface the frame claims.
-        answered: PanelSurface,
-    },
-    /// The frame answers a tick the host has moved on from.
-    #[error("a panel frame for tick {answered} answers the lease for tick {leased}")]
-    Tick {
-        /// The tick the lease was for.
-        leased: u64,
-        /// The tick the frame echoed.
-        answered: u64,
-    },
-    /// The frame addresses a cell the lease does not hold.
-    #[error(transparent)]
-    Overflow(
-        /// Which edge it ran past.
-        #[from]
-        PanelOverflow,
-    ),
-}
-
 /// The extent of a panel's lease, in terminal cells.
 ///
-/// **An extent and no origin**, which is what makes addressing outside the
-/// lease unrepresentable rather than refused after the fact: a panel counts
-/// rows and columns from its own top-left corner, so the host's buffer
-/// coordinates are a number it is never told and can never write. The host adds
-/// its own origin when it blits, and the border it drew is outside the
-/// translation entirely.
+/// **An extent and no origin.** A panel counts rows and columns from its own
+/// top-left corner. It is never told the host's buffer coordinates, so it
+/// can never write them — a stronger rule than a check that refuses a bad
+/// number after the fact. The host adds its own origin when it blits, and
+/// the border it drew sits outside the translation entirely.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PanelRect {
@@ -841,12 +815,12 @@ impl PanelPatch {
 /// Glyphs a panel writes into cells it was leased.
 ///
 /// **The no-raw-escapes rule, held by the type.** The body is a private
-/// `String` whose only constructor is [`PanelText::new`], and that constructor
-/// refuses every control character — `\x1b`, and with it every CSI, OSC and SGR
-/// sequence a plugin could use to move the cursor out of its rectangle, clear
-/// the screen, repaint Stella's own chrome, or set a window title. `\n`, `\r`
-/// and `\t` go with them: a row's structure is the frame's, and a tab's width
-/// is the terminal's rather than this contract's.
+/// `String`, and [`PanelText::new`] is its only door. That constructor
+/// refuses every control character — `\x1b`, and with it every CSI, OSC and
+/// SGR run. A plugin cannot use one to move the cursor out of its rectangle,
+/// clear the screen, repaint Stella's own chrome, or set a window title.
+/// `\n`, `\r` and `\t` go with them: a row's shape is the frame's, and a
+/// tab's width is the terminal's, not this contract's.
 ///
 /// **And the no-flip rule, held the same way.** The same constructor turns
 /// away the bidi `char`s — `U+061C`, `U+200E`, `U+200F`, `U+202A`–`U+202E`,
@@ -970,39 +944,6 @@ impl<'de> Deserialize<'de> for PanelText {
     }
 }
 
-/// Why a run of glyphs is not drawable.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum PanelTextError {
-    /// The text carries a control character. A panel writes glyphs into cells;
-    /// every escape byte the terminal sees is the host's.
-    #[error(
-        "panel text carries the control character U+{code:04X} at position {index}: a panel \
-         writes glyphs into the cells it was leased, and Stella writes every escape sequence \
-         the terminal sees"
-    )]
-    ControlCharacter {
-        /// Which character of the text, counted in `char`s from zero.
-        index: usize,
-        /// The Unicode scalar value that was refused.
-        code: u32,
-    },
-
-    /// The text carries a bidi `char`. Its own error, not a reused
-    /// [`PanelTextError::ControlCharacter`]. The two refusals ask different
-    /// things, and a host that printed the wrong one would send an author
-    /// hunting an escape that is not there.
-    #[error(
-        "panel text carries the bidi formatting character U+{code:04X} at position {index}: it \
-         reorders the glyphs after it, so the panel would read one way and mean another"
-    )]
-    BidiControl {
-        /// Which character of the text, counted in `char`s from zero.
-        index: usize,
-        /// The Unicode scalar value that was refused.
-        code: u32,
-    },
-}
-
 /// How a run of glyphs is drawn.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1044,11 +985,11 @@ impl PanelStyle {
 
 /// The colours a panel may paint with.
 ///
-/// Token names and never an RGB triple, which is what keeps §2's two-metal rule
-/// and §3.2's hue clamp true of a plugin's pixels as well as Stella's: the host
-/// resolves each name against the live theme, so a panel follows a degraded
-/// sixteen-colour terminal (§3.5) without knowing one exists, and no plugin can
-/// author the warm hue the clamp exists to refuse.
+/// Token names, never an RGB triple. That keeps §2's two-metal rule and
+/// §3.2's hue clamp true of a plugin's pixels, not just Stella's own. The
+/// host resolves each name against the live theme, so a panel follows a
+/// degraded sixteen-colour terminal (§3.5) with no idea one exists, and no
+/// plugin can author the warm hue the clamp exists to refuse.
 ///
 /// The set is `design/tui-v2/SPEC.md` §3.1's `tui` surface exactly. This crate
 /// spells its own copy because it is a near-leaf that may not depend on the
@@ -1111,373 +1052,4 @@ pub enum PanelEmphasis {
     Italic,
     /// Ruled underneath.
     Underline,
-}
-
-/// Why a frame does not fit the rectangle it was leased.
-///
-/// Four cases because the two frame shapes fail in two ways each, and a host
-/// refusing a frame should be able to print which row, which column and which
-/// edge without re-deriving any of it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum PanelOverflow {
-    /// A [`PanelPaint::Lines`] frame carries more rows than the lease has.
-    #[error("a panel frame of {lines} line(s) does not fit a lease {rows} row(s) tall")]
-    Rows {
-        /// How many rows the frame carries.
-        lines: usize,
-        /// How many the lease holds.
-        rows: u16,
-    },
-    /// A row of a [`PanelPaint::Lines`] frame runs past the lease's right edge.
-    #[error("line {line} of a panel frame is {cells} cell(s) wide, past a {cols}-column lease")]
-    Line {
-        /// Which row, counted from the top of the frame.
-        line: usize,
-        /// How wide it is.
-        cells: usize,
-        /// How wide the lease is.
-        cols: u16,
-    },
-    /// A [`PanelPaint::Diff`] patch addresses a row the lease does not have.
-    #[error("a panel frame patches row {row}, past a lease {rows} row(s) tall")]
-    Row {
-        /// The row the patch addressed.
-        row: u16,
-        /// How many rows the lease holds.
-        rows: u16,
-    },
-    /// A [`PanelPaint::Diff`] patch starts past the lease's right edge, or runs
-    /// past it. Both are this one case because both are answered by the same
-    /// edit — move the patch left or shorten it — and a host printing the
-    /// refusal wants the column and the run length either way.
-    #[error(
-        "a panel frame patches {cells} cell(s) from column {col} of row {row}, past a \
-         {cols}-column lease"
-    )]
-    Patch {
-        /// The row the patch addressed.
-        row: u16,
-        /// The column it started at.
-        col: u16,
-        /// How many cells it writes.
-        cells: usize,
-        /// How wide the lease is.
-        cols: u16,
-    },
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn text(glyphs: &str) -> PanelText {
-        PanelText::new(glyphs).expect("plain glyphs")
-    }
-
-    #[test]
-    fn every_denial_has_a_distinct_wire_name_and_a_sentence() {
-        let mut names: Vec<&str> = PanelDenial::all()
-            .iter()
-            .map(|denial| denial.as_str())
-            .collect();
-        let count = names.len();
-        names.sort_unstable();
-        names.dedup();
-        assert_eq!(names.len(), count, "two denials share a wire name");
-        for denial in PanelDenial::all() {
-            assert!(!denial.consent_sentence().trim().is_empty(), "{denial}");
-        }
-    }
-
-    #[test]
-    fn all_is_exhaustive_over_the_denial_set() {
-        // Round-tripping every wire name back through the deserializer proves
-        // `all()` and the enum agree, without a hand-maintained count.
-        for denial in PanelDenial::all() {
-            let json = serde_json::to_string(denial).expect("a denial serializes");
-            let back: PanelDenial = serde_json::from_str(&json).expect("and reads back");
-            assert_eq!(back, *denial);
-        }
-        assert!(
-            serde_json::from_str::<PanelDenial>("\"read-anything\"").is_err(),
-            "the denial set is Stella's, so an unknown limit is a refusal"
-        );
-    }
-
-    /// A grant that passes every rule, for a test that is about one of them.
-    fn grant(surfaces: Vec<PanelSurface>) -> PanelGrant {
-        PanelGrant {
-            surfaces,
-            command: None,
-            denies: PanelDenial::all().to_vec(),
-            process: None,
-        }
-    }
-
-    #[test]
-    fn a_grant_reports_the_first_denial_it_fails_to_name() {
-        let partial = PanelGrant {
-            denies: vec![PanelDenial::WriteOutsideSandbox],
-            ..grant(vec![PanelSurface::Overlay])
-        };
-        assert_eq!(partial.missing_denial(), Some(PanelDenial::Network));
-        let complete = grant(vec![PanelSurface::Overlay]);
-        assert_eq!(complete.missing_denial(), None);
-        assert!(complete.denies(PanelDenial::Network));
-    }
-
-    #[test]
-    fn every_surface_has_a_distinct_wire_name_and_a_sentence() {
-        let mut names: Vec<&str> = PanelSurface::all()
-            .iter()
-            .map(|surface| surface.as_str())
-            .collect();
-        let count = names.len();
-        names.sort_unstable();
-        names.dedup();
-        assert_eq!(names.len(), count, "two surfaces share a wire name");
-        for surface in PanelSurface::all() {
-            assert!(!surface.consent_sentence().trim().is_empty(), "{surface}");
-            let json = serde_json::to_string(surface).expect("a surface serializes");
-            let back: PanelSurface = serde_json::from_str(&json).expect("and reads back");
-            assert_eq!(back, *surface);
-        }
-        assert!(
-            serde_json::from_str::<PanelSurface>("\"status_bar\"").is_err(),
-            "the placements are Stella's, so an unknown one is a refusal"
-        );
-    }
-
-    #[test]
-    fn a_panel_that_draws_nowhere_is_refused() {
-        assert!(matches!(
-            grant(Vec::new()).validate("gates"),
-            Err(ManifestError::PanelNoSurface)
-        ));
-        assert!(matches!(
-            grant(vec![PanelSurface::Settings, PanelSurface::Settings]).validate("gates"),
-            Err(ManifestError::PanelDuplicateSurface {
-                surface: PanelSurface::Settings
-            })
-        ));
-        assert!(
-            grant(vec![PanelSurface::Settings])
-                .validate("gates")
-                .is_ok()
-        );
-    }
-
-    /// The name a panel registers is the one `command_or` resolves, so the
-    /// derived name is held to the same shape rules as a declared one.
-    ///
-    /// A plugin that declares no `command` registers its own name. Left
-    /// unchecked, `name = "vera:admin"` bought the namespace-shaped slash
-    /// command the explicit path refuses by its own dedicated error, and the
-    /// consent document then told the reader the panel answers to
-    /// `/vera:admin` and to `/vera:admin:vera:admin`. The plugin name itself
-    /// is only checked for control characters, so spaces and capitals got
-    /// through too and registered a command nobody can type.
-    #[test]
-    fn a_derived_slash_name_is_held_to_the_same_shape_as_a_declared_one() {
-        let derived = |name: &str| grant(vec![PanelSurface::Command]).validate(name);
-
-        assert!(
-            matches!(
-                derived("vera:admin"),
-                Err(ManifestError::PanelCommandCarriesNamespace { .. })
-            ),
-            "a plugin cannot buy the alias namespace by spelling it in its name"
-        );
-        assert!(matches!(
-            derived("Vera Admin"),
-            Err(ManifestError::PanelCommandNotASlug { .. })
-        ));
-        assert!(
-            derived("vera").is_ok(),
-            "an ordinary slug name still passes"
-        );
-        assert!(
-            grant(vec![PanelSurface::Settings])
-                .validate("vera:admin")
-                .is_ok(),
-            "a panel with no popup registers no name, so its plugin's name is \
-             not a slash command and is not judged as one"
-        );
-    }
-
-    #[test]
-    fn a_slash_name_resolves_only_for_a_panel_that_has_a_popup() {
-        let popup = PanelGrant {
-            command: Some("hello".to_string()),
-            ..grant(vec![PanelSurface::Command])
-        };
-        assert_eq!(popup.command_or("gates"), Some("hello"));
-        // Absent means the plugin's id, which is the product rule.
-        assert_eq!(
-            grant(vec![PanelSurface::Command]).command_or("gates"),
-            Some("gates")
-        );
-        // And a panel with no popup registers no name, declared or defaulted.
-        assert_eq!(
-            grant(vec![PanelSurface::Settings]).command_or("gates"),
-            None
-        );
-    }
-
-    #[test]
-    fn a_run_of_glyphs_refuses_every_control_character() {
-        for hazard in ["\u{1b}[2J", "a\nb", "a\rb", "a\tb", "a\u{9b}c"] {
-            assert!(
-                PanelText::new(hazard).is_err(),
-                "{hazard:?} decoded as drawable glyphs"
-            );
-        }
-        assert_eq!(
-            PanelText::new("\u{1b}").unwrap_err(),
-            PanelTextError::ControlCharacter { index: 0, code: 27 }
-        );
-        // The index counts `char`s, so a multi-byte glyph before the hazard
-        // does not shift it into a byte offset a reader cannot navigate by.
-        assert_eq!(
-            PanelText::new("✦\u{1b}").unwrap_err(),
-            PanelTextError::ControlCharacter { index: 1, code: 27 }
-        );
-    }
-
-    #[test]
-    fn a_frame_of_lines_that_overruns_its_lease_is_refused() {
-        let rect = PanelRect::new(8, 2);
-        let one = || PanelLine::new(vec![PanelSpan::new(text("gates"), PanelStyle::plain())]);
-        let fits = PanelPaint::Lines(vec![one(), one()]);
-        assert_eq!(fits.fits(rect), Ok(()));
-
-        let too_tall = PanelPaint::Lines(vec![one(), one(), one()]);
-        assert_eq!(
-            too_tall.fits(rect),
-            Err(PanelOverflow::Rows { lines: 3, rows: 2 })
-        );
-
-        let too_wide = PanelPaint::Lines(vec![PanelLine::new(vec![PanelSpan::new(
-            text("nine cells"),
-            PanelStyle::plain(),
-        )])]);
-        assert_eq!(
-            too_wide.fits(rect),
-            Err(PanelOverflow::Line {
-                line: 0,
-                cells: 10,
-                cols: 8,
-            })
-        );
-    }
-
-    #[test]
-    fn a_cell_diff_outside_the_lease_is_refused() {
-        let rect = PanelRect::new(8, 2);
-        let patch = |row, col, glyphs| PanelPatch::new(row, col, text(glyphs), PanelStyle::plain());
-
-        assert_eq!(PanelPaint::Diff(vec![patch(1, 7, "x")]).fits(rect), Ok(()));
-        assert_eq!(
-            PanelPaint::Diff(vec![patch(2, 0, "x")]).fits(rect),
-            Err(PanelOverflow::Row { row: 2, rows: 2 })
-        );
-        assert_eq!(
-            PanelPaint::Diff(vec![patch(0, 6, "abc")]).fits(rect),
-            Err(PanelOverflow::Patch {
-                row: 0,
-                col: 6,
-                cells: 3,
-                cols: 8,
-            })
-        );
-    }
-
-    #[test]
-    fn a_column_plus_a_long_run_cannot_wrap_back_into_the_lease() {
-        // `u16::MAX` cells past the right edge is the addition that wraps in
-        // `u16` and lands back inside a small rectangle. The check runs in
-        // `usize`, so it refuses.
-        let rect = PanelRect::new(4, 1);
-        let long = text(&"x".repeat(usize::from(u16::MAX) + 8));
-        let paint = PanelPaint::Diff(vec![PanelPatch::new(0, 2, long, PanelStyle::plain())]);
-        assert!(matches!(
-            paint.fits(rect),
-            Err(PanelOverflow::Patch {
-                col: 2,
-                cols: 4,
-                ..
-            })
-        ));
-    }
-
-    #[test]
-    fn an_empty_frame_fits_every_lease_including_an_empty_one() {
-        let empty = PanelRect::new(0, 0);
-        assert_eq!(PanelPaint::Lines(Vec::new()).fits(empty), Ok(()));
-        assert_eq!(PanelPaint::Diff(Vec::new()).fits(empty), Ok(()));
-        // And a lease with no cells admits no patch at all.
-        let paint = PanelPaint::Diff(vec![PanelPatch::new(0, 0, text("x"), PanelStyle::plain())]);
-        assert_eq!(
-            paint.fits(empty),
-            Err(PanelOverflow::Row { row: 0, rows: 0 })
-        );
-    }
-
-    #[test]
-    fn a_patch_of_no_glyphs_is_still_anchored_inside_the_lease() {
-        // A run of nothing writes nothing, so the *extent* check has no opinion
-        // about where it starts: `col + 0` is inside every lease. A host that
-        // reads the column before it measures the run is handed one its buffer
-        // does not have, and `fits` is the only thing standing between the two.
-        let rect = PanelRect::new(8, 2);
-        let empty_run = |col| PanelPatch::new(0, col, text(""), PanelStyle::plain());
-
-        assert_eq!(PanelPaint::Diff(vec![empty_run(7)]).fits(rect), Ok(()));
-        assert_eq!(
-            PanelPaint::Diff(vec![empty_run(8)]).fits(rect),
-            Err(PanelOverflow::Patch {
-                row: 0,
-                col: 8,
-                cells: 0,
-                cols: 8,
-            })
-        );
-        assert_eq!(
-            PanelPaint::Diff(vec![empty_run(u16::MAX)]).fits(rect),
-            Err(PanelOverflow::Patch {
-                row: 0,
-                col: u16::MAX,
-                cells: 0,
-                cols: 8,
-            })
-        );
-
-        // The same rule read from the other end: a lease with rows but no
-        // columns is a lease with no cells, so it admits no patch either.
-        let columnless = PanelRect::new(0, 2);
-        assert_eq!(
-            PanelPaint::Diff(vec![empty_run(0)]).fits(columnless),
-            Err(PanelOverflow::Patch {
-                row: 0,
-                col: 0,
-                cells: 0,
-                cols: 0,
-            })
-        );
-    }
-
-    #[test]
-    fn a_lease_admits_the_frame_that_answers_it() {
-        let lease = PanelLease::new("gates", PanelSurface::Overlay, 7, PanelRect::new(12, 1), 33);
-        let frame = PanelFrame::new(
-            PanelSurface::Overlay,
-            7,
-            PanelPaint::Lines(vec![PanelLine::new(vec![PanelSpan::new(
-                text("3 green"),
-                PanelStyle::ink(PanelInk::Green),
-            )])]),
-        );
-        assert_eq!(lease.admits(&frame), Ok(()));
-        assert_eq!(frame.protocol_version, PROTOCOL_VERSION);
-    }
 }

--- a/crates/stella-plugin/src/panel/error.rs
+++ b/crates/stella-plugin/src/panel/error.rs
@@ -1,0 +1,130 @@
+//! Why a panel's text, lease, or frame was refused.
+//!
+//! Split out of `panel.rs` at the gate's line ceiling. These three error
+//! enums were already a group on their own in that file, so the move costs
+//! no rework.
+
+use super::PanelSurface;
+
+/// Why a host will not draw a frame it was handed.
+///
+/// Two routing cases and the geometry, because a frame can be wrong in ways
+/// that have nothing to do with its size: a plugin drawing three surfaces can
+/// answer the wrong lease, and one that fell behind can answer a tick the host
+/// has already replaced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum PanelRefusal {
+    /// The frame answers a different panel than the one leased.
+    #[error("a panel frame for the \"{answered}\" surface answers a \"{leased}\" lease")]
+    Surface {
+        /// The surface the lease was for.
+        leased: PanelSurface,
+        /// The surface the frame claims.
+        answered: PanelSurface,
+    },
+    /// The frame answers a tick the host has moved on from.
+    #[error("a panel frame for tick {answered} answers the lease for tick {leased}")]
+    Tick {
+        /// The tick the lease was for.
+        leased: u64,
+        /// The tick the frame echoed.
+        answered: u64,
+    },
+    /// The frame addresses a cell the lease does not hold.
+    #[error(transparent)]
+    Overflow(
+        /// Which edge it ran past.
+        #[from]
+        PanelOverflow,
+    ),
+}
+
+/// Why a run of glyphs is not drawable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum PanelTextError {
+    /// The text carries a control character. A panel writes glyphs into cells;
+    /// every escape byte the terminal sees is the host's.
+    #[error(
+        "panel text carries the control character U+{code:04X} at position {index}: a panel \
+         writes glyphs into the cells it was leased, and Stella writes every escape sequence \
+         the terminal sees"
+    )]
+    ControlCharacter {
+        /// Which character of the text, counted in `char`s from zero.
+        index: usize,
+        /// The Unicode scalar value that was refused.
+        code: u32,
+    },
+
+    /// The text carries a bidi `char`. Its own error, not a reused
+    /// [`PanelTextError::ControlCharacter`]. The two refusals ask different
+    /// things, and a host that printed the wrong one would send an author
+    /// hunting an escape that is not there.
+    #[error(
+        "panel text carries the bidi formatting character U+{code:04X} at position {index}: it \
+         reorders the glyphs after it, so the panel would read one way and mean another"
+    )]
+    BidiControl {
+        /// Which character of the text, counted in `char`s from zero.
+        index: usize,
+        /// The Unicode scalar value that was refused.
+        code: u32,
+    },
+}
+
+/// Why a frame does not fit the rectangle it was leased.
+///
+/// Four cases because the two frame shapes fail in two ways each, and a host
+/// refusing a frame should be able to print which row, which column and which
+/// edge without re-deriving any of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum PanelOverflow {
+    /// A [`crate::panel::PanelPaint::Lines`] frame carries more rows than the
+    /// lease has.
+    #[error("a panel frame of {lines} line(s) does not fit a lease {rows} row(s) tall")]
+    Rows {
+        /// How many rows the frame carries.
+        lines: usize,
+        /// How many the lease holds.
+        rows: u16,
+    },
+    /// A row of a [`crate::panel::PanelPaint::Lines`] frame runs past the
+    /// lease's right edge.
+    #[error("line {line} of a panel frame is {cells} cell(s) wide, past a {cols}-column lease")]
+    Line {
+        /// Which row, counted from the top of the frame.
+        line: usize,
+        /// How wide it is.
+        cells: usize,
+        /// How wide the lease is.
+        cols: u16,
+    },
+    /// A [`crate::panel::PanelPaint::Diff`] patch addresses a row the lease
+    /// does not have.
+    #[error("a panel frame patches row {row}, past a lease {rows} row(s) tall")]
+    Row {
+        /// The row the patch addressed.
+        row: u16,
+        /// How many rows the lease holds.
+        rows: u16,
+    },
+    /// A [`crate::panel::PanelPaint::Diff`] patch starts past the lease's
+    /// right edge, or runs past it. Both are this one case because both are
+    /// answered by the same edit — move the patch left or shorten it — and a
+    /// host printing the refusal wants the column and the run length either
+    /// way.
+    #[error(
+        "a panel frame patches {cells} cell(s) from column {col} of row {row}, past a \
+         {cols}-column lease"
+    )]
+    Patch {
+        /// The row the patch addressed.
+        row: u16,
+        /// The column it started at.
+        col: u16,
+        /// How many cells it writes.
+        cells: usize,
+        /// How wide the lease is.
+        cols: u16,
+    },
+}

--- a/crates/stella-plugin/src/panel/tests.rs
+++ b/crates/stella-plugin/src/panel/tests.rs
@@ -1,0 +1,315 @@
+//! Tests for [`super`], the panel wire contract.
+//!
+//! Split out of `panel.rs` at the gate's line ceiling. Only the tests moved.
+//! The types they exercise stayed put, so the move changes no behavior.
+
+use super::*;
+
+fn text(glyphs: &str) -> PanelText {
+    PanelText::new(glyphs).expect("plain glyphs")
+}
+
+#[test]
+fn every_denial_has_a_distinct_wire_name_and_a_sentence() {
+    let mut names: Vec<&str> = PanelDenial::all()
+        .iter()
+        .map(|denial| denial.as_str())
+        .collect();
+    let count = names.len();
+    names.sort_unstable();
+    names.dedup();
+    assert_eq!(names.len(), count, "two denials share a wire name");
+    for denial in PanelDenial::all() {
+        assert!(!denial.consent_sentence().trim().is_empty(), "{denial}");
+    }
+}
+
+#[test]
+fn all_is_exhaustive_over_the_denial_set() {
+    // Round-trip every wire name through the deserializer. That shows
+    // `all()` and the enum agree, with no count to keep by hand.
+    for denial in PanelDenial::all() {
+        let json = serde_json::to_string(denial).expect("a denial serializes");
+        let back: PanelDenial = serde_json::from_str(&json).expect("and reads back");
+        assert_eq!(back, *denial);
+    }
+    assert!(
+        serde_json::from_str::<PanelDenial>("\"read-anything\"").is_err(),
+        "the denial set is Stella's, so an unknown limit is a refusal"
+    );
+}
+
+/// A grant that passes every rule, for a test that is about one of them.
+fn grant(surfaces: Vec<PanelSurface>) -> PanelGrant {
+    PanelGrant {
+        surfaces,
+        command: None,
+        denies: PanelDenial::all().to_vec(),
+        process: None,
+    }
+}
+
+#[test]
+fn a_grant_reports_the_first_denial_it_fails_to_name() {
+    let partial = PanelGrant {
+        denies: vec![PanelDenial::WriteOutsideSandbox],
+        ..grant(vec![PanelSurface::Overlay])
+    };
+    assert_eq!(partial.missing_denial(), Some(PanelDenial::Network));
+    let complete = grant(vec![PanelSurface::Overlay]);
+    assert_eq!(complete.missing_denial(), None);
+    assert!(complete.denies(PanelDenial::Network));
+}
+
+#[test]
+fn every_surface_has_a_distinct_wire_name_and_a_sentence() {
+    let mut names: Vec<&str> = PanelSurface::all()
+        .iter()
+        .map(|surface| surface.as_str())
+        .collect();
+    let count = names.len();
+    names.sort_unstable();
+    names.dedup();
+    assert_eq!(names.len(), count, "two surfaces share a wire name");
+    for surface in PanelSurface::all() {
+        assert!(!surface.consent_sentence().trim().is_empty(), "{surface}");
+        let json = serde_json::to_string(surface).expect("a surface serializes");
+        let back: PanelSurface = serde_json::from_str(&json).expect("and reads back");
+        assert_eq!(back, *surface);
+    }
+    assert!(
+        serde_json::from_str::<PanelSurface>("\"status_bar\"").is_err(),
+        "the placements are Stella's, so an unknown one is a refusal"
+    );
+}
+
+#[test]
+fn a_panel_that_draws_nowhere_is_refused() {
+    assert!(matches!(
+        grant(Vec::new()).validate("gates"),
+        Err(ManifestError::PanelNoSurface)
+    ));
+    assert!(matches!(
+        grant(vec![PanelSurface::Settings, PanelSurface::Settings]).validate("gates"),
+        Err(ManifestError::PanelDuplicateSurface {
+            surface: PanelSurface::Settings
+        })
+    ));
+    assert!(
+        grant(vec![PanelSurface::Settings])
+            .validate("gates")
+            .is_ok()
+    );
+}
+
+/// The name a panel registers is the one `command_or` resolves. So the
+/// derived name is held to the same shape rules as a declared one.
+///
+/// A plugin with no `command` field registers its own name instead. A past
+/// bug let `name = "vera:admin"` buy the namespace-shaped slash command the
+/// explicit path refuses on its own. The consent text then told a reader
+/// the panel answers to `/vera:admin` and to `/vera:admin:vera:admin`. Spaces
+/// and capitals got through too, and registered a command nobody can type.
+#[test]
+fn a_derived_slash_name_is_held_to_the_same_shape_as_a_declared_one() {
+    let derived = |name: &str| grant(vec![PanelSurface::Command]).validate(name);
+
+    assert!(
+        matches!(
+            derived("vera:admin"),
+            Err(ManifestError::PanelCommandCarriesNamespace { .. })
+        ),
+        "a plugin cannot buy the alias namespace by spelling it in its name"
+    );
+    assert!(matches!(
+        derived("Vera Admin"),
+        Err(ManifestError::PanelCommandNotASlug { .. })
+    ));
+    assert!(
+        derived("vera").is_ok(),
+        "an ordinary slug name still passes"
+    );
+    assert!(
+        grant(vec![PanelSurface::Settings])
+            .validate("vera:admin")
+            .is_ok(),
+        "a panel with no popup registers no name, so its plugin's name is \
+         not a slash command and is not judged as one"
+    );
+}
+
+#[test]
+fn a_slash_name_resolves_only_for_a_panel_that_has_a_popup() {
+    let popup = PanelGrant {
+        command: Some("hello".to_string()),
+        ..grant(vec![PanelSurface::Command])
+    };
+    assert_eq!(popup.command_or("gates"), Some("hello"));
+    // Absent means the plugin's id, which is the product rule.
+    assert_eq!(
+        grant(vec![PanelSurface::Command]).command_or("gates"),
+        Some("gates")
+    );
+    // And a panel with no popup registers no name, declared or defaulted.
+    assert_eq!(
+        grant(vec![PanelSurface::Settings]).command_or("gates"),
+        None
+    );
+}
+
+#[test]
+fn a_run_of_glyphs_refuses_every_control_character() {
+    for hazard in ["\u{1b}[2J", "a\nb", "a\rb", "a\tb", "a\u{9b}c"] {
+        assert!(
+            PanelText::new(hazard).is_err(),
+            "{hazard:?} decoded as drawable glyphs"
+        );
+    }
+    assert_eq!(
+        PanelText::new("\u{1b}").unwrap_err(),
+        PanelTextError::ControlCharacter { index: 0, code: 27 }
+    );
+    // The index counts `char`s. A multi-byte glyph before the hazard does
+    // not turn it into a byte offset nobody can find.
+    assert_eq!(
+        PanelText::new("✦\u{1b}").unwrap_err(),
+        PanelTextError::ControlCharacter { index: 1, code: 27 }
+    );
+}
+
+#[test]
+fn a_frame_of_lines_that_overruns_its_lease_is_refused() {
+    let rect = PanelRect::new(8, 2);
+    let one = || PanelLine::new(vec![PanelSpan::new(text("gates"), PanelStyle::plain())]);
+    let fits = PanelPaint::Lines(vec![one(), one()]);
+    assert_eq!(fits.fits(rect), Ok(()));
+
+    let too_tall = PanelPaint::Lines(vec![one(), one(), one()]);
+    assert_eq!(
+        too_tall.fits(rect),
+        Err(PanelOverflow::Rows { lines: 3, rows: 2 })
+    );
+
+    let too_wide = PanelPaint::Lines(vec![PanelLine::new(vec![PanelSpan::new(
+        text("nine cells"),
+        PanelStyle::plain(),
+    )])]);
+    assert_eq!(
+        too_wide.fits(rect),
+        Err(PanelOverflow::Line {
+            line: 0,
+            cells: 10,
+            cols: 8,
+        })
+    );
+}
+
+#[test]
+fn a_cell_diff_outside_the_lease_is_refused() {
+    let rect = PanelRect::new(8, 2);
+    let patch = |row, col, glyphs| PanelPatch::new(row, col, text(glyphs), PanelStyle::plain());
+
+    assert_eq!(PanelPaint::Diff(vec![patch(1, 7, "x")]).fits(rect), Ok(()));
+    assert_eq!(
+        PanelPaint::Diff(vec![patch(2, 0, "x")]).fits(rect),
+        Err(PanelOverflow::Row { row: 2, rows: 2 })
+    );
+    assert_eq!(
+        PanelPaint::Diff(vec![patch(0, 6, "abc")]).fits(rect),
+        Err(PanelOverflow::Patch {
+            row: 0,
+            col: 6,
+            cells: 3,
+            cols: 8,
+        })
+    );
+}
+
+#[test]
+fn a_column_plus_a_long_run_cannot_wrap_back_into_the_lease() {
+    // `u16::MAX` cells past the right edge is the addition that wraps in
+    // `u16` and lands back inside a small rectangle. The check runs in
+    // `usize`, so it refuses.
+    let rect = PanelRect::new(4, 1);
+    let long = text(&"x".repeat(usize::from(u16::MAX) + 8));
+    let paint = PanelPaint::Diff(vec![PanelPatch::new(0, 2, long, PanelStyle::plain())]);
+    assert!(matches!(
+        paint.fits(rect),
+        Err(PanelOverflow::Patch {
+            col: 2,
+            cols: 4,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn an_empty_frame_fits_every_lease_including_an_empty_one() {
+    let empty = PanelRect::new(0, 0);
+    assert_eq!(PanelPaint::Lines(Vec::new()).fits(empty), Ok(()));
+    assert_eq!(PanelPaint::Diff(Vec::new()).fits(empty), Ok(()));
+    // And a lease with no cells admits no patch at all.
+    let paint = PanelPaint::Diff(vec![PanelPatch::new(0, 0, text("x"), PanelStyle::plain())]);
+    assert_eq!(
+        paint.fits(empty),
+        Err(PanelOverflow::Row { row: 0, rows: 0 })
+    );
+}
+
+#[test]
+fn a_patch_of_no_glyphs_is_still_anchored_inside_the_lease() {
+    // A run of nothing writes nothing. So the *extent* check has no opinion
+    // about where it starts: `col + 0` is inside every lease. But a host
+    // reads the column first. Give it one its buffer lacks, and `fits` is
+    // the only guard standing in the way.
+    let rect = PanelRect::new(8, 2);
+    let empty_run = |col| PanelPatch::new(0, col, text(""), PanelStyle::plain());
+
+    assert_eq!(PanelPaint::Diff(vec![empty_run(7)]).fits(rect), Ok(()));
+    assert_eq!(
+        PanelPaint::Diff(vec![empty_run(8)]).fits(rect),
+        Err(PanelOverflow::Patch {
+            row: 0,
+            col: 8,
+            cells: 0,
+            cols: 8,
+        })
+    );
+    assert_eq!(
+        PanelPaint::Diff(vec![empty_run(u16::MAX)]).fits(rect),
+        Err(PanelOverflow::Patch {
+            row: 0,
+            col: u16::MAX,
+            cells: 0,
+            cols: 8,
+        })
+    );
+
+    // The same rule read from the other end: a lease with rows but no
+    // columns is a lease with no cells, so it admits no patch either.
+    let columnless = PanelRect::new(0, 2);
+    assert_eq!(
+        PanelPaint::Diff(vec![empty_run(0)]).fits(columnless),
+        Err(PanelOverflow::Patch {
+            row: 0,
+            col: 0,
+            cells: 0,
+            cols: 0,
+        })
+    );
+}
+
+#[test]
+fn a_lease_admits_the_frame_that_answers_it() {
+    let lease = PanelLease::new("gates", PanelSurface::Overlay, 7, PanelRect::new(12, 1), 33);
+    let frame = PanelFrame::new(
+        PanelSurface::Overlay,
+        7,
+        PanelPaint::Lines(vec![PanelLine::new(vec![PanelSpan::new(
+            text("3 green"),
+            PanelStyle::ink(PanelInk::Green),
+        )])]),
+    );
+    assert_eq!(lease.admits(&frame), Ok(()));
+    assert_eq!(frame.protocol_version, PROTOCOL_VERSION);
+}

--- a/crates/stella-plugin/tests/panel_contract.rs
+++ b/crates/stella-plugin/tests/panel_contract.rs
@@ -212,10 +212,10 @@ fn a_panel_frame_addressing_a_cell_outside_its_lease_is_refused() {
         }))
     );
 
-    // A run of no glyphs is anchored too. `col + 0` is inside every lease, so
-    // an extent check on its own would admit a patch naming a column the host's
-    // buffer does not have — nothing to blit, and exactly the coordinate a host
-    // that reads the column before it measures the run would index with.
+    // A run of no glyphs is anchored too. `col + 0` is inside every lease.
+    // So an extent check on its own would admit a patch naming a column the
+    // host's buffer lacks — nothing to blit, and exactly the coordinate a
+    // host reading the column first would index with.
     let anchored_out = PanelFrame::new(
         PanelSurface::Overlay,
         42,
@@ -432,10 +432,10 @@ fn every_panel_vocabulary_is_pinned_on_both_sides() {
 /// The panel tables refuse a key they do not know, as every other table on this
 /// wire does.
 ///
-/// A **frame** still may not caption itself: the caption is a manifest
-/// declaration a human consented to at install, so a per-tick title would let a
-/// panel relabel itself after the fact, which is the spoof the block's caption
-/// rule exists to prevent (#5203).
+/// A **frame** still may not caption itself. The caption is a manifest
+/// declaration a human consented to at install. A per-tick title would let a
+/// panel relabel itself after the fact — the spoof the block's caption rule
+/// exists to prevent (#5203).
 #[test]
 fn a_panel_may_not_name_itself_or_carry_a_key_the_contract_lacks() {
     let err = serde_json::from_str::<PanelResponse>(
@@ -562,9 +562,9 @@ fn a_panel_block_says_where_it_draws() {
 }
 
 /// **The witness for #5210.** A plugin drawing several surfaces gets several
-/// leases a tick, and a frame says which one it answers — so a host with three
-/// in flight routes the answer instead of guessing, and cannot blit a settings
-/// pane into a command popup that happens to be the same size.
+/// leases a tick. A frame says which one it answers. A host with three in
+/// flight routes the answer instead of guessing. It cannot blit a settings
+/// pane into a command popup that happens to share its size.
 #[test]
 fn a_frame_for_one_surface_does_not_answer_another_surfaces_lease() {
     let leased = PanelLease::new("gates", PanelSurface::Settings, 7, PanelRect::new(8, 2), 33);
@@ -640,6 +640,57 @@ fn a_plugin_name_that_is_not_drawable_does_not_load() {
         assert!(
             PluginManifest::from_toml_str(&format!("name = \"{fine}\"")).is_ok(),
             "{fine:?} is drawable and should load"
+        );
+    }
+}
+
+/// A plugin's `name` is the one string Stella prints into chrome it owns —
+/// the panel label, the install prompt, a popup heading, the rules panel.
+/// A name that can reorder itself with a bidi override is the Trojan Source
+/// shape (`CVE-2021-42574`), printed under Stella's own border next to the
+/// consent prompt a person reads to decide whether to trust the plugin.
+///
+/// Mirrors [`a_panel_frame_carrying_a_bidi_override_does_not_decode`]: the
+/// same twelve `char`s, the same refusal by position, and the same two
+/// joiners a script needs left alone.
+#[test]
+fn a_plugin_name_that_reorders_itself_with_a_bidi_override_does_not_load() {
+    // The whole refused set, written as the TOML escapes a plugin author's
+    // own encoder would put in the manifest.
+    for hazard in [
+        "\\u061c", "\\u200e", "\\u200f", "\\u202a", "\\u202b", "\\u202c", "\\u202d", "\\u202e",
+        "\\u2066", "\\u2067", "\\u2068", "\\u2069",
+    ] {
+        let toml = format!("name = \"gates {hazard}neerg\"");
+        let err = PluginManifest::from_toml_str(&toml)
+            .expect_err("a name that reorders itself must not load");
+        assert!(
+            matches!(
+                err,
+                stella_plugin::ManifestError::NameCarriesBidiControl { .. }
+            ),
+            "{hazard:?} loaded, or was refused by the wrong rule: {err}"
+        );
+    }
+
+    // The refusal names the position in `char`s, so a multi-byte glyph before
+    // the hazard does not shift it into a byte offset nobody can navigate by.
+    assert!(matches!(
+        PluginManifest::from_toml_str("name = \"\\u2726\\u202e\"").expect_err("refused"),
+        stella_plugin::ManifestError::NameCarriesBidiControl {
+            index: 1,
+            code: 0x202e
+        }
+    ));
+
+    // The joiners stay allowed: barring `U+200C`/`U+200D` here would bar a
+    // plugin author writing in Persian or naming an emoji family from having
+    // the same name they could give a panel's own text.
+    for kept in ["\\u200c", "\\u200d"] {
+        let toml = format!("name = \"gates{kept}status\"");
+        assert!(
+            PluginManifest::from_toml_str(&toml).is_ok(),
+            "{kept:?} is a joiner, not a bidi override, and should load"
         );
     }
 }


### PR DESCRIPTION
## What & why

Batch PR for #6304 (`plugin: fix batch — 2 small defects`), landing both
members:

- **#5922 — `panel.rs` sat 11 lines from the gate's 1500-line ceiling.**
  Split it the way `manifest.rs` already splits: `panel.rs` beside
  `panel/`, with the test module moved to `panel/tests.rs` and the three
  error enums (`PanelRefusal`, `PanelTextError`, `PanelOverflow`) moved to
  `panel/error.rs`, re-exported so every public path
  (`stella_plugin::PanelText` and its siblings) is unchanged. `panel.rs`
  is now 1055 lines.
- **#5917 — a plugin's `name` was still allowed to reorder itself with a
  bidi override.** `validate_plugin_name` asked `first_control_character`
  but never `first_bidi_control`, so a manifest could ship a `name`
  carrying `U+202E` or its eleven siblings — the Trojan Source shape
  (CVE-2021-42574) — and Stella would print it under its own chrome, next
  to the consent prompt a person reads to decide whether to trust the
  plugin. `validate_plugin_name` now asks both, returning a new
  `ManifestError::NameCarriesBidiControl` naming the character and its
  position; the joiners `U+200C`/`U+200D` stay allowed, matching
  `PanelText`'s own rule.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

For #5917:
- `a_name_that_reorders_itself_with_a_bidi_control_is_refused_by_position`
  (`crates/stella-plugin/src/drawable.rs`) — on `main`,
  `validate_plugin_name` never calls `first_bidi_control`, so every one of
  the twelve bidi formatting characters loads clean; this test asserts
  each one is refused by `ManifestError::NameCarriesBidiControl` at the
  right position, and that the two joiners still load.
- `a_plugin_name_that_reorders_itself_with_a_bidi_override_does_not_load`
  (`crates/stella-plugin/tests/panel_contract.rs`) — the same fact through
  `PluginManifest::from_toml_str`, so a manifest carrying the hazard in
  its `name` field is what actually gets exercised end to end.

For #5922 (pure split, no behavior change): `panel_contract.rs`'s existing
suite and `panel/tests.rs`'s moved suite both exercise the same wire
types through the same public paths before and after, so the split is
covered by the tests that already existed rather than a new one.

## The gate

- [x] Format check
- [ ] Clippy over the affected crate and its dependents — CI (this laptop
      does not build the workspace; see the CI run linked on this PR)
- [ ] Full test run — CI, same reason
- [x] Docs updated where behavior/flags changed — `crates/stella-plugin/README.md`'s
      `src/drawable.rs` entry no longer says the bidi rule is asked only for
      panel text
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: none beyond the two batch members — the
      `crates/stella-plugin/README.md` line describing `drawable.rs` was
      stale against the #5917 fix and is corrected in the same commit
      (AGENTS.md: "chase a renamed concept through comments and docs in
      the same PR").
- [x] Nothing was deferred — both #6304 members ride this PR; no member
      is listed under "could not ride."

## Ground-rule check

- [x] No I/O added to `stella-core`
- [x] No new outbound network calls
- [x] No new cross-boundary types (one new error variant on an existing
      `serde`-free `thiserror` enum; no wire-schema change)

## Anything reviewers should know?

- `make wire-schema` is unaffected: `ManifestError` is not part of the
  wire contract (no `Serialize`/`Deserialize`), so the new variant is a
  Rust-side-only addition.
- The split moves `PanelDenial`, `PanelSurface`, `PanelGrant`, `PanelText`
  and friends' *tests* and the three error enums; every other type in
  `panel.rs` (the wire structs) stayed put, unchanged.

Closes #6304
Closes #5922
Closes #5917

## Summary by Sourcery

Prevent bidi-based plugin-name spoofing and reorganize the panel module while preserving its public contract.

Bug Fixes:
- Reject plugin names containing bidi formatting characters and report the offending character and position while continuing to allow the U+200C and U+200D joiners.

Enhancements:
- Split the panel implementation, panel error types, and panel tests into dedicated modules without changing public APIs or behavior.

Documentation:
- Update the plugin documentation to describe bidi validation for plugin names as well as panel text.

Tests:
- Add unit and end-to-end coverage for rejecting bidi-flipped plugin names across all supported bidi formatting characters.