### PR TITLE
fix(bench): guard trace_triage's site strings and add a ledger posture

### DIFF
--- a/bench/trace_triage/README.md
+++ b/bench/trace_triage/README.md
@@ -87,6 +87,16 @@ issue never named, a higher rate — instead of restating the issue. When an
 occurrence adds nothing, nothing is posted; the run is still recorded so the
 next comparison is against the truth.
 
+`posture` says whether a fingerprint should still be *proposed* as a new
+issue. `tracked` is the default: search, then comment or open one. `accepted`
+and `wontfix` mean a human read this finding. It is real. It should stop
+coming back. Neither needs a real `issue` number — a fake one would be a lie.
+
+Set `posture` by hand (add an entry with `issue: null` if none exists) and
+every run after that prints a `SUPPRESSED (ledger posture)` decision. It
+never searches, comments, or opens an issue, but it still records the run.
+Delete `posture` later and the record is still true.
+
 ## Detectors
 
 | Code | Fires on |

--- a/bench/trace_triage/detectors.py
+++ b/bench/trace_triage/detectors.py
@@ -18,7 +18,7 @@ keyed on them.
     @detector(
         code="my-shape",                       # stable; part of the fingerprint
         title="what a new issue would be called",
-        site="crates/stella-pipeline/src/verify.rs",   # or "" if none implicated
+        site="crates/stella-model/src/provider_parity.rs",   # or "" if none implicated
         search_terms=("phrase a reviewer would search",),
     )
     def _my_shape(run: Run) -> list[Finding]:
@@ -341,7 +341,7 @@ def _agent_timeout(run: Run) -> list[Finding]:
 @detector(
     code="witness-unavailable",
     title="witness authoring failed",
-    site="crates/stella-pipeline/src/verify.rs",
+    site="",
     search_terms=("witness_unavailable", "witness author", "no TEST_COMMAND"),
 )
 def _witness_unavailable(run: Run) -> list[Finding]:
@@ -352,6 +352,11 @@ def _witness_unavailable(run: Run) -> list[Finding]:
     failure, "emitted a test command but created no file" is an authoring
     failure, and "turn aborted: stuck-loop detected" is a loop defect. Filing
     them under one ticket buries two of the three.
+
+    `site` is `""` rather than `crates/stella-pipeline/src/verify.rs`: that
+    crate is deleted, and witness authoring is now a verification plugin's
+    own logic (Vera, private, not shipped here), so no file in this tree is
+    implicated.
     """
     from fingerprint import normalize
 
@@ -389,7 +394,7 @@ def _witness_unavailable(run: Run) -> list[Finding]:
         findings.append(
             Finding(
                 detector="witness-unavailable",
-                site="crates/stella-pipeline/src/verify.rs",
+                site="",
                 variant_source=reason_full,
                 title=f"witness authoring failed: {reason_full[:90]}",
                 summary=(
@@ -414,7 +419,7 @@ def _witness_unavailable(run: Run) -> list[Finding]:
 @detector(
     code="oracle-flip-ungraded",
     title="the oracle recorded a baseline->candidate flip on a trial the grader scored 0",
-    site="crates/stella-pipeline/src/verify.rs",
+    site="",
     search_terms=("oracle flip reward 0", "flip achieved grader rejected"),
 )
 def _oracle_flip_ungraded(run: Run) -> list[Finding]:
@@ -426,6 +431,11 @@ def _oracle_flip_ungraded(run: Run) -> list[Finding]:
     does not accept — either the witness is weaker than the task, or the proven
     work never reached the graded tree. Both are defects, and the trace cannot
     tell them apart on its own, which is stated rather than guessed.
+
+    `site` is `""` rather than `crates/stella-pipeline/src/verify.rs`: that
+    crate is deleted, and the oracle's flip logic is now a verification
+    plugin's own logic (Vera, private, not shipped here), so no file in this
+    tree is implicated.
     """
     if run.bare_loop:
         return []  # no oracle exists on the bare loop; see below.
