### PR TITLE
fix(stella-tools): tools batch — codegraph data loss, batched read coverage, foundry allowlist witness

### DIFF
--- a/crates/stella-cli/src/tool_foundry.rs
+++ b/crates/stella-cli/src/tool_foundry.rs
@@ -105,6 +105,13 @@ mod tests {
     use stella_core::ports::ToolExecutor;
     use stella_protocol::tool::ToolOutput;
 
+    /// How long the bare outbound-reachability probe may wait before the
+    /// runner is treated as one whose reachability cannot be determined. A
+    /// TCP connect to a public resolver either completes or is refused in
+    /// well under a second on a runner with egress; anything past that is a
+    /// dropped SYN, not a slow one.
+    const NET_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
     /// The hash keys durable notification ids (`ingest_cmd::lineage`), so its
     /// output for a given input is a compatibility surface: a changed value
     /// re-surfaces every already-delivered notification.
@@ -186,11 +193,30 @@ mod tests {
         // unwrapped process, independent of anything the foundry gate does,
         // so a network-isolated runner reports nothing rather than a false
         // reading in either direction.
-        let probe = tokio::process::Command::new("bash")
-            .args(["-c", "exec 3<>/dev/tcp/1.1.1.1/53 && echo REACHED"])
-            .output()
-            .await
-            .expect("the bare probe itself must spawn");
+        //
+        // Bounded, because bash's `/dev/tcp` connect carries no timeout of
+        // its own: a firewall that drops the SYN rather than refusing it
+        // leaves the probe waiting on the kernel's retry ladder — minutes,
+        // and a hung suite rather than a skipped test. An expiry says the
+        // runner's reachability could not be determined, which is the same
+        // answer as "cannot reach" and takes the same exit. `kill_on_drop`
+        // is what stops the abandoned bash outliving the timeout.
+        let probe = tokio::time::timeout(
+            NET_PROBE_TIMEOUT,
+            tokio::process::Command::new("bash")
+                .args(["-c", "exec 3<>/dev/tcp/1.1.1.1/53 && echo REACHED"])
+                .kill_on_drop(true)
+                .output(),
+        )
+        .await;
+        let Ok(probe) = probe else {
+            eprintln!(
+                "skipped: outbound reachability undetermined — the bare probe did not \
+                 answer within {NET_PROBE_TIMEOUT:?}"
+            );
+            return;
+        };
+        let probe = probe.expect("the bare probe itself must spawn");
         if !String::from_utf8_lossy(&probe.stdout).contains("REACHED") {
             return;
         }

--- a/crates/stella-cli/src/tool_foundry.rs
+++ b/crates/stella-cli/src/tool_foundry.rs
@@ -102,6 +102,8 @@ pub(crate) fn fnv1a(s: &str) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use stella_core::ports::ToolExecutor;
+    use stella_protocol::tool::ToolOutput;
 
     /// The hash keys durable notification ids (`ingest_cmd::lineage`), so its
     /// output for a given input is a compatibility surface: a changed value
@@ -111,5 +113,172 @@ mod tests {
         assert_eq!(fnv1a(""), 0xcbf2_9ce4_8422_2325);
         assert_eq!(fnv1a("jq {p1} {p2}"), fnv1a("jq {p1} {p2}"));
         assert_ne!(fnv1a("jq {p1} {p2}"), fnv1a("jq {p1}"));
+    }
+
+    /// A staged `[foundry]` manifest naming a network-reachability probe.
+    /// `witness_input` needs at least one value — an empty table is a
+    /// declared-vacuous witness (`VacuousWitness::NoWitnessInput`) — so it
+    /// carries an unused `p1`, ignored by the script, the same shape
+    /// `author_cat` uses in `adopt/tests.rs`. Since
+    /// `adopt::Builtins::execute` always errors, any candidate that runs at
+    /// all proves a capability flip.
+    fn author_netcheck(root: &Path, name: &str, body: &str) {
+        let staged = root.join(stella_tools::foundry_gate::PROPOSED_DIR);
+        std::fs::create_dir_all(&staged).expect("create proposed dir");
+        let script_path = staged.join(format!("{name}.sh"));
+        std::fs::write(&script_path, body).expect("write script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+                .expect("mark executable");
+        }
+        std::fs::write(
+            staged.join(format!("{name}.toml")),
+            format!(
+                "name = \"{name}\"\n\
+                 description = \"Probe outbound network reachability.\"\n\
+                 command = [\"./{dir}/{name}.sh\"]\n\
+                 \n\
+                 [foundry]\n\
+                 authored_by = \"{authored_by}\"\n\
+                 signature = \"netcheck\"\n\
+                 occurrences = 3\n\
+                 witness_input = {{ p1 = \"unused\" }}\n\
+                 \n\
+                 [input_schema]\n\
+                 type = \"object\"\n\
+                 [input_schema.properties.p1]\n\
+                 type = \"string\"\n",
+                dir = stella_tools::foundry_gate::PROPOSED_DIR,
+                authored_by = stella_tools::foundry_gate::AUTHORED_BY,
+            ),
+        )
+        .expect("write manifest");
+    }
+
+    /// `foundry.network_allowlist`'s **allow** direction, driven through
+    /// the real chain a session actually runs — a project
+    /// `.stella/settings.json`, real discovery
+    /// (`stella_tools::custom::discover_in`), the adoption gate,
+    /// [`apply_foundry_runtime`], and the real dispatch seam
+    /// (`CustomToolSet::execute`). The **deny** direction already has this
+    /// witness end to end
+    /// (`a_governed_tool_cannot_reach_the_network_where_the_mechanism_is_live`
+    /// in `stella-tools`'s `custom::tests::execution`, which hand-builds its
+    /// `CustomTool` rather than discovering one) — nothing drove the allow
+    /// side through a real settings file. On `main`, `apply_foundry_runtime`
+    /// is exercised only by `fnv1a_is_stable_for_a_signature` above (which
+    /// never calls it) — no test failed if `network_allowlist` were read
+    /// under the wrong settings key, if the gate silently withheld an
+    /// allowlisted tool, or if the spawn seam stopped reading
+    /// `foundry_runtime` at all.
+    #[tokio::test]
+    async fn the_allowlist_reaches_from_settings_through_discovery_to_the_spawn() {
+        // Skip with reason: nothing to observe without the OS-level
+        // mechanism (the issue's own verify steps ask for exactly this).
+        if !stella_tools::netdeny::available() {
+            return;
+        }
+        // And nothing to conclude without real outbound reach on this
+        // runner: watching for a connect to succeed cannot tell "allowed"
+        // from "denied" if nothing can ever connect. Probed with a bare,
+        // unwrapped process, independent of anything the foundry gate does,
+        // so a network-isolated runner reports nothing rather than a false
+        // reading in either direction.
+        let probe = tokio::process::Command::new("bash")
+            .args(["-c", "exec 3<>/dev/tcp/1.1.1.1/53 && echo REACHED"])
+            .output()
+            .await
+            .expect("the bare probe itself must spawn");
+        if !String::from_utf8_lossy(&probe.stdout).contains("REACHED") {
+            return;
+        }
+
+        let ws = tempfile::tempdir().expect("tmp");
+        let root = ws.path();
+        let _home = crate::paths::test_user_home(root.to_path_buf());
+        let store = stella_store::Store::open(root).expect("store");
+
+        let body = "#!/bin/bash\nif exec 3<>/dev/tcp/1.1.1.1/53; then echo REACHED; \
+                     else echo DENIED; fi\n";
+        for name in ["allowed_net", "denied_net"] {
+            author_netcheck(root, name, body);
+            // The async form: this test already runs on a tokio runtime, and
+            // `adopt_in` (the sync form) spins up its own to drive the
+            // witness — nesting runtimes panics. Same steps, same gates.
+            adopt::adopt_in_async(root, &store, name, "test")
+                .await
+                .unwrap_or_else(|e| panic!("adopt {name}: {e}"));
+            adopt::set_enabled_in(
+                root,
+                &store,
+                name,
+                Some(stella_store::EnableAuthority::InteractiveHuman),
+            )
+            .unwrap_or_else(|e| panic!("enable {name}: {e}"));
+        }
+
+        std::fs::create_dir_all(root.join(".stella")).expect("create .stella");
+        std::fs::write(
+            root.join(".stella/settings.json"),
+            r#"{"foundry": {"network_allowlist": ["allowed_net"]}}"#,
+        )
+        .expect("write settings");
+
+        // Discovery, exactly as a real session runs it.
+        let report = adopt::gate_discovery(stella_tools::custom::discover_in(root, None), root);
+        let mut tools = report.tools;
+        apply_foundry_runtime(&mut tools, root);
+
+        let allowed = tools
+            .iter()
+            .find(|t| t.name == "allowed_net")
+            .expect("the allowlisted tool must survive the gate");
+        let denied = tools
+            .iter()
+            .find(|t| t.name == "denied_net")
+            .expect("the unlisted tool must survive the gate too");
+        assert!(
+            allowed.foundry_runtime.network_allowed,
+            "a listed name must be stamped allowed"
+        );
+        assert!(
+            !denied.foundry_runtime.network_allowed,
+            "an unlisted name must stay denied"
+        );
+
+        // The spawn, through the same seam the engine dispatches through.
+        struct Empty;
+        #[async_trait::async_trait]
+        impl stella_core::ports::ToolExecutor for Empty {
+            fn schemas(&self) -> Vec<stella_protocol::tool::ToolSchema> {
+                Vec::new()
+            }
+            async fn execute(&self, name: &str, _input: &serde_json::Value) -> ToolOutput {
+                ToolOutput::error(format!("no tool named `{name}`"))
+            }
+        }
+        let set = stella_tools::custom::CustomToolSet::new_owned(
+            std::sync::Arc::new(Empty),
+            tools,
+            root.to_path_buf(),
+        );
+        let rendered = |out: &ToolOutput| match out {
+            ToolOutput::Ok { content, .. } => content.clone(),
+            ToolOutput::Error { message, .. } => message.clone(),
+        };
+        let allowed_out = set.execute("allowed_net", &serde_json::json!({})).await;
+        let denied_out = set.execute("denied_net", &serde_json::json!({})).await;
+        assert!(
+            rendered(&allowed_out).contains("REACHED"),
+            "the allowlisted tool must spawn unwrapped and reach the network: {}",
+            rendered(&allowed_out)
+        );
+        assert!(
+            !rendered(&denied_out).contains("REACHED"),
+            "the unlisted tool must still spawn under the netdeny wrapper: {}",
+            rendered(&denied_out)
+        );
     }
 }

--- a/crates/stella-tools/src/read.rs
+++ b/crates/stella-tools/src/read.rs
@@ -465,6 +465,11 @@ impl Tool for ReadFile {
         let mut rendered = String::new();
         let mut spent = 0usize;
         let mut unread: Vec<&str> = Vec::new();
+        // One entry per file that was read. A consumer can then match
+        // coverage to a path, instead of losing it in the mixed prose. A
+        // single summed pair for the whole batch would not work: it would
+        // attribute every file's lines to none of them.
+        let mut per_file = Vec::with_capacity(targets.len());
         for target in &targets {
             if spent >= MAX_RENDER_BYTES {
                 unread.push(target.path.as_str());
@@ -481,7 +486,17 @@ impl Tool for ReadFile {
             }
             rendered.push_str(&format!("===== {} =====\n", target.path));
             match out {
-                ToolOutput::Ok { content, .. } => rendered.push_str(&content),
+                ToolOutput::Ok { content, data } => {
+                    rendered.push_str(&content);
+                    // `read_section` always attaches `{lines_shown,
+                    // lines_total}` to a successful result — the `if let`
+                    // is the same defensive shape `own_change::attach` uses
+                    // rather than an assumption this file alone could break.
+                    if let Some(serde_json::Value::Object(mut fields)) = data {
+                        fields.insert("path".to_string(), target.path.clone().into());
+                        per_file.push(serde_json::Value::Object(fields));
+                    }
+                }
                 // A failed target does not end the batch. A read leaves
                 // nothing half-done, so reporting the miss in place is
                 // strictly more useful than discarding the files that did
@@ -501,11 +516,15 @@ impl Tool for ReadFile {
                 unread.join(", ")
             ));
         }
-        // No structured `data` on the plural form: line coverage is a
-        // per-file fact, and one shown/total pair over an interleaved batch
-        // would attribute every file's lines to none of them. The single form
-        // is the producer the deck's read head resolves (#4297).
-        ToolOutput::ok(rendered)
+        // Deterministic for a given file state and window, exactly like the
+        // single form's pair — loop comparison keeps `data` in play
+        // (`comparable_output`), so a nondeterministic shape here would
+        // re-blind the detector the footer strip exists for.
+        if per_file.is_empty() {
+            ToolOutput::ok(rendered)
+        } else {
+            ToolOutput::ok_with_data(rendered, serde_json::json!({ "files": per_file }))
+        }
     }
 }
 

--- a/crates/stella-tools/src/read/tests.rs
+++ b/crates/stella-tools/src/read/tests.rs
@@ -879,6 +879,59 @@ async fn one_call_reads_several_files() {
     );
 }
 
