### PR TITLE
fix(stella-core): fifteen defects from the 2026-09-06 core audit

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -14,12 +14,12 @@ name: windows-check
 # owns `rootfd`, `durable_write` and `exec`; `stella-runtime`'s two wrapper
 # transports arm that guard — on a real MSVC runner.
 #
-# `stella-core` joins them (#5773). It carries no `#[cfg(windows)]` arm, and by
-# invariant 2 it never will carry one that does I/O — but a Windows defect can
-# still land there as a `std::path` assumption, which is what #5320 was, and it
-# is cheap to keep green because it has no I/O to port. It already compiled
-# here as `stella-runtime`'s dependency; naming it is what puts it under
-# `-D warnings` instead of plain rustc warnings.
+# `stella-core` is here for a different reason. It carries no
+# `#[cfg(windows)]` arm, and by invariant 2 it never will carry one that does
+# I/O — but a Windows defect still lands there as a `std::path` assumption, and
+# a skill path separator was one. It has no I/O to port, so it is cheap to keep
+# green. It already compiled here as `stella-runtime`'s dependency; naming it
+# is what puts it under `-D warnings` instead of plain rustc warnings.
 #
 # `stella-cli` stays out. It is the crate most likely to hold a real platform
 # assumption, so widening to it is work with its own PR rather than a name

--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -10,16 +10,27 @@ name: windows-check
 # the Job Object half of `exec::GroupKillGuard` beside them; "it compiles" was
 # a claim nobody could check for any of them.
 #
-# So this compiles the two crates that carry a platform split — `stella-tools`
+# So this compiles the crates that carry a platform split — `stella-tools`
 # owns `rootfd`, `durable_write` and `exec`; `stella-runtime`'s two wrapper
 # transports arm that guard — on a real MSVC runner.
 #
-# Its reach is wider than those two names: `-D warnings` travels to every
+# `stella-core` joins them (#5773). It carries no `#[cfg(windows)]` arm, and by
+# invariant 2 it never will carry one that does I/O — but a Windows defect can
+# still land there as a `std::path` assumption, which is what #5320 was, and it
+# is cheap to keep green because it has no I/O to port. It already compiled
+# here as `stella-runtime`'s dependency; naming it is what puts it under
+# `-D warnings` instead of plain rustc warnings.
+#
+# `stella-cli` stays out. It is the crate most likely to hold a real platform
+# assumption, so widening to it is work with its own PR rather than a name
+# added to a line.
+#
+# Its reach is wider than the names on the line: `-D warnings` travels to every
 # workspace crate they pull in, which is how it found a `cfg(unix)`-only
 # parameter left unread in `stella-store`. That is the job working, not a
 # scope error — a platform arm nobody compiles is the same defect wherever it
-# sits, and these two crates are simply the entry point that reaches the ones
-# holding the splits.
+# sits, and the named crates are the entry point that reaches the ones holding
+# the splits.
 #
 # `cargo clippy`, and deliberately **not** `--all-targets`. The shipping code
 # is what carries the platform split, and it is what this can honestly claim
@@ -66,6 +77,7 @@ on:
     paths:
       - "crates/stella-tools/**"
       - "crates/stella-runtime/**"
+      - "crates/stella-core/**"
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/windows-check.yml"
@@ -74,6 +86,7 @@ on:
     paths:
       - "crates/stella-tools/**"
       - "crates/stella-runtime/**"