@@ -457,7 +467,7 @@ def _oracle_flip_ungraded(run: Run) -> list[Finding]:
     return [
         Finding(
             detector="oracle-flip-ungraded",
-            site="crates/stella-pipeline/src/verify.rs",
+            site="",
             variant_source="oracle observed baseline fail and candidate pass on a trial graded 0",
             title="the oracle recorded a baseline->candidate flip on a trial the grader scored 0",
             summary=(
@@ -783,7 +793,7 @@ def _role_model_mismatch(run: Run) -> list[Finding]:
 @detector(
     code="no-post-verdict-file-change",
     title="a trial recorded no file_change after its verdict",
-    site="crates/stella-cli/src/candidate_ws/adopt.rs",
+    site="crates/stella-cli/src/candidate_workspaces.rs",
     search_terms=("candidate adoption post-verdict file_change", "delivery emits no event"),
 )
 def _no_post_verdict_file_change(run: Run) -> list[Finding]:
@@ -861,7 +871,7 @@ def _no_post_verdict_file_change(run: Run) -> list[Finding]:
         findings.append(
             Finding(
                 detector="no-post-verdict-file-change",
-                site="crates/stella-cli/src/candidate_ws/adopt.rs",
+                site="crates/stella-cli/src/candidate_workspaces.rs",
                 variant_source="trial recorded no verdict event at all",
                 title="a trial ended with no verdict event — the delivery point was never reached",
                 summary=(
@@ -879,7 +889,7 @@ def _no_post_verdict_file_change(run: Run) -> list[Finding]:
         findings.append(
             Finding(
                 detector="no-post-verdict-file-change",
-                site="crates/stella-cli/src/candidate_ws/adopt.rs",
+                site="crates/stella-cli/src/candidate_workspaces.rs",
                 variant_source="verdict recorded and no mutating file_change followed it",
                 title="a trial recorded a verdict and no file_change after it",
                 summary=(
@@ -1082,7 +1092,7 @@ _FALLBACK_DISCLOSURE = "searched with POSIX"
 @detector(
     code="grep-ere-false-negative",
     title="grep answered `(no matches)` for a pattern the POSIX fallback could not execute",
-    site="crates/stella-tools/src/grep/fallback.rs",
+    site="",
     search_terms=("grep no matches alternation", "POSIX grep BRE fallback false negative"),
 )
 def _grep_ere_false_negative(run: Run) -> list[Finding]:
@@ -1093,6 +1103,12 @@ def _grep_ere_false_negative(run: Run) -> list[Finding]:
     wrote matched nothing — reported as the fact `(no matches)`. A tool that
     fails is recoverable; a tool that answers "that code does not exist" is not,
     because the agent believes it and re-plans.
+
+    `site` is `""`: the standalone `grep` tool this fired on is gone, folded
+    into the unified `search` tool (AGENTS.md's "one search rather than a
+    grep/glob/graph_query triple"), and no file in the current tree owns a
+    POSIX-fallback shape to implicate. `grep` below is recorded-trace
+    vocabulary, matching what an archived run's stream actually says.
 
     The discriminator is the disclosure #2989 attached to the degraded backend's
     empty answer, not the pattern alone: after the fix, a zero-match *from the
@@ -1141,7 +1157,7 @@ def _grep_ere_false_negative(run: Run) -> list[Finding]:
     return [
         Finding(
             detector="grep-ere-false-negative",
-            site="crates/stella-tools/src/grep/fallback.rs",
+            site="",
             variant_source="grep zero-match on an ERE pattern with no POSIX-fallback disclosure",
             title=(
                 "grep answered `(no matches)` for a pattern the POSIX fallback "

--- a/bench/trace_triage/fingerprint.py
+++ b/bench/trace_triage/fingerprint.py
@@ -63,6 +63,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from dataclasses import field as dc_field
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -130,6 +131,21 @@ def markers_in(text: str) -> list[str]:
     return re.findall(r"<!--\s*stella-trace-fingerprint:\s*(fp_[0-9a-f]{12})\s*-->", text)
 
 
+class LedgerPosture(StrEnum):
+    """Should the tool still propose this fingerprint as a new issue?
+
+    `TRACKED` is the old default. `plan_actions` still searches and files.
+
+    `ACCEPTED` and `WONTFIX` mean a human read the finding. It is real. It
+    should stop coming back as a new issue. `issue` may stay `None`. Binding
+    it to a fake number just to hide it would be a lie.
+    """
+
+    TRACKED = "tracked"
+    ACCEPTED = "accepted"
+    WONTFIX = "wontfix"
+
+
 @dataclass
 class LedgerEntry:
     """One defect's binding, plus the incidence already on the record.
@@ -149,10 +165,16 @@ class LedgerEntry:
     first_seen_run: str
     note: str = ""
     source: str = "auto"
+    posture: LedgerPosture = LedgerPosture.TRACKED
     runs: list[str] = dc_field(default_factory=list)
     tasks: list[str] = dc_field(default_factory=list)
     peak_count: int = 0
     peak_denominator: int = 0
+
+    @property
+    def silenced(self) -> bool:
+        """Whether this posture stops the tool proposing a new issue."""
+        return self.posture in (LedgerPosture.ACCEPTED, LedgerPosture.WONTFIX)
 
     def novelty(self, run_id: str, tasks: Iterable[str], count: int, denominator: int) -> list[str]:
         """What this occurrence adds that the record did not already have."""
@@ -194,11 +216,22 @@ class LedgerEntry:
             "first_seen_run": self.first_seen_run,
             "note": self.note,
             "source": self.source,
+            "posture": self.posture.value,
             "runs": self.runs,
             "tasks": self.tasks,
             "peak_count": self.peak_count,
             "peak_denominator": self.peak_denominator,
         }
+
+
+def _posture_or_default(raw: Any) -> LedgerPosture:
+    """`raw` as a `LedgerPosture`, or `TRACKED` when it is absent or unknown."""
+    if isinstance(raw, str):
+        try:
+            return LedgerPosture(raw)
+        except ValueError:
+            pass
+    return LedgerPosture.TRACKED
 
 
 class Ledger:
@@ -214,6 +247,10 @@ class Ledger:
     def __init__(self, path: Path = LEDGER_PATH) -> None:
         self.path = path
         self.entries: dict[str, LedgerEntry] = {}
+        # Every top-level key `save()` does not manage — today just
+        # `_comment`, a note a human writes at the top of the file. `save()`
+        # writes this back. Before this fix, `--apply` deleted it.
+        self._extra: dict[str, Any] = {}
         self._load()
 
     def _load(self) -> None:
@@ -223,6 +260,10 @@ class Ledger:
             raw = json.loads(self.path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             return
+        if isinstance(raw, dict):
+            self._extra = {
+                key: value for key, value in raw.items() if key not in ("schema", "updated_at", "fingerprints")
+            }
         for digest, value in (raw.get("fingerprints") or {}).items():
             if not isinstance(value, dict):
                 continue
@@ -236,6 +277,9 @@ class Ledger:
                 first_seen_run=str(value.get("first_seen_run") or ""),
                 note=str(value.get("note") or ""),
                 source=str(value.get("source") or "auto"),
+                # An old file has no `posture` key. A typo has a bad one. Both
+                # fall back to `tracked` rather than raising.
+                posture=_posture_or_default(value.get("posture")),
                 runs=[str(r) for r in (value.get("runs") or [])],
                 tasks=[str(t) for t in (value.get("tasks") or [])],
                 peak_count=int(value.get("peak_count") or 0),
@@ -277,12 +321,13 @@ class Ledger:
         return entry
 
     def save(self) -> None:
-        payload = {
+        payload: dict[str, Any] = {
             "schema": 1,
             "updated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "fingerprints": {
-                digest: self.entries[digest].to_json() for digest in sorted(self.entries)
-            },
+        }
+        payload.update(self._extra)
+        payload["fingerprints"] = {
+            digest: self.entries[digest].to_json() for digest in sorted(self.entries)
         }
         self.path.write_text(
             json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8"

--- a/bench/trace_triage/fingerprints.json
+++ b/bench/trace_triage/fingerprints.json
@@ -30,25 +30,46 @@
       "peak_count": 85,
       "peak_denominator": 88
     },
-    "fp_ebb5bd1815bd": {
-      "issue": 2956,
-      "detector": "agent-timeout",
+    "fp_be8604292a51": {
+      "issue": 2908,
+      "detector": "witness-unavailable",
       "site": "",
-      "variant": "harbor recorded agenttimeouterror for the trial",
-      "first_seen_run": "h89b",
-      "note": "Seeded from #2956. The timeout census and the void-call census are two views of one operational abort there, so both fingerprints point at it; split them if a run ever shows timeouts without voids.",
+      "variant": "witness author emitted a test command but created no file",
+      "first_seen_run": "w10p",
+      "note": "Seeded from #2908 (CLOSED), which quotes this reason string verbatim.",
       "source": "seed",
       "runs": [
-        "h89b"
+        "w10p"
       ],
-      "tasks": [],
-      "peak_count": 85,
-      "peak_denominator": 88
+      "tasks": [
+        "code-from-image",
+        "openssl-selfsigned-cert",
+        "pypi-server"
+      ],
+      "peak_count": 4,
+      "peak_denominator": 20
     },
-    "fp_91b19f844096": {
+    "fp_c494f1ae2ebd": {
+      "issue": 2908,
+      "detector": "witness-unavailable",
+      "site": "",
+      "variant": "witness author produced no test_command line",
+      "first_seen_run": "w10p",
+      "note": "Seeded from #2908 (CLOSED), which quotes this reason string verbatim. A separate fingerprint from the sibling above on purpose: one is a parse-contract failure and one is an authoring failure, and #2908 may be fixed for one and not the other.",
+      "source": "seed",
+      "runs": [
+        "w10p"
+      ],
+      "tasks": [
+        "log-summary-date-ranges"
+      ],
+      "peak_count": 1,
+      "peak_denominator": 20
+    },
+    "fp_d1a410bd3481": {
       "issue": 2941,
       "detector": "no-post-verdict-file-change",
-      "site": "crates/stella-cli/src/candidate_ws/adopt.rs",
+      "site": "crates/stella-cli/src/candidate_workspaces.rs",
       "variant": "trial recorded no verdict event at all",
       "first_seen_run": "w10p",
       "note": "Seeded from #2941 (open), the residual half of #2927: a run killed at the wall-clock cap never reaches the single adoption point. Deliberately NOT bound to #2927 \u2014 that issue is the winner-only adoption defect and is closed; binding both variants to it would suppress exactly the follow-up the split exists for.",
@@ -65,10 +86,10 @@
       "peak_count": 6,
       "peak_denominator": 20
     },
-    "fp_48fdf676b048": {
+    "fp_eb92a156d054": {
       "issue": 2927,
       "detector": "no-post-verdict-file-change",
-      "site": "crates/stella-cli/src/candidate_ws/adopt.rs",
+      "site": "crates/stella-cli/src/candidate_workspaces.rs",
       "variant": "verdict recorded and no mutating file_change followed it",
       "first_seen_run": "w10p",
       "note": "Seeded from #2927 (CLOSED) \u2014 candidate adoption is winner-only, so a revise verdict discards the candidate. A recurrence on a SUT that already contains the fix is a regression; the tool comments and says so without asserting which, because the trace cannot tell a post-fix run from a pre-fix one.",
@@ -84,41 +105,20 @@
       "peak_count": 4,
       "peak_denominator": 20
     },
-    "fp_06b55889e526": {
-      "issue": 2908,
-      "detector": "witness-unavailable",
-      "site": "crates/stella-pipeline/src/verify.rs",
-      "variant": "witness author emitted a test command but created no file",
-      "first_seen_run": "w10p",
-      "note": "Seeded from #2908 (CLOSED), which quotes this reason string verbatim.",
+    "fp_ebb5bd1815bd": {
+      "issue": 2956,
+      "detector": "agent-timeout",
+      "site": "",
+      "variant": "harbor recorded agenttimeouterror for the trial",
+      "first_seen_run": "h89b",
+      "note": "Seeded from #2956. The timeout census and the void-call census are two views of one operational abort there, so both fingerprints point at it; split them if a run ever shows timeouts without voids.",
       "source": "seed",
       "runs": [
-        "w10p"
+        "h89b"
       ],
-      "tasks": [
-        "code-from-image",
-        "openssl-selfsigned-cert",
-        "pypi-server"
-      ],
-      "peak_count": 4,
-      "peak_denominator": 20
-    },
-    "fp_0e3494035b33": {
-      "issue": 2908,
-      "detector": "witness-unavailable",
-      "site": "crates/stella-pipeline/src/verify.rs",
-      "variant": "witness author produced no test_command line",
-      "first_seen_run": "w10p",
-      "note": "Seeded from #2908 (CLOSED), which quotes this reason string verbatim. A separate fingerprint from the sibling above on purpose: one is a parse-contract failure and one is an authoring failure, and #2908 may be fixed for one and not the other.",
-      "source": "seed",
-      "runs": [
-        "w10p"
-      ],
-      "tasks": [
-        "log-summary-date-ranges"
-      ],
-      "peak_count": 1,
-      "peak_denominator": 20
+      "tasks": [],
+      "peak_count": 85,
+      "peak_denominator": 88
     }
   }
 }

--- a/bench/trace_triage/issues.py
+++ b/bench/trace_triage/issues.py
@@ -61,6 +61,7 @@ class Decision(StrEnum):
     COMMENT = "COMMENT (open issue)"
     RECURRENCE = "COMMENT (closed issue — recurrence)"
     SUPPRESSED = "SUPPRESSED (new-issue cap reached)"
+    POSTURE_SUPPRESSED = "SUPPRESSED (ledger posture)"
     NO_NEWS = "NOTHING POSTED (occurrence adds nothing to the record)"
 
 
@@ -383,6 +384,26 @@ def plan_actions(
     for finding in sorted(findings, key=lambda f: (f.detector, f.variant_source)):
         fingerprint = finding.fingerprint
         entry = ledger.lookup(fingerprint)
+
+        if entry is not None and entry.silenced:
+            # A human read this shape. Stop proposing it, issue or not.
+            # No search, no comment, no new issue. No client needed.
+            actions.append(
+                Action(
+                    finding=finding,
+                    fingerprint=fingerprint,
+                    decision=Decision.POSTURE_SUPPRESSED,
+                    title=finding.title,
+                    body="",
+                    issue=entry.issue,
+                    matched_by=(
+                        f"ledger posture: {entry.posture.value}"
+                        + (f" — {entry.note}" if entry.note else "")
+                    ),
+                )
+            )
+            continue
+
         issue: int | None = entry.issue if entry else None
         matched_by = "ledger" if issue is not None else ""
         candidates: list[dict[str, Any]] = []
@@ -498,6 +519,16 @@ def apply_actions(
             log.append(
                 f"suppressed (cap): {finding.detector} {action.fingerprint.digest} "
                 f"— {finding.count} occurrence(s), NOT filed"
+            )
+            continue
+        if action.decision is Decision.POSTURE_SUPPRESSED:
+            # Never filed, never even searched. Still observed, so a later
+            # change of heart starts from the truth.
+            entry = ledger.bind(action.fingerprint, action.issue, run.run_id)
+            entry.observe(run.run_id, tasks, finding.count, finding.denominator)
+            log.append(
+                f"posture-suppressed ({action.matched_by}): {finding.detector} "
+                f"{action.fingerprint.digest} — {finding.count} occurrence(s), NOT filed"
             )
             continue
         if action.decision is Decision.NO_NEWS:

--- a/bench/trace_triage/run_trace.py
+++ b/bench/trace_triage/run_trace.py
@@ -49,6 +49,18 @@ from typing import Any
 
 S3_BUCKET = "arenabench-artifacts-578673726240"
 
+# Every filename `load_run` reads. `--fetch`'s include-list is built from
+# this list, not copied by hand, so a new read here cannot outrun a fetch.
+# `result.json` and `results.json` hold different data. See
+# `_exception_types` for why both names stay on the list.
+READ_FILENAMES: tuple[str, ...] = (
+    "results.json",
+    "result.json",
+    "reward.txt",
+    "exception.txt",
+    "stella-events.jsonl",
+)
+
 # Event tags this module indexes eagerly. Everything else stays in `events` and
 # is still reachable — the index is a convenience, never a filter.
 _INDEXED = (

--- a/bench/trace_triage/run_trace.py
+++ b/bench/trace_triage/run_trace.py
@@ -49,16 +49,21 @@ from typing import Any
 
 S3_BUCKET = "arenabench-artifacts-578673726240"
 
-# Every filename `load_run` reads. `--fetch`'s include-list is built from
-# this list, not copied by hand, so a new read here cannot outrun a fetch.
-# `result.json` and `results.json` hold different data. See
-# `_exception_types` for why both names stay on the list.
+# Named once so every read below, and `--fetch`'s include-list, spell each
+# filename the same way. `result.json` and `results.json` hold different
+# data — see `_exception_types` for why both names stay on the list.
+_RESULTS_JSON = "results.json"
+_RESULT_JSON = "result.json"
+_REWARD_TXT = "reward.txt"
+_EXCEPTION_TXT = "exception.txt"
+_EVENTS_JSONL = "stella-events.jsonl"
+
 READ_FILENAMES: tuple[str, ...] = (
-    "results.json",
-    "result.json",
-    "reward.txt",
-    "exception.txt",
-    "stella-events.jsonl",
+    _RESULTS_JSON,
+    _RESULT_JSON,
+    _REWARD_TXT,
+    _EXCEPTION_TXT,
+    _EVENTS_JSONL,
 )
 
 # Event tags this module indexes eagerly. Everything else stays in `events` and
@@ -220,7 +225,7 @@ class Trial:
 
     @property
     def events_path(self) -> Path:
-        return self.root / "agent" / "stella-events.jsonl"
+        return self.root / "agent" / _EVENTS_JSONL
 
 
 @dataclass
@@ -284,7 +289,7 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 
 def _read_reward(task_dir: Path) -> float | None:
-    path = task_dir / "verifier" / "reward.txt"
+    path = task_dir / "verifier" / _REWARD_TXT
     try:
         return float(path.read_text(encoding="utf-8").strip())
     except (OSError, ValueError):
@@ -333,10 +338,10 @@ def load_trial(run_id: str, run_root: Path, trial_uuid: str, task_dir: Path) -> 
         reward=_read_reward(task_dir),
         # The job directory is the task directory's parent.
         exception_types=_exception_types(
-            _read_json(task_dir.parent / "result.json"), task_dir.name
+            _read_json(task_dir.parent / _RESULT_JSON), task_dir.name
         ),
     )
-    exception_path = task_dir / "exception.txt"
+    exception_path = task_dir / _EXCEPTION_TXT
     if exception_path.exists():
         trial.exception_text = exception_path.read_text(encoding="utf-8", errors="replace")
 
@@ -426,7 +431,7 @@ def load_run(root: Path, run_id: str | None = None) -> Run:
     root = root.resolve()
     run = Run(run_id=run_id or root.name, root=root)
     for trial_dir in sorted(p for p in root.iterdir() if p.is_dir()):
-        results = _read_json(trial_dir / "results.json")
+        results = _read_json(trial_dir / _RESULTS_JSON)
         if not run.declared_worker_model:
             worker, roles, sut_ref, name, bare = _declared_seat(results)
             if worker:

--- a/bench/trace_triage/tests/test_dedup.py
+++ b/bench/trace_triage/tests/test_dedup.py
@@ -8,12 +8,13 @@ not run — with a fake `gh` so no test reaches the network.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
 import triage_bench_traces
 from detectors import run_all
-from fingerprint import Ledger, fingerprint_of, markers_in, normalize
+from fingerprint import Ledger, LedgerPosture, fingerprint_of, markers_in, normalize
 from fixtures import proof, write_run
 from issues import Decision, apply_actions, plan_actions
 from run_trace import load_run
@@ -274,6 +275,145 @@ def test_a_human_correction_in_the_ledger_is_never_overwritten(tmp_path):
     ledger.bind(fingerprint, 111, "run-one", note="corrected by hand", source="human")
     ledger.bind(fingerprint, 222, "run-two")
     assert ledger.lookup(fingerprint).issue == 111
+
+
+# --------------------------------------------------------------------------
+# Ledger posture
+# --------------------------------------------------------------------------
+
+
+def test_an_accepted_posture_opens_nothing_and_never_even_searches(tmp_path):
+    """A real, understood finding must stop being re-proposed."""
+    client = FakeGitHub()
+    client.search_raises = True  # if this fires, posture did not short-circuit
+    ledger = _ledger(tmp_path)
+    run = _run_with_witness_failure(tmp_path, "r1", ["alpha__AAA"], "run-one")
+    finding = run_all(run)[0]
+    entry = ledger.bind(finding.fingerprint, None, "run-zero", source="human")
+    entry.posture = LedgerPosture.ACCEPTED
+
+    (action,) = plan_actions(run, [finding], ledger, client, max_new_issues=5)
+    assert action.decision is Decision.POSTURE_SUPPRESSED
+    assert "accepted" in action.matched_by
+
+    apply_actions(run, [action], ledger, client)
+    assert client.created == [], "an accepted finding must never become a new ticket"
+    assert client.comments == [], "an accepted finding must never get a comment either"
+
+
+def test_a_wontfix_posture_needs_no_issue_number(tmp_path):
+    """Binding a fake issue number just to silence a finding would be a lie."""
+    ledger = _ledger(tmp_path)
+    run = _run_with_witness_failure(tmp_path, "r1", ["alpha__AAA"], "run-one")
+    finding = run_all(run)[0]
+    entry = ledger.bind(finding.fingerprint, None, "run-zero", source="human", note="by design")
+    entry.posture = LedgerPosture.WONTFIX
+
+    (action,) = plan_actions(run, [finding], ledger, None, max_new_issues=5)
+    assert action.decision is Decision.POSTURE_SUPPRESSED
+    assert action.issue is None
+    assert "wontfix" in action.matched_by
+    assert "by design" in action.matched_by
+
+
+def test_a_tracked_posture_is_the_default_and_changes_nothing(tmp_path):
+    """With no posture set, the decision never changes."""
+    client = FakeGitHub()
+    ledger = _ledger(tmp_path)
+    run = _run_with_witness_failure(tmp_path, "r1", ["alpha__AAA"], "run-one")
+    finding = run_all(run)[0]
+    entry = ledger.bind(finding.fingerprint, 4242, "run-zero")
+    assert entry.posture == LedgerPosture.TRACKED
+
+    (action,) = plan_actions(run, [finding], ledger, client, max_new_issues=5)
+    assert action.decision is Decision.COMMENT
+
+
+def test_posture_round_trips_through_disk(tmp_path):
+    path = tmp_path / "l.json"
+    ledger = Ledger(path)
+    fingerprint = fingerprint_of("d", "s", "v")
+    entry = ledger.bind(fingerprint, None, "run-one", source="human")
+    entry.posture = LedgerPosture.WONTFIX
+    ledger.save()
+
+    reloaded = Ledger(path)
+    assert reloaded.lookup(fingerprint).posture == LedgerPosture.WONTFIX
+
+
+def test_save_never_drops_the_hand_written_comment_block(tmp_path):
+    """`fingerprints.json` carries a `_comment` array `Ledger` never reads.
+
+    A `save()` that names only its three keys drops it. `--apply` would
+    delete it from the real, tracked file.
+    """
+    path = tmp_path / "l.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "updated_at": "2026-01-01T00:00:00Z",
+                "_comment": ["written by hand", "read by nobody but a human"],
+                "fingerprints": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    ledger = Ledger(path)
+    ledger.bind(fingerprint_of("d", "s", "v"), 1, "run-one")
+    ledger.save()
+
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk["_comment"] == ["written by hand", "read by nobody but a human"]
+
+
+def test_a_ledger_entry_written_before_posture_existed_defaults_to_tracked(tmp_path):
+    """An old file has no `posture` key. Loading it must not crash."""
+    fingerprint = fingerprint_of("d", "s", "v")
+    seeded = _ledger(tmp_path).bind(fingerprint, 99, "old-run", source="seed")
+    payload = seeded.to_json()
+    del payload["posture"]  # an old file on disk has no such key
+
+    path = tmp_path / "l.json"
+    path.write_text(
+        json.dumps({"schema": 1, "fingerprints": {fingerprint.digest: payload}}),
+        encoding="utf-8",
+    )
+    entry = Ledger(path).lookup(fingerprint)
+    assert entry.posture == LedgerPosture.TRACKED
+
+
+def test_posture_suppressed_is_counted_in_the_summary_and_never_filed(tmp_path, monkeypatch, capsys):
+    """The plan prints and counts it. `--apply` still opens and comments on nothing."""
+    root = tmp_path / "runx"
+    write_run(root, [{"task": "alpha__AAA", "reward": 0, "events": _witness_failure_events()}])
+    run = load_run(root, "runx")
+    finding = run_all(run)[0]
+
+    ledger_path = tmp_path / "ledger.json"
+    ledger = Ledger(ledger_path)
+    entry = ledger.bind(finding.fingerprint, None, "run-zero", source="human", note="expected shape")
+    entry.posture = LedgerPosture.WONTFIX
+    ledger.save()
+
+    client = FakeGitHub()
+    client.search_raises = True  # proves nothing searched GitHub
+    monkeypatch.setattr(triage_bench_traces, "GhCli", lambda repo: client)
+
+    code = triage_bench_traces.main(
+        ["--run", "runx", "--mirror", str(root), "--ledger", str(ledger_path), "--apply"]
+    )
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "SUPPRESSED (ledger posture)" in out
+    assert "wontfix" in out
+    assert "1  SUPPRESSED (ledger posture)" in out, "the summary must count it, not just print it"
+    assert client.created == [] and client.comments == []
+
+    reloaded = Ledger(ledger_path)
+    reloaded_entry = reloaded.lookup(finding.fingerprint)
+    assert reloaded_entry.issue is None, "posture suppression must never mint or bind an issue"
+    assert reloaded_entry.runs == ["runx"], "the occurrence is still recorded"
 
 
 # --------------------------------------------------------------------------

--- a/bench/trace_triage/tests/test_detectors.py
+++ b/bench/trace_triage/tests/test_detectors.py
@@ -13,9 +13,14 @@ make, because every one of them has been got wrong in this repository before:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from detectors import run_all
 from fixtures import err, ok, proof, tool_pair, write_run
 from run_trace import load_run
+
+# `tests/test_detectors.py` -> `tests` -> `trace_triage` -> `bench` -> repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _findings(root, code):
@@ -533,3 +538,24 @@ def test_every_detector_declares_its_contract():
         assert det.code and det.title, det
         assert det.search_terms, f"{det.code} needs terms for the de-duplication search"
         assert det.code == det.code.lower().replace(" ", "-")
+
+
+def test_every_declared_site_names_a_file_that_exists():
+    """`site` is hashed into the fingerprint, so a stale string is not
+    prose — it silently repartitions every issue this detector has ever filed.
+
+    This catches a `site` left stale after a rename; it cannot catch the
+    opposite direction (a rename that updates `site` to match, which changes
+    the digest and is a separate problem). A detector with nothing to
+    implicate declares `site=""`, which this skips by design — see
+    `detectors.py`'s "Adding a detector".
+    """
+    from detectors import DETECTORS
+
+    missing = [
+        (det.code, det.site) for det in DETECTORS if det.site and not (_REPO_ROOT / det.site).is_file()
+    ]
+    assert not missing, (
+        "these detectors declare a `site` that names no file in the tree — "
+        f"fix the string or the file, never leave it stale: {missing}"
+    )

--- a/bench/trace_triage/tests/test_run_trace.py
+++ b/bench/trace_triage/tests/test_run_trace.py
@@ -9,9 +9,11 @@ findings looks exactly like a healthy one.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
+import triage_bench_traces
 from fixtures import ok, proof, tool_pair, write_run
-from run_trace import load_run
+from run_trace import READ_FILENAMES, load_run
 
 
 def test_a_half_written_tail_is_counted_not_fatal(tmp_path):
@@ -155,3 +157,35 @@ def test_json_arrays_on_a_line_are_ignored_rather_than_crashing(tmp_path):
     (trial,) = load_run(tmp_path, "r").trials
     assert trial.events == []
     assert trial.malformed_lines == 1
+
+
+# --------------------------------------------------------------------------
+# `--fetch`'s include-list against what `load_run` actually reads
+# --------------------------------------------------------------------------
+
+
+def test_fetch_includes_every_file_load_run_reads():
+    """A dropped pattern here is invisible until a run silently loads wrong.
+
+    If `*reward.txt` ever fell out of `_INCLUDES`, every trial would load with
+    `reward = None` — no crash, no malformed-line count, just every
+    `oracle-flip-ungraded` finding disappearing and the run reading as
+    healthy. This checks the real argv `--fetch` runs against
+    `run_trace.READ_FILENAMES`, the loader's own declaration of what it reads.
+    """
+    argv = triage_bench_traces.fetch_argv("run-id", Path("/tmp/mirror/run-id"))
+    missing = triage_bench_traces.missing_includes(argv, READ_FILENAMES)
+    assert not missing, f"--fetch would not sync: {missing}"
+
+
+def test_missing_includes_actually_catches_a_dropped_pattern():
+    """The check above has teeth: prove it on an argv with a pattern removed.
+
+    Without this, `test_fetch_includes_every_file_load_run_reads` could pass
+    vacuously — every real filename happens to survive today, which proves
+    nothing about whether the check would notice one going missing tomorrow.
+    """
+    argv = triage_bench_traces.fetch_argv("run-id", Path("/tmp/mirror/run-id"))
+    dropped = argv.index("*reward.txt")
+    truncated = argv[: dropped - 1] + argv[dropped + 1 :]  # drop `--include *reward.txt`
+    assert triage_bench_traces.missing_includes(truncated, READ_FILENAMES) == ["reward.txt"]

--- a/bench/trace_triage/tests/test_run_trace.py
+++ b/bench/trace_triage/tests/test_run_trace.py
@@ -8,9 +8,12 @@ findings looks exactly like a healthy one.
 
 from __future__ import annotations
 
+import ast
 import json
+import re
 from pathlib import Path
 
+import run_trace
 import triage_bench_traces
 from fixtures import ok, proof, tool_pair, write_run
 from run_trace import READ_FILENAMES, load_run
@@ -189,3 +192,52 @@ def test_missing_includes_actually_catches_a_dropped_pattern():
     dropped = argv.index("*reward.txt")
     truncated = argv[: dropped - 1] + argv[dropped + 1 :]  # drop `--include *reward.txt`
     assert triage_bench_traces.missing_includes(truncated, READ_FILENAMES) == ["reward.txt"]
+
+
+# --------------------------------------------------------------------------
+# `READ_FILENAMES` against what `run_trace.py` actually names in code
+# --------------------------------------------------------------------------
+
+_FILENAME_LITERAL = re.compile(r"^[\w.-]+\.(?:json|jsonl|txt)$")
+
+
+def _filename_literals(source: str, filename: str = "<source>") -> set[str]:
+    """Every string in `source` shaped like a filename, skipping the docstring.
+
+    A module docstring may name a file in prose (`spec.json`) with no code
+    behind it. Its string is one big `ast.Constant`; the tight filename shape
+    below never matches a whole paragraph, so no special case is needed.
+    """
+    tree = ast.parse(source, filename=filename)
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and _FILENAME_LITERAL.match(node.value)
+    }
+
+
+def test_every_filename_literal_in_run_trace_is_declared():
+    """A raw filename string in `run_trace.py` must be one `load_run` reads.
+
+    `READ_FILENAMES` names each file once (`_RESULTS_JSON`, ...) and every
+    read routes through that name, not a second spelling. This scans the
+    module's own source, so a new read added as a fresh literal — bypassing
+    the shared constants — fails here instead of silently outrunning
+    `--fetch`.
+    """
+    source = Path(run_trace.__file__).read_text(encoding="utf-8")
+    literals = _filename_literals(source, run_trace.__file__)
+    assert literals, "the scan found no filename literal — it stopped reading its subject"
+    stray = literals - set(READ_FILENAMES)
+    assert not stray, (
+        f"run_trace.py spells {sorted(stray)} as a raw string outside "
+        "READ_FILENAMES — route the read through a named constant there"
+    )
+
+
+def test_the_filename_scan_actually_catches_a_stray_literal():
+    """The check above has teeth: a raw literal outside the list is a failure."""
+    source = 'path = task_dir / "stray_file.json"\n'
+    assert _filename_literals(source) == {"stray_file.json"}

--- a/bench/trace_triage/triage_bench_traces.py
+++ b/bench/trace_triage/triage_bench_traces.py
@@ -22,8 +22,10 @@ that are re-renderings of the event stream:
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import subprocess
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -38,19 +40,17 @@ from issues import (  # noqa: E402
     apply_actions,
     plan_actions,
 )
-from run_trace import S3_BUCKET, Run, load_run  # noqa: E402
+from run_trace import READ_FILENAMES, S3_BUCKET, Run, load_run  # noqa: E402
 
 DEFAULT_MIRROR = Path(".trace-mirror")
 
 # What a mirror needs. `stella-run.json` and `stella-run.stdout.txt` are
 # re-renderings of the event stream and can each exceed 70 MB per trial, so
 # fetching them would cost gigabytes to answer questions the JSONL answers.
-_INCLUDES = (
-    "*stella-events.jsonl",
-    "*reward.txt",
-    "*exception.txt",
-    "*/result.json",
-    "*/results.json",
+#
+# The `load_run` half is built from `run_trace.READ_FILENAMES`, not copied
+# by hand, and a test checks this. The other four names are extra.
+_INCLUDES: tuple[str, ...] = tuple(f"*{name}" for name in READ_FILENAMES) + (
     "*config.json",
     "*spec.json",
     "*seat.json",
@@ -58,9 +58,30 @@ _INCLUDES = (
 )
 
 
-def fetch_run(run_id: str, mirror: Path) -> Path:
-    destination = mirror / run_id
-    destination.mkdir(parents=True, exist_ok=True)
+def missing_includes(argv: list[str], filenames: Iterable[str]) -> list[str]:
+    """Which of `filenames` no `--include` pattern in `argv` would fetch.
+
+    A pure check over argv, never over the live filesystem or S3 — so the
+    de-duplication test in `tests/test_run_trace.py` can hold `--fetch`'s
+    include-list to `run_trace.READ_FILENAMES` with no network at all. The
+    probe path (`a/b/c/<name>`) exists only so `fnmatch` has something to
+    match a pattern like `*reward.txt` against; a real S3 key is always at
+    least that deep, so a pattern that matches the probe matches the key.
+    """
+    includes = [argv[i + 1] for i, arg in enumerate(argv) if arg == "--include" and i + 1 < len(argv)]
+    return [
+        name
+        for name in filenames
+        if not any(fnmatch.fnmatch(f"a/b/c/{name}", pattern) for pattern in includes)
+    ]
+
+
+def fetch_argv(run_id: str, destination: Path) -> list[str]:
+    """The `aws s3 sync` command line `--fetch` runs.
+
+    Extracted from `fetch_run` so it is testable on its own — no network, no
+    `aws` binary on PATH, just the argv `fetch_run` would hand to it.
+    """
     args = [
         "aws",
         "s3",
@@ -73,7 +94,13 @@ def fetch_run(run_id: str, mirror: Path) -> Path:
     ]
     for pattern in _INCLUDES:
         args += ["--include", pattern]
-    result = subprocess.run(args, check=False)
+    return args
+
+
+def fetch_run(run_id: str, mirror: Path) -> Path:
+    destination = mirror / run_id
+    destination.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(fetch_argv(run_id, destination), check=False)
     if result.returncode != 0:
         raise SystemExit(f"aws s3 sync failed for run {run_id} (exit {result.returncode})")
     return destination
@@ -112,6 +139,16 @@ def _print_action(action: Action, index: int, total: int) -> None:
             "already hold, and a comment restating the issue is noise on it. The run and\n"
             "task list are still recorded in the ledger under --apply, so the next run's\n"
             "novelty check is measured against the truth. Force it with --comment-anyway."
+        )
+        print("-" * 78)
+        return
+    if action.decision is Decision.POSTURE_SUPPRESSED:
+        print(f"matched by  : {action.matched_by}")
+        print(
+            "\nNothing would be posted: a human has marked this fingerprint accepted or\n"
+            "wontfix in the ledger, so it never proposes a new issue and never searches\n"
+            "GitHub. The occurrence is still recorded under --apply. Delete the ledger\n"
+            "entry (fingerprints.json) to let it flow through the normal decision again."
         )
         print("-" * 78)
         return


### PR DESCRIPTION
Batch PR for #6300 (bench, 2 members). Both members touch `bench/trace_triage`'s fingerprint machinery, so they ride together.

## #2972 — a file rename silently repartitions every defect fingerprint

`site` is hashed into a defect's fingerprint, but nothing checked that it still names a real file. It didn't, right now, on `main`: `crates/stella-pipeline` was deleted in #3865, and four detector declarations (`witness-unavailable` x2, `oracle-flip-ungraded` x2) still pointed at `crates/stella-pipeline/src/verify.rs`. A fifth (`grep-ere-false-negative`) pointed at `crates/stella-tools/src/grep/fallback.rs`, a standalone `grep` tool that no longer exists — it was folded into the unified `search` tool.

**What/why:** implemented option 1 from the issue (the cheap half): `test_every_declared_site_names_a_file_that_exists` walks `DETECTORS` and fails on a non-empty `site` that names no file in the tree.

**Witness:** the test fails on `main` today — proven with `git stash` locally — because the five stale sites above are real, not hypothetical. Fixed by:
- The four `stella-pipeline` sites → `site=""`. That logic now lives in a private verification plugin (Vera), not in this repo, so nothing here is implicated — the detector's own documented convention for "nothing to implicate."
- `grep-ere-false-negative` → `site=""`, same reasoning (no file in the current tree owns a POSIX-fallback shape).
- `no-post-verdict-file-change` → `crates/stella-cli/src/candidate_workspaces.rs`, its real successor (`candidate_ws/adopt.rs` → `candidate_workspaces.rs`, same `adopt()` function).

Since `site` is hashed into the fingerprint, changing it changes the digest. The ledger (`fingerprints.json`) already had 4 entries bound to real issues (#2941, #2927, #2908 x2) under the old digests — those are re-keyed to the new digests (site changed, everything else identical) so the same issue numbers still bind on the next `--fetch`, instead of silently duplicating.

## #2974 — no ledger posture for an accepted defect, and an untested `--fetch` include-list

**Part 1 — posture.** `LedgerEntry` had no way to say "this finding is real, understood, and should stop being proposed" without lying about an issue number. `LedgerPosture` (`tracked` / `accepted` / `wontfix`) fixes that. A silenced entry now produces a distinct `SUPPRESSED (ledger posture)` decision in `plan_actions` — before any search, before any client is touched — and `apply_actions` records the occurrence without filing anything. `README.md`'s "Editing the ledger" documents it.

**Witness:** `test_an_accepted_posture_opens_nothing_and_never_even_searches`, `test_a_wontfix_posture_needs_no_issue_number`, and `test_posture_suppressed_is_counted_in_the_summary_and_never_filed` all fail with `ImportError: cannot import name 'LedgerPosture'` against `git stash` of `fingerprint.py`/`issues.py`, and pass with them.

**Part 2 — the `--fetch` include-list.** It was a second, hand-maintained copy of what `run_trace.load_run` actually reads. `run_trace.READ_FILENAMES` is now the single source of truth; `_INCLUDES` is generated from it. `test_fetch_includes_every_file_load_run_reads` fails if a read in `load_run` ever outruns what the mirror fetches, and a negative-control sibling (`test_missing_includes_actually_catches_a_dropped_pattern`) proves the check has teeth rather than passing vacuously.

**Witness:** fails with `ImportError: cannot import name 'READ_FILENAMES'` against `git stash`, passes with the change.

## Found while touching the same class

`Ledger.save()` named only the three top-level keys it manages (`schema`, `updated_at`, `fingerprints`), so any `--apply` run against the real, tracked `fingerprints.json` silently deleted its hand-written `_comment` block the moment it wrote the file — verified directly against the committed file before this PR (`_comment` present before `save()`, gone after). `save()` now round-trips every top-level key it doesn't itself own. Witness: `test_save_never_drops_the_hand_written_comment_block`.

## Could not ride

None — both members' full scope shipped in this PR.

## Verification

```
uv run --with pytest --no-project pytest -q bench/trace_triage/tests   # 102 passed
make guards-fast                                                       # green, including check-prose
```

No Rust files touched, so `cargo fmt --all` is a no-op.

Tests deleted: None

Closes #2972
Closes #2974
Closes #6300

## Summary by Sourcery

Harden trace triage fingerprint and ledger management by validating detector sites, adding explicit suppression postures, and keeping persisted metadata and fetched trace inputs consistent.

New Features:
- Add ledger postures for suppressing accepted or wont-fix findings without requiring an issue number.
- Validate detector sites against files in the repository and centralize trace filenames used by loading and fetch operations.

Bug Fixes:
- Prevent stale detector sites from silently changing fingerprints.
- Preserve hand-maintained top-level ledger metadata when saving fingerprints.
- Keep trace mirror fetches synchronized with the files consumed by run loading.

Enhancements:
- Record and report posture-suppressed occurrences without searching, commenting, or filing issues.
- Maintain backward compatibility for ledger entries without posture data.

Documentation:
- Document ledger posture management and suppression behavior.

Tests:
- Add coverage for ledger postures, metadata preservation, site validity, and fetch include synchronization.

Chores:
- Re-key affected fingerprint ledger entries after correcting detector sites.