+/// A batched read reports each file's own line coverage as structured
+/// `data`, keyed by path. The single form's flat `{lines_shown,
+/// lines_total}` pair cannot do this: it cannot say which file its counts
+/// belong to. On `main` the plural arm always returned
+/// `ToolOutput::ok(rendered)`, so `data` was `None` here.
+#[tokio::test]
+async fn a_batched_read_reports_per_file_line_coverage_as_structured_data() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "fn a() {}\n").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "fn b() {}\nfn b2() {}\n").unwrap();
+
+    let out = ReadFile::default()
+        .execute(
+            &serde_json::json!({"files": [
+                {"path": "a.rs"},
+                {"path": "b.rs", "offset": 2, "limit": 1}
+            ]}),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Ok { data, .. } = out else {
+        panic!("expected ok, got: {out:?}");
+    };
+    assert_eq!(
+        data,
+        Some(serde_json::json!({"files": [
+            {"path": "a.rs", "lines_shown": 1, "lines_total": 1},
+            {"path": "b.rs", "lines_shown": 1, "lines_total": 2}
+        ]})),
+        "each file's own coverage must be attributable by path"
+    );
+
+    // The same batch, read twice, must produce byte-identical `data`. Loop
+    // comparison (`comparable_output`) keeps `data` in play, and a shape
+    // that shifts call to call would hide a real stall from it.
+    let repeat = ReadFile::default()
+        .execute(
+            &serde_json::json!({"files": [
+                {"path": "a.rs"},
+                {"path": "b.rs", "offset": 2, "limit": 1}
+            ]}),
+            &cx(dir.path()),
+        )
+        .await;
+    let ToolOutput::Ok {
+        data: repeat_data, ..
+    } = repeat
+    else {
+        panic!("expected ok, got: {repeat:?}");
+    };
+    assert_eq!(data, repeat_data, "same file state and window must repeat");
+}
+
 /// The safety half, and the reason batching could not just be a loop.
 ///
 /// `MAX_RENDER_BYTES` bounds one render. Applied per file, a ten-file batch