+      - "crates/stella-core/**"
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/windows-check.yml"
@@ -111,7 +124,7 @@ jobs:
 
       - name: clippy on the crates that carry a platform split
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
-        run: cargo clippy -p stella-tools -p stella-runtime -- -D warnings
+        run: cargo clippy -p stella-tools -p stella-runtime -p stella-core -- -D warnings
 
       - name: the plugin socket's own tests, on Windows (#3497, #3550)
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -416,12 +416,18 @@ looks at a `#[cfg(windows)]` arm: `ci.yml` runs on `ubuntu-latest` and
 non-unix body in the tree — `rootfd.rs`'s and `durable_write.rs`'s string
 resolvers, and the Job Object half of `exec::GroupKillGuard` (#3550) — was
 code no toolchain here or in CI ever parsed. It runs
-`cargo clippy -p stella-tools -p stella-runtime` on a Windows runner, on the
-paths that reach those two crates — the shipping code, deliberately not
+`cargo clippy -p stella-tools -p stella-runtime -p stella-core` on a Windows
+runner, on the paths that reach those three crates — the shipping code,
+deliberately not
 `--all-targets`, because several `#[cfg(test)]` bodies import
 `std::os::unix::fs::PermissionsExt` unconditionally and would fail the job on
 a fixture rather than on the platform split. Those fixtures are #3497's
-subject. It then **runs** two of them: `stella-runtime`'s `wrapper_socket` and
+subject. `stella-core` joined the list for #5773: it holds no platform arm,
+but a Windows defect lands there as a `std::path` assumption (#5320 was one),
+and it already compiled here as `stella-runtime`'s dependency, so naming it
+costs a lint pass rather than a build. `stella-cli` stays out, as the crate
+most likely to need real work before it compiles there. It then **runs** two
+of them: `stella-runtime`'s `wrapper_socket` and
 `wrapper_transport_limits`, which stopped being `/bin/sh` scripts when #3497
 gave the crate a portable in-tree plugin binary
 (`crates/stella-runtime/tests/fixtures/wrapper-plugin-fixture.rs`). That is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,11 +422,11 @@ deliberately not
 `--all-targets`, because several `#[cfg(test)]` bodies import
 `std::os::unix::fs::PermissionsExt` unconditionally and would fail the job on
 a fixture rather than on the platform split. Those fixtures are #3497's
-subject. `stella-core` joined the list for #5773: it holds no platform arm,
-but a Windows defect lands there as a `std::path` assumption (#5320 was one),
-and it already compiled here as `stella-runtime`'s dependency, so naming it
-costs a lint pass rather than a build. `stella-cli` stays out, as the crate
-most likely to need real work before it compiles there. It then **runs** two
+subject. `stella-core` is on the list because a Windows defect lands there as
+a `std::path` assumption — a skill path separator was one — and because it
+already compiled here as `stella-runtime`'s dependency, so naming it costs a
+lint pass rather than a build. `stella-cli` stays out, as the crate most
+likely to need real work before it compiles there. It then **runs** two
 of them: `stella-runtime`'s `wrapper_socket` and
 `wrapper_transport_limits`, which stopped being `/bin/sh` scripts when #3497
 gave the crate a portable in-tree plugin binary

--- a/crates/stella-cli/src/claims.rs
+++ b/crates/stella-cli/src/claims.rs
@@ -602,6 +602,13 @@ impl ToolExecutor for ClaimTap<'_> {
         self.inner.live_services()
     }
 
+    /// Forwarded: this tap claims files. It mounts no invocation plane of its
+    /// own. The empty default reads as "no skill is running here", which stops
+    /// a live skill's procedure text surviving summarization.
+    fn active_skill_slugs(&self) -> Vec<String> {
+        self.inner.active_skill_slugs()
+    }
+
     /// Forwarded: letting the empty default stand would silently serialize the
     /// inner executor's sibling spawns (see the port's contract). The spawn
     /// tool names no mutating path and no transient lane, so concurrent
@@ -630,6 +637,19 @@ mod tests {
     use stella_fleet::{GitError, GitOutput};
 
     use super::*;
+
+    /// Every method the port tells a decorator to forward, over this tap.
+    ///
+    /// The tap coordinates writes. It changes nothing about what the inner
+    /// executor mounts. `active_skill_slugs` was the one it dropped. The tap
+    /// sits above the invocation mount in the deck's lead turn, so a live
+    /// skill's text stopped surviving summarization there.
+    #[test]
+    fn the_tap_forwards_what_a_decorator_must() {
+        let loaded = stella_tools::forwarding::LoadedExecutor;
+        let tap = ClaimTap::new(&loaded, None, "holder");
+        stella_tools::forwarding::assert_forwards("ClaimTap", &tap);
+    }
 
     /// A recording fake: succeeds every call and remembers what ran.
     struct Passthrough(std::sync::Mutex<Vec<String>>);

--- a/crates/stella-cli/src/command_deck/task_tap.rs
+++ b/crates/stella-cli/src/command_deck/task_tap.rs
@@ -887,12 +887,17 @@ mod tests {
         );
     }
 
-    /// Same shape for the invocation plane (#2685): the tap sits above the
-    /// discovery mount, so swallowing the live-slug answer would stop active
-    /// skill bodies surviving summarization on every deck session.
+    /// Every method the port tells a decorator to forward, over this tap.
+    ///
+    /// The tap observes board writes; it changes nothing about what the inner
+    /// executor mounts. It sits above the discovery mount, so swallowing the
+    /// live-slug answer would stop active skill bodies surviving
+    /// summarization on every deck session. The checks live in
+    /// `stella_tools::forwarding::assert_forwards`, so a method added to the
+    /// port is added there once.
     #[test]
-    fn the_task_tap_forwards_active_skill_slugs() {
-        let inner = Claiming;
+    fn the_task_tap_forwards_what_a_decorator_must() {
+        let inner = stella_tools::forwarding::LoadedExecutor;
         let registry = ToolRegistry::new(std::path::PathBuf::from("."));
         let tap = TaskTap {
             inner: &inner,
@@ -901,10 +906,6 @@ mod tests {
             dispatched_by: None,
             plan_gate: None,
         };
-        assert_eq!(
-            tap.active_skill_slugs(),
-            vec!["deploy".to_string()],
-            "the tap must forward the inner executor's live invocations"
-        );
+        stella_tools::forwarding::assert_forwards("TaskTap", &tap);
     }
 }

--- a/crates/stella-cli/src/extensions/plan.rs
+++ b/crates/stella-cli/src/extensions/plan.rs
@@ -1068,10 +1068,10 @@ mod tests {
     /// A bad `description:` costs a label, since the first line of the body
     /// stands in. A bad `tools:` costs the whole registry. Refusing the file
     /// for the first would take an agent away over a key nobody reads.
-    /// The false stop the parent-key record removes. A bare `tools:` means
-    /// every tool, and nesting under `description:` widens nothing — but the
-    /// refusal used to read "the toolbelt is empty AND something is nested"
-    /// and take the agent away.
+    /// The false stop the parent key removes. A bare `tools:` means every
+    /// tool, and nesting under `description:` widens nothing, so the file
+    /// loads. Refusing on "the toolbelt is empty and something is nested"
+    /// took the agent away over a key nobody reads.
     #[test]
     fn a_bare_toolbelt_beside_an_unrelated_nesting_still_loads() {
         let raw = "---\nname: reviewer\ntools:\ndescription:\n  short: s\n  long: l\n---\nReview.";

--- a/crates/stella-cli/src/extensions/plan.rs
+++ b/crates/stella-cli/src/extensions/plan.rs
@@ -301,6 +301,19 @@ fn definition_from_file(
 pub fn command_from_file(path: &str, raw: &str) -> Result<CommandDef, ExtensionDiagnostic> {
     let (fm, name, description, body) = definition_from_file(path, raw, "COMMAND.md")?;
     let get = |key: &str| fm.data.get(key).map(String::as_str);
+    // The same widening `agent_from_file` refuses, one loader over: a nested
+    // `allowed-tools:` leaves the key empty, and an empty one is the spelling
+    // of "no restriction".
+    if get("allowed-tools")
+        .or_else(|| get("allowed_tools"))
+        .is_some_and(str::is_empty)
+        && nests_a_toolbelt_key(&fm)
+    {
+        return Err(ExtensionDiagnostic {
+            path: path.to_string(),
+            problem: ExtensionProblem::NestedToolbelt,
+        });
+    }
     Ok(CommandDef {
         name,
         namespace: None,
@@ -442,14 +455,31 @@ pub fn parse_toolbelt(value: Option<&str>) -> Option<Vec<String>> {
     (!tools.is_empty()).then_some(tools)
 }
 
+/// The frontmatter keys that name a toolbelt, in every spelling a loader
+/// here reads.
+const TOOLBELT_KEYS: [&str; 3] = ["tools", "allowed-tools", "allowed_tools"];
+
+/// Whether a nested mapping sat under a key that grants tools.
+///
+/// ADR 0025's rule: a nested value is refused where reading it wrong would
+/// widen what the file may do, and tolerated everywhere else. A toolbelt key
+/// left empty by nesting reads as "every tool", so it is the widening case.
+fn nests_a_toolbelt_key(fm: &Frontmatter) -> bool {
+    fm.nested_parents
+        .iter()
+        .any(|parent| TOOLBELT_KEYS.contains(&parent.as_str()))
+}
+
 /// Parse one agent file.
 pub fn agent_from_file(path: &str, raw: &str) -> Result<AgentDef, ExtensionDiagnostic> {
     let (fm, name, description, body) = definition_from_file(path, raw, "AGENT.md")?;
     let declared = fm.data.get("tools").map(String::as_str);
-    // A nested mapping leaves its parent key holding an empty value and its
-    // children in `nested_keys`, which is indistinguishable here from a bare
-    // `tools:` — and a bare one means every tool. Refuse rather than widen.
-    if declared.is_some_and(str::is_empty) && !fm.nested_keys.is_empty() {
+    // A nested mapping leaves its parent key holding an empty value, which
+    // reads here exactly like a bare `tools:` — and a bare one means every
+    // tool. Refuse rather than widen, but only when the toolbelt key is the
+    // one that got nested: nesting under `description:` widens nothing, and
+    // refusing for it took an agent away over a key nobody reads (ADR 0025).
+    if declared.is_some_and(str::is_empty) && nests_a_toolbelt_key(&fm) {
         return Err(ExtensionDiagnostic {
             path: path.to_string(),
             problem: ExtensionProblem::NestedToolbelt,
@@ -1006,9 +1036,9 @@ mod tests {
     /// The frontmatter parser is tolerant on purpose, and for `description:`
     /// or `model:` an unreadable value costs a fallback. For `tools:` it costs
     /// the whole registry, because the parser leaves the key holding an empty
-    /// value, the children go to `nested_keys`, and an empty `tools:` is the
-    /// documented spelling of "all tools". The author asked for two tools and
-    /// was handed every one, silently.
+    /// value, the children go to `nested_keys` under a `tools` parent, and an
+    /// empty `tools:` is the documented spelling of "all tools". The author
+    /// asked for two tools and was handed every one, silently.
     #[test]
     fn a_tools_mapping_is_refused_rather_than_read_as_every_tool() {
         let raw =
@@ -1038,6 +1068,34 @@ mod tests {
     /// A bad `description:` costs a label, since the first line of the body
     /// stands in. A bad `tools:` costs the whole registry. Refusing the file
     /// for the first would take an agent away over a key nobody reads.
+    /// The false stop the parent-key record removes. A bare `tools:` means
+    /// every tool, and nesting under `description:` widens nothing — but the
+    /// refusal used to read "the toolbelt is empty AND something is nested"
+    /// and take the agent away.
+    #[test]
+    fn a_bare_toolbelt_beside_an_unrelated_nesting_still_loads() {
+        let raw = "---\nname: reviewer\ntools:\ndescription:\n  short: s\n  long: l\n---\nReview.";
+        let agent = agent_from_file("/x/reviewer.md", raw).expect("nothing widened, so it loads");
+        assert_eq!(agent.tools, None, "a bare `tools:` is still every tool");
+    }
+
+    /// A nested `allowed-tools:` in a command file is the same widening
+    /// `agent_from_file` refuses: the key is left empty, and empty means no
+    /// restriction.
+    #[test]
+    fn a_command_with_a_nested_toolbelt_is_refused() {
+        let raw = "---\nname: ship\nallowed-tools:\n  bash: true\n---\nShip it.";
+        let err = command_from_file("/x/ship.md", raw).unwrap_err();
+        assert_eq!(err.problem, ExtensionProblem::NestedToolbelt);
+
+        let ok = command_from_file(
+            "/x/ok.md",
+            "---\nname: ok\nallowed-tools:\ndescription:\n  short: s\n---\nGo.",
+        )
+        .expect("nesting under a key that grants nothing still loads");
+        assert_eq!(ok.allowed_tools, None);
+    }
+
     #[test]
     fn nesting_under_a_key_that_grants_nothing_still_loads() {
         let raw = "---\nname: reviewer\ndescription:\n  short: s\n  long: l\n---\nReview the diff.";

--- a/crates/stella-cli/src/fleet_commits.rs
+++ b/crates/stella-cli/src/fleet_commits.rs
@@ -154,6 +154,14 @@ impl ToolExecutor for CommitObserver<'_> {
         self.inner.live_services()
     }
 
+    /// Forwarded: this observer watches commits, it mounts no invocation
+    /// plane of its own. The empty default would read as "no skill is running
+    /// here", and a live skill's procedure text would stop surviving overflow
+    /// summarization for every fleet worker composed through it.
+    fn active_skill_slugs(&self) -> Vec<String> {
+        self.inner.active_skill_slugs()
+    }
+
     /// Forwarded: letting the empty default stand would silently serialize
     /// the inner executor's sibling spawns (see the port's contract) — the
     /// spawn tool is not commit-lane routed, so nothing is observed for it.
@@ -411,6 +419,21 @@ mod tests {
 
     fn shas(commits: &[CommitRecord]) -> Vec<&str> {
         commits.iter().map(|c| c.sha.as_str()).collect()
+    }
+
+    /// Every method the port tells a decorator to forward, over this
+    /// observer.
+    ///
+    /// It wraps every shared-tree fleet worker's stack and changes nothing
+    /// about what the stack below it mounts. `active_skill_slugs` was the one
+    /// it dropped.
+    #[test]
+    fn the_commit_observer_forwards_what_a_decorator_must() {
+        let loaded = stella_tools::forwarding::LoadedExecutor;
+        let tree = Arc::new(SharedTree::default());
+        let observer =
+            CommitObserver::new(&loaded, ScriptedGit(tree.clone()), Path::new("/repo"), "t1");
+        stella_tools::forwarding::assert_forwards("CommitObserver", &observer);
     }
 
     /// The observer wraps every shared-tree fleet worker's stack, so one that

--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -83,6 +83,10 @@ use std::process::{Command, Stdio};
 
 use stella_protocol::issue::Issue;
 
+mod steering;
+
+pub(super) use steering::refuse_if_unsteered;
+
 use super::budget::RunBudget;
 use super::turn_flags::TurnFlags;
 use crate::settings::toml_config::WorkerKind;
@@ -787,64 +791,6 @@ pub(crate) fn start(
     Ok(outcome)
 }
 
-/// Refuse to work an issue with the workspace's steering switched off.
-///
-/// **A loop-driven turn must get exactly the steering a person-driven turn
-/// gets.** The whole design says the loop's behaviour comes from context
-/// records — how this repository wants code written, what to prefer, what to
-/// harden — and none of that reaches a turn when project steering is untrusted.
-///
-/// The trap is that it fails *silently and successfully*: the turn runs, writes
-/// plausible code, commits, and the pull request looks like every other one. A
-/// loop working unsteered is not a degraded loop, it is a loop doing work under
-/// nobody's standards, and it is worse than one that did not run — so this
-/// refuses rather than warns.
-///
-/// It refuses only when there is something to lose: a workspace with no records
-/// has no steering to miss, and demanding a trust flag from it would be
-/// ceremony.
-pub(super) fn refuse_if_unsteered(root: &Path) -> Result<(), String> {
-    refuse_unless_trusted(root, crate::settings::project_code_execution_trusted())
-}
-
-/// The rule of [`refuse_if_unsteered`], with the process it reads taken out.
-///
-/// Separated for the reason [`classify`] is: `project_code_execution_trusted`
-/// answers from the process environment, which this test suite shares with
-/// every other test running beside it. A pure function takes the answer as an
-/// argument, so both directions of the rule can be pinned without a race.
-fn refuse_unless_trusted(root: &Path, trusted: bool) -> Result<(), String> {
-    let records = root.join(".stella").join("rules");
-    let count = std::fs::read_dir(&records)
-        .map(|entries| {
-            entries
-                .filter_map(Result::ok)
-                .filter(|e| {
-                    e.path()
-                        .extension()
-                        .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
-                })
-                .count()
-        })
-        .unwrap_or(0);
-
-    if count == 0 || trusted {
-        return Ok(());
-    }
-
-    Err(format!(
-        "refusing to work an issue with this workspace's steering switched off.\n\
-         \n\
-         {} declares context records and none of them would reach the turn, so it \
-         would write code under nobody's standards — and it would look exactly like \
-         a turn that did.\n\
-         \n\
-         Set STELLA_TRUST_PROJECT=1 to let this repository steer the loop it is \
-         driving.",
-        records.display()
-    ))
-}
-
 /// Turn `git worktree add`'s branch collision into an actionable message.
 ///
 /// The slug is deterministic per issue — deliberately, so `deliver` can find
@@ -1380,42 +1326,6 @@ mod tests {
         assert!(
             budget.exhausted().is_some(),
             "which is the condition `drive` reports as *budget reached*"
-        );
-    }
-
-    /// **Witness.** The loop refuses to work an issue when the workspace's
-    /// records would not reach the turn, and runs when they would.
-    ///
-    /// The failure this guards is silent. An untrusted checkout loads none of
-    /// its records, so the turn writes plausible code under nobody's standards
-    /// and the pull request looks like every other one. Both directions are
-    /// asserted, because a check that only ever refused would be satisfied by
-    /// a function that always refuses.
-    ///
-    /// A workspace with no records is the third cell: there is no steering to
-    /// miss, so asking it for a trust flag would be ceremony.
-    #[test]
-    fn the_loop_will_not_work_an_issue_that_its_records_cannot_steer() {
-        let bare = tempfile::tempdir().expect("workspace");
-        assert!(
-            refuse_unless_trusted(bare.path(), false).is_ok(),
-            "a workspace with no records has no steering to miss"
-        );
-
-        let steered = tempfile::tempdir().expect("workspace");
-        let rules = steered.path().join(".stella").join("rules");
-        std::fs::create_dir_all(&rules).expect("rules directory");
-        std::fs::write(rules.join("ctx.example.one.toml"), "").expect("a record file");
-
-        let refusal = refuse_unless_trusted(steered.path(), false)
-            .expect_err("records that cannot steer must stop the work");
-        assert!(
-            refusal.contains("STELLA_TRUST_PROJECT"),
-            "the refusal must name the remedy: {refusal}"
-        );
-        assert!(
-            refuse_unless_trusted(steered.path(), true).is_ok(),
-            "a trusted workspace steers the turn, so the work proceeds"
         );
     }
 

--- a/crates/stella-cli/src/self_driving_cmd/work/steering.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work/steering.rs
@@ -1,0 +1,276 @@
+//! Whether this workspace has steering the loop would lose by running
+//! untrusted.
+//!
+//! Split out of `work.rs` so the counting rule has room to be precise. The
+//! question is narrow: does `<root>/.stella/rules` hold a record that would
+//! reach a turn if the project were trusted? A `.toml` file sitting there is
+//! not the answer, because two kinds of file live beside the records and
+//! neither ever steers anything.
+
+use std::path::Path;
+
+use crate::rules::RESERVED_RULE_FILENAMES;
+
+/// Refuse to work an issue with the workspace's steering switched off.
+///
+/// **A loop-driven turn must get exactly the steering a person-driven turn
+/// gets.** The whole design says the loop's behaviour comes from context
+/// records — how this repository wants code written, what to prefer, what to
+/// harden — and none of that reaches a turn when project steering is untrusted.
+///
+/// The trap is that it fails *silently and successfully*: the turn runs, writes
+/// plausible code, commits, and the pull request looks like every other one. A
+/// loop working unsteered is not a degraded loop, it is a loop doing work under
+/// nobody's standards, and it is worse than one that did not run — so this
+/// refuses rather than warns.
+///
+/// It refuses only when there is something to lose: a workspace with nothing
+/// that would steer has no steering to miss, and demanding a trust flag from it
+/// would be ceremony.
+pub(in crate::self_driving_cmd) fn refuse_if_unsteered(root: &Path) -> Result<(), String> {
+    refuse_unless_trusted(root, crate::settings::project_code_execution_trusted())
+}
+
+/// The rule of [`refuse_if_unsteered`], with the process it reads taken out.
+///
+/// Separated because `project_code_execution_trusted` answers from the process
+/// environment, which this test suite shares with every other test running
+/// beside it. A pure function takes the answer as an argument, so both
+/// directions of the rule can be pinned without a race.
+fn refuse_unless_trusted(root: &Path, trusted: bool) -> Result<(), String> {
+    let records = root.join(".stella").join("rules");
+    if trusted || !holds_a_steering_record(&records) {
+        return Ok(());
+    }
+
+    Err(format!(
+        "refusing to work an issue with this workspace's steering switched off.\n\
+         \n\
+         {} declares context records and none of them would reach the turn, so it \
+         would write code under nobody's standards — and it would look exactly like \
+         a turn that did.\n\
+         \n\
+         Set STELLA_TRUST_PROJECT=1 to let this repository steer the loop it is \
+         driving.",
+        records.display()
+    ))
+}
+
+/// Whether `dir` holds at least one record that trust would let steer a turn.
+///
+/// Counting `*.toml` files answered a different question, and stopped the loop
+/// over two kinds of file that steer nothing either way (#5712):
+///
+/// - `governance.toml` and anything else in [`RESERVED_RULE_FILENAMES`], which
+///   the record loader never parses as a record at all.
+/// - A record whose `status` is `archived` or `retracted`. The registry's
+///   `blocking_reason` refuses to let those steer, so a workspace that has
+///   retired its records has nothing left to lose.
+///
+/// Reads and parses the files rather than taking the session's registry:
+/// `load_registry` runs truth probes and writes a sweep cache, which would put
+/// filesystem probes in front of every work unit. Nothing here creates a
+/// directory.
+fn holds_a_steering_record(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        let path = entry.path();
+        let is_toml = path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"));
+        let reserved = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| RESERVED_RULE_FILENAMES.contains(&name));
+        if !is_toml || reserved {
+            return false;
+        }
+        match std::fs::read_to_string(&path) {
+            Ok(text) => file_holds_a_steering_record(&text),
+            // Unreadable is not "absent": the file is there and something is
+            // wrong with reading it, so take the refusing answer.
+            Err(_) => true,
+        }
+    })
+}
+
+/// The `status` of each `[[record]]` in one file, and nothing else. Reading the
+/// full record type here would make a cheap pre-flight check a second parser to
+/// keep in step with `stella_records`.
+#[derive(serde::Deserialize)]
+struct RecordFileStatuses {
+    #[serde(default)]
+    record: Vec<RecordStatusOnly>,
+}
+
+#[derive(serde::Deserialize)]
+struct RecordStatusOnly {
+    status: Option<String>,
+}
+
+/// Whether one record file's contents hold a record that could steer.
+///
+/// A file that will not parse counts as steering. It is a record the loader
+/// will report on, and refusing is the safe direction for an unknown.
+fn file_holds_a_steering_record(text: &str) -> bool {
+    let Ok(parsed) = toml::from_str::<RecordFileStatuses>(text) else {
+        return true;
+    };
+    parsed
+        .record
+        .iter()
+        // An unset status is active: `RecordStatus` is optional on the wire and
+        // the registry reads `None` as active.
+        .any(|record| matches!(record.status.as_deref(), None | Some("active")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One record file holding one record, the shape `.stella/rules/*.toml`
+    /// actually carries.
+    fn record_with_status(status: &str) -> String {
+        format!(
+            "schema = \"context-record/v0.1\"\n\
+             set_id = \"example.one\"\n\
+             \n\
+             [[record]]\n\
+             lineage_id = \"ctx.example.one.thing\"\n\
+             statement = \"Do the thing.\"\n\
+             status = \"{status}\"\n"
+        )
+    }
+
+    fn active_record() -> String {
+        record_with_status("active")
+    }
+
+    fn rules_dir(root: &Path) -> std::path::PathBuf {
+        let rules = root.join(".stella").join("rules");
+        std::fs::create_dir_all(&rules).expect("rules directory");
+        rules
+    }
+
+    /// **Witness.** The loop refuses to work an issue when the workspace's
+    /// records would not reach the turn, and runs when they would.
+    ///
+    /// The failure this guards is silent. An untrusted checkout loads none of
+    /// its records, so the turn writes plausible code under nobody's standards
+    /// and the pull request looks like every other one. Both directions are
+    /// asserted, because a check that only ever refused would be satisfied by
+    /// a function that always refuses.
+    ///
+    /// A workspace with no records is the third cell: there is no steering to
+    /// miss, so asking it for a trust flag would be ceremony.
+    #[test]
+    fn the_loop_will_not_work_an_issue_that_its_records_cannot_steer() {
+        let bare = tempfile::tempdir().expect("workspace");
+        assert!(
+            refuse_unless_trusted(bare.path(), false).is_ok(),
+            "a workspace with no records has no steering to miss"
+        );
+
+        let steered = tempfile::tempdir().expect("workspace");
+        let rules = rules_dir(steered.path());
+        std::fs::write(rules.join("ctx.example.one.toml"), active_record()).expect("a record file");
+
+        let refusal = refuse_unless_trusted(steered.path(), false)
+            .expect_err("records that cannot steer must stop the work");
+        assert!(
+            refusal.contains("STELLA_TRUST_PROJECT"),
+            "the refusal must name the remedy: {refusal}"
+        );
+        assert!(
+            refuse_unless_trusted(steered.path(), true).is_ok(),
+            "a trusted workspace steers the turn, so the work proceeds"
+        );
+    }
+
+    /// **Witness.** Two kinds of `.toml` in the rules directory steer nothing,
+    /// and neither may stop the loop (#5712).
+    ///
+    /// Both stopped it before the count read the files. `governance.toml` is a
+    /// reserved name the record loader never parses, and an archived or
+    /// retracted record is one the registry already refuses to let steer. The
+    /// operator was told to set a trust flag so records could steer the loop,
+    /// in a workspace where no record would steer it either way.
+    #[test]
+    fn a_file_that_would_never_steer_does_not_stop_the_loop() {
+        let governance_only = tempfile::tempdir().expect("workspace");
+        let rules = rules_dir(governance_only.path());
+        std::fs::write(rules.join("governance.toml"), "mode = \"regulated\"\n")
+            .expect("a governance file");
+        assert!(
+            refuse_unless_trusted(governance_only.path(), false).is_ok(),
+            "governance is not a record, so there is no steering to lose"
+        );
+
+        for status in ["archived", "retracted"] {
+            let retired = tempfile::tempdir().expect("workspace");
+            let rules = rules_dir(retired.path());
+            std::fs::write(
+                rules.join("ctx.example.one.toml"),
+                record_with_status(status),
+            )
+            .expect("a record file");
+            assert!(
+                refuse_unless_trusted(retired.path(), false).is_ok(),
+                "a {status} record does not steer, so it cannot be lost"
+            );
+        }
+
+        // The same directory with one live record beside the retired one still
+        // stops an untrusted loop, so the two cases above are about what was
+        // written and not about the fixture.
+        let mixed = tempfile::tempdir().expect("workspace");
+        let rules = rules_dir(mixed.path());
+        std::fs::write(rules.join("governance.toml"), "mode = \"regulated\"\n")
+            .expect("a governance file");
+        std::fs::write(
+            rules.join("ctx.example.gone.toml"),
+            record_with_status("archived"),
+        )
+        .expect("a retired record");
+        std::fs::write(rules.join("ctx.example.live.toml"), active_record())
+            .expect("a live record");
+        assert!(
+            refuse_unless_trusted(mixed.path(), false).is_err(),
+            "one live record is still steering the loop would lose"
+        );
+    }
+
+    /// A record with no `status` key is active. A file the parser cannot read
+    /// takes the refusing answer, and a file declaring no record at all
+    /// declares no steering.
+    #[test]
+    fn an_unset_status_steers_and_an_unparseable_file_refuses() {
+        let unset = tempfile::tempdir().expect("workspace");
+        let rules = rules_dir(unset.path());
+        std::fs::write(
+            rules.join("ctx.example.one.toml"),
+            "schema = \"context-record/v0.1\"\n\n[[record]]\nlineage_id = \"ctx.a.b.c\"\n",
+        )
+        .expect("a record file");
+        assert!(refuse_unless_trusted(unset.path(), false).is_err());
+
+        let broken = tempfile::tempdir().expect("workspace");
+        let rules = rules_dir(broken.path());
+        std::fs::write(rules.join("ctx.example.one.toml"), "[[record\nnot toml")
+            .expect("a broken file");
+        assert!(
+            refuse_unless_trusted(broken.path(), false).is_err(),
+            "an unknown takes the safe direction"
+        );
+
+        let empty = tempfile::tempdir().expect("workspace");
+        let rules = rules_dir(empty.path());
+        std::fs::write(rules.join("ctx.example.one.toml"), "").expect("an empty file");
+        assert!(
+            refuse_unless_trusted(empty.path(), false).is_ok(),
+            "a file declaring no record declares no steering"
+        );
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/work/steering.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work/steering.rs
@@ -1,11 +1,10 @@
-//! Whether this workspace has steering the loop would lose by running
-//! untrusted.
+//! What steering this workspace would lose by running untrusted.
 //!
-//! Split out of `work.rs` so the counting rule has room to be precise. The
-//! question is narrow: does `<root>/.stella/rules` hold a record that would
-//! reach a turn if the project were trusted? A `.toml` file sitting there is
-//! not the answer, because two kinds of file live beside the records and
-//! neither ever steers anything.
+//! One question: does `<root>/.stella/rules` hold a record that would reach a
+//! turn if the project were trusted? A `.toml` file there is not the answer.
+//! Two kinds of file sit beside the records. Neither one ever steers.
+//!
+//! Split out of `work.rs`, which is close to the file-size ceiling.
 
 use std::path::Path;
 
@@ -13,30 +12,27 @@ use crate::rules::RESERVED_RULE_FILENAMES;
 
 /// Refuse to work an issue with the workspace's steering switched off.
 ///
-/// **A loop-driven turn must get exactly the steering a person-driven turn
-/// gets.** The whole design says the loop's behaviour comes from context
-/// records — how this repository wants code written, what to prefer, what to
-/// harden — and none of that reaches a turn when project steering is untrusted.
+/// **A loop turn gets the steering a person's turn gets.** The loop takes its
+/// behaviour from context records. They say how this repository wants code
+/// written. None of them reach a turn while project steering is untrusted.
 ///
-/// The trap is that it fails *silently and successfully*: the turn runs, writes
-/// plausible code, commits, and the pull request looks like every other one. A
-/// loop working unsteered is not a degraded loop, it is a loop doing work under
-/// nobody's standards, and it is worse than one that did not run — so this
-/// refuses rather than warns.
+/// The trap is that it fails quietly, and looks like success. The turn runs.
+/// It writes plausible code. It commits. The pull request reads like every
+/// other one. Work under nobody's standards is worse than no work at all, so
+/// this refuses instead of warning.
 ///
-/// It refuses only when there is something to lose: a workspace with nothing
-/// that would steer has no steering to miss, and demanding a trust flag from it
-/// would be ceremony.
+/// It refuses only when there is something to lose. A workspace with nothing
+/// that would steer has no steering to miss. Asking that one for a trust flag
+/// is ceremony.
 pub(in crate::self_driving_cmd) fn refuse_if_unsteered(root: &Path) -> Result<(), String> {
     refuse_unless_trusted(root, crate::settings::project_code_execution_trusted())
 }
 
 /// The rule of [`refuse_if_unsteered`], with the process it reads taken out.
 ///
-/// Separated because `project_code_execution_trusted` answers from the process
-/// environment, which this test suite shares with every other test running
-/// beside it. A pure function takes the answer as an argument, so both
-/// directions of the rule can be pinned without a race.
+/// `project_code_execution_trusted` answers from the process environment. This
+/// test suite shares that with every test beside it. A pure function takes the
+/// answer as an argument, so both directions pin without a race.
 fn refuse_unless_trusted(root: &Path, trusted: bool) -> Result<(), String> {
     let records = root.join(".stella").join("rules");
     if trusted || !holds_a_steering_record(&records) {
@@ -56,21 +52,20 @@ fn refuse_unless_trusted(root: &Path, trusted: bool) -> Result<(), String> {
     ))
 }
 
-/// Whether `dir` holds at least one record that trust would let steer a turn.
+/// Whether `dir` holds a record that trust would let steer a turn.
 ///
-/// Counting `*.toml` files answered a different question, and stopped the loop
-/// over two kinds of file that steer nothing either way (#5712):
+/// Counting `*.toml` files asks a different question. Two kinds of file there
+/// steer nothing:
 ///
-/// - `governance.toml` and anything else in [`RESERVED_RULE_FILENAMES`], which
-///   the record loader never parses as a record at all.
+/// - `governance.toml`, and every other name in [`RESERVED_RULE_FILENAMES`].
+///   The record loader never reads one as a record.
 /// - A record whose `status` is `archived` or `retracted`. The registry's
-///   `blocking_reason` refuses to let those steer, so a workspace that has
-///   retired its records has nothing left to lose.
+///   `blocking_reason` refuses to let those steer. A workspace that has retired
+///   its records has nothing left to lose.
 ///
-/// Reads and parses the files rather than taking the session's registry:
+/// This reads and parses the files. It does not take the session's registry:
 /// `load_registry` runs truth probes and writes a sweep cache, which would put
-/// filesystem probes in front of every work unit. Nothing here creates a
-/// directory.
+/// file probes in front of every work unit. Nothing here creates a directory.
 fn holds_a_steering_record(dir: &Path) -> bool {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return false;
@@ -96,9 +91,9 @@ fn holds_a_steering_record(dir: &Path) -> bool {
     })
 }
 
-/// The `status` of each `[[record]]` in one file, and nothing else. Reading the
-/// full record type here would make a cheap pre-flight check a second parser to
-/// keep in step with `stella_records`.
+/// The `status` of each `[[record]]` in one file, and nothing else. Reading
+/// the whole record type here would make this cheap check a second parser, to
+/// be kept in step with `stella_records`.
 #[derive(serde::Deserialize)]
 struct RecordFileStatuses {
     #[serde(default)]
@@ -110,10 +105,10 @@ struct RecordStatusOnly {
     status: Option<String>,
 }
 
-/// Whether one record file's contents hold a record that could steer.
+/// Whether one record file holds a record that could steer.
 ///
-/// A file that will not parse counts as steering. It is a record the loader
-/// will report on, and refusing is the safe direction for an unknown.
+/// A file that will not parse counts as steering. The loader will report on
+/// it, and refusing is the safe answer for an unknown.
 fn file_holds_a_steering_record(text: &str) -> bool {
     let Ok(parsed) = toml::from_str::<RecordFileStatuses>(text) else {
         return true;
@@ -130,8 +125,7 @@ fn file_holds_a_steering_record(text: &str) -> bool {
 mod tests {
     use super::*;
 
-    /// One record file holding one record, the shape `.stella/rules/*.toml`
-    /// actually carries.
+    /// One record file holding one record, the shape a real one carries.
     fn record_with_status(status: &str) -> String {
         format!(
             "schema = \"context-record/v0.1\"\n\
@@ -154,17 +148,16 @@ mod tests {
         rules
     }
 
-    /// **Witness.** The loop refuses to work an issue when the workspace's
-    /// records would not reach the turn, and runs when they would.
+    /// **Witness.** The loop refuses when the records would not reach the
+    /// turn, and runs when they would.
     ///
-    /// The failure this guards is silent. An untrusted checkout loads none of
-    /// its records, so the turn writes plausible code under nobody's standards
-    /// and the pull request looks like every other one. Both directions are
-    /// asserted, because a check that only ever refused would be satisfied by
-    /// a function that always refuses.
+    /// The failure it guards is silent. An untrusted checkout loads none of
+    /// its records. The turn then writes plausible code under nobody's
+    /// standards. Both directions are asserted. A check that only ever refused
+    /// would pass on a function that always refuses.
     ///
-    /// A workspace with no records is the third cell: there is no steering to
-    /// miss, so asking it for a trust flag would be ceremony.
+    /// A workspace with no records is the third cell. It has no steering to
+    /// miss, so a trust flag would be ceremony.
     #[test]
     fn the_loop_will_not_work_an_issue_that_its_records_cannot_steer() {
         let bare = tempfile::tempdir().expect("workspace");
@@ -189,14 +182,14 @@ mod tests {
         );
     }
 
-    /// **Witness.** Two kinds of `.toml` in the rules directory steer nothing,
-    /// and neither may stop the loop (#5712).
+    /// **Witness.** Two kinds of `.toml` steer nothing, and neither may stop
+    /// the loop.
     ///
-    /// Both stopped it before the count read the files. `governance.toml` is a
-    /// reserved name the record loader never parses, and an archived or
-    /// retracted record is one the registry already refuses to let steer. The
-    /// operator was told to set a trust flag so records could steer the loop,
-    /// in a workspace where no record would steer it either way.
+    /// `governance.toml` is a reserved name. The loader never parses it. An
+    /// archived or retracted record is one the registry refuses to let steer.
+    /// A count that reads only file extensions stops on both. It then tells
+    /// the operator to set a trust flag, so that records can steer a loop no
+    /// record would steer either way.
     #[test]
     fn a_file_that_would_never_steer_does_not_stop_the_loop() {
         let governance_only = tempfile::tempdir().expect("workspace");
@@ -243,8 +236,8 @@ mod tests {
     }
 
     /// A record with no `status` key is active. A file the parser cannot read
-    /// takes the refusing answer, and a file declaring no record at all
-    /// declares no steering.
+    /// takes the refusing answer. A file with no record in it declares no
+    /// steering.
     #[test]
     fn an_unset_status_steers_and_an_unparseable_file_refuses() {
         let unset = tempfile::tempdir().expect("workspace");

--- a/crates/stella-cli/src/settings.rs
+++ b/crates/stella-cli/src/settings.rs
@@ -1289,7 +1289,7 @@ fn project_trust() -> ProjectTrust {
 /// | Project-scope `active_plugins` — a name here makes the host spawn that plugin's program on every turn, so an untrusted scope keeps the user/managed list and adds nothing | the same function, immediately below `context_providers` |
 /// | The MCP servers declared in `.stella/mcp.toml` — an arbitrary stdio `command` run at session start, or an attacker-chosen http endpoint | `agent::load_mcp_plan` |
 /// | `<workspace>/.stella/plugins/` — a plugin declares a program the host spawns and can arbitrate the agent loop | `plugin_cmd::roster::read_project_tier` |
-/// | `stella self-driving`'s issue work — refused outright when the workspace declares context records that would not reach the turn, because unsteered work is indistinguishable from steered work in the pull request it produces | `self_driving_cmd::work::refuse_if_unsteered` |
+/// | `stella self-driving`'s issue work — refused outright when the workspace declares context records that would not reach the turn, because unsteered work is indistinguishable from steered work in the pull request it produces | `self_driving_cmd::work::steering::refuse_if_unsteered` |
 ///
 /// `stella plugin install --scope project` consults it once more, to *warn*
 /// rather than gate: the copy onto disk is the operator's own act, but the

--- a/crates/stella-cli/src/settings/tests/trust.rs
+++ b/crates/stella-cli/src/settings/tests/trust.rs
@@ -37,7 +37,7 @@ fn every_code_execution_gate_is_reachable_by_one_grep() {
             // refuses to read the tier back.
             "plugin_cmd.rs",
             // "`stella self-driving`'s issue work".
-            "self_driving_cmd/work.rs",
+            "self_driving_cmd/work/steering.rs",
             // The definition, and the doc comment that is the normative list.
             "settings.rs",
             // "Project-scope lifecycle hooks" and "project-scope

--- a/crates/stella-core/src/bus.rs
+++ b/crates/stella-core/src/bus.rs
@@ -76,6 +76,9 @@ use stella_protocol::{AgentEvent, Denial};
 // The event-name catalog, split to a sibling file (the `driver/settlement.rs`
 // pattern) so this file stays under its file-size ceiling (#1857).
 pub mod names;
+mod policy_bridge;
+
+pub use policy_bridge::bridge_policy_plane;
 
 // Envelope + decisions
 
@@ -725,64 +728,6 @@ impl HookBus {
             });
         }
     }
-}
-
-/// Bridge the policy/extension audit plane into an `AgentEvent` stream
-/// (receipts spec §6.4, #364 gap 6): subscribes an observer that maps the
-/// four audit event names — `policy.evaluated`, `policy.blocked`,
-/// `approval.requested`, `secret.detected` — onto
-/// [`AgentEvent::PolicyDecision`], content-free. Whatever journal the host
-/// hangs off `events` is what makes the plane durable; the bus itself still
-/// never writes (its module contract), and every other event name passes
-/// through untouched.
-///
-/// `subject` is the gated chain's event name (`tool.call.requested`,
-/// `file.updated`, …) — or the workspace-relative path for a secret
-/// detection. `outcome` is the decision record's compact JSON (`decision` +
-/// `handlers_consulted`) or the detector's kind list; neither ever carries
-/// file contents or a secret value.
-pub fn bridge_policy_plane(
-    bus: &HookBus,
-    events: crate::event_sender::EventSender,
-) -> HookSubscription {
-    use stella_protocol::PolicyKind;
-    bus.on("*", move |event| {
-        let kind = match event.name.as_str() {
-            names::POLICY_EVALUATED => PolicyKind::Evaluated,
-            names::POLICY_BLOCKED => PolicyKind::Blocked,
-            names::APPROVAL_REQUESTED => PolicyKind::ApprovalRequested,
-            names::SECRET_DETECTED => PolicyKind::SecretDetected,
-            _ => return Ok(()),
-        };
-        let (subject, outcome) = if kind == PolicyKind::SecretDetected {
-            (
-                event.payload["path"]
-                    .as_str()
-                    .unwrap_or_default()
-                    .to_string(),
-                event.payload["kinds"].to_string(),
-            )
-        } else {
-            (
-                event.payload["event_name"]
-                    .as_str()
-                    .unwrap_or_default()
-                    .to_string(),
-                serde_json::json!({
-                    "decision": event.payload["decision"],
-                    "handlers_consulted": event.payload["handlers_consulted"],
-                })
-                .to_string(),
-            )
-        };
-        events
-            .send(AgentEvent::PolicyDecision {
-                kind,
-                subject,
-                outcome,
-            })
-            .map_err(|e| e.to_string())
-    })
 }
 
 /// The running count of envelopes [`forward_to`] dropped because its bounded

--- a/crates/stella-core/src/bus.rs
+++ b/crates/stella-core/src/bus.rs
@@ -71,7 +71,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use stella_protocol::{AgentEvent, Denial};
+use stella_protocol::Denial;
 
 // The event-name catalog, split to a sibling file (the `driver/settlement.rs`
 // pattern) so this file stays under its file-size ceiling (#1857).
@@ -1016,6 +1016,7 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
 mod tests {
     use super::*;
     use std::sync::atomic::AtomicUsize;
+    use stella_protocol::AgentEvent;
 
     /// Bus + a `Vec` capturing every event a `"*"` observer sees.
     fn observed_bus(session: &str) -> (HookBus, Arc<Mutex<Vec<HookEvent>>>) {

--- a/crates/stella-core/src/bus/policy_bridge.rs
+++ b/crates/stella-core/src/bus/policy_bridge.rs
@@ -1,0 +1,208 @@
+//! The policy plane, bridged onto the `AgentEvent` stream.
+//!
+//! Split out of `bus.rs`, which is a god file closed to growth.
+
+use std::sync::Mutex;
+
+use stella_protocol::AgentEvent;
+
+use super::{HookBus, HookSubscription, names};
+
+/// Bridge the policy plane onto an `AgentEvent` stream (receipts spec §6.4).
+///
+/// Subscribes an observer that maps the four audit event names —
+/// `policy.evaluated`, `policy.blocked`, `approval.requested`,
+/// `secret.detected` — onto [`AgentEvent::PolicyDecision`], content-free.
+/// Every other event name passes through untouched. The bus itself never
+/// writes, which is its module contract. What makes the plane durable is
+/// whatever journal the host hangs off `events`.
+///
+/// `subject` is the gated chain's event name (`tool.call.requested`,
+/// `file.updated`, …). For a secret detection it is the workspace-relative
+/// path. `outcome` is the decision record's compact JSON (`decision` plus
+/// `handlers_consulted`), or the detector's kind list. Neither one ever
+/// carries file contents or a secret value.
+///
+/// # One ask, one row
+///
+/// `approval.requested` reaches the bus twice for one question.
+/// `emit_blocking` stamps it when a chain ends in `RequireApproval`. The
+/// approval flow emits a richer one of its own before it parks. Both map to a
+/// `PolicyDecision`, so a journal held two rows per ask and a count of asks
+/// read double.
+///
+/// Neither emission may simply be dropped. A chain can require approval with
+/// no flow behind it. A flow can park for a gate no chain evaluated. So each
+/// one is the only signal on some path.
+///
+/// The bridge holds one ask open per gate instead. The first
+/// `approval.requested` for a gate emits a row. A second for that same gate is
+/// the pair's other half, and emits nothing. A resolution —
+/// `approval.granted`, `.denied`, `.expired` — closes the ask, so the next
+/// question about that gate is a new row.
+pub fn bridge_policy_plane(
+    bus: &HookBus,
+    events: crate::event_sender::EventSender,
+) -> HookSubscription {
+    use stella_protocol::PolicyKind;
+    // The gate of the ask now open, if one is. A `Mutex` because the bus
+    // holds an observer as `Fn` + `Sync`. Two threads can gate a call at once,
+    // and the pair this collapses must not be split across them.
+    let open_ask: Mutex<Option<String>> = Mutex::new(None);
+    bus.on("*", move |event| {
+        if matches!(
+            event.name.as_str(),
+            names::APPROVAL_GRANTED | names::APPROVAL_DENIED | names::APPROVAL_EXPIRED
+        ) {
+            *open_ask.lock().unwrap_or_else(|p| p.into_inner()) = None;
+            return Ok(());
+        }
+        let kind = match event.name.as_str() {
+            names::POLICY_EVALUATED => PolicyKind::Evaluated,
+            names::POLICY_BLOCKED => PolicyKind::Blocked,
+            names::APPROVAL_REQUESTED => PolicyKind::ApprovalRequested,
+            names::SECRET_DETECTED => PolicyKind::SecretDetected,
+            _ => return Ok(()),
+        };
+        let (subject, outcome) = if kind == PolicyKind::SecretDetected {
+            (
+                event.payload["path"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+                event.payload["kinds"].to_string(),
+            )
+        } else {
+            (
+                event.payload["event_name"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+                serde_json::json!({
+                    "decision": event.payload["decision"],
+                    "handlers_consulted": event.payload["handlers_consulted"],
+                })
+                .to_string(),
+            )
+        };
+        if kind == PolicyKind::ApprovalRequested {
+            let mut open = open_ask.lock().unwrap_or_else(|p| p.into_inner());
+            if open.as_deref() == Some(subject.as_str()) {
+                return Ok(());
+            }
+            *open = Some(subject.clone());
+        }
+        events
+            .send(AgentEvent::PolicyDecision {
+                kind,
+                subject,
+                outcome,
+            })
+            .map_err(|e| e.to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use stella_protocol::PolicyKind;
+
+    use super::super::{HookDecision, HookEventDraft};
+    use super::*;
+
+    fn kinds(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AgentEvent>) -> Vec<PolicyKind> {
+        std::iter::from_fn(|| rx.try_recv().ok())
+            .map(|event| match event {
+                AgentEvent::PolicyDecision { kind, .. } => kind,
+                other => panic!("only PolicyDecision crosses the bridge: {other:?}"),
+            })
+            .collect()
+    }
+
+    /// **Witness.** One question, one row.
+    ///
+    /// The chain's stamp and the flow's richer emission both name the same
+    /// gate. Before they were paired, a journal held two `ApprovalRequested`
+    /// rows per ask, and a count of asks read double.
+    #[test]
+    fn one_ask_is_one_row_however_many_emissions_it_makes() {
+        let bus = HookBus::new("approval-pair");
+        bus.on_blocking(names::TOOL_CALL_REQUESTED, |_| {
+            HookDecision::RequireApproval {
+                reason: "destructive".into(),
+            }
+        })
+        .detach();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let _bridge = bridge_policy_plane(&bus, crate::event_sender::EventSender::new(tx));
+
+        // The chain's own stamp.
+        bus.emit_blocking(HookEventDraft::new(
+            names::TOOL_CALL_REQUESTED,
+            serde_json::json!({ "tool": "bash" }),
+        ));
+        // The flow's richer emission, before it parks.
+        bus.emit_named(
+            names::APPROVAL_REQUESTED,
+            serde_json::json!({
+                "event_name": names::TOOL_CALL_REQUESTED,
+                "tool": "bash",
+                "read_only": false,
+            }),
+        );
+
+        assert_eq!(
+            kinds(&mut rx),
+            vec![PolicyKind::Evaluated, PolicyKind::ApprovalRequested],
+            "the pair is one row, and the chain's evaluation still gets its own"
+        );
+    }
+
+    /// A resolution closes the ask. The next question about the same gate is
+    /// a new row, not the other half of the last one.
+    #[test]
+    fn a_resolved_ask_lets_the_next_one_through() {
+        let bus = HookBus::new("approval-reopen");
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let _bridge = bridge_policy_plane(&bus, crate::event_sender::EventSender::new(tx));
+
+        let ask = || {
+            serde_json::json!({
+                "event_name": names::TOOL_CALL_REQUESTED,
+                "tool": "bash",
+            })
+        };
+        bus.emit_named(names::APPROVAL_REQUESTED, ask());
+        bus.emit_named(
+            names::APPROVAL_GRANTED,
+            serde_json::json!({ "event_name": names::TOOL_CALL_REQUESTED }),
+        );
+        bus.emit_named(names::APPROVAL_REQUESTED, ask());
+
+        assert_eq!(
+            kinds(&mut rx),
+            vec![PolicyKind::ApprovalRequested, PolicyKind::ApprovalRequested],
+            "a granted ask is finished, so the next one is a new question"
+        );
+    }
+
+    /// Two gates asked about at once are two asks. Keying the pair on the gate
+    /// is what keeps them apart.
+    #[test]
+    fn two_gates_are_two_asks() {
+        let bus = HookBus::new("approval-two-gates");
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let _bridge = bridge_policy_plane(&bus, crate::event_sender::EventSender::new(tx));
+
+        for gate in [names::TOOL_CALL_REQUESTED, names::FILE_UPDATED] {
+            bus.emit_named(
+                names::APPROVAL_REQUESTED,
+                serde_json::json!({ "event_name": gate }),
+            );
+        }
+
+        assert_eq!(
+            kinds(&mut rx),
+            vec![PolicyKind::ApprovalRequested, PolicyKind::ApprovalRequested]
+        );
+    }
+}

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -146,7 +146,7 @@ mod drive;
 mod model_fallback;
 pub mod output_budget_recovery;
 pub(crate) mod overflow_recovery;
-mod rate_limit;
+pub mod rate_limit;
 mod restore;
 // The step boundary's host consults (steering, soft stop, #3243 re-query).
 mod settlement;

--- a/crates/stella-core/src/driver/lifecycle.rs
+++ b/crates/stella-core/src/driver/lifecycle.rs
@@ -38,7 +38,7 @@
 //! (#2452). Nothing in this workspace calls these from outside `driver` today.
 //! They stay public for the host that frames its own turn, which is a supported
 //! shape rather than a hypothetical one, and `stella-engine` re-exports both
-//! so such a host reaches them through the facade (#2481).
+//! so such a host reaches them through the facade.
 
 use super::{StepOutcome, TurnOutcome};
 

--- a/crates/stella-core/src/driver/lifecycle.rs
+++ b/crates/stella-core/src/driver/lifecycle.rs
@@ -37,8 +37,8 @@
 //! own `TurnState` to `Engine::drive`, which emits both boundaries itself
 //! (#2452). Nothing in this workspace calls these from outside `driver` today.
 //! They stay public for the host that frames its own turn, which is a supported
-//! shape rather than a hypothetical one — but note `stella-engine` does not
-//! re-export them, so such a host must depend on `stella-core` directly.
+//! shape rather than a hypothetical one, and `stella-engine` re-exports both
+//! so such a host reaches them through the facade (#2481).
 
 use super::{StepOutcome, TurnOutcome};
 

--- a/crates/stella-core/src/driver/rate_limit.rs
+++ b/crates/stella-core/src/driver/rate_limit.rs
@@ -39,7 +39,7 @@ use crate::step::CancelUsageGuard;
 /// this, a deadline-less interactive session against a hard-down provider
 /// would park forever; with it, the session narrates its waits for six hours
 /// and then surfaces the provider's own error.
-pub(super) const MAX_PARKED_WAIT_MS: u64 = 6 * 60 * 60 * 1000;
+pub const MAX_PARKED_WAIT_MS: u64 = 6 * 60 * 60 * 1000;
 
 /// Wall clock a park must leave unspent under a task deadline: waking with
 /// less than this left means the retried call itself would be aborted at the

--- a/crates/stella-core/src/engine_markers.rs
+++ b/crates/stella-core/src/engine_markers.rs
@@ -23,7 +23,7 @@
 //! absent entirely, and the recall marker was described but never spelled. A
 //! prose list has no failure mode; a table does.
 //!
-//! # The tie, in both directions
+//! # The tie, in every direction
 //!
 //! The entries are the marker constants themselves, by path — not copies — so
 //! the table cannot drift from what the engine actually writes: editing a
@@ -34,6 +34,12 @@
 //! the same change that introduces it** — that is what makes the prompt fail
 //! by name until it teaches the new marker, instead of silently narrowing the
 //! model's injection test.
+//!
+//! That sentence is a check rather than an instruction:
+//! `the_table_holds_every_marker_shaped_constant` scans the sources that own
+//! an entry for marker-shaped constants and fails, by name, on one that opens
+//! a bracketed tag and is not in the table. An instruction in a doc comment is
+//! the convention-only coupling this repository removed for prompt contracts.
 //!
 //! This module is a leaf: two `pub` tables and one predicate over them,
 //! declared outside `driver.rs` because that file is closed to growth
@@ -204,6 +210,178 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Every source file that owns an [`ENGINE_MARKERS`] entry today.
+    ///
+    /// A file that stops owning one fails the scan below by name rather than
+    /// dropping out of it silently, which is what makes this list safe to keep
+    /// by hand.
+    const MARKER_SOURCES: &[(&str, &str)] = &[
+        ("driver.rs", include_str!("driver.rs")),
+        ("driver/truncation.rs", include_str!("driver/truncation.rs")),
+        ("driver/user_hooks.rs", include_str!("driver/user_hooks.rs")),
+        (
+            "driver/deadline_notice.rs",
+            include_str!("driver/deadline_notice.rs"),
+        ),
+        ("receipts.rs", include_str!("receipts.rs")),
+        ("restore.rs", include_str!("restore.rs")),
+        ("waiting.rs", include_str!("waiting.rs")),
+        ("skill_invocation.rs", include_str!("skill_invocation.rs")),
+        (
+            "compaction/read_digest.rs",
+            include_str!("compaction/read_digest.rs"),
+        ),
+    ];
+
+    /// Marker-shaped constants that are not [`ENGINE_MARKERS`] entries, with
+    /// the reason each one is out.
+    ///
+    /// The table is for `User`-role message *openings*. A constant that marks
+    /// something else is not a candidate, and saying so here is what stops the
+    /// scan's rule accreting one.
+    const NOT_A_USER_ROLE_OPENING: &[(&str, &str)] = &[(
+        "FILE_CAP_MARKER",
+        "marks a truncation point inside restored file content, not the \
+         opening of a message",
+    )];
+
+    /// Whether a constant's name is marker-shaped.
+    ///
+    /// `REASONING_ONLY_PARTIAL` is the shape this rule must not admit: it is a
+    /// bracketed assistant-role stand-in, and its name carries neither token.
+    fn marker_shaped(name: &str) -> bool {
+        name.contains("MARKER") || name.ends_with("_PREFIX")
+    }
+
+    /// The string literal a `const NAME: &str = "…"` declaration opens with,
+    /// or `None` when the declaration has no literal to read.
+    ///
+    /// Reads past the end of the line, because a long literal is written on
+    /// the next one.
+    fn first_literal(after_equals: &str) -> Option<String> {
+        let open = after_equals.find('"')?;
+        let rest = &after_equals[open + 1..];
+        let mut literal = String::new();
+        let mut chars = rest.chars();
+        while let Some(c) = chars.next() {
+            match c {
+                '\\' => {
+                    literal.push(c);
+                    literal.push(chars.next()?);
+                }
+                '"' => return Some(literal),
+                _ => literal.push(c),
+            }
+        }
+        None
+    }
+
+    /// Every marker-shaped constant one source file declares, as
+    /// `(name, literal)`.
+    fn marker_constants(source: &str) -> Vec<(String, String)> {
+        let mut found = Vec::new();
+        for (offset, _) in source.match_indices("const ") {
+            let rest = &source[offset + "const ".len()..];
+            let Some(colon) = rest.find(':') else {
+                continue;
+            };
+            let name = rest[..colon].trim();
+            if name.is_empty() || !marker_shaped(name) {
+                continue;
+            }
+            let after_colon = &rest[colon + 1..];
+            // Only `&str` constants; a `&[&str]` table is not a marker.
+            if !after_colon.trim_start().starts_with("&str") {
+                continue;
+            }
+            let Some(equals) = after_colon.find('=') else {
+                continue;
+            };
+            if let Some(literal) = first_literal(&after_colon[equals + 1..]) {
+                found.push((name.to_string(), literal));
+            }
+        }
+        found
+    }
+
+    /// **Witness.** A marker-shaped constant that opens a bracketed tag and
+    /// never joins [`ENGINE_MARKERS`] fails here, by name.
+    ///
+    /// This is the third coupling direction. Table→prompt is enforced by
+    /// `stella-cli`'s prompt parity suite and table→classifier by
+    /// `receipts::tests`; nothing else asks whether the *constants* are all in
+    /// the table, and a doc comment saying to add one is not a check.
+    ///
+    /// Add `pub(crate) const FAKE_STEER_PREFIX: &str = "[fake steer";` to
+    /// `driver/truncation.rs` and this fails naming it, until it joins the
+    /// table — whereupon the receipts and prompt couplings fail in turn, which
+    /// is the designed cascade.
+    #[test]
+    fn the_table_holds_every_marker_shaped_constant() {
+        let mut scanned: Vec<(&str, String, String)> = Vec::new();
+        for (path, source) in MARKER_SOURCES {
+            let found = marker_constants(source);
+            assert!(
+                !found.is_empty(),
+                "{path} declares no marker-shaped constant, so the scan reads \
+                 it for nothing — the marker moved and this list is stale"
+            );
+            for (name, literal) in found {
+                scanned.push((path, name, literal));
+            }
+        }
+
+        for (path, name, literal) in &scanned {
+            if NOT_A_USER_ROLE_OPENING
+                .iter()
+                .any(|(excluded, _)| excluded == name)
+            {
+                continue;
+            }
+            if !literal.starts_with('[') {
+                continue;
+            }
+            assert!(
+                ENGINE_MARKERS.contains(&literal.as_str()),
+                "{path}'s {name} opens a bracketed User-role marker that \
+                 ENGINE_MARKERS does not list. Add it to the table in this \
+                 change, or record it in NOT_A_USER_ROLE_OPENING with the \
+                 reason it is not one."
+            );
+        }
+
+        for marker in ENGINE_MARKERS {
+            assert!(
+                scanned.iter().any(|(_, _, literal)| literal == marker),
+                "no scanned source declares {marker:?}, so MARKER_SOURCES no \
+                 longer covers every file that owns a table entry"
+            );
+        }
+    }
+
+    /// Anti-vacuity for the scan itself: a parser that recognised nothing
+    /// would pass every assertion above.
+    #[test]
+    fn the_marker_scan_reads_the_shapes_it_claims_to() {
+        let sample = "pub(crate) const A_MARKER_PREFIX: &str = \"[a marker\";\n\
+                      const PLAIN: &str = \"[not marker shaped\";\n\
+                      const B_MARKER: &str =\n    \"[wrapped onto the next line\";\n\
+                      const A_TABLE: &[&str] = &[\"[not a single marker\"];\n";
+        let found = marker_constants(sample);
+        assert_eq!(
+            found,
+            vec![
+                ("A_MARKER_PREFIX".to_string(), "[a marker".to_string()),
+                (
+                    "B_MARKER".to_string(),
+                    "[wrapped onto the next line".to_string()
+                ),
+            ],
+            "the scan must read a wrapped literal, skip a name that is not \
+             marker-shaped, and skip a table of them"
+        );
     }
 
     /// A marked message is never also a nudge, in either direction: the two

--- a/crates/stella-core/src/estimator.rs
+++ b/crates/stella-core/src/estimator.rs
@@ -183,14 +183,20 @@ const CALIBRATION_MAX_FACTOR: f64 = 2.0;
 const CALIBRATION_SAMPLE_MIN_RATIO: f64 = CALIBRATION_MIN_FACTOR / 2.0;
 const CALIBRATION_SAMPLE_MAX_RATIO: f64 = CALIBRATION_MAX_FACTOR * 2.0;
 
-/// Drift correction for one provider/model: an EWMA of the observed
-/// actual/estimated input-token ratio, fed by `(estimated, actual)` pairs
-/// from committed steps (`AgentEvent::StepUsage`) and applied as a bounded
-/// multiplicative factor on the byte-heuristic estimate.
+/// Drift correction for one provider/model, fed by `(estimated, actual)`
+/// input-token pairs from committed steps (`AgentEvent::StepUsage`) and
+/// applied as a bounded factor on the byte-heuristic estimate.
 ///
-/// The ratio also absorbs systematic per-request overhead the heuristic
-/// cannot see (tool schemas, provider framing): those inflate `actual`
-/// uniformly, so they surface as a stable ratio rather than noise.
+/// Two models sit behind that factor. The fallback is an EWMA of the
+/// actual/estimated ratio. The one that sizes a budget is a fitted line,
+/// `actual ≈ slope · estimated + intercept`. The intercept holds the
+/// per-request overhead the heuristic cannot see, such as tool schemas and
+/// provider framing. That overhead is a fixed block of tokens, not a share
+/// of the conversation, so it never settles into a stable ratio: an 8k block
+/// reads 2.6 against a 5k conversation and 1.08 against a 100k one.
+/// [`Calibration::effective_budget`] solves that line for the size a budget
+/// affords instead of dividing by a ratio, and
+/// `a_constant_overhead_does_not_halve_the_compaction_budget` is the witness.
 ///
 /// Pure state — no I/O, no clock. Persistence of samples across sessions is
 /// `stella-store`'s job; replay them through [`Calibration::record`] (oldest

--- a/crates/stella-core/src/subagent.rs
+++ b/crates/stella-core/src/subagent.rs
@@ -293,19 +293,26 @@ pub struct SubAgentSpec {
     /// The name of the seat this child runs on, as its requester spelled it.
     ///
     /// **Opaque to the engine, by design.** A plugin declares the roles its
-    /// process needs — `"planner"`, `"reviewer"`, `"second-opinion"` — and the
-    /// host resolves that name against whatever model the *user* assigned to
-    /// it. Nothing in `stella-core` may branch on the contents of this string:
+    /// process needs and sends a bare role name. The host writes the plugin
+    /// half in front of it, so the value that reaches this field is a whole
+    /// seat key, `<plugin-id>/<role>` — `"vera/verifier"`,
+    /// `"acme-plan/planner"`. `stella-plugin`'s `seat_key` is the one place a
+    /// key is built. The host then resolves the whole string against whatever
+    /// model the *user* assigned to it under `[seats]`.
+    ///
+    /// Nothing in `stella-core` may branch on the contents of this string:
     /// the moment the engine knows that `"planner"` means planning, the set of
     /// processes a plugin can express is capped at the set core anticipated,
-    /// which is the coupling the wrapper socket exists to remove.
+    /// which is the coupling the wrapper socket exists to remove. The engine
+    /// does not split the key either. A half is something a screen shows, not
+    /// something a lookup reads.
     ///
     /// `None` means "the requester named no seat", which every caller resolves
-    /// to the session's own model. That is also what an unassigned seat
-    /// resolves to, so a plugin that declares a `planner` role runs
-    /// single-model until a user decides otherwise — the plugin describes its
-    /// process, and whether that process is multi-model is the user's choice,
-    /// never the plugin's and never core's.
+    /// to the session's own model. A `delegate` child carries `None`, and so
+    /// does an unassigned seat, so a plugin that declares a `planner` role
+    /// runs single-model until a user decides otherwise — the plugin describes
+    /// its process, and whether that process is multi-model is the user's
+    /// choice, never the plugin's and never core's.
     pub seat: Option<String>,
     /// Receipt turn slot. Context receipts key on
     /// `(execution_id, turn_instance, step, call_seq)` and every turn

--- a/crates/stella-core/tests/spend_gate.rs
+++ b/crates/stella-core/tests/spend_gate.rs
@@ -28,11 +28,12 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use async_trait::async_trait;
 use serde_json::Value;
 use stella_core::budget::BudgetGuard;
+use stella_core::driver::rate_limit::MAX_PARKED_WAIT_MS;
 use stella_core::hooks::{
     HookAction, HookExecError, HookExecResult, HookMatcher, HookRunner, Hooks,
 };
 use stella_core::ports::{FallbackResolver, ResolvedFallback, ToolExecutor};
-use stella_core::retry::Sleeper;
+use stella_core::retry::{ParkPlan, Sleeper, plan_park};
 use stella_core::{Engine, EngineConfig, TurnCapabilities, TurnOutcome};
 use stella_protocol::{
     BudgetMode, CompletionMessage, CompletionRequestRef, CompletionResult, CompletionUsage,
@@ -748,6 +749,209 @@ async fn a_denying_stop_hook_buys_one_call_per_held_round() {
             model_calls: 4,
             tool_calls: 0,
             cost_usd: 4.0 * CALL_COST_USD,
+        },
+    );
+}
+
+/// How many parks a deadline-less turn can take before its wait allowance is
+/// spent.
+///
+/// Derived from the two things that decide it: `plan_park` and
+/// `MAX_PARKED_WAIT_MS`. The loop mirrors the park accounting in
+/// `retry::retry_with_backoff_observed`. The allowance is what the ceiling has
+/// left. The streak is how many parks came before.
+fn parks_a_deadline_less_turn_can_take() -> u32 {
+    let mut waited_ms = 0u64;
+    let mut parks = 0u32;
+    loop {
+        let allowance_ms = MAX_PARKED_WAIT_MS.saturating_sub(waited_ms);
+        match plan_park(None, parks, allowance_ms) {
+            ParkPlan::Wait { total_ms } => {
+                waited_ms = waited_ms.saturating_add(total_ms);
+                parks = parks.saturating_add(1);
+            }
+            ParkPlan::GiveUp => return parks,
+        }
+    }
+}
+
+/// The worst case of a parked wait: every paid attempt a deadline-less turn
+/// can buy before the allowance runs out.
+///
+/// `a_parked_rate_limit_buys_one_attempt_per_park` prices one park.
+/// `a_stated_backoff_no_park_can_afford_buys_one_attempt` prices the fail-fast
+/// direction. Neither pins the total, and the total is what bounds the spend.
+/// A provider that refuses every call parks dozens of times, and each park
+/// buys one more paid attempt.
+///
+/// The pin is derived, not a literal. Change the ceiling or the backoff and
+/// the expected number moves with it. A literal here would be a magic number
+/// nobody can check.
+#[tokio::test]
+async fn a_deadline_less_parked_wait_buys_a_bounded_number_of_attempts() {
+    let refused = Err(ProviderError::RateLimited {
+        message: "429, never clearing".into(),
+        retry_after_ms: None,
+    });
+    // One entry, and the scripted provider repeats its last: every call is
+    // refused, so the turn ends when the allowance is spent rather than when
+    // the script runs out.
+    let (outcome, spend) = run_turn(vec![refused]).await;
+
+    let inline_attempts = EngineConfig::default().retry_policy.max_retries + 1;
+    let parks = parks_a_deadline_less_turn_can_take();
+    assert!(
+        parks > 1,
+        "the fixture must actually park more than once, or this prices the \
+         same thing the one-park scenario does: {parks}"
+    );
+
+    match &outcome {
+        TurnOutcome::Aborted { reason, .. } => {
+            assert!(reason.contains("429"), "unexpected reason: {reason}");
+        }
+        other => panic!("a provider that never clears cannot complete: {other:?}"),
+    }
+    assert_spend(
+        "every park a deadline-less wait can take (driver::rate_limit)",
+        &spend,
+        &Spend {
+            // The inline ladder's attempts, then one more per park.
+            model_calls: inline_attempts + parks,
+            tool_calls: 0,
+            cost_usd: 0.0,
+        },
+    );
+}
+
+/// A step the provider cut off at the output-token limit, with text to keep.
+fn truncated(text: &str) -> CompletionResult {
+    CompletionResult {
+        finish_reason: Some(stella_protocol::FinishReason::Length),
+        ..answer(text)
+    }
+}
+
+/// A call that hit the output limit before producing a single answer token —
+/// the shape `starvation::starved_of_output` recognises.
+fn starved() -> CompletionResult {
+    CompletionResult {
+        finish_reason: Some(stella_protocol::FinishReason::Length),
+        ..answer("")
+    }
+}
+
+/// The summarizer's own request rejected for its size, over and over.
+///
+/// The call that shrinks the transcript is refused for being too big. So the
+/// older head of the render is dropped and the summarizer is asked again.
+/// Every rejected attempt reached the provider and is a paid call.
+/// `SUMMARIZER_OVERFLOW_ATTEMPTS` is what stops it buying more.
+///
+/// Pinned from both sides: what the ladder buys, and the bound. The script
+/// holds the ladder's worth of rejections and then an answer, and the provider
+/// repeats its last entry. Raise the bound and the summarizer eats the answer,
+/// so the count moves. Lower it and the worker call meets a rejection. Either
+/// way this fails.
+#[tokio::test]
+async fn the_summarizers_head_dropping_ladder_buys_one_call_per_attempt() {
+    let rejected = || -> Result<CompletionResult, ProviderError> {
+        Err(ProviderError::ContextOverflow {
+            message: "summarizer request is too long".into(),
+        })
+    };
+    let mut script: Vec<Result<CompletionResult, ProviderError>> =
+        (0..3).map(|_| rejected()).collect();
+    script.push(Ok(answer("done")));
+
+    let (outcome, spend) = Turn::new(script)
+        .messages(long_transcript())
+        .config(|config| config.compaction_budget_tokens = 1)
+        .run()
+        .await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "done".into(),
+            cost_usd: CALL_COST_USD,
+        },
+        "the summarizer gives up, the context is left intact, and the worker \
+         step still answers"
+    );
+    assert_spend(
+        "summarizer head-dropping ladder (driver::restore's \
+         summarize_overflow_span)",
+        &spend,
+        &Spend {
+            // Three rejected summarizer dispatches, then the worker's call.
+            // A rejection bills nothing, so only the answer is in the cost.
+            model_calls: 4,
+            tool_calls: 0,
+            cost_usd: CALL_COST_USD,
+        },
+    );
+}
+
+/// The summarizer answered empty at its token limit, so it is asked once more
+/// with real room.
+///
+/// Both attempts bill. Reporting only the surviving one would understate the
+/// turn by what the starvation cost.
+#[tokio::test]
+async fn the_summarizers_starved_retry_buys_one_more_call() {
+    let (outcome, spend) = Turn::new(vec![
+        Ok(starved()),
+        Ok(answer("SUMMARY")),
+        Ok(answer("done")),
+    ])
+    .messages(long_transcript())
+    .config(|config| config.compaction_budget_tokens = 1)
+    .run()
+    .await;
+
+    assert_eq!(
+        outcome,
+        TurnOutcome::Completed {
+            text: "done".into(),
+            cost_usd: 3.0 * CALL_COST_USD,
+        },
+        "the starved attempt's cost folds into the turn total beside the \
+         retry's"
+    );
+    assert_spend(
+        "summarizer starved retry (crate::starvation through driver::restore)",
+        &spend,
+        &Spend {
+            model_calls: 3,
+            tool_calls: 0,
+            cost_usd: 3.0 * CALL_COST_USD,
+        },
+    );
+}
+
+/// A tool-less step cut off at the output limit is continued. One paid call
+/// per continuation, up to the turn's allowance.
+///
+/// The script truncates more times than the allowance can absorb, so the bound
+/// is what ends the turn. That is the second half of the pin.
+#[tokio::test]
+async fn the_length_continuation_ladder_buys_one_call_per_continuation() {
+    let script: Vec<Result<CompletionResult, ProviderError>> = (0..8)
+        .map(|i| Ok(truncated(&format!("part {i} "))))
+        .collect();
+
+    let (_outcome, spend) = run_turn(script).await;
+
+    assert_spend(
+        "length-continuation ladder (driver::truncation)",
+        &spend,
+        &Spend {
+            // The first cut-off step, then one call per continuation until
+            // the allowance is spent.
+            model_calls: 5,
+            tool_calls: 0,
+            cost_usd: 5.0 * CALL_COST_USD,
         },
     );
 }

--- a/crates/stella-engine/README.md
+++ b/crates/stella-engine/README.md
@@ -88,13 +88,18 @@ because a host forwards or serializes an event rather than constructing one. A
 facade closed over mere reachability would be `stella-protocol` with extra
 steps.
 
-The rule is a coherence property of what is *already* exported, not a licence
-to widen the facade for an imagined caller — the distinction that separates it
-from #2481, which asked for turn-boundary payload shapers no exported
-signature names and was closed as speculative. A genuinely new capability is
-still a design question; making an already-reachable one writable is not.
-Every entry arrives with doc prose explaining its place in the host-driving
-story.
+The rule is a coherence property of what is *already* exported. A genuinely
+new capability is still a design question; making an already-reachable one
+writable is not. Every entry arrives with doc prose explaining its place in
+the host-driving story.
+
+**Two ways to run a turn, and only one of them frames it for you.** Hand a
+`TurnState` to `Engine::drive` and the engine emits `agent.turn.started` and
+`agent.turn.completed` itself. Drive `run_step` in your own loop and the
+framing is yours: `turn_started_payload` and `turn_outcome_payload` are
+re-exported so those two events carry the shape a locally-driven turn carries,
+which is what stops an extension watching the bus from telling the two apart
+(#2481).
 
 **The hook plane is the wrong layer, by design.** Two seams are not closed
 over: `hooks` (`Hooks`, `HookRunner`) and `bus` (`HookBus`). Their closure is the shell-command hook plane, an extension surface

--- a/crates/stella-engine/src/lib.rs
+++ b/crates/stella-engine/src/lib.rs
@@ -136,11 +136,19 @@
 //! one. A facade closed over mere reachability would be `stella-protocol`
 //! with extra steps.
 //!
-//! This is a coherence property of what is *already* exported, not a widening
-//! for an imagined caller — the distinction that separates it from #2481,
-//! which asked for turn-boundary payload shapers no exported signature names
-//! and was closed as speculative. Nothing below adds a capability; each entry
-//! makes an already-reachable one writable.
+//! Most of the block below is a coherence property of what is *already*
+//! exported: each entry makes an already-reachable capability writable rather
+//! than adding one.
+//!
+//! [`turn_started_payload`] and [`turn_outcome_payload`] are the exception,
+//! and they earn their place under obligation 3 read at the bus rather than
+//! at a return value. A host that drives [`Engine::run_step`] owns the turn
+//! framing its loop does not carry, and must emit `agent.turn.started` and
+//! `agent.turn.completed` in the engine's own shape — otherwise an extension
+//! watching the bus can tell a host-driven turn from a local one, which is
+//! the drift the shared `run_step` exists to prevent. That is a contract this
+//! facade owes, so the two shapers are here instead of costing such a host a
+//! direct `stella-core` dependency (#2481).
 //!
 //! ## The hook plane is the wrong layer, by design
 //!
@@ -221,6 +229,14 @@ pub use stella_core::driver::{
 // its seams with no frame above holding them is the case that struct exists
 // for, which is exactly an out-of-process host.
 pub use stella_core::driver::capabilities::{OwnedTurnCapabilities, TurnCapabilities};
+// ── framing a turn the host drives itself ─────────────────────────────────
+//
+// The two shapers a `run_step`-driving host needs to emit `agent.turn.started`
+// and `agent.turn.completed` in the shape `Engine::drive` emits them (#2481).
+// `TurnLane` rides with them because `turn_started_payload` takes one — and
+// obligation 2 already owed it, since `OwnedTurnCapabilities::lane` is an
+// `Option<TurnLane>` a host fills and could not name.
+pub use stella_core::driver::lifecycle::{turn_outcome_payload, turn_started_payload};
 pub use stella_core::estimator::CalibrationMap;
 pub use stella_core::event_sender::{EventSendError, EventSender};
 pub use stella_core::loop_detect::LoopDetectionConfig;
@@ -291,7 +307,7 @@ pub use stella_protocol::{
     AgentEvent, Attachment, AttachmentKind, AttachmentSource, BudgetMode, CompletionMessage,
     CompletionRequestRef, CompletionResult, CompletionUsage, FinishReason, GenerationParams,
     MessageRole, ModelCallRole, Provider, ProviderError, ReasoningEffort, ServiceTier, ToolCall,
-    ToolCallObserver, ToolContract, ToolOutput, ToolResult, ToolSchema, Verbosity,
+    ToolCallObserver, ToolContract, ToolOutput, ToolResult, ToolSchema, TurnLane, Verbosity,
 };
 
 /// Encode a checkpoint for durable storage.

--- a/crates/stella-engine/src/lib.rs
+++ b/crates/stella-engine/src/lib.rs
@@ -116,9 +116,9 @@
 //!
 //! # What earns a re-export: the closure rule
 //!
-//! This is the crate's whole editorial policy, and `README.md` states it in
-//! the same words. A narrower rule in one of the two places is what leaves a
-//! builder reachable through the facade and uncallable through it.
+//! The crate's editorial policy, stated in `README.md` in the same words. A
+//! narrower rule in one place leaves a builder reachable through the facade
+//! and uncallable through it.
 //!
 //! **The rule.** A host must be able to write, naming nothing but
 //! `stella_engine::` paths:
@@ -130,25 +130,17 @@
 //!
 //! Closure is transitive through those three obligations and stops where they
 //! stop. [`GenerationParams`] is re-exported because a host fills that config
-//! field, so [`Verbosity`] and [`ServiceTier`] come with it; [`AgentEvent`] is
-//! re-exported because a host receives one, and its payload types are not,
-//! because a host forwards or serializes an event rather than constructing
-//! one. A facade closed over mere reachability would be `stella-protocol`
-//! with extra steps.
+//! field, so [`Verbosity`] and [`ServiceTier`] come with it. [`AgentEvent`] is
+//! re-exported because a host receives one; its payload types are not, because
+//! a host forwards an event rather than building one. Closing over mere
+//! reachability would make this `stella-protocol` with extra steps.
 //!
-//! Most of the block below is a coherence property of what is *already*
-//! exported: each entry makes an already-reachable capability writable rather
-//! than adding one.
-//!
-//! [`turn_started_payload`] and [`turn_outcome_payload`] are the exception,
-//! and they earn their place under obligation 3 read at the bus rather than
-//! at a return value. A host that drives [`Engine::run_step`] owns the turn
-//! framing its loop does not carry, and must emit `agent.turn.started` and
-//! `agent.turn.completed` in the engine's own shape — otherwise an extension
-//! watching the bus can tell a host-driven turn from a local one, which is
-//! the drift the shared `run_step` exists to prevent. That is a contract this
-//! facade owes, so the two shapers are here instead of costing such a host a
-//! direct `stella-core` dependency (#2481).
+//! Most of the block below makes an already-reachable capability writable
+//! rather than adding one. [`turn_started_payload`] and
+//! [`turn_outcome_payload`] are the exception: obligation 3, read at the bus.
+//! A host driving [`Engine::run_step`] frames its own turn, and must emit
+//! both boundaries in the engine's shape or an extension can tell its turn
+//! from a local one.
 //!
 //! ## The hook plane is the wrong layer, by design
 //!
@@ -232,10 +224,10 @@ pub use stella_core::driver::capabilities::{OwnedTurnCapabilities, TurnCapabilit
 // ── framing a turn the host drives itself ─────────────────────────────────
 //
 // The two shapers a `run_step`-driving host needs to emit `agent.turn.started`
-// and `agent.turn.completed` in the shape `Engine::drive` emits them (#2481).
+// and `agent.turn.completed` in the shape `Engine::drive` emits them.
 // `TurnLane` rides with them because `turn_started_payload` takes one — and
 // obligation 2 already owed it, since `OwnedTurnCapabilities::lane` is an
-// `Option<TurnLane>` a host fills and could not name.
+// `Option<TurnLane>` a host fills and cannot otherwise name.
 pub use stella_core::driver::lifecycle::{turn_outcome_payload, turn_started_payload};
 pub use stella_core::estimator::CalibrationMap;
 pub use stella_core::event_sender::{EventSendError, EventSender};

--- a/crates/stella-engine/tests/embedding.rs
+++ b/crates/stella-engine/tests/embedding.rs
@@ -556,9 +556,9 @@ mod the_exclusion_is_enforced {
 /// turn, and the facade must let it do that without naming `stella_core::`.
 ///
 /// Every path below is a `stella_engine::` one, so on a tree that does not
-/// re-export the two shapers this file does not compile. That is the witness
-/// (#2481). The assertions pin the shape a locally-driven turn puts on the
-/// bus, so a host copying these payloads cannot drift from it.
+/// re-export the two shapers this file does not compile. That is the witness.
+/// The assertions pin the shape a locally-driven turn puts on the bus, so a
+/// host copying these payloads cannot drift from it.
 #[test]
 fn a_host_can_frame_its_own_turn_through_the_facade_alone() {
     let lane: Option<&stella_engine::TurnLane> = None;

--- a/crates/stella-engine/tests/embedding.rs
+++ b/crates/stella-engine/tests/embedding.rs
@@ -551,3 +551,41 @@ mod the_exclusion_is_enforced {
         let _draft: HookEventDraft = HookEventDraft;
     }
 }
+
+/// A host that drives `run_step` rather than `Engine::drive` frames its own
+/// turn, and the facade must let it do that without naming `stella_core::`.
+///
+/// Every path below is a `stella_engine::` one, so on a tree that does not
+/// re-export the two shapers this file does not compile. That is the witness
+/// (#2481). The assertions pin the shape a locally-driven turn puts on the
+/// bus, so a host copying these payloads cannot drift from it.
+#[test]
+fn a_host_can_frame_its_own_turn_through_the_facade_alone() {
+    let lane: Option<&stella_engine::TurnLane> = None;
+    let started = stella_engine::turn_started_payload(
+        3,
+        Some(12),
+        stella_engine::ModelCallRole::Worker,
+        lane,
+    );
+    assert_eq!(started["message_count"], 3);
+    assert_eq!(started["max_steps"], 12);
+    assert!(
+        started["lane"].is_null(),
+        "an unnamed lane is its own bucket, not a missing key: {started}"
+    );
+
+    let completed = stella_engine::turn_outcome_payload(
+        &stella_engine::TurnOutcome::Completed {
+            text: "done".to_string(),
+            cost_usd: 0.25,
+        },
+        4,
+    );
+    assert_eq!(completed["outcome"], "completed");
+    assert_eq!(completed["steps"], 4);
+    assert!(
+        completed.get("text").is_none(),
+        "answer text is transcript content and never rides the boundary: {completed}"
+    );
+}

--- a/crates/stella-fleet/src/fleet/tests.rs
+++ b/crates/stella-fleet/src/fleet/tests.rs
@@ -474,12 +474,21 @@ async fn a_cancelled_dispatch_releases_its_claims_and_control_handle() {
     // return does. Without the RAII guards both leak: the claim row
     // outlives the process and blocks every later run on that path, and
     // `pause_task` keeps answering `true` for a worker that is gone.
+    //
+    // The repo root is this test's alone, and it has to stay that way. This is
+    // the one test here that asserts on a SINGLE poll, and the poll has to
+    // reach `register_controls`. On the way it takes the worktree lock, which
+    // `git::worktree_lock` keys by repo root in a process-global map — so a
+    // sibling test holding `/repo`'s lock at that instant parks this poll at
+    // the acquire, before the registration, and the assertion below fails
+    // with a worker that was never registered rather than one that leaked.
+    // Cargo runs these on parallel threads and a dozen of them share `/repo`.
     use futures_util::FutureExt;
 
     let gate = Arc::new(tokio::sync::Semaphore::new(0));
     let f = Fleet::new(
         GatedWorker { gate: gate.clone() },
-        WorktreeManager::new(OkGit::new(), "/repo"),
+        WorktreeManager::new(OkGit::new(), "/repo-cancelled-dispatch"),
         Ledger::open_in_memory().unwrap(),
         BudgetGuard::new(BudgetMode::Observed, None, None),
         SeqClock::new(),

--- a/crates/stella-learn/src/skills.rs
+++ b/crates/stella-learn/src/skills.rs
@@ -100,6 +100,34 @@ pub enum SkillOrigin {
     Contributed,
 }
 
+impl SkillOrigin {
+    /// Every origin, in declaration order.
+    ///
+    /// A test that means "for every origin that is not `AutoCreated`" reads
+    /// this and filters, rather than spelling the list. A spelled list goes
+    /// stale the day an origin joins the enum: the demotion-protection suite
+    /// named three of five, so a plugin's skill was protected by the code and
+    /// checked by nothing.
+    ///
+    /// `every_origin_is_listed` holds this table to the enum.
+    pub const ALL: &'static [Self] = &[
+        Self::Workspace,
+        Self::User,
+        Self::AutoCreated,
+        Self::Installed,
+        Self::Contributed,
+    ];
+
+    /// Whether a person wrote this skill, rather than the mining loop.
+    ///
+    /// The one question `decide_demotion` asks about provenance, named here so
+    /// a test can enumerate the protected origins instead of listing them.
+    #[must_use]
+    pub fn is_hand_authored(self) -> bool {
+        !matches!(self, Self::AutoCreated)
+    }
+}
+
 /// One workspace skill, parsed from a `SKILL.md`/`<slug>.md` file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Skill {

--- a/crates/stella-learn/src/skills/appraisal/tests.rs
+++ b/crates/stella-learn/src/skills/appraisal/tests.rs
@@ -188,8 +188,12 @@ fn a_regressing_skill_is_demoted_with_its_evidence() {
 }
 
 /// #1068's scope guard: a hand-authored skill with an identically regressing
-/// window is not demoted. Checked for every origin that is not `AutoCreated`,
-/// so a new origin is protected by default rather than by remembering.
+/// window is not demoted. Checked for every origin that is not `AutoCreated`.
+///
+/// Read off `SkillOrigin::ALL` rather than spelled. A spelled list named
+/// three origins while the enum held five. So `Contributed` — a plugin's
+/// skill — was safe in the code and pinned by nothing. That is the accident
+/// the line above promises will not happen.
 #[test]
 fn a_hand_authored_skill_is_never_auto_demoted() {
     let trials = window(8, 0, 8);
@@ -199,11 +203,16 @@ fn a_hand_authored_skill_is_never_auto_demoted() {
         "the fixture's window really does regress"
     );
 
-    for origin in [
-        SkillOrigin::Workspace,
-        SkillOrigin::User,
-        SkillOrigin::Installed,
-    ] {
+    let protected: Vec<SkillOrigin> = SkillOrigin::ALL
+        .iter()
+        .copied()
+        .filter(|origin| origin.is_hand_authored())
+        .collect();
+    assert!(
+        protected.contains(&SkillOrigin::Contributed),
+        "a plugin's skill is hand-authored by somebody, and the enumeration          must reach it: {protected:?}"
+    );
+    for origin in protected {
         assert_eq!(
             decide_demotion(origin, &appraisal),
             DemotionDecision::Keep {
@@ -214,6 +223,40 @@ fn a_hand_authored_skill_is_never_auto_demoted() {
     }
     // Only the auto-created one moves.
     assert!(decide_demotion(SkillOrigin::AutoCreated, &appraisal).is_demotion());
+}
+
+/// `SkillOrigin::ALL` really is every origin.
+///
+/// The `match` is exhaustive. A new origin stops this file compiling until
+/// somebody adds an arm. The arm sits beside the check that the same origin is
+/// in `ALL`, which is the list every caller reads.
+#[test]
+fn every_origin_is_listed() {
+    let each = [
+        SkillOrigin::Workspace,
+        SkillOrigin::User,
+        SkillOrigin::AutoCreated,
+        SkillOrigin::Installed,
+        SkillOrigin::Contributed,
+    ];
+    for origin in each {
+        match origin {
+            SkillOrigin::Workspace
+            | SkillOrigin::User
+            | SkillOrigin::AutoCreated
+            | SkillOrigin::Installed
+            | SkillOrigin::Contributed => {}
+        }
+        assert!(
+            SkillOrigin::ALL.contains(&origin),
+            "{origin:?} is an origin the ALL table does not list"
+        );
+    }
+    assert_eq!(
+        SkillOrigin::ALL.len(),
+        each.len(),
+        "ALL holds an entry this test does not know about"
+    );
 }
 
 /// A short window never demotes: "we have not measured anything" must not be
@@ -410,7 +453,7 @@ proptest! {
         trials in proptest::collection::vec(arb_trial(), 0..60),
     ) {
         let appraisal = appraise("s", &trials, &AppraisalConfig::default());
-        for origin in [SkillOrigin::Workspace, SkillOrigin::User, SkillOrigin::Installed] {
+        for origin in SkillOrigin::ALL.iter().copied().filter(|o| o.is_hand_authored()) {
             prop_assert_eq!(
                 decide_demotion(origin, &appraisal),
                 DemotionDecision::Keep { reason: KeepSkillReason::HandAuthored }

--- a/crates/stella-learn/src/skills/tests.rs
+++ b/crates/stella-learn/src/skills/tests.rs
@@ -8,6 +8,8 @@
 
 use super::*;
 
+mod selection;
+
 // ---- parsing: frontmatter, layouts, diagnostics ----
 
 #[test]

--- a/crates/stella-learn/src/skills/tests/selection.rs
+++ b/crates/stella-learn/src/skills/tests/selection.rs
@@ -1,0 +1,136 @@
+//! Selection tests for [`crate::skills`] that the parent module has no room
+//! for. `skills/tests.rs` is close to the file-size ceiling, and the rule is
+//! to split rather than grow.
+
+use super::super::*;
+use super::skill;
+
+/// The panic `floor_char_boundary` exists to stop: a body of CJK or emoji cut
+/// at a byte offset inside a character.
+///
+/// The other truncation tests are ASCII. Every byte there is a boundary, so
+/// the walk-back never runs. The result must be a valid `str`, since a bad
+/// slice would have panicked. It must also be a *prefix* of the input, so the
+/// cut goes back and never forward.
+#[test]
+fn a_multi_byte_body_is_cut_at_a_character_boundary() {
+    for glyph in ["漢", "🙂", "é"] {
+        let text: String = std::iter::repeat_n(glyph, 4000).collect();
+        // A budget the byte cut cannot land on cleanly for a 3-byte or
+        // 4-byte glyph. That is the case the walk-back is for.
+        let cut = truncate_to_tokens(&text, 100);
+        let body = cut
+            .strip_suffix(SKILL_BODY_TRUNCATION_MARKER)
+            .expect("a body over budget is marked as truncated");
+        assert!(
+            text.starts_with(body),
+            "{glyph} truncation moved forward past the budget: {body:?}"
+        );
+        assert!(
+            !body.is_empty(),
+            "{glyph} truncation walked all the way back to nothing"
+        );
+    }
+
+    let ascii = "a".repeat(4000);
+    assert!(
+        truncate_to_tokens(&ascii, 100).starts_with(&ascii[..10]),
+        "the ASCII path is unchanged by the boundary walk"
+    );
+}
+
+/// Two skills that score the same are ordered by name, low to high.
+///
+/// `auto_created_skill_wins_the_tie_break` asserts unequal scores, so it never
+/// reaches `then_with`. A real workspace makes equal scores all the time: two
+/// skills over one vocabulary. With no total order the output is stable at
+/// best, which means the input order decides it.
+#[test]
+fn skills_with_the_same_score_are_ordered_by_name() {
+    // Same description and same body. The only difference is the one term
+    // each name adds. Neither term is in the prompt, and there is one apiece,
+    // so both coverage sums divide by the same number.
+    let twin = |name: &str| Skill {
+        name: name.to_string(),
+        description: "prefer tables for comparisons".to_string(),
+        domains: Vec::new(),
+        body: "prefer tables for comparisons in every answer".to_string(),
+        source_path: format!("{name}.md"),
+        origin: SkillOrigin::Workspace,
+        contributed_by: None,
+    };
+
+    for order in [["zulu", "alpha"], ["alpha", "zulu"]] {
+        let skills = vec![twin(order[0]), twin(order[1])];
+        let selected = select_skills(
+            &skills,
+            "prefer tables for comparisons please",
+            &[],
+            &SelectionConfig::default(),
+        );
+        assert_eq!(selected.len(), 2, "both skills clear the floor");
+        assert_eq!(
+            selected[0].score, selected[1].score,
+            "the fixture really is a tie"
+        );
+        assert_eq!(
+            [
+                selected[0].skill.name.as_str(),
+                selected[1].skill.name.as_str()
+            ],
+            ["alpha", "zulu"],
+            "input order {order:?} must not decide the output order"
+        );
+    }
+}
+
+/// `SkillSelection::over_top_k` holds what `max_skills` cut, in the same
+/// order, and `selected` matches `select_skills` exactly.
+///
+/// `steering::adapt` reads that tail to name an eviction. Nothing pinned the
+/// split, so a `split_off` at the wrong index would move a survivor into the
+/// tail and nothing would notice.
+#[test]
+fn over_top_k_holds_exactly_what_max_skills_cut() {
+    let skills: Vec<Skill> = ["alpha", "bravo", "charlie", "delta"]
+        .iter()
+        .map(|name| skill(name, "format sql queries", &["sql"], SkillOrigin::Workspace))
+        .collect();
+    let config = SelectionConfig {
+        max_skills: 2,
+        ..SelectionConfig::default()
+    };
+    let reported = select_skills_reporting(&skills, "format sql", &["sql".to_string()], &config);
+
+    assert_eq!(reported.selected.len(), 2, "top-k is the cut, not a hint");
+    assert_eq!(
+        reported.over_top_k.len(),
+        2,
+        "every skill that cleared the floor and lost a seat is kept"
+    );
+    assert_eq!(
+        reported.selected,
+        select_skills(&skills, "format sql", &["sql".to_string()], &config),
+        "the survivors are what the plain call returns"
+    );
+    let tail_scores: Vec<f64> = reported.over_top_k.iter().map(|s| s.score).collect();
+    assert!(
+        tail_scores.windows(2).all(|w| w[0] >= w[1]),
+        "the tail keeps the descending order: {tail_scores:?}"
+    );
+    assert!(
+        reported.selected.last().unwrap().score >= reported.over_top_k[0].score,
+        "nothing in the tail outranks a survivor"
+    );
+
+    let roomy = SelectionConfig {
+        max_skills: 10,
+        ..SelectionConfig::default()
+    };
+    assert!(
+        select_skills_reporting(&skills, "format sql", &["sql".to_string()], &roomy)
+            .over_top_k
+            .is_empty(),
+        "a cut that removes nothing reports nothing"
+    );
+}

--- a/crates/stella-protocol/src/frontmatter.rs
+++ b/crates/stella-protocol/src/frontmatter.rs
@@ -20,16 +20,11 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Frontmatter {
     pub data: HashMap<String, String>,
-    /// Keys that showed up more than once, first repeat first. The last
-    /// value still wins in `data`, as it always has. A caller that checks a
-    /// schema can turn that around and refuse the file.
-    pub duplicate_keys: Vec<String>,
     /// Keys **indented under another key**. That is a nested map, and one
     /// line at a time cannot hold it.
     ///
-    /// Noted here, acted on elsewhere, for the reason `duplicate_keys` is:
-    /// skills, rules and extensions all read this, and a nested key means a
-    /// different thing to each of them.
+    /// Noted here, acted on elsewhere: skills, rules and extensions all read
+    /// this, and a nested key means a different thing to each of them.
     /// `stella_learn::rules::rule_from_file` refuses a rule that has any.
     ///
     /// Why it matters (ADR 0011, Consequences): the parser drops the
@@ -45,6 +40,20 @@ pub struct Frontmatter {
     /// have. That is the shape of a guard script that prints OK and skips
     /// most of its input.
     pub nested_keys: Vec<String>,
+    /// The top-level keys those nested children sat under, first parent
+    /// first.
+    ///
+    /// A caller that must decide per field needs the parent, not the child:
+    /// ADR 0025 refuses a nested value only where reading it wrong would
+    /// widen what the file may do, and `tools:` is such a key while
+    /// `description:` is not. `nested_keys` alone cannot tell those apart, so
+    /// `stella-cli`'s `agent_from_file` used to refuse an agent for nesting
+    /// under any key at all.
+    ///
+    /// A set of parents, not pairs. Every caller so far asks whether one
+    /// named key was nested, and a pair list would answer that no better
+    /// while making the common `is_empty` read longer.
+    pub nested_parents: Vec<String>,
     pub body: String,
 }
 
@@ -70,8 +79,9 @@ pub(crate) fn strip_matched_quotes(value: &str) -> &str {
 /// the author wrote it.
 ///
 /// A key **indented under another key** goes to
-/// [`Frontmatter::nested_keys`]. It is not raised to the top level. That
-/// field's own docs say why raising it was a bug.
+/// [`Frontmatter::nested_keys`], and the key it sat under goes to
+/// [`Frontmatter::nested_parents`]. Neither is raised to the top level. The
+/// first field's own docs say why raising it was a bug.
 pub fn parse_frontmatter(raw: &str) -> Frontmatter {
     let text = raw.strip_prefix('\u{feff}').unwrap_or(raw);
     if !text.starts_with("---") {
@@ -97,8 +107,8 @@ pub fn parse_frontmatter(raw: &str) -> Frontmatter {
         .to_string();
 
     let mut data = HashMap::new();
-    let mut duplicate_keys = Vec::new();
     let mut nested_keys = Vec::new();
+    let mut nested_parents = Vec::new();
     // The key whose scalar value was empty on its own line — the head of a
     // possible YAML block sequence (`tools:` followed by `- Read` lines).
     let mut pending_list_key: Option<String> = None;
@@ -106,6 +116,9 @@ pub fn parse_frontmatter(raw: &str) -> Frontmatter {
     // Anything deeper is a nested mapping. Read from the file rather than assumed
     // to be zero so a frontmatter block someone indented wholesale still parses.
     let mut base_indent: Option<usize> = None;
+    // The most recent key at the base indent — the parent any deeper key
+    // hangs under.
+    let mut last_base_key: Option<String> = None;
     for line in header.lines() {
         let trimmed = line.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
@@ -144,18 +157,21 @@ pub fn parse_frontmatter(raw: &str) -> Frontmatter {
             if !nested_keys.iter().any(|seen| seen == key) {
                 nested_keys.push(key.to_string());
             }
+            if let Some(parent) = &last_base_key
+                && !nested_parents.iter().any(|seen| seen == parent)
+            {
+                nested_parents.push(parent.clone());
+            }
             continue;
-        }
-        if data.contains_key(key) && !duplicate_keys.iter().any(|seen| seen == key) {
-            duplicate_keys.push(key.to_string());
         }
         data.insert(key.to_string(), value.to_string());
         pending_list_key = value.is_empty().then(|| key.to_string());
+        last_base_key = Some(key.to_string());
     }
     Frontmatter {
         data,
-        duplicate_keys,
         nested_keys,
+        nested_parents,
         body,
     }
 }
@@ -224,5 +240,37 @@ mod tests {
         let fm = parse_frontmatter("---\ndescription: d\n- stray item\n---\nbody");
         assert_eq!(fm.data.len(), 1);
         assert_eq!(fm.data.get("description").unwrap(), "d");
+    }
+
+    /// A nested mapping records both halves: the child names, and the key the
+    /// nesting hung under. Without the parent, a caller cannot ask whether
+    /// the nested key was one that grants a capability, which is the question
+    /// ADR 0025 turns on.
+    #[test]
+    fn a_nested_mapping_records_the_key_it_sat_under() {
+        let fm = parse_frontmatter(
+            "---\nname: reviewer\ntools:\n  read: true\n  write: false\ndescription: d\n---\nbody",
+        );
+        assert_eq!(fm.nested_keys, vec!["read", "write"]);
+        assert_eq!(fm.nested_parents, vec!["tools"]);
+        assert_eq!(
+            fm.data.get("description").unwrap(),
+            "d",
+            "the key after the nesting parses normally"
+        );
+        assert!(
+            !fm.data.contains_key("read"),
+            "a nested child is still never raised to the top level"
+        );
+    }
+
+    /// Two nested mappings keep their own parents, so a caller asking about
+    /// one key is not answered by the other.
+    #[test]
+    fn each_nested_mapping_names_its_own_parent() {
+        let fm =
+            parse_frontmatter("---\ndescription:\n  short: s\ntools:\n  read: true\n---\nbody");
+        assert_eq!(fm.nested_parents, vec!["description", "tools"]);
+        assert_eq!(fm.nested_keys, vec!["short", "read"]);
     }
 }

--- a/crates/stella-protocol/src/frontmatter.rs
+++ b/crates/stella-protocol/src/frontmatter.rs
@@ -43,16 +43,15 @@ pub struct Frontmatter {
     /// The top-level keys those nested children sat under, first parent
     /// first.
     ///
-    /// A caller that must decide per field needs the parent, not the child:
-    /// ADR 0025 refuses a nested value only where reading it wrong would
-    /// widen what the file may do, and `tools:` is such a key while
-    /// `description:` is not. `nested_keys` alone cannot tell those apart, so
-    /// `stella-cli`'s `agent_from_file` used to refuse an agent for nesting
-    /// under any key at all.
+    /// A caller that decides per field needs the parent, not the child. ADR
+    /// 0025 refuses a nested value where reading it wrong would widen what the
+    /// file may do. `tools:` is such a key. `description:` is not.
+    /// `nested_keys` cannot tell them apart, so a caller reading it alone
+    /// refuses an agent for nesting under any key at all.
     ///
-    /// A set of parents, not pairs. Every caller so far asks whether one
-    /// named key was nested, and a pair list would answer that no better
-    /// while making the common `is_empty` read longer.
+    /// A set of parents, not pairs. Every caller so far asks whether one named
+    /// key was nested. Pairs answer that no better, and they make the common
+    /// `is_empty` read longer.
     pub nested_parents: Vec<String>,
     pub body: String,
 }

--- a/crates/stella-records/src/records/bridge.rs
+++ b/crates/stella-records/src/records/bridge.rs
@@ -318,11 +318,10 @@ mod tests {
 
     /// The shared base case both gates read, asked of both of them at once.
     ///
-    /// `verified_by = "   "` is a name nobody wrote. Before the rule was named
-    /// once, the guard gate trimmed and the probe gate did not, so this exact
-    /// record could not approve its own blocking guard and could still arm a
-    /// command. Whichever way that pair is later tightened, both gates move —
-    /// which is what stops the two copies drifting again (#5799).
+    /// `verified_by = "   "` is a name nobody wrote. Two copies of one rule
+    /// drift: one trimmed the name and one did not, so this exact record
+    /// could not approve its own blocking guard and could still arm a
+    /// command. Whichever way the pair is tightened, both gates move.
     #[test]
     fn a_blank_verifier_refuses_at_both_self_attestation_gates() {
         let mut record = user_decree_with_guard();

--- a/crates/stella-records/src/records/bridge.rs
+++ b/crates/stella-records/src/records/bridge.rs
@@ -48,6 +48,7 @@
 
 use super::super::context_record::kind::Origin;
 use super::super::ingest::record::{EnforcementMode, Record, TruthBasis};
+use super::trust::decreed_by_a_named_human_at;
 use super::{LoadedRecord, Trust};
 use stella_learn::rules::{Rule, RuleGuard};
 
@@ -131,18 +132,12 @@ fn may_block(origin: Option<Origin>) -> bool {
 ///
 /// [`Trust::Project`] never qualifies, however impeccable the fields look — see the
 /// module docs. A repository record's route to blocking is the decision ledger.
+/// The shared half is [`decreed_by_a_named_human_at`], which `sweep`'s
+/// `honored_probe` asks too. This gate's own condition is `origin = "user"`:
+/// a `system` record is Stella's own policy and approves nothing on the
+/// user's behalf.
 fn self_attested(record: &Record, trust: Trust) -> bool {
-    if trust != Trust::User {
-        return false;
-    }
-    let named_human = record.truth.as_ref().is_some_and(|truth| {
-        truth.basis == TruthBasis::Decree
-            && truth
-                .verified_by
-                .as_deref()
-                .is_some_and(|by| !by.trim().is_empty())
-    });
-    matches!(record.origin, Some(Origin::User)) && named_human
+    decreed_by_a_named_human_at(record, trust) && matches!(record.origin, Some(Origin::User))
 }
 
 /// Whether a guard's fields amount to something [`evaluate_guards`][ev] can act on.
@@ -319,6 +314,45 @@ mod tests {
             })
         );
         assert_eq!(decision.refusal, None);
+    }
+
+    /// The shared base case both gates read, asked of both of them at once.
+    ///
+    /// `verified_by = "   "` is a name nobody wrote. Before the rule was named
+    /// once, the guard gate trimmed and the probe gate did not, so this exact
+    /// record could not approve its own blocking guard and could still arm a
+    /// command. Whichever way that pair is later tightened, both gates move —
+    /// which is what stops the two copies drifting again (#5799).
+    #[test]
+    fn a_blank_verifier_refuses_at_both_self_attestation_gates() {
+        let mut record = user_decree_with_guard();
+        if let Some(truth) = record.truth.as_mut() {
+            truth.verified_by = Some("   ".to_string());
+            truth.probe = Some(Probe {
+                kind: ProbeKind::CommandSucceeds,
+                path: None,
+                pattern: None,
+                expect: None,
+                note: None,
+            });
+        }
+
+        assert!(
+            !self_attested(&record, Trust::User),
+            "a blank verifier must not approve a blocking guard"
+        );
+        assert!(
+            super::super::sweep::honored_probe(&record, Trust::User).is_none(),
+            "and must not arm a gated probe either"
+        );
+
+        // The same record with a real name passes both, so the assertions
+        // above are about the blank verifier and not about the fixture.
+        if let Some(truth) = record.truth.as_mut() {
+            truth.verified_by = Some("mac".to_string());
+        }
+        assert!(self_attested(&record, Trust::User));
+        assert!(super::super::sweep::honored_probe(&record, Trust::User).is_some());
     }
 
     // The absolute refusal — the acceptance test #890 asks for.

--- a/crates/stella-records/src/records/bridge.rs
+++ b/crates/stella-records/src/records/bridge.rs
@@ -47,7 +47,7 @@
 //! any other.
 
 use super::super::context_record::kind::Origin;
-use super::super::ingest::record::{EnforcementMode, Record, TruthBasis};
+use super::super::ingest::record::{EnforcementMode, Record};
 use super::trust::decreed_by_a_named_human_at;
 use super::{LoadedRecord, Trust};
 use stella_learn::rules::{Rule, RuleGuard};
@@ -267,7 +267,7 @@ pub fn rule_from_record(loaded: &LoadedRecord, ledger_approved: bool) -> (Rule, 
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::ingest::record::{Enforcement, Probe, ProbeKind, Truth};
+    use super::super::super::ingest::record::{Enforcement, Probe, ProbeKind, Truth, TruthBasis};
     use super::super::tests::{hard_guard, record_named, with_truth};
     use super::*;
 

--- a/crates/stella-records/src/records/sweep.rs
+++ b/crates/stella-records/src/records/sweep.rs
@@ -40,6 +40,7 @@ use super::super::ingest::gate::origin_is_untrusted;
 use super::super::ingest::record::{Probe, Record, TruthBasis, Verdict};
 use super::Trust;
 use super::clock;
+use super::trust::decreed_by_a_named_human_at;
 
 /// What `truth.on_expiry` asks for when a claim stops being believed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -152,21 +153,25 @@ impl Disposition {
 /// file's authority behind it. So three things must hold, and each one closes a
 /// way to fake the other two:
 ///
-/// - **The loader stamped [`Trust::User`].** Every other field here is written
+/// - **The loader stamped [`Trust::User`], and `truth.basis` is a `decree`
+///   with a non-empty `verified_by`.** Every other field here is written
 ///   inside the file being judged. A checkout can set a clean `origin` and a
 ///   named `verified_by` as easily as it sets anything else. That would let
 ///   anyone who can open a pull request arm a command. Where the file was read
 ///   from is the one fact it cannot write, and [`super::registry::load`] stamps
-///   that from the directory. [`super::bridge`] asks the same question before
-///   it lets a record approve its own blocking guard.
+///   that from the directory. What is then being relied on is a person whose
+///   name is on the claim, and a name nobody wrote is not one. Both halves are
+///   [`decreed_by_a_named_human_at`], which [`super::bridge`]'s `self_attested`
+///   asks before it lets a record approve its own blocking guard — one rule,
+///   called twice, so tightening it cannot move one gate and leave the other.
 /// - **The origin is stamped, and is not `imported` or `inferred`.** A record
 ///   with no origin is refused too. It has said nothing about where it came
 ///   from, and saying nothing must not be the permissive answer.
 ///   `origin_is_untrusted` belongs to `super::super::ingest::gate`, so
-///   extraction and the sweep read one rule rather than two copies.
-/// - **`truth.basis` is a `decree` with a non-empty `verified_by`.** What is
-///   being relied on is a person whose name is on the claim. A name nobody
-///   wrote is not one.
+///   extraction and the sweep read one rule rather than two copies. This is
+///   the condition the guard gate does not share: a blocking guard runs
+///   nothing, so an `observed` origin there is only a question of who wrote
+///   the policy.
 ///
 /// The gate runs here as well as at extraction because a record can be edited
 /// by hand afterwards. The file is all the loader sees.
@@ -176,18 +181,13 @@ pub fn honored_probe(record: &Record, trust: Trust) -> Option<&Probe> {
     if !probe.kind.is_gated() {
         return Some(probe);
     }
-    if trust != Trust::User {
+    if !decreed_by_a_named_human_at(record, trust) {
         return None;
     }
     let trusted_origin = record
         .origin
         .is_some_and(|origin| !origin_is_untrusted(origin));
-    let decreed_by_a_human = truth.basis == TruthBasis::Decree
-        && truth
-            .verified_by
-            .as_deref()
-            .is_some_and(|by| !by.is_empty());
-    (trusted_origin && decreed_by_a_human).then_some(probe)
+    trusted_origin.then_some(probe)
 }
 
 /// Whether this record's probe should run now.

--- a/crates/stella-records/src/records/sweep.rs
+++ b/crates/stella-records/src/records/sweep.rs
@@ -159,19 +159,19 @@ impl Disposition {
 ///   named `verified_by` as easily as it sets anything else. That would let
 ///   anyone who can open a pull request arm a command. Where the file was read
 ///   from is the one fact it cannot write, and [`super::registry::load`] stamps
-///   that from the directory. What is then being relied on is a person whose
-///   name is on the claim, and a name nobody wrote is not one. Both halves are
-///   [`decreed_by_a_named_human_at`], which [`super::bridge`]'s `self_attested`
-///   asks before it lets a record approve its own blocking guard — one rule,
-///   called twice, so tightening it cannot move one gate and leave the other.
+///   that from the directory. What is relied on then is a person whose name is
+///   on the claim. A name nobody wrote is not one.
+///   [`decreed_by_a_named_human_at`] holds both conditions.
+///   [`super::bridge`]'s `self_attested` asks it too, before it lets a record
+///   approve its own blocking guard. One rule, called twice, so tightening it
+///   moves both gates.
 /// - **The origin is stamped, and is not `imported` or `inferred`.** A record
 ///   with no origin is refused too. It has said nothing about where it came
 ///   from, and saying nothing must not be the permissive answer.
 ///   `origin_is_untrusted` belongs to `super::super::ingest::gate`, so
-///   extraction and the sweep read one rule rather than two copies. This is
-///   the condition the guard gate does not share: a blocking guard runs
-///   nothing, so an `observed` origin there is only a question of who wrote
-///   the policy.
+///   extraction and the sweep read one rule rather than two copies. The guard
+///   gate does not share this one. A blocking guard runs nothing, so an
+///   `observed` origin there is only a question of who wrote the policy.
 ///
 /// The gate runs here as well as at extraction because a record can be edited
 /// by hand afterwards. The file is all the loader sees.

--- a/crates/stella-records/src/records/sweep.rs
+++ b/crates/stella-records/src/records/sweep.rs
@@ -37,7 +37,7 @@
 //! what the agent sees.
 
 use super::super::ingest::gate::origin_is_untrusted;
-use super::super::ingest::record::{Probe, Record, TruthBasis, Verdict};
+use super::super::ingest::record::{Probe, Record, Verdict};
 use super::Trust;
 use super::clock;
 use super::trust::decreed_by_a_named_human_at;
@@ -161,7 +161,9 @@ impl Disposition {
 ///   from is the one fact it cannot write, and [`super::registry::load`] stamps
 ///   that from the directory. What is relied on then is a person whose name is
 ///   on the claim. A name nobody wrote is not one.
-///   [`decreed_by_a_named_human_at`] holds both conditions.
+///   `trust`'s `decreed_by_a_named_human_at` holds both conditions. Named in
+///   prose rather than linked: it is `pub(crate)`, and a public item's doc
+///   cannot link a private one without `--document-private-items` carrying it.
 ///   [`super::bridge`]'s `self_attested` asks it too, before it lets a record
 ///   approve its own blocking guard. One rule, called twice, so tightening it
 ///   moves both gates.
@@ -276,7 +278,7 @@ pub fn disposition(input: &SweepInput<'_>) -> Disposition {
 #[cfg(test)]
 mod tests {
     use super::super::super::context_record::kind::Origin;
-    use super::super::super::ingest::record::{ProbeKind, Truth};
+    use super::super::super::ingest::record::{ProbeKind, Truth, TruthBasis};
     use super::super::tests::{record_named, with_truth};
     use super::*;
 

--- a/crates/stella-records/src/records/trust.rs
+++ b/crates/stella-records/src/records/trust.rs
@@ -24,6 +24,43 @@
 //! allowed to load: may this record *remove* enforcement another record
 //! established, and may it approve itself for the tool boundary.
 
+use super::super::ingest::record::{Record, TruthBasis};
+
+/// The base rule both self-attestation gates share: the loader stamped
+/// [`Trust::User`], and the record's own claim is a decree with a person's
+/// name on it.
+///
+/// A record's fields cannot establish the authority they claim. `origin`,
+/// `truth.basis` and `verified_by` are all written inside the file being
+/// judged, so a checkout can set them as easily as it sets anything else. The
+/// tier the loader stamps is the one fact the file cannot write, and a decree
+/// only counts when somebody signed it.
+///
+/// Two gates ask this, and each adds one condition of its own:
+///
+/// - `super::bridge`'s `self_attested` adds `origin = "user"`, because a
+///   record approving its own blocking guard must be the user's own record
+///   and not a `system` one.
+/// - `super::sweep`'s `honored_probe` adds a stamped origin that is neither
+///   `imported` nor `inferred`, because a probe runs a command or reaches a
+///   host and mined content must never arm one.
+///
+/// The extra conditions stay with their callers. Moving either one here would
+/// tighten the other gate silently, which is the drift naming the shared half
+/// exists to prevent (#5799).
+pub(crate) fn decreed_by_a_named_human_at(record: &Record, trust: Trust) -> bool {
+    if trust != Trust::User {
+        return false;
+    }
+    record.truth.as_ref().is_some_and(|truth| {
+        truth.basis == TruthBasis::Decree
+            && truth
+                .verified_by
+                .as_deref()
+                .is_some_and(|by| !by.trim().is_empty())
+    })
+}
+
 /// The authority a record was published under.
 ///
 /// Ordered: `Project < User`, so `>=` reads as "at least as trusted as".

--- a/crates/stella-records/src/records/trust.rs
+++ b/crates/stella-records/src/records/trust.rs
@@ -47,7 +47,7 @@ use super::super::ingest::record::{Record, TruthBasis};
 ///
 /// The extra conditions stay with their callers. Moving either one here would
 /// tighten the other gate silently, which is the drift naming the shared half
-/// exists to prevent (#5799).
+/// exists to prevent.
 pub(crate) fn decreed_by_a_named_human_at(record: &Record, trust: Trust) -> bool {
     if trust != Trust::User {
         return false;

--- a/crates/stella-tools/src/custom/tests.rs
+++ b/crates/stella-tools/src/custom/tests.rs
@@ -409,54 +409,21 @@ impl ToolExecutor for FakeInner {
     }
 }
 
-/// An inner executor that answers every forwardable method with something
-/// other than its default, so a decorator that drops one is visible.
-struct LoadedInner;
-
-#[async_trait]
-impl ToolExecutor for LoadedInner {
-    fn schemas(&self) -> Vec<ToolSchema> {
-        FakeInner.schemas()
-    }
-    async fn execute(&self, name: &str, input: &Value) -> ToolOutput {
-        FakeInner.execute(name, input).await
-    }
-    fn active_skill_slugs(&self) -> Vec<String> {
-        vec!["release-checklist".to_string()]
-    }
-    fn live_services(&self) -> Vec<stella_core::LiveService> {
-        vec![stella_core::LiveService {
-            handle: "proc-3".to_string(),
-            name: None,
-            display: "npm run dev".to_string(),
-        }]
-    }
-}
-
 /// Every method the port tells a decorator to forward, checked together.
 ///
-/// Each has a trait default that reads as "this executor mounts none of that"
-/// — right for a leaf, wrong for a wrapper — so a dropped forward compiles
-/// clean and answers the default. `active_skill_slugs` was the one this set
-/// dropped: a live skill's procedure text stopped surviving overflow
-/// summarization for any workspace that also had a custom tool installed.
+/// `active_skill_slugs` is the one this set dropped: a live skill's procedure
+/// text stopped surviving overflow summarization for any workspace that also
+/// had a custom tool installed. The checks live in
+/// `crate::forwarding::assert_forwards`, so a method added to the port is
+/// added there once rather than to every decorator's own copy.
 #[tokio::test]
 async fn the_set_forwards_what_a_decorator_must() {
     let dir = tempfile::tempdir().unwrap();
     let tool = script_tool(dir.path(), "s.sh", "#!/bin/sh\necho hi\n");
-    let inner = LoadedInner;
+    let inner = crate::forwarding::LoadedExecutor;
     let set = CustomToolSet::new(&inner, vec![tool], dir.path().to_path_buf());
 
-    assert_eq!(
-        set.active_skill_slugs(),
-        vec!["release-checklist".to_string()],
-        "a live skill invocation must survive the custom set"
-    );
-    assert_eq!(
-        set.live_services().len(),
-        1,
-        "so must a still-running service"
-    );
+    crate::forwarding::assert_forwards("CustomToolSet", &set);
 }
 
 #[tokio::test]

--- a/crates/stella-tools/src/forwarding.rs
+++ b/crates/stella-tools/src/forwarding.rs
@@ -1,0 +1,176 @@
+//! One inner executor and one assertion, for every decorator's forwarding
+//! test.
+//!
+//! Four [`ToolExecutor`] methods have a trait default that reads "this
+//! executor mounts none of that". That is right for a leaf. It is wrong for a
+//! wrapper, and the port says so under its own `# Decorators MUST forward
+//! this` headings. A decorator that drops one compiles clean and answers the
+//! default. Only a test can catch it.
+//!
+//! One audit hit that shape twice in a single pass. `CustomToolSet` dropped
+//! `active_skill_slugs`, so a live skill's procedure text stopped surviving
+//! summarization in any workspace with a custom tool installed.
+//!
+//! [`LoadedExecutor`] answers all four with a value of its own.
+//! [`assert_forwards`] reads them back through the decorator. A method added
+//! to the port is added here once, rather than to every decorator's own copy.
+//!
+//! **Not a `#[cfg(test)]` module.** Three crates hold decorators of this
+//! trait, and a test-gated item is invisible to the other two.
+//!
+//! # What this does not check
+//!
+//! Narrowing. Decorators narrow `schemas`, `contracts`,
+//! `parallel_safe_names`, `tool_origin` and `dispatch_gate` on purpose.
+//! `ReadOnlyTools` hides a mutating tool, and hiding it is the whole job. The
+//! four here are the ones the port marks as pass-through. Narrowing one of
+//! those is always a defect.
+
+use stella_core::LiveService;
+use stella_core::ports::ToolExecutor;
+use stella_core::waiting::{WaitCall, WaitRequest};
+use stella_protocol::tool::{ToolOutput, ToolSchema};
+
+/// The sub-agent spend [`LoadedExecutor`] reports.
+pub const SPEND_USD: f64 = 2.5;
+/// The skill slug [`LoadedExecutor`] reports as active.
+pub const SKILL_SLUG: &str = "release-checklist";
+/// The handle of the service [`LoadedExecutor`] reports as still up.
+pub const SERVICE_HANDLE: &str = "proc-3";
+/// The description of the wait [`LoadedExecutor`] deposits.
+pub const WAIT_DESCRIPTION: &str = "CI settles";
+
+/// An inner executor that answers every pass-through method with a value no
+/// trait default returns. A decorator that drops one is then visible.
+pub struct LoadedExecutor;
+
+#[async_trait::async_trait]
+impl ToolExecutor for LoadedExecutor {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: "bash".into(),
+            description: "run".into(),
+            input_schema: serde_json::json!({ "type": "object" }),
+            read_only: false,
+            speculation_safe: false,
+        }]
+    }
+
+    async fn execute(&self, name: &str, _input: &serde_json::Value) -> ToolOutput {
+        ToolOutput::Ok {
+            content: format!("inner ran {name}"),
+            data: None,
+        }
+    }
+
+    fn drain_sub_agent_spend_usd(&self) -> f64 {
+        SPEND_USD
+    }
+
+    fn drain_wait_request(&self) -> Option<WaitRequest> {
+        Some(WaitRequest {
+            description: WAIT_DESCRIPTION.to_string(),
+            probe: WaitCall {
+                name: "bash".to_string(),
+                input: serde_json::json!({ "cmd": "gh run list" }),
+            },
+            baseline: "none yet".to_string(),
+            on_wake: None,
+            poll_interval_secs: 30,
+            timeout_secs: 300,
+        })
+    }
+
+    fn active_skill_slugs(&self) -> Vec<String> {
+        vec![SKILL_SLUG.to_string()]
+    }
+
+    fn live_services(&self) -> Vec<LiveService> {
+        vec![LiveService {
+            handle: SERVICE_HANDLE.to_string(),
+            name: None,
+            display: "npm run dev".to_string(),
+        }]
+    }
+}
+
+/// Read every pass-through method back through `decorator`, which must wrap
+/// a [`LoadedExecutor`].
+///
+/// `what` names the decorator. A failure then says which wrapper dropped
+/// which method, rather than which line of this file noticed.
+///
+/// # Panics
+///
+/// When `decorator` answers any of the four with the trait default instead of
+/// the inner's value.
+pub fn assert_forwards(what: &str, decorator: &dyn ToolExecutor) {
+    assert_eq!(
+        decorator.drain_sub_agent_spend_usd(),
+        SPEND_USD,
+        "{what} dropped drain_sub_agent_spend_usd: a nested turn's spend \
+         vanishes from the ceiling"
+    );
+    assert_eq!(
+        decorator
+            .drain_wait_request()
+            .map(|request| request.description),
+        Some(WAIT_DESCRIPTION.to_string()),
+        "{what} dropped drain_wait_request: the model burns steps polling \
+         instead of parking"
+    );
+    assert_eq!(
+        decorator.active_skill_slugs(),
+        vec![SKILL_SLUG.to_string()],
+        "{what} dropped active_skill_slugs: a live skill's procedure text \
+         stops surviving summarization"
+    );
+    assert_eq!(
+        decorator
+            .live_services()
+            .into_iter()
+            .map(|service| service.handle)
+            .collect::<Vec<_>>(),
+        vec![SERVICE_HANDLE.to_string()],
+        "{what} dropped live_services: the turn declares a service done \
+         without asking whether it is still listening"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The helper's own anti-vacuity. A wrapper that forwards nothing must
+    /// fail every check. Without that, `assert_forwards` proves nothing about
+    /// the ones that pass.
+    struct ForgetsEverything<'a>(&'a dyn ToolExecutor);
+
+    #[async_trait::async_trait]
+    impl ToolExecutor for ForgetsEverything<'_> {
+        fn schemas(&self) -> Vec<ToolSchema> {
+            self.0.schemas()
+        }
+        async fn execute(&self, name: &str, input: &serde_json::Value) -> ToolOutput {
+            self.0.execute(name, input).await
+        }
+    }
+
+    #[test]
+    fn the_loaded_executor_forwards_to_itself() {
+        assert_forwards("LoadedExecutor", &LoadedExecutor);
+    }
+
+    #[test]
+    fn a_decorator_that_forwards_nothing_is_caught() {
+        let inner = LoadedExecutor;
+        let forgetful = ForgetsEverything(&inner);
+        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            assert_forwards("ForgetsEverything", &forgetful);
+        }));
+        assert!(
+            caught.is_err(),
+            "a wrapper answering every default must fail the assertion"
+        );
+    }
+}

--- a/crates/stella-tools/src/gated.rs
+++ b/crates/stella-tools/src/gated.rs
@@ -723,14 +723,14 @@ mod tests {
     /// grouping, with no compiler complaint.
     #[test]
     fn the_decorator_forwards_what_a_decorator_must() {
+        let loaded = crate::forwarding::LoadedExecutor;
+        let over_loaded = GatedToolSet::new(&loaded, Arc::new(DenyAll), Principal::User);
+        crate::forwarding::assert_forwards("GatedToolSet", &over_loaded);
+
+        // The two this decorator answers for itself, over the leaf that
+        // declares them: a gate narrows execution, never the advertised set.
         let leaf = Leaf::new();
         let gated = GatedToolSet::new(&leaf, Arc::new(DenyAll), Principal::User);
-
-        assert_eq!(
-            gated.drain_sub_agent_spend_usd(),
-            2.5,
-            "sub-agent spend must not vanish through the gate"
-        );
         assert!(
             gated.parallel_safe_names().contains("delegate"),
             "the inner concurrency claim must survive"

--- a/crates/stella-tools/src/lib.rs
+++ b/crates/stella-tools/src/lib.rs
@@ -55,6 +55,7 @@ pub mod durable_write;
 pub mod edit;
 pub mod environment;
 pub mod exec;
+pub mod forwarding;
 pub mod foundry_gate;
 pub mod foundry_witness;
 pub mod gated;

--- a/crates/stella-tools/src/skill_plane.rs
+++ b/crates/stella-tools/src/skill_plane.rs
@@ -259,6 +259,21 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// Every method the port tells a decorator to forward, over this view.
+    ///
+    /// The narrowing is what this decorator is for, and it applies to the
+    /// advertised surface. The four pass-through methods are not part of it:
+    /// a scoped span must not hide a nested turn's spend, a parked wait, or a
+    /// service that is still up. `active_skill_slugs` is the one this view
+    /// adds to rather than filters, so an empty plane leaves the inner's
+    /// answer alone.
+    #[test]
+    fn the_scoped_view_forwards_what_a_decorator_must() {
+        let loaded = crate::forwarding::LoadedExecutor;
+        let scoped = SkillScopedTools::new(&loaded, SkillInvocationPlane::new());
+        crate::forwarding::assert_forwards("SkillScopedTools", &scoped);
+    }
+
     /// A leaf advertising one read and one write tool, recording what
     /// actually executed — so a denial is proven at the process, not by the
     /// text that came back.

--- a/docs/adr/0025-nested-frontmatter-refusal-scope.md
+++ b/docs/adr/0025-nested-frontmatter-refusal-scope.md
@@ -54,8 +54,17 @@ record.
 The two loaders stay apart. A reader who spots that and reaches for one rule
 should read this first.
 
-The check is weaker than the rule. `nested_keys` holds the child names, not
-the parent's. So the check asks whether `tools:` is empty and whether
-anything is nested at all. A file with a bare `tools:` and a nested
-`description:` is refused, and nothing widened. That is `#5737`. Fixing it is
-what would let the rule hold per field.
+The check now asks the rule's own question. `Frontmatter::nested_parents`
+records the key a nested mapping sat under, beside the child names in
+`nested_keys`, so `plan.rs`'s `nests_a_toolbelt_key` can ask whether the
+nesting was under a toolbelt key rather than whether anything was nested at
+all. A file with a bare `tools:` and a nested `description:` loads, because
+nothing widened. That was `#5737`.
+
+`command_from_file` asks the same question now. A nested `allowed-tools:`
+leaves that key empty, and an empty one means no restriction, so the command
+loader had the widening the agent loader was already refusing.
+
+A rule record is still refused for any nesting. `rule_from_file` reads
+`nested_keys` and does not care which parent held them, because a record is
+policy and every field of it steers.

--- a/docs/spec/verification-gate.md
+++ b/docs/spec/verification-gate.md
@@ -67,13 +67,18 @@ pins what the turn bought: the model calls, the tool runs, and the reported
 cost. Four scenarios are plain, one model call per step: a one-step answer, a
 two-tool step, a retry after a 429, and a turn the loop detector stops.
 
-The rest are the paths that buy a call no step asked for, and each names the
-module it prices: the overflow summarizer, a mid-turn provider fallback, an
-output-budget clamp, a parked wait for a 429 that will not clear, a loop
-steer the model obeys, the prove-it re-ask, and a Stop hook that denies and
-holds the turn open. Several are pinned from both sides: what the arm buys,
-and the bound that stops it buying more. A failure names the scenario, the
-pinned numbers and the new ones.
+The rest are the paths that buy a call no step asked for. Each one names the
+module it prices. The overflow summarizer. Its head-dropping ladder, for when
+the summarizer's own request is refused for its size. Its starved retry. A
+mid-turn provider fallback. An output-budget clamp. A parked wait for a 429
+that will not clear, and every park such a wait can take before its allowance
+runs out. The length-continuation ladder. A loop steer the model obeys. The
+prove-it re-ask. A Stop hook that denies and holds the turn open.
+
+Several are pinned from both sides: what the arm buys, and the bound that
+stops it buying more. The parked-wait total reads its bound off `plan_park`
+and the wait ceiling rather than a literal, so a change to either moves the
+pin. A failure names the scenario, the pinned numbers and the new ones.
 
 It needs no verification machinery, which is why it could be rebuilt here at
 all. The engine does no I/O, so scripted ports are the whole harness

--- a/scripts/check-core-reachability.py
+++ b/scripts/check-core-reachability.py
@@ -178,6 +178,19 @@ def module_file(src: Path, name: str) -> Path | None:
     return None
 
 
+def retired_because(src: Path, name: str) -> str:
+    """Why a baseline entry stopped being unreached.
+
+    A name drops out of the unreached set for two reasons, and they are
+    opposites: the engine started naming the module, or the module is gone.
+    `module_file` answers which, so a run reports the one that happened
+    instead of asserting the first in both cases (#6174).
+    """
+    if module_file(src, name) is None:
+        return "evicted, no longer in stella-core"
+    return "the engine reaches it now"
+
+
 def referenced_modules(text: str) -> set[str]:
     """Every top-level crate module this text names."""
     names = set(CRATE_PATH.findall(text))
@@ -302,17 +315,16 @@ def main() -> int:
         baseline_path.write_text(
             BASELINE_HEADER + "\n".join(kept) + ("\n" if kept else ""), encoding="utf-8"
         )
-        retired = sorted(baseline - set(unreached))
-        for name in retired:
+        for name in sorted(baseline - set(unreached)):
             print(
                 f"check-core-reachability: retired {name} — "
-                "it left the crate, or the engine reaches it now"
+                f"{retired_because(src, name)}"
             )
         print(f"check-core-reachability: baseline holds {len(kept)} module(s)")
         return 0
 
     new_debt = sorted(set(unreached) - baseline)
-    reachable_now = sorted(baseline - set(unreached))
+    dead_entries = sorted(baseline - set(unreached))
 
     if new_debt:
         print("check-core-reachability: FAILED\n")
@@ -330,12 +342,11 @@ def main() -> int:
         )
         return 1
 
-    if reachable_now:
+    if dead_entries:
         print("check-core-reachability: baseline is STALE\n")
-        print("These left the crate or the engine reaches them, so their")
-        print("baseline entries are dead:\n")
-        for name in reachable_now:
-            print(f"  {name}")
+        print("These baseline entries are dead:\n")
+        for name in dead_entries:
+            print(f"  {name} — {retired_because(src, name)}")
         print("\nRun ./scripts/check-core-reachability.py --update and commit the diff.")
         return 1
 

--- a/scripts/check-core-reachability.py
+++ b/scripts/check-core-reachability.py
@@ -184,10 +184,10 @@ def retired_because(src: Path, name: str) -> str:
     A name drops out of the unreached set for two reasons, and they are
     opposites: the engine started naming the module, or the module is gone.
     `module_file` answers which, so a run reports the one that happened
-    instead of asserting the first in both cases (#6174).
+    instead of asserting the first in both cases.
     """
     if module_file(src, name) is None:
-        return "evicted, no longer in stella-core"
+        return "evicted, gone from stella-core"
     return "the engine reaches it now"
 
 

--- a/scripts/test-core-reachability.sh
+++ b/scripts/test-core-reachability.sh
@@ -182,6 +182,44 @@ else
   cat "$TMP/shrink/scripts/core-reachability-baseline.txt"
 fi
 
+# ── W: the two ways a baseline entry dies read differently ───────────────────
+# Both leave the unreached set, and the guard used to state the reachable one
+# as fact in both cases — so every eviction PR read "the engine reaches it now"
+# about a module that no longer existed (#6174).
+src="$(new_core evicted)"
+seed_baseline evicted records
+out="$(python3 "$SCRIPT" --update "$TMP/evicted" 2>&1)"
+case "$out" in
+  *"retired records — evicted, no longer in stella-core"*)
+    pass=$((pass + 1)); echo "ok   --update names an evicted module as evicted" ;;
+  *)
+    fail=$((fail + 1)); echo "FAIL --update mis-named an evicted module:"; echo "$out" ;;
+esac
+
+src="$(new_core nowreached)"
+printf 'pub mod budget;\n' >>"$src/lib.rs"
+printf 'pub fn spend() {}\n' >"$src/budget.rs"
+printf 'pub fn drive() { crate::budget::spend(); }\n' >"$src/driver.rs"
+seed_baseline nowreached budget
+out="$(python3 "$SCRIPT" --update "$TMP/nowreached" 2>&1)"
+case "$out" in
+  *"retired budget — the engine reaches it now"*)
+    pass=$((pass + 1)); echo "ok   --update still names a reached module as reached" ;;
+  *)
+    fail=$((fail + 1)); echo "FAIL --update mis-named a reached module:"; echo "$out" ;;
+esac
+
+# The plain run's STALE block splits the same way, and it is the one an author
+# reads first — the update branch only runs once they believe the diagnosis.
+want "the STALE block names an eviction as one" expect-fail stale "evicted, no longer in stella-core"
+
+src="$(new_core stalereached)"
+printf 'pub mod budget;\n' >>"$src/lib.rs"
+printf 'pub fn spend() {}\n' >"$src/budget.rs"
+printf 'pub fn drive() { crate::budget::spend(); }\n' >"$src/driver.rs"
+seed_baseline stalereached budget
+want "the STALE block names a reached module as reached" expect-fail stalereached "budget — the engine reaches it now"
+
 # ── the real tree ────────────────────────────────────────────────────────────
 # It must pass with its seeded baseline; a guard that cannot run green on the
 # repository it ships in is not adoptable.

--- a/scripts/test-core-reachability.sh
+++ b/scripts/test-core-reachability.sh
@@ -183,14 +183,14 @@ else
 fi
 
 # ── W: the two ways a baseline entry dies read differently ───────────────────
-# Both leave the unreached set, and the guard used to state the reachable one
-# as fact in both cases — so every eviction PR read "the engine reaches it now"
-# about a module that no longer existed (#6174).
+# Both leave the unreached set. Stating the reachable one as fact in both cases
+# makes every eviction PR read "the engine reaches it now" about a module that
+# is gone.
 src="$(new_core evicted)"
 seed_baseline evicted records
 out="$(python3 "$SCRIPT" --update "$TMP/evicted" 2>&1)"
 case "$out" in
-  *"retired records — evicted, no longer in stella-core"*)
+  *"retired records — evicted, gone from stella-core"*)
     pass=$((pass + 1)); echo "ok   --update names an evicted module as evicted" ;;
   *)
     fail=$((fail + 1)); echo "FAIL --update mis-named an evicted module:"; echo "$out" ;;
@@ -211,7 +211,7 @@ esac
 
 # The plain run's STALE block splits the same way, and it is the one an author
 # reads first — the update branch only runs once they believe the diagnosis.
-want "the STALE block names an eviction as one" expect-fail stale "evicted, no longer in stella-core"
+want "the STALE block names an eviction as one" expect-fail stale "evicted, gone from stella-core"
 
 src="$(new_core stalereached)"
 printf 'pub mod budget;\n' >>"$src/lib.rs"


### PR DESCRIPTION
Fifteen members of the `area:core` fix batch, each a contained fix inside a
crate this PR already touches. Two members could not ride; they are named at
the bottom with the case that stopped them.

## Defects, each with the witness that fails on the old code

### #5737 — nested frontmatter could not be traced to the key it sat under

`parse_frontmatter` recorded the child names of a nested mapping and not the
parent, so `agent_from_file` could only ask "is anything nested". A bare
`tools:` beside a nested `description:` lost the agent, and nothing had
widened. `Frontmatter::nested_parents` records the parent, and
`nests_a_toolbelt_key` asks ADR 0025's actual question.

`command_from_file` gets the same refusal in the same change: a nested
`allowed-tools:` leaves that key empty, and an empty one is the spelling of
"no restriction" — the identical widening, one loader over, refused by nothing.

**Witness:** `a_bare_toolbelt_beside_an_unrelated_nesting_still_loads` fails on
the old code, where `!fm.nested_keys.is_empty()` is true and the agent is
refused. `a_command_with_a_nested_toolbelt_is_refused` fails on the old code,
where the command loads with every tool. Two parser tests pin the new field.
ADR 0025's Consequences section says the proxy is gone.

### #5799 — the self-attestation rule was written twice, and had drifted

`bridge.rs`'s `self_attested` and `sweep.rs`'s `honored_probe` each spelled the
shared half — `Trust::User` plus a decree with a non-empty `verified_by` — in
their own code. The guard gate trimmed the verifier name and the probe gate did
not. `trust.rs`'s `decreed_by_a_named_human_at` is that rule, called by both;
each caller keeps only its own extra condition (`origin = "user"` for the
guard, a non-`imported`/`inferred` origin for the probe), and both doc comments
say why the extras are not shared.

**Witness:** `a_blank_verifier_refuses_at_both_self_attestation_gates` fails on
the old code — `verified_by = "   "` was refused by the guard gate and
*honored* by the probe gate. That is the drift, stated as a test.

### #2792 — one approval question wrote two journal rows

`approval.requested` reaches the bus twice per ask: `emit_blocking` stamps it
when a chain ends in `RequireApproval`, and the approval flow emits a richer
one before it parks. `bridge_policy_plane` mapped both onto `PolicyDecision`,
so a count of asks read double.

Neither emission can be dropped outright — a chain can require approval with no
flow behind it, and a flow can park for a gate no chain evaluated. The bridge
holds one ask open per gate instead, and a resolution (`approval.granted`,
`.denied`, `.expired`) closes it.

The bridge moves to `bus/policy_bridge.rs` with its tests: `bus.rs` sits at its
grandfathered ceiling, and the split takes 55 lines off it.

**Witness:** `one_ask_is_one_row_however_many_emissions_it_makes` emits the
stamp and the flow's message and asserts one row. On the old bridge it is two.
`a_resolved_ask_lets_the_next_one_through` and `two_gates_are_two_asks` are the
negative controls.

### #5712 — the loop refused to work an issue over rule files that never steer it

`refuse_if_unsteered` counted every `*.toml` in `.stella/rules`. Two of the
things it counted are not steering: `governance.toml`, a reserved name the
record loader never parses, and a record whose `status` is `archived` or
`retracted`, which the registry already refuses to let steer. The operator was
told to set `STELLA_TRUST_PROJECT=1` so records could steer a loop no record
would steer either way. The count now reads and parses the files, runs no truth
probe, and creates no directory; an unreadable or unparseable file counts as
steering, which is the safe direction.

It moves to `self_driving_cmd/work/steering.rs`: `work.rs` was 59 lines from
the ceiling, and the split leaves it at 1351.

**Witness:** `a_file_that_would_never_steer_does_not_stop_the_loop` fails on the
old code, where both fixtures are one `.toml` file and the count is 1. Its
mixed-directory arm shows one live record still stops an untrusted loop, so the
first two assertions are about what was written and not about the fixture.

### #6174 — the reachability guard called an evicted module one the engine reaches

`scripts/check-core-reachability.py` printed `the engine reaches it now` for
every baseline entry that left the unreached set, including one whose file is
gone — the common case under the eviction epic, so every eviction PR read a
false sentence. `retired_because` splits on `module_file`, and the plain run's
`baseline is STALE` block splits the same way.

**Witness:** `scripts/test-core-reachability.sh` gains four cases — `--update`
and the `STALE` block, each against an evicted module and against one the
engine started naming. They fail on the old code by construction: the old
message was one string for both facts, so the "evicted" assertion has nothing
to match. 15 passed, 0 failed locally.

### #5512 — a decorator that forgets to forward failed nothing

Four `ToolExecutor` methods have a trait default that reads "this executor
mounts none of that" — right for a leaf, wrong for a wrapper. A decorator that
drops one compiles clean and answers the default, and each decorator that had a
forwarding test had hand-written its own.

`stella_tools::forwarding` is that test's shared half: `LoadedExecutor` answers
all four with a value of its own, and `assert_forwards` reads them back through
the decorator. Every decorator in `stella-tools` and `stella-cli` has one now.

**It found two live drops.** `ClaimTap` and `CommitObserver` both swallowed
`active_skill_slugs`, so a live skill's procedure text stopped surviving
overflow summarization on the deck's lead turn and on every shared-tree fleet
worker — the same defect #5489 fixed one decorator over. Both forward it now.

**Witness:** `a_decorator_that_forwards_nothing_is_caught` is the helper's own
anti-vacuity. `the_tap_forwards_what_a_decorator_must` and
`the_commit_observer_forwards_what_a_decorator_must` fail on the old code, on
the method each of those two dropped.

## Coverage the code already earned

### #5749 — three call-buying paths the spend gate did not price

The summarizer's head-dropping ladder when its own request is refused for size,
its starved retry, and the length-continuation ladder. Each new scenario names
the module it prices and is pinned from both sides where it has a bound: the
head-dropping script holds the ladder's worth of rejections and then an answer,
so raising the bound makes the summarizer eat the answer and lowering it makes
the worker call meet a rejection. 18 passed locally.

### #5746 — how many attempts a parked wait can buy in total

`a_parked_rate_limit_buys_one_attempt_per_park` prices one park. Nothing priced
the total, which is the number that bounds the spend. The new pin reads
`plan_park` and `MAX_PARKED_WAIT_MS` rather than a literal, so a change to the
ceiling or the backoff moves the expected number with it.

Reading the ceiling from an integration test needed it public. `rate_limit`
becomes a `pub mod` and `MAX_PARKED_WAIT_MS` a `pub const` — a visibility
change, so `driver.rs` gains no line and stays inside its grandfathered
ceiling.

`doc:verification-gate` lists all four new scenarios.

### #5334 — four claims the skills suite made and did not check

- `a_multi_byte_body_is_cut_at_a_character_boundary` — the panic
  `floor_char_boundary` exists to prevent, over CJK, emoji and a 2-byte Latin
  glyph. The existing truncation tests are ASCII, where the walk-back never
  runs.
- `skills_with_the_same_score_are_ordered_by_name` — the `then_with` tie-break.
  `auto_created_skill_wins_the_tie_break` asserts strictly unequal scores, so it
  never reaches it. Asserted from both input orders.
- `over_top_k_holds_exactly_what_max_skills_cut` — the `split_off`, including
  that `selected` matches `select_skills` exactly and that a cut removing
  nothing reports nothing.
- `a_hand_authored_skill_is_never_auto_demoted` claimed "every origin that is
  not `AutoCreated`" and enumerated three of five, so `Contributed` — a
  plugin's skill — was safe in the code and pinned by nothing. It reads
  `SkillOrigin::ALL` and filters on `is_hand_authored` now, and
  `every_origin_is_listed` holds that table to the enum with an exhaustive
  `match`.

The three selection tests land in `skills/tests/selection.rs`:
`skills/tests.rs` was 15 lines from the ceiling.

### #2795 — the constant→table coupling was enforced by a doc comment

Table→prompt and table→classifier are enforced by tests; the third direction,
"a new marker constant joins `ENGINE_MARKERS`", was an instruction in the module
doc. `the_table_holds_every_marker_shaped_constant` scans the nine sources that
own an entry for `const NAME: &str = "[…"` where the name contains `MARKER` or
ends in `_PREFIX`, and fails by name on one the table does not list.
`REASONING_ONLY_PARTIAL` is excluded by the name rule (it is an assistant-role
stand-in); `FILE_CAP_MARKER` is excluded by name with its reason recorded.
`the_marker_scan_reads_the_shapes_it_claims_to` is the scan's own anti-vacuity.

**Witness, run:** adding `pub(crate) const FAKE_STEER_PREFIX: &str = "[fake
steer";` to `driver/truncation.rs` fails the test with
`driver/truncation.rs's FAKE_STEER_PREFIX opens a bracketed User-role marker
that ENGINE_MARKERS does not list`. Removed again; the tree carries no such
constant.

## Reach, and stale prose

### #5773 — no Windows toolchain compiled `stella-core`

Decision recorded on the issue: **option 1**. `windows-check.yml` adds
`-p stella-core` to the clippy invocation and `crates/stella-core/**` to both
path filters. `stella-cli` stays out, as the crate most likely to need real
work before it compiles there. `stella-core` already compiled on that runner as
`stella-runtime`'s dependency, so naming it costs a lint pass rather than a
build. `AGENTS.md`'s eighth-workflow description matches the workflow.

**Witness:** this PR touches `crates/stella-core/**`, so the job runs here with
`stella-core` under `-D warnings` — the run is the evidence. The issue's
red-then-green demonstration is **not** included: proving it needs a deliberate
compile error pushed and then removed, and that edit-and-undo pair is what
`rebase-replay` rejects on the next rebase.

### #2481 — the `stella-engine` facade omitted the turn-boundary shapers

A host that drives `run_step` rather than `Engine::drive` owns its own turn
framing and must emit `agent.turn.started` / `agent.turn.completed` in the
engine's shape, or an extension watching the bus can tell a host-driven turn
from a local one. The facade did not export the two shapers, so such a host had
to depend on `stella-core` directly — the coupling the facade exists to remove.
`TurnLane` joins them: `turn_started_payload` takes one, and obligation 2
already owed it, since `OwnedTurnCapabilities::lane` is an `Option<TurnLane>` a
host fills and could not name.

`driver/lifecycle.rs`'s stale caveat is dropped, and `README.md` names the
choice between "call `drive`" and "drive `run_step` and frame it yourself".

**Witness:** `a_host_can_frame_its_own_turn_through_the_facade_alone` in
`crates/stella-engine/tests/embedding.rs`. Every path in it is a
`stella_engine::` one, so the file does not compile on the old tree — the
fail-on-old mechanism for a re-export.

### #2303 — `Frontmatter.duplicate_keys` was written on every parse, read by nothing

Its only consumer left with the `rules::metadata` layer. `rg duplicate_keys`
over `crates/` now returns only unrelated Python symbols in a test fixture.
Field and population deleted. (The issue's line numbers pointed at
`stella-core/src/rules.rs`; the parser has since moved to
`stella-protocol/src/frontmatter.rs`.)

### #2210 — the `Calibration` doc comment claimed overhead is a stable ratio

The comment described a multiplicative ratio model; the code has fitted a line
with an additive intercept since #1841, and the witness 730 lines below it
asserts the opposite of what the comment said. Comment-only, no test — the
existing `a_constant_overhead_does_not_halve_the_compaction_budget` is the
witness the comment now names.

### #5979 — `SubAgentSpec::seat`'s doc comment showed half a key

The examples were bare role names. Every host dispatch path qualifies a seat as
`<plugin-id>/<role>`, so a `[seats]` line written from that comment is one no
lookup can find. Comment-only. `stella-core`'s dependency list is unchanged —
the comment names `stella-plugin`'s `seat_key` in prose, not as an intra-doc
link.

## Could not ride

- **#5716 — give the two completion nudges bracketed markers.** The change
  moves prompt bytes the model answers, and the issue's own verification asks
  for the prove-it gate's bench arm to be re-run before and after. That is a rig
  and real provider spend, one of the three defer cases. Nothing here is
  half-done: `ENGINE_NUDGE_PREFIXES` and `is_engine_nudge` are untouched, and
  #2795's new scan covers `ENGINE_MARKERS` without depending on that decision.
- **#6261 — emit a stage event per resolved plugin stage.** It opens with a
  design decision the issue states outright ("whether the boundary belongs to
  the driver or to `WrapperDispatch::open_round`"), then spans three
  `stella-cli` drivers, `stella-runtime`, the acceptance script and
  `doc:roleless-core`. Larger than this session, and a partial wiring would
  leave a producer on one driver and not the others — worse than the gap.

## Tests deleted

Two renamed, none removed:

- `the_task_tap_forwards_active_skill_slugs` →
  `the_task_tap_forwards_what_a_decorator_must`
- `the_commit_observer_forwards_parallel_safe_names` keeps its name; a second
  test `the_commit_observer_forwards_what_a_decorator_must` joins it.

The `LoadedInner` fixture in `custom/tests.rs` is deleted, superseded by
`stella_tools::forwarding::LoadedExecutor`. It is a fixture, not a test.

Closes #6298

## Summary by Sourcery

Correct core audit defects across frontmatter loading, policy and trust handling, steering detection, executor forwarding, reachability reporting, and verification coverage.

New Features:
- Expose turn-boundary payload shapers and lane types through the stella-engine facade for hosts that drive turns themselves.

Bug Fixes:
- Prevent nested frontmatter under unrelated keys from causing false refusals while rejecting nested tool restrictions that could silently widen access.
- Unify self-attestation validation across record guard and probe gates, including rejecting blank verifiers.
- Collapse duplicate approval-request events into one journal row per open gate and resolution cycle.
- Ignore reserved, archived, and retracted rule files when deciding whether untrusted self-driving work lacks steering.
- Distinguish evicted modules from newly reachable modules in core reachability diagnostics.
- Preserve active skill information through CLI executor decorators and other forwarding layers.

Enhancements:
- Add shared forwarding assertions for ToolExecutor decorators and strengthen skill selection, marker-table, and parked-wait accounting coverage.
- Remove the unused frontmatter duplicate-key tracking and correct stale calibration and sub-agent seat documentation.

CI:
- Run stella-core clippy with warnings denied in the Windows workflow and trigger it for stella-core changes.

Documentation:
- Update ADR, verification-gate, engine facade, and workflow documentation to reflect the corrected behavior and coverage.

Tests:
- Add regression coverage for frontmatter parent tracking, approval deduplication, steering detection, reachability diagnostics, decorator forwarding, Unicode skill truncation, tie-breaking, top-k reporting, marker coupling, and spend limits.

Chores:
- Split policy bridging and steering checks into focused modules to keep core files within their size limits.