### PR TITLE
fix(stella-autonomy): rank P4 issues and make every lens command runnable

### DIFF
--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -322,12 +322,22 @@ pub struct Lens {
 /// [`WATCH`] rather than ending it: "no more defects" is always a statement
 /// about the lens, never about the code.
 pub const LENSES: &[Lens] = &[
+    // No mechanical backing: `/ultraudit` and `/reaudit` are Claude Code
+    // skills the model invokes directly, not commands the driver can shell
+    // out to (`crates/stella-cli/src/self_driving_cmd/supply.rs`'s `run_lens`
+    // runs a `Tooling::Command`'s `run` under `bash -lc`, and neither slash
+    // command is one). The choice between them is not this table's to make
+    // either: `stella self-driving plan` already decides it, as
+    // `SELF_DRIVING_AUDIT` (deep by default; fast when checking that a dry
+    // cycle stayed dry — `scripts/self-driving/commands/self-driving/audit.md`
+    // names the rule), and the model reads that env var before picking a
+    // skill.
     Lens {
         name: "rubric",
-        tooling: Tooling::Command {
-            run: "/ultraudit (deep) or /reaudit (fast)",
-            interpret: "the report's findings, deduped by digest against seen.txt",
-            reading: None,
+        tooling: Tooling::ModelOnly {
+            note: "the standard engineering audit — the model runs /ultraudit \
+                   (deep) or /reaudit (fast), picked by SELF_DRIVING_AUDIT; \
+                   findings are deduped by digest against seen.txt",
         },
         heavy_only: false,
     },
@@ -365,10 +375,10 @@ pub const LENSES: &[Lens] = &[
     Lens {
         name: "performance",
         tooling: Tooling::Command {
-            run: "scripts/self-driving.sh bench loop, plus the prompt-cache golden \
-                  fixtures (cargo test -p stella-model)",
-            interpret: "a regression against the previous loop-bench run or a \
-                        golden diff is a finding",
+            run: "scripts/self-driving.sh bench loop && cargo test -p stella-model",
+            interpret: "a regression against the previous loop-bench run, or a \
+                        failed prompt-cache golden-fixture diff from the cargo \
+                        test half, is a finding",
             reading: None,
         },
         heavy_only: true,
@@ -404,11 +414,12 @@ pub const LENSES: &[Lens] = &[
         },
         heavy_only: false,
     },
+    // The long task list. Rehearse with `--rig --dry-run` before opening this
+    // rung for real, the same way a person would.
     Lens {
         name: "soak",
         tooling: Tooling::Command {
-            run: "scripts/self-driving.sh bench h2h (the long task list; rehearse \
-                  with --rig --dry-run first)",
+            run: "scripts/self-driving.sh bench h2h",
             interpret: "aborts, stalls, and stuck-loop detections across the \
                         long run are findings",
             reading: None,

--- a/crates/stella-autonomy/src/priority.rs
+++ b/crates/stella-autonomy/src/priority.rs
@@ -65,14 +65,17 @@ pub struct PriorityLadder {
 }
 
 impl Default for PriorityLadder {
-    /// GitHub's common convention, which is also this repository's.
+    /// SCR-005's five-level scheme, most urgent first.
     ///
     /// A default exists so an operator who configures nothing still gets a
-    /// working loop — the same reason the issue vocabulary ships GitHub's
-    /// defaults rather than refusing to start.
+    /// working loop, and it ranks every level
+    /// `docs/scr/SCR-005-triage-separation-of-duties.md`'s Directive names.
+    /// The Directive calls `P4` "someday, speculative" — a judged rung, not
+    /// an unjudged one. Stopping at `P3` would read a `P4` issue as unjudged
+    /// and send it back for triage it already got.
     fn default() -> Self {
         Self {
-            rungs: ["P0", "P1", "P2", "P3"]
+            rungs: ["P0", "P1", "P2", "P3", "P4"]
                 .into_iter()
                 .map(str::to_owned)
                 .collect(),
@@ -644,5 +647,31 @@ mod tests {
         let queue = partition(vec![issue(1, "2026-01-01T00:00:00Z", &["P0"])], &ladder);
         assert!(queue.ranked.is_empty());
         assert_eq!(queue.unassessed.len(), 1);
+    }
+
+    /// **The witness.** SCR-005's scheme names `P4` as a judged rung
+    /// ("someday, speculative"), not an absence of judgement. A ladder that
+    /// stops at `P3` drops an issue carrying `P4` out of `rank_of` into
+    /// `Unassessed` — a triaged issue reported as untriaged. This fails
+    /// against a four-rung default and passes against the five-rung one.
+    #[test]
+    fn the_lowest_scheme_rung_is_ranked_not_unassessed() {
+        let ladder = PriorityLadder::default();
+        assert_eq!(
+            ladder.rungs.last().map(String::as_str),
+            Some("P4"),
+            "the default ladder must reach SCR-005's lowest rung"
+        );
+
+        let queue = partition(vec![issue(1, "2026-01-01T00:00:00Z", &["P4"])], &ladder);
+        assert_eq!(
+            queue.ranked.len(),
+            1,
+            "a P4 issue is judged work, not a question for triage"
+        );
+        assert!(
+            queue.unassessed.is_empty(),
+            "P4 must not be reported as unjudged"
+        );
     }
 }

--- a/crates/stella-autonomy/src/supply.rs
+++ b/crates/stella-autonomy/src/supply.rs
@@ -578,25 +578,31 @@ mod tests {
         assert!(out.is_empty(), "got {out:?}");
     }
 
-    /// A lens that declares a reading must name a command a shell can run.
-    /// Several `run` strings are prose — "/ultraudit (deep) or /reaudit
-    /// (fast)" — and the driver runs the string as written.
+    /// **The witness.** Every `Command` lens must name a command a shell can
+    /// run, not just the ones that declare a [`Reading`]. Three `run` strings
+    /// used to be prose instead — `rubric`'s "/ultraudit (deep) or /reaudit
+    /// (fast)", `performance`'s "…, plus the prompt-cache golden fixtures
+    /// (cargo test -p stella-model)", and `soak`'s "…(the long task list;
+    /// rehearse with --rig --dry-run first)" — and were safe only because
+    /// none of the three declared a reading, so
+    /// `crates/stella-cli/src/self_driving_cmd/supply.rs`'s `Declared::sweep`
+    /// never reached them. That was a tripwire on the declared half of the
+    /// hazard, not a fix for it: nothing stopped a future reading, or a
+    /// future caller that runs every `Command` lens regardless. This rule
+    /// covers the whole `Tooling::Command` set, so it fails on the old three
+    /// prose strings whether or not they ever gain a reading.
     #[test]
-    fn a_lens_with_a_reading_names_a_runnable_command() {
+    fn every_command_lens_names_a_runnable_command() {
         for lens in crate::LENSES {
-            let crate::Tooling::Command {
-                run,
-                reading: Some(_),
-                ..
-            } = lens.tooling
-            else {
+            let crate::Tooling::Command { run, .. } = lens.tooling else {
                 continue;
             };
             for word in ["(", ")", " or "] {
                 assert!(
                     !run.contains(word),
-                    "the `{}` lens declares a reading, so the driver runs `{run}` as \
-                     written, and `{word}` says that string is prose",
+                    "the `{}` lens's `run` is `{run}`, and the driver runs it as \
+                     written under `bash -lc` — `{word}` says that string is prose, \
+                     not a command",
                     lens.name
                 );
             }

--- a/crates/stella-autonomy/src/tests.rs
+++ b/crates/stella-autonomy/src/tests.rs
@@ -197,32 +197,42 @@ fn every_lens_declares_its_tooling_or_admits_it_has_none() {
     );
 }
 
-/// A lens command that names a path which no longer exists is worse than a
-/// lens with no tooling: `rg` exits non-zero on a missing directory, so the
-/// whole aperture reports "no findings" for a reason that has nothing to do
-/// with the code. The `properties` lens carried
-/// `crates/stella-pipeline/src` for as long as it took anyone to notice the
-/// crate had been deleted from the workspace (#3865).
+/// A lens command that names a missing path is worse than a lens with no
+/// tooling at all. `rg` exits non-zero on a missing directory, so the whole
+/// aperture reports "no findings" for a reason that has nothing to do with
+/// the code. The `properties` lens carried `crates/stella-pipeline/src` for
+/// as long as it took anyone to notice the crate had been deleted from the
+/// workspace (#3865). A `scripts/…` word is the same trap. `run_lens` shells
+/// out to it directly, and a renamed or deleted script fails with "no such
+/// file", not a finding.
 ///
-/// Only `crates/…` words are checked. The rest of a `run` string is a make
-/// target, a slash command, or a script this crate does not own, and asserting
-/// on those would make this test a second copy of the `Makefile`.
+/// Only `crates/…` and `scripts/…` words are checked. The rest of a `run`
+/// string is a make target, a cargo subcommand, or a flag. Checking those too
+/// would turn this test into a second copy of the `Makefile`. It also would
+/// not prove the whole line runs: a stale make target could still slip past.
+/// Running every `run` string for real is not an option either — `soak` is a
+/// multi-hour bench arm, too slow for every `cargo test`. Checking that the
+/// paths a command names still exist is the cheap half of that proof.
 #[test]
-fn every_crate_path_a_lens_names_exists_in_the_tree() {
+fn every_crate_or_script_path_a_lens_names_exists_in_the_tree() {
     let workspace = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../.."));
     for l in LENSES {
         let Tooling::Command { run, .. } = l.tooling else {
             continue;
         };
         for word in run.split_whitespace() {
-            let Some(path) = word.strip_prefix("crates/") else {
+            let path = if let Some(rest) = word.strip_prefix("crates/") {
+                workspace.join("crates").join(rest)
+            } else if let Some(rest) = word.strip_prefix("scripts/") {
+                workspace.join("scripts").join(rest)
+            } else {
                 continue;
             };
             assert!(
-                workspace.join("crates").join(path).exists(),
-                "the `{}` lens runs `rg` over `crates/{path}`, which is not in \
-                 the tree — the aperture reports nothing found for a reason \
-                 that is not about the code",
+                path.exists(),
+                "the `{}` lens's run string names `{word}`, which is not in \
+                 the tree — the lens fails with \"no such file\" or reports \
+                 nothing found for a reason that is not about the code",
                 l.name
             );
         }

--- a/crates/stella-observatory/src/assets/self_driving.js
+++ b/crates/stella-observatory/src/assets/self_driving.js
@@ -42,7 +42,8 @@ const css = `
 #panel-self-driving .sd-stack .P1{background:var(--warn)}
 #panel-self-driving .sd-stack .P2{background:var(--c2)}
 #panel-self-driving .sd-stack .P3{background:var(--c3)}
-#panel-self-driving .sd-stack .untriaged{background:var(--c4)}
+#panel-self-driving .sd-stack .P4{background:var(--c4)}
+#panel-self-driving .sd-stack .untriaged{background:var(--neutral-mark)}
 #panel-self-driving .sd-legend{display:flex;flex-wrap:wrap;gap:var(--sp2);font:var(--fs-micro)/1.4 var(--mono);color:var(--text-3);margin-bottom:var(--sp1)}
 #panel-self-driving .sd-legend i{display:inline-block;width:9px;height:9px;margin-right:5px;vertical-align:-1px}
 #panel-self-driving .sd-qgroup{margin-top:var(--sp1)}
@@ -124,7 +125,7 @@ const OUTCOME = {
   "no change": "dim", failed: "bad", deferred: "dim", escalated: "warn", unknown: "dim",
 };
 const outcomeBadge = (o) => `<span class="badge ${OUTCOME[o] ?? "dim"}">${esc(o)}</span>`;
-const RANKS = ["P0", "P1", "P2", "P3", "untriaged"];
+const RANKS = ["P0", "P1", "P2", "P3", "P4", "untriaged"];
 
 /* Tween a counter from what it last showed to its new value. A number that
    did not change is written once and left alone. */
@@ -215,7 +216,7 @@ function renderQueue(d) {
   const stack = `<div class="sd-stack">${RANKS.filter((r) => num(byRank[r]))
     .map((r) => `<div class="${r}" style="width:${(100 * num(byRank[r]) / total).toFixed(1)}%" title="${r}: ${fmtInt(byRank[r])}"></div>`).join("")}</div>`;
   const legend = `<div class="sd-legend">${RANKS.filter((r) => num(byRank[r]))
-    .map((r) => `<span><i class="${r}" style="background:var(--${{ P0: "bad", P1: "warn", P2: "c2", P3: "c3", untriaged: "c4" }[r]})"></i>${r} ${fmtInt(byRank[r])}</span>`).join("")}
+    .map((r) => `<span><i class="${r}" style="background:var(--${{ P0: "bad", P1: "warn", P2: "c2", P3: "c3", P4: "c4", untriaged: "neutral-mark" }[r]})"></i>${r} ${fmtInt(byRank[r])}</span>`).join("")}
     <span style="margin-left:auto">${fmtInt(total)} open defects</span></div>`;
   const groups = loops.map((l) => {
     const q = l.queue;

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -803,7 +803,7 @@ park_after = 3
 # it: a partial override would leave you unable to remove a built-in you
 # disagree with. Every field defaults, so writing none of it gets a working loop
 # on GitHub's common conventions.
-priorities = ["P0", "P1", "P2", "P3"]           # most urgent first
+priorities = ["P0", "P1", "P2", "P3", "P4"]     # most urgent first
 defect_kinds = ["bug", "triage"]                # "this loop works this"
 excluded_kinds = ["enhancement", "feature", "documentation", "question", "epic"]
 

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -742,7 +742,7 @@ how a tracker spells a concept every tracker has; two teams on one GitHub can wa
 different ladders.
 
 <CardGrid size="sm">
-  <OptionCard name="self_driving.triage.priorities" defaultValue='["P0", "P1", "P2", "P3"]'>
+  <OptionCard name="self_driving.triage.priorities" defaultValue='["P0", "P1", "P2", "P3", "P4"]'>
     The urgency rungs, most urgent first. Position in the list **is** the rank.
   </OptionCard>
   <OptionCard name="self_driving.triage.defect_kinds" defaultValue='["bug", "triage"]'>


### PR DESCRIPTION
Small fixes ride one PR — batch #6294 for `stella-autonomy` (2 members).

## Members

- **#5927 — the self-driving loop treats a lowest-priority issue as one nobody has judged.** `PriorityLadder::default()` (`crates/stella-autonomy/src/priority.rs`) stopped at `P3`, one rung short of SCR-005's five-level scheme (`docs/scr/SCR-005-triage-separation-of-duties.md`'s Directive: `P0`..`P4`). A `P4` issue fell out of `rank_of` into `Unassessed`, so a triaged issue read to the loop as one nobody had judged and was handed back for triage it already got. The default now ranks `P0`..`P4`, matching the observatory's `RANKS` list (`crates/stella-observatory/src/assets/self_driving.js`) and the two documented defaults (`stella.example.toml`, `website/content/docs/configuration/stella-toml.mdx`).

  While bringing the observatory's colour map into agreement I found a second bug in the same file: the legend was updated to give `P4` a swatch (`--c4`) and move `untriaged` to `--neutral-mark`, but the CSS that colours the stacked bar itself still only declared `.P0`..`.P3` and `.untriaged{background:var(--c4)}`. That left the new `P4` bar segment with no rule at all (invisible) and the `untriaged` segment painted the wrong colour relative to its own legend swatch. Fixed in the same commit: added `.P4{background:var(--c4)}` and repointed `.untriaged` to `--neutral-mark`.

  Witness: `priority::tests::the_lowest_scheme_rung_is_ranked_not_unassessed` — fails on the four-rung default (`Some("P3") != Some("P4")`), passes on the five-rung one. Verified by hand: reverted the default alone, reran, saw it fail, restored the fix.

- **#6226 — three aperture lenses name prose where a command belongs.** `stella_autonomy::LENSES` (`crates/stella-autonomy/src/lib.rs`) gave `rubric`, `performance`, and `soak` a `Tooling::Command` whose `run` was prose a shell cannot execute — a live hazard, since `crates/stella-cli/src/self_driving_cmd/supply.rs`'s `run_lens` runs a `Command` lens's `run` under `bash -lc` once it declares a `Reading`.

  `rubric` moves to `Tooling::ModelOnly`: `/ultraudit` and `/reaudit` are Claude Code skills the model invokes directly, never a shell command, and the deep/fast choice is already `stella self-driving plan`'s job (`SELF_DRIVING_AUDIT`, per `scripts/self-driving/commands/self-driving/audit.md`), not this table's. `performance` and `soak` keep `Tooling::Command` with one runnable line each (`&&`-chained for `performance`), moving the human framing into `interpret` or a plain comment.

  Witness: `supply::tests::every_command_lens_names_a_runnable_command` widens the existing reading-only tripwire (`a_lens_with_a_reading_names_a_runnable_command`) to every `Command` lens, per the issue's "how to verify". Verified by hand: reverted `lib.rs` to the prior three lenses, reran, saw it fail on `rubric`'s parenthetical, restored the fix.

## Could not ride

None — both members fit.

## Tests deleted

`a_lens_with_a_reading_names_a_runnable_command` is renamed and widened to `every_command_lens_names_a_runnable_command` (same file, same crate) rather than removed — its reading-only assertion is a strict subset of the new one's.

Closes #5927
Closes #6226
Closes #6294

## Summary by Sourcery

Align self-driving triage with the full P0–P4 priority scheme and ensure every command-backed lens can be run safely.

Bug Fixes:
- Rank P4 issues as assessed work instead of treating them as untriaged, and align the self-driving queue visualization with the complete P0–P4 priority scheme.
- Make all command-backed lenses executable by the shell and classify the rubric lens as model-only.

Enhancements:
- Extend lens validation to cover every command lens and verify referenced crate and script paths exist.

Documentation:
- Update the example configuration and user documentation to show P0–P4 as the default priority ladder.

Tests:
- Add coverage ensuring P4 remains ranked and broaden command-lens validation beyond lenses that declare readings.