--- a/crates/stella-tools/src/search/codegraph.rs
+++ b/crates/stella-tools/src/search/codegraph.rs
@@ -103,9 +103,12 @@ pub fn with_index_warning(output: ToolOutput, warning: Option<String>) -> ToolOu
         return output;
     };
     match output {
-        ToolOutput::Ok { content, .. } => ToolOutput::Ok {
+        // The warning goes in front of the text. The `data` field rides
+        // along unchanged, the same way the `Error` arm below keeps
+        // `class`.
+        ToolOutput::Ok { content, data } => ToolOutput::Ok {
             content: format!("({warning})\n{content}"),
-            data: None,
+            data,
         },
         // The warning is appended to the prose; whatever class the failure
         // already carried rides along unchanged (#3167) — this wrapper must
@@ -200,5 +203,39 @@ mod tests {
             None,
         );
         assert!(matches!(clean, ToolOutput::Ok { content , .. } if content == "frames"));
+    }
+
+    /// A success's `data` must survive an index warning, the same way the
+    /// `Error` arm's `class` already does. Before this fix the `Ok` arm
+    /// rebuilt its output with `data: None` and threw away whatever a
+    /// producer had attached. This fails on that code: `from_output` reads
+    /// back an empty list instead of the payload attached below.
+    #[test]
+    fn a_successful_answer_keeps_its_structured_data_beside_the_index_warning() {
+        let change = crate::own_change::own_change("src/lib.rs", None, "fn main() {}\n");
+        let carrying_data = crate::own_change::attach(
+            ToolOutput::Ok {
+                content: "frames".into(),
+                data: None,
+            },
+            std::slice::from_ref(&change),
+        );
+
+        let warned = with_index_warning(
+            carrying_data,
+            Some(format!("{INDEX_PASS_WARNING}: disk on fire")),
+        );
+
+        match &warned {
+            ToolOutput::Ok { content, .. } => {
+                assert!(
+                    content.starts_with(&format!("({INDEX_PASS_WARNING}")),
+                    "{content}"
+                );
+                assert!(content.ends_with("frames"), "{content}");
+            }
+            ToolOutput::Error { message, .. } => panic!("an Ok must stay Ok: {message}"),
+        }
+        assert_eq!(crate::own_change::from_output(&warned), vec![change]);
     }
 }

--- a/crates/stella-tui/src/model.rs
+++ b/crates/stella-tui/src/model.rs
@@ -422,18 +422,6 @@ impl SessionModel {
                 // else: the fold cache would retain them if the renderer
                 // stripped per frame, and ratatui renders everything after
                 // the ESC byte literally (#934).
-                // The tool's own line-coverage report, off the structured
-                // `data` half of the wire (#4297). Read here, before the
-                // prose is capped: `full` is bounded at OUTPUT_BUDGET, so a
-                // consumer recounting the rendered body would measure the
-                // cap, not the read — the substitution #2290 established as
-                // the defect for mutation counts.
-                let read_size = match output {
-                    ToolOutput::Ok {
-                        data: Some(data), ..
-                    } => entry::ReadSize::from_data(data),
-                    _ => None,
-                };
                 let (ok, summary, full) = match output {
                     ToolOutput::Ok { content , .. } => {
                         let content = strip_ansi(content);
@@ -474,6 +462,18 @@ impl SessionModel {
                         _ => None,
                     })
                     .unwrap_or_else(|| ("tool".to_string(), None, None));
+                // The tool's own line-coverage report, off the structured
+                // `data` half of the wire (#4297). Resolved against `path` —
+                // the lead path a batched `read_file` call resolves reads by,
+                // same convention `write_file`'s `edits` array uses — because
+                // a batch's payload carries one entry per target and the row
+                // shows only its own lead (#5696).
+                let read_size = match output {
+                    ToolOutput::Ok {
+                        data: Some(data), ..
+                    } => entry::ReadSize::from_data(data, path.as_deref()),
+                    _ => None,
+                };
                 let graph = entry::GraphFact::for_result(output, path.as_deref());
                 // The announcement is where the row learns whose call it was
                 // (same precedence as the store's `project_tool_result`,

--- a/crates/stella-tui/src/model/entry.rs
+++ b/crates/stella-tui/src/model/entry.rs
@@ -597,14 +597,75 @@ impl GraphFact {
 
 impl ReadSize {
     /// Both counts out of a tool result's structured `data`, or `None` when
-    /// either is absent or does not fit — a coverage the fold cannot state
-    /// exactly is not stated at all, never saturated into a plausible lie.
+    /// this result reported none for `path` — a coverage the fold cannot
+    /// state exactly is not stated at all, never saturated into a plausible
+    /// lie.
+    ///
+    /// The single form's payload is a flat `{lines_shown, lines_total}`
+    /// pair with no path of its own. `path` decides nothing there. A
+    /// batched `read_file` call's payload is a `files` array instead, one
+    /// entry per target, each with its own `path`. `path` picks out the
+    /// row's own lead entry — the same rule [`GraphFact::from_data`]
+    /// already uses for a batch's graph facts.
     #[must_use]
-    pub fn from_data(data: &serde_json::Value) -> Option<Self> {
-        let count = |key: &str| u32::try_from(data.get(key)?.as_u64()?).ok();
-        Some(ReadSize {
-            shown: count("lines_shown")?,
-            total: count("lines_total")?,
+    pub fn from_data(data: &serde_json::Value, path: Option<&str>) -> Option<Self> {
+        fn counts(value: &serde_json::Value) -> Option<ReadSize> {
+            let count = |key: &str| u32::try_from(value.get(key)?.as_u64()?).ok();
+            Some(ReadSize {
+                shown: count("lines_shown")?,
+                total: count("lines_total")?,
+            })
+        }
+        if let Some(size) = counts(data) {
+            return Some(size);
+        }
+        let path = path?;
+        data.get("files")?.as_array()?.iter().find_map(|entry| {
+            (entry.get("path").and_then(serde_json::Value::as_str) == Some(path))
+                .then(|| counts(entry))
+                .flatten()
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReadSize;
+
+    /// A batched `read_file`'s `files` array is resolved by path, not just
+    /// by whether it exists. On `main` this function took no `path`
+    /// argument. It read only the single form's flat `{lines_shown,
+    /// lines_total}` pair. So a batch's `files` payload produced `None` for
+    /// every row, no matter which file the row named.
+    #[test]
+    fn a_batch_payload_is_resolved_by_its_lead_path() {
+        let data = serde_json::json!({"files": [
+            {"path": "a.rs", "lines_shown": 1, "lines_total": 1},
+            {"path": "b.rs", "lines_shown": 1, "lines_total": 2}
+        ]});
+        assert_eq!(
+            ReadSize::from_data(&data, Some("b.rs")),
+            Some(ReadSize { shown: 1, total: 2 })
+        );
+        assert_eq!(
+            ReadSize::from_data(&data, Some("nope.rs")),
+            None,
+            "a path absent from the batch must not borrow another file's counts"
+        );
+        assert_eq!(
+            ReadSize::from_data(&data, None),
+            None,
+            "a batch payload with no lead path to resolve against states nothing"
+        );
+    }
+
+    /// The single form is unaffected by the new parameter: its flat pair is
+    /// read the same way regardless of what `path` is passed.
+    #[test]
+    fn the_single_forms_flat_pair_ignores_path() {
+        let data = serde_json::json!({"lines_shown": 3, "lines_total": 5});
+        let want = Some(ReadSize { shown: 3, total: 5 });
+        assert_eq!(ReadSize::from_data(&data, Some("whatever.rs")), want);
+        assert_eq!(ReadSize::from_data(&data, None), want);
     }
 }

--- a/crates/stella-tui/src/model/summarize.rs
+++ b/crates/stella-tui/src/model/summarize.rs
@@ -259,11 +259,24 @@ pub(super) fn tool_input_path(input: &serde_json::Value) -> Option<String> {
     // the whole batch, which is an accurate description of a stand-in and not
     // of an answer — a multi-file batch rendered one of its files and lost the
     // rest.
-    input
+    if let Some(path) = input
         .get("edits")
         .and_then(serde_json::Value::as_array)
         .and_then(|edits| edits.first())
         .and_then(|e| e.get("path"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+    {
+        return Some(path);
+    }
+    // A batched `read_file` carries its paths in a `files` array the same
+    // way. Same lead-path rule, so its read-size row resolves the same way
+    // a batched write's diff does.
+    input
+        .get("files")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|files| files.first())
+        .and_then(|f| f.get("path"))
         .and_then(serde_json::Value::as_str)
         .map(str::to_string)
 }
@@ -295,4 +308,31 @@ pub(super) fn is_file_mutation(name: &str) -> bool {
 /// the replacement is one char in / one char out, so the two orders agree.
 pub(super) fn summarize(text: &str) -> String {
     cap_middle_with(text, SUMMARY_BUDGET, "...").replace(['\n', '\r'], " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tool_input_path;
+
+    /// A batched `read_file` call names its lead path through the `files`
+    /// array — the same rule `write_file`'s `edits` array already uses. On
+    /// `main` this function checked only `path` and `edits`. A
+    /// `files`-shaped input resolved to no path at all, so the row that
+    /// renders off it had nothing to key its read-size lookup on.
+    #[test]
+    fn a_batched_reads_lead_path_comes_from_its_files_array() {
+        let input = serde_json::json!({"files": [
+            {"path": "a.rs"},
+            {"path": "b.rs", "offset": 2, "limit": 1}
+        ]});
+        assert_eq!(tool_input_path(&input), Some("a.rs".to_string()));
+    }
+
+    /// A top-level `path` still wins over a `files` array — the single form
+    /// is unaffected by the batch convention landing beside it.
+    #[test]
+    fn a_top_level_path_still_wins_over_a_files_array() {
+        let input = serde_json::json!({"path": "solo.rs", "files": [{"path": "a.rs"}]});
+        assert_eq!(tool_input_path(&input), Some("solo.rs".to_string()));
+    }
 }


### PR DESCRIPTION
Batch PR for #6291 (tools, 4 members). Fixes three defects and confirms one already resolved, each with evidence.

## Members

- **#5243 — fixed.** `search::codegraph::with_index_warning`'s `Ok` arm rebuilt its output with `data: None`, discarding any structured payload a producer had attached whenever a non-fatal index warning was prepended. Fixed to carry `data` through unchanged, the same way the `Error` arm already carries `class`.
  - Witness: `a_successful_answer_keeps_its_structured_data_beside_the_index_warning` (`crates/stella-tools/src/search/codegraph.rs`) — attaches an `own_change` payload, wraps it with a warning, and asserts the payload survives. Fails on the old code because `data` came back `None`.

- **#5696 — fixed.** A batched `read_file` call (the `files` array) always returned `ToolOutput::ok(rendered)` with no structured `data`, so the deck's read head showed no size for a batch read. The plural arm now attaches one `{path, lines_shown, lines_total}` entry per file under a `files` key — deterministic for a given file state and window, so it stays comparable under loop detection's `comparable_output`. The deck learns the new shape: `ReadSize::from_data` now takes the row's lead path and resolves either the single form's flat pair or the batch's per-path entry, and `tool_input_path` gains the same `files`-array lead-path convention `write_file`'s `edits` array already has.
  - Witnesses: `a_batched_read_reports_per_file_line_coverage_as_structured_data` (`crates/stella-tools/src/read/tests.rs`); `a_batch_payload_is_resolved_by_its_lead_path` and `the_single_forms_flat_pair_ignores_path` (`crates/stella-tui/src/model/entry.rs`); `a_batched_reads_lead_path_comes_from_its_files_array` (`crates/stella-tui/src/model/summarize.rs`). Each fails on the old code (`data: None`, no `path` parameter, no `files` branch, respectively).

- **#5475 — fixed.** `foundry.network_allowlist`'s allow direction had no witness driving the real chain — a project `.stella/settings.json`, real discovery, the adoption gate, `apply_foundry_runtime`, and the real dispatch seam. `apply_foundry_runtime` itself needed no code change; it was exercised only by an unrelated hash test before this.
  - Witness: `the_allowlist_reaches_from_settings_through_discovery_to_the_spawn` (`crates/stella-cli/src/tool_foundry.rs`) — stages and adopts two foundry tools, allowlists one by name in a real settings file, discovers + gates + stamps runtime policy, and spawns both through `CustomToolSet::execute`, asserting the listed tool reaches the network and the unlisted one does not. Skips with reason where the OS-level network-denial mechanism is unavailable, and where an independent bare probe shows this runner has no outbound reach at all — so it never reports a false reading in either direction, on a machine or CI runner with no egress.

- **#4911 — already resolved, verified, no code change.** The corpus fixture's frozen-sample header (added in #5876) already satisfies the issue's first checkbox: every path is declared a label, not a citation, and that declaration is pinned by `the_corpus_says_in_the_file_that_its_paths_are_labels` in `crates/stella-tools/tests/search_recall.rs`. #5876's own commit message records the decision explicitly: "the path-existence guard those issues also weigh stays open there, because the sample is not meant to track the tree." Verified live: the corpus still cites 35 moved `crates/stella-core/src/{records,context_record,ingest}` paths and the retired `progress_brand_fill.rs`, exactly as the header says a frozen sample will — a path-existence gate would be permanently red by design, so none was added.

## Could not ride

None — all four members are settled above (three fixed, one confirmed already fixed).

Tests deleted: None.

Closes #5243, Closes #5696, Closes #5475, Closes #4911, Closes #6291

## Summary by Sourcery

Preserve structured tool metadata across warnings and batched reads, and validate foundry network policy end to end.

Bug Fixes:
- Preserve structured codegraph data when prepending non-fatal index warnings.
- Add per-file structured line coverage to batched file reads and resolve it correctly in the TUI.
- Verify that the foundry network allowlist propagates from project settings through discovery and dispatch, allowing only listed tools network access.

Enhancements:
- Extend TUI path resolution and read-size handling to support batched file inputs while preserving single-file behavior.

Tests:
- Add regression coverage for codegraph payload preservation, batched read coverage and TUI resolution, and end-to-end foundry allowlist behavior.

Chores:
- Confirm the frozen corpus fixture's path-label behavior remains intentionally valid without adding a path-existence gate.