### PR TITLE
fix(stella-cli): batch fix — seventeen cli defects from the 2026-09-06 audit

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -69,8 +69,8 @@ mod turn_close;
 // close-out sets the count. The run summary prints it. The self-driving loop
 // adds it up over a run.
 pub(crate) use audit_writes::{
-    note_child_dropped_audit_writes, take_dropped_audit_writes, warn_dropped_audit_writes,
-    warn_store_write_failed,
+    DroppedWrite, dropped_write_report, note_child_dropped_audit_writes, take_dropped_audit_writes,
+    warn_dropped_audit_writes, warn_store_write_failed,
 };
 pub(crate) use budget::{build_budget_guard, remaining_budget, settle_reflection_budget};
 pub(crate) use graph_view::{graph_query_snapshot, graph_snapshot, graph_snapshot_focus};

--- a/crates/stella-cli/src/agent/audit_writes.rs
+++ b/crates/stella-cli/src/agent/audit_writes.rs
@@ -140,7 +140,11 @@ pub(crate) fn warn_dropped_audit_writes(db_path: Option<&Path>, dropped: &[Dropp
 ///
 /// It reads only what was lost, so both answers to "which file" can be tested
 /// without a database.
-fn dropped_write_report(db_path: Option<&Path>, dropped: &[DroppedWrite]) -> String {
+///
+/// Reachable from the deck and the fleet, which have no stderr to print to:
+/// their close-outs send the same text through their own surfaces rather than
+/// telling a watching person that the record is incomplete and stopping there.
+pub(crate) fn dropped_write_report(db_path: Option<&Path>, dropped: &[DroppedWrite]) -> String {
     let mut report = String::new();
     for write in dropped {
         report.push_str(&format!("      {}\n", write.diagnosis()));

--- a/crates/stella-cli/src/claims.rs
+++ b/crates/stella-cli/src/claims.rs
@@ -42,10 +42,11 @@
 //!
 //! **Declared**, before the call: [`mutating_path`] reads the path out of the
 //! call's own arguments, and the tap claims it or refuses. It keys on the tool
-//! NAME, so it covers the shipped file tools `write_file`, `edit_file`,
-//! `delete_file` and the conventional `apply_edits`, plus any workspace custom
-//! tool adopting one of those names. An MCP tool can never match — its wire
-//! name carries the `mcp__<server>__` prefix.
+//! NAME, so it covers the shipped file tools `write_file`, `edit_file` and
+//! `delete_file`, the retired `apply_edits`, and any workspace custom tool
+//! adopting one of those names. An MCP tool can never match — its wire name
+//! carries the `mcp__<server>__` prefix. [`mutating_path`] is the list; this
+//! sentence is a summary of it and a test holds the two together.
 //!
 //! **Observed**, after the call: a shell command's writes cannot be read out
 //! of its arguments, and guessing them from a command line would refuse work
@@ -178,11 +179,25 @@ fn pid_alive(pid: u32) -> bool {
     }
 }
 
-/// The conventional tool names whose successful call mutates the path in
-/// their `path` input. No built-in carries these names; a workspace custom
-/// tool that adopts one is claim-gated by construction (an MCP tool cannot —
-/// its wire name is `mcp__`-prefixed), and anything else writes outside
-/// claim tracking (the witness/verify ladder covers it).
+/// The tool names whose successful call mutates the path in their `path`
+/// input. **This match is the coverage list**; prose that restates it drifts.
+///
+/// It keys on the tool NAME, not on a schema. Three of the arms are shipped
+/// built-ins — `write_file`, `edit_file` and `delete_file` are rows in
+/// `stella_tools::catalog` — so claim-on-first-write is live for the file
+/// CRUD surface, not merely for conventions. `apply_edits` is a retired name
+/// (`stella_tools::catalog::RETIRED_TOOL_NAMES`), kept because nothing
+/// reserves a retired name: a workspace custom tool may still adopt it, and
+/// an unclaimed batch edit is the failure this module exists to stop.
+///
+/// A workspace custom tool adopting any of these names is claim-gated by the
+/// same arm. An MCP tool never can — its wire name is `mcp__`-prefixed.
+/// Anything else writes outside declared claim tracking; [`ShellWatch`]'s
+/// observed route is what covers `bash`.
+///
+/// `the_declared_route_only_names_tools_the_catalog_knows` pins every arm
+/// here to that catalog, so a name can neither drift out of the tree nor be
+/// invented here.
 fn mutating_path<'i>(name: &str, input: &'i Value) -> Option<&'i str> {
     match name {
         "write_file" | "edit_file" | "delete_file" => input.get("path").and_then(Value::as_str),
@@ -1176,6 +1191,64 @@ mod tests {
                 assert!(message.contains(&live_holder), "{message}")
             }
             other => panic!("a live holder's claim must refuse, got {other:?}"),
+        }
+    }
+
+    /// Every name [`mutating_path`] accepts, as prose claims them.
+    const DECLARED_MUTATORS: &[&str] = &["write_file", "edit_file", "delete_file", "apply_edits"];
+
+    /// An input carrying a path in both shapes the match arms read.
+    fn mutating_input() -> Value {
+        serde_json::json!({
+            "path": "src/lib.rs",
+            "edits": [{ "path": "src/lib.rs", "old_string": "a", "new_string": "b" }],
+        })
+    }
+
+    /// **The coverage witness.** Every declared mutator is a name the tree
+    /// knows, and no other catalog tool takes the declared route.
+    ///
+    /// Without it the prose above and this match drift apart in silence: a
+    /// module doc claiming no built-in carries these names reads as a dead
+    /// mechanism, and this asserts three of them are live rows in
+    /// `catalog::ALL_NAMES`. A name invented here — a typo, or a tool renamed
+    /// in the catalog and not here — is in neither the live nor the retired
+    /// list and fails too.
+    #[test]
+    fn the_declared_route_only_names_tools_the_catalog_knows() {
+        use stella_tools::catalog::{ALL_NAMES, RETIRED_TOOL_NAMES};
+
+        let input = mutating_input();
+        for name in DECLARED_MUTATORS {
+            assert!(
+                mutating_path(name, &input).is_some(),
+                "`{name}` is claimed as a declared mutator and the match does not read it"
+            );
+            assert!(
+                ALL_NAMES.contains(name) || RETIRED_TOOL_NAMES.contains(name),
+                "`{name}` is neither a live tool nor a retired one; the catalog never knew it"
+            );
+        }
+
+        assert!(
+            ["write_file", "edit_file", "delete_file"]
+                .iter()
+                .all(|name| ALL_NAMES.contains(name)),
+            "the file CRUD tools ship, so this coverage reaches built-ins"
+        );
+        assert!(
+            RETIRED_TOOL_NAMES.contains(&"apply_edits"),
+            "apply_edits is kept as a retired name; if it came back the doc above is wrong"
+        );
+
+        for name in ALL_NAMES {
+            if DECLARED_MUTATORS.contains(name) {
+                continue;
+            }
+            assert!(
+                mutating_path(name, &input).is_none(),
+                "`{name}` takes the declared route and the doc above does not say so"
+            );
         }
     }
 }

--- a/crates/stella-cli/src/cli/command.rs
+++ b/crates/stella-cli/src/cli/command.rs
@@ -342,8 +342,9 @@ pub(crate) enum Command {
         #[arg(long, value_name = "NAME", conflicts_with = "validate")]
         adopt: Option<String>,
 
-        /// Enable an adopted tool — the one approval in the protocol a
-        /// machine never grants itself. Refused if the tool's bytes changed
+        /// Enable an adopted tool by hand. This is the draft-only path. Take
+        /// it when `foundry.autonomy` is off, or when the sandbox the auto
+        /// path needs is missing. Refused if the tool's bytes changed
         /// since its witness ran, and refused with no terminal attached
         /// unless --yes says a human already read the declaration.
         #[arg(long, value_name = "NAME", conflicts_with_all = ["validate", "adopt"])]

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -243,15 +243,19 @@ fn system_notice(text: String) -> Inbound {
 }
 
 /// Where this workspace keeps the command palette's `recent` section
-/// (SPEC 10). It sits under `.stella/private/` with the rest of the generated
-/// local state, so it is gitignored and never travels: the last five commands
-/// a person ran are theirs, and a clone that inherited someone else's would be
-/// wrong as well as private (AGENTS.md § the `.stella/` directory).
-fn palette_recent_path(workspace_root: &std::path::Path) -> PathBuf {
-    workspace_root
-        .join(".stella")
-        .join("private")
-        .join("palette-recent.json")
+/// (SPEC 10), through the owner-only tier that already holds
+/// `reflections.jsonl` and `mcp_oauth.json`.
+///
+/// A hand-joined path buys none of what the tier gives. The directory is made
+/// `0700` and checked for symlinks. The ignore file is written beside it. And
+/// `STELLA_WORKSPACE_STATE_ROOT` moves it. The move is what a worktree
+/// session needs. Agents here run under `.claude/worktrees/`. A list written
+/// there goes when the worktree does.
+///
+/// `None` on any failure, like the debug log beside it: a lost recents list
+/// never gates a session.
+fn palette_recent_path(workspace_root: &std::path::Path) -> Option<PathBuf> {
+    stella_store::workspace_private_state_path(workspace_root, "palette-recent.json").ok()
 }
 
 /// `STELLA_DEBUG=1` → the structured deck log path (L-T8), mirroring the
@@ -807,7 +811,7 @@ pub async fn run_deck_session(
         // Seeded below, once the deck is up: reading the graph is SQLite, and
         // reading it here delayed the first frame by however long it took.
         initial_graph: None,
-        recent_path: Some(palette_recent_path(&cfg.workspace_root)),
+        recent_path: palette_recent_path(&cfg.workspace_root),
         no_anim,
         accessible,
         mouse_capture: mouse,

--- a/crates/stella-cli/src/command_deck/dropped_turn.rs
+++ b/crates/stella-cli/src/command_deck/dropped_turn.rs
@@ -97,10 +97,21 @@ pub(super) fn close_dropped_execution(
     if outcome.write_ok {
         return;
     }
+    // The result code, the retries and the file, on the same terms the run
+    // path prints them: "not recorded" is a fact nobody can act on, and the
+    // code is what says where to look.
+    let detail = if outcome.dropped.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\n{}",
+            agent::dropped_write_report(store.db_path(), &outcome.dropped).trim_end()
+        )
+    };
     let _ = in_tx.send(Inbound::Event {
         agent: LEAD.to_string(),
         event: AgentEvent::Error {
-            message: format!("store write failed — this {noun} execution was not recorded"),
+            message: format!("store write failed — this {noun} execution was not recorded{detail}"),
             retryable: true,
         },
     });

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -48,6 +48,7 @@ pub(crate) fn warn_audit_record_incomplete(
     inbound: &UnboundedSender<Inbound>,
     lane: &str,
     persistence_complete: bool,
+    detail: &AuditWriteDetail<'_>,
 ) {
     if !persistence_complete {
         return;
@@ -55,12 +56,45 @@ pub(crate) fn warn_audit_record_incomplete(
     let _ = inbound.send(Inbound::Event {
         agent: lane.to_string(),
         event: AgentEvent::Error {
-            message: "store write failed — the audit record (files touched / memory \
-                      citations / outcome) for this execution is incomplete"
-                .to_string(),
+            message: audit_record_incomplete_message(detail),
             retryable: true,
         },
     });
+}
+
+/// What a deck close-out knows about a refused audit write.
+///
+/// The deck has no stderr, so it cannot call `warn_dropped_audit_writes`. It
+/// carries the same two facts that function reads and renders them into the
+/// lane's own error text.
+pub(crate) struct AuditWriteDetail<'a> {
+    /// The writes that were given up on, each with the error that refused it.
+    pub(crate) dropped: &'a [crate::agent::DroppedWrite],
+    /// The database file they were meant for, or `None` for a memory store.
+    pub(crate) db_path: Option<&'a std::path::Path>,
+}
+
+/// The lane's message: what went wrong, then the result code, the retries and
+/// the file.
+///
+/// The bare half — the record is incomplete — is a fact nobody can act on. A
+/// person watching a deck lane needs the SQLite code, because that is what
+/// says where to look: `DatabaseBusy` points at whatever else holds the file,
+/// `ReadOnly` at its mode, `Full` at the disk. A close-out with nothing
+/// dropped says only the first half, since the record is short for some other
+/// reason — a cancelled turn, an event that never reached the journal.
+fn audit_record_incomplete_message(detail: &AuditWriteDetail<'_>) -> String {
+    let head = "store write failed — the audit record (files touched / memory citations / \
+                outcome) for this execution is incomplete";
+    if detail.dropped.is_empty() {
+        return head.to_owned();
+    }
+    format!(
+        "{head}\n{}",
+        crate::agent::dropped_write_report(detail.db_path, detail.dropped)
+            .trim_end()
+            .to_owned()
+    )
 }
 
 /// Persist each event (via the shared [`agent::persist_event`] write path)
@@ -773,5 +807,62 @@ mod tests {
         assert_eq!(proposal.gate, "tests");
         assert_eq!(proposal.subject, "repair a_short_cycle_is_detected");
         assert_eq!(proposal.revision.to_string(), "r2");
+    }
+
+    /// **The deck-detail witness.** A lane whose audit write was refused
+    /// names the SQLite code, not just that the record is short.
+    ///
+    /// Send the head line alone and this fails by construction: "the audit
+    /// record is incomplete" is a fact a person watching the lane cannot act
+    /// on, while `ConstraintViolation` says where to look. The refusal is a
+    /// real one — the MCP usage table turns away a second row at a `seq` it
+    /// already holds.
+    #[test]
+    fn a_refused_deck_audit_write_names_the_sqlite_code() {
+        let store = stella_store::Store::in_memory().expect("store");
+        let id = store
+            .begin_execution("run", "p", "anthropic", "claude")
+            .expect("execution");
+        let root = tempfile::tempdir().expect("root");
+        let registry = stella_tools::ToolRegistry::new(root.path().to_path_buf());
+        stella_store::mcp_usage::push_usage(
+            &registry.mcp_usage_ledger(),
+            stella_store::mcp_usage::McpUsageRecord::new("github", "search_issues", "", 1),
+        );
+        store
+            .record_mcp_usage(
+                id,
+                &[stella_store::McpUsageRow {
+                    server: "github".into(),
+                    tool: "search_issues".into(),
+                    reason: String::new(),
+                    called_at_ms: 1,
+                }],
+            )
+            .expect("occupy the seq the closeout will write");
+
+        let end = crate::agent::record_execution_end(&store, id, &registry, "completed", 0.0, true);
+        assert!(!end.dropped.is_empty(), "the write must have been refused");
+
+        let message = super::audit_record_incomplete_message(&AuditWriteDetail {
+            dropped: &end.dropped,
+            db_path: store.db_path(),
+        });
+
+        assert!(message.contains("incomplete"), "{message}");
+        assert!(message.contains("MCP usage"), "{message}");
+        assert!(message.contains("ConstraintViolation"), "{message}");
+    }
+
+    /// A close-out with nothing dropped says only what it knows. The record is
+    /// short for some other reason, and there is no code to name.
+    #[test]
+    fn a_close_out_with_no_refused_write_says_only_that_much() {
+        let message = super::audit_record_incomplete_message(&AuditWriteDetail {
+            dropped: &[],
+            db_path: None,
+        });
+        assert!(message.contains("incomplete"), "{message}");
+        assert!(!message.contains("store:"), "{message}");
     }
 }

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -91,9 +91,7 @@ fn audit_record_incomplete_message(detail: &AuditWriteDetail<'_>) -> String {
     }
     format!(
         "{head}\n{}",
-        crate::agent::dropped_write_report(detail.db_path, detail.dropped)
-            .trim_end()
-            .to_owned()
+        crate::agent::dropped_write_report(detail.db_path, detail.dropped).trim_end()
     )
 }
 

--- a/crates/stella-cli/src/command_deck/lead_turn.rs
+++ b/crates/stella-cli/src/command_deck/lead_turn.rs
@@ -226,17 +226,24 @@ pub(super) async fn run_lead_turn(
             TurnOutcome::Completed { cost_usd, .. } => ("completed", *cost_usd),
             TurnOutcome::Aborted { cost_usd, .. } => ("aborted", *cost_usd),
         };
-        if !agent::record_execution_end(
+        let end = agent::record_execution_end(
             store,
             *id,
             registry,
             outcome_label,
             cost,
             persistence_complete,
-        )
-        .fully_recorded()
-        {
-            forwarder::warn_audit_record_incomplete(in_tx, LEAD, persistence_complete);
+        );
+        if !end.fully_recorded() {
+            forwarder::warn_audit_record_incomplete(
+                in_tx,
+                LEAD,
+                persistence_complete,
+                &forwarder::AuditWriteDetail {
+                    dropped: &end.dropped,
+                    db_path: store.db_path(),
+                },
+            );
             // That warning lands AFTER the turn's Complete event, and the
             // deck's status fold maps a retryable Error back to Running — so
             // without this re-assert a finished turn would show as running

--- a/crates/stella-cli/src/command_deck/tests.rs
+++ b/crates/stella-cli/src/command_deck/tests.rs
@@ -867,3 +867,40 @@ fn every_command_a_relevance_rule_can_name_is_a_real_one() {
         );
     }
 }
+
+/// **The redirect witness.** A worktree session's palette recents land in the
+/// repository the state root names, not in the worktree.
+///
+/// Join `.stella/private/palette-recent.json` onto the workspace root and
+/// this fails by construction: the path lands inside the worktree, and the
+/// list goes when the worktree does. Agents in this repository run under
+/// `.claude/worktrees/`, so that is where the list would be least kept.
+///
+/// The env var is process-wide, so this runs under the same serial lock every
+/// other test that sets it takes.
+#[test]
+fn palette_recents_follow_the_workspace_state_root() {
+    let anchor = tempfile::tempdir().expect("tempdir");
+    let worktree = tempfile::tempdir().expect("tempdir");
+
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&[stella_home::WORKSPACE_STATE_ROOT_ENV]);
+    // SAFETY: `test_env::lock` is held for the whole window, and `_restore`
+    // puts the variable back even if an assertion below unwinds.
+    unsafe {
+        std::env::set_var(stella_home::WORKSPACE_STATE_ROOT_ENV, anchor.path());
+    }
+
+    let resolved = super::palette_recent_path(worktree.path()).expect("the private tier resolves");
+    assert!(
+        resolved.starts_with(anchor.path()),
+        "recents must follow the state root, got {}",
+        resolved.display()
+    );
+    assert!(
+        !resolved.starts_with(worktree.path()),
+        "recents must not stay in the worktree, got {}",
+        resolved.display()
+    );
+    assert!(resolved.ends_with("palette-recent.json"), "{resolved:?}");
+}

--- a/crates/stella-cli/src/commands_cmd.rs
+++ b/crates/stella-cli/src/commands_cmd.rs
@@ -151,6 +151,14 @@ pub fn to_toml(cmd: &CommandDef) -> Result<String, String> {
             cmd.name
         ));
     }
+    if let Some(found) = forbidden_control(&cmd.body) {
+        return Err(format!(
+            "{}: the prompt body contains the control character U+{:04X}, which a TOML \
+             multi-line literal string cannot carry — strip it from the body. A literal \
+             string has no escapes, so there is nothing to write it as.",
+            cmd.name, found as u32
+        ));
+    }
     let mut out = String::new();
     out.push_str(&format!("name = {}\n", quote(&cmd.name)));
     out.push_str(&format!("description = {}\n", quote(&cmd.description)));
@@ -173,14 +181,64 @@ pub fn to_toml(cmd: &CommandDef) -> Result<String, String> {
     Ok(out)
 }
 
+/// The first character a TOML multi-line literal string cannot carry, if the
+/// text has one.
+///
+/// A literal string has no escapes. So a control character in one has no
+/// spelling at all. TOML's `ml-literal-char` takes a tab and printed text. A
+/// line break comes in as `LF` or `CRLF`. A lone carriage return is out.
+///
+/// The failure this stops is silent. Paste the body in unchecked and
+/// `stella commands convert` says it worked. The file it wrote will not
+/// parse.
+fn forbidden_control(body: &str) -> Option<char> {
+    let mut chars = body.chars().peekable();
+    while let Some(found) = chars.next() {
+        match found {
+            '\t' | '\n' => {}
+            '\r' if chars.peek() == Some(&'\n') => {}
+            other if toml_forbids_raw(other) => return Some(other),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Whether TOML refuses this character unescaped in any string.
+///
+/// The C0 range, plus delete. Not `char::is_control`. That also covers
+/// U+0080 to U+009F, which TOML takes raw. Refusing those would refuse a body
+/// TOML accepts.
+fn toml_forbids_raw(found: char) -> bool {
+    found < ' ' || found == '\u{7f}'
+}
+
 /// A TOML basic string. Backslashes first, or the escapes added after would
 /// themselves be escaped.
+///
+/// Every control character is written as an escape. A basic string bars them
+/// raw. So a description with a tab in it would else write a file nothing can
+/// parse.
 fn quote(value: &str) -> String {
-    let escaped = value
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n");
-    format!("\"{escaped}\"")
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for found in value.chars() {
+        match found {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{8}' => escaped.push_str("\\b"),
+            '\u{c}' => escaped.push_str("\\f"),
+            other if toml_forbids_raw(other) => {
+                escaped.push_str(&format!("\\u{:04X}", other as u32));
+            }
+            other => escaped.push(other),
+        }
+    }
+    escaped.push('"');
+    escaped
 }
 
 /// One conversion the run would perform or did.
@@ -397,6 +455,55 @@ mod tests {
         let cmd = command_from_file("/ws/.stella/commands/quote.md", "before '''after").unwrap();
         let err = to_toml(&cmd).unwrap_err();
         assert!(err.contains("'''"), "{err}");
+    }
+
+    /// **The control-character witness.** A body carrying one is reported,
+    /// not written into a file that will not parse.
+    ///
+    /// Paste the body into a literal string unchecked and this fails by
+    /// construction. `to_toml` returns `Ok`. The TOML it writes will not
+    /// parse. The converter reports a success that lost the command.
+    #[test]
+    fn a_body_containing_a_control_character_is_rejected() {
+        for (label, raw) in [
+            ("a bell", "before \u{7}after"),
+            ("a vertical tab", "before \u{b}after"),
+            ("a lone carriage return", "before \rafter"),
+            ("delete", "before \u{7f}after"),
+        ] {
+            let cmd = command_from_file("/ws/.stella/commands/ctl.md", raw).unwrap();
+            let err = to_toml(&cmd)
+                .err()
+                .unwrap_or_else(|| panic!("{label} must be refused"));
+            assert!(err.contains("control character"), "{label}: {err}");
+        }
+    }
+
+    /// Tab, newline and CRLF are the three TOML admits in a literal string,
+    /// so a body carrying them still converts.
+    #[test]
+    fn tabs_and_newlines_still_convert() {
+        let body = "one\ttab\nand a line\r\nand a crlf";
+        let cmd = command_from_file("/ws/.stella/commands/ws.md", body).unwrap();
+        let toml_src = to_toml(&cmd).expect("tab and newline are allowed");
+        let round_tripped = command_from_toml("/ws/.stella/commands/ws.toml", &toml_src).unwrap();
+        assert!(round_tripped.body.contains('\t'), "{toml_src}");
+    }
+
+    /// A control character in a basic-string field is escaped, not pasted
+    /// raw. TOML bars it raw. A description with one would else write a file
+    /// nothing can read.
+    #[test]
+    fn a_description_carrying_a_control_character_is_escaped() {
+        let mut cmd = command_from_file("/ws/.stella/commands/odd.md", "Body.").unwrap();
+        cmd.description = "a\ttab and a \u{7} bell".to_owned();
+        let toml_src = to_toml(&cmd).expect("a basic string can escape it");
+        assert!(
+            !toml_src.contains('\t'),
+            "the tab must be escaped, not raw: {toml_src:?}"
+        );
+        command_from_toml("/ws/.stella/commands/odd.toml", &toml_src)
+            .expect("the emitted document parses");
     }
 
     #[test]

--- a/crates/stella-cli/src/extensions.rs
+++ b/crates/stella-cli/src/extensions.rs
@@ -768,8 +768,12 @@ impl CustomExtensions {
                 stella_learn::skills::SkillProblem::MissingName => "no usable name",
                 stella_learn::skills::SkillProblem::MissingDescription => "no description",
                 stella_learn::skills::SkillProblem::EmptyBody => "empty body",
+                stella_learn::skills::SkillProblem::Unreadable => "could not be read",
             };
-            problems.push(format!("{}: {why}", diag.path));
+            match &diag.detail {
+                Some(detail) => problems.push(format!("{}: {why} ({detail})", diag.path)),
+                None => problems.push(format!("{}: {why}", diag.path)),
+            }
         }
         Self {
             commands,

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -1193,6 +1193,13 @@ fn finalize_fleet_execution(
         return false;
     };
     let _ = store.record_delivery(*execution_id, delivery);
+    // The SQLite code behind a refused write goes unread here, and the reason
+    // is the terminal. `agent::warn_dropped_audit_writes` prints to stderr,
+    // and an attempt settles while the live grid owns the alternate screen —
+    // a line written there is wiped by the next frame. The deck's lanes carry
+    // the same detail through `forwarder::AuditWriteDetail`; a fleet attempt
+    // has no lane of its own, and the report channel that would hold it until
+    // teardown is `wrapped::HeldReports`, which is a plugin's, not a store's.
     agent::record_execution_end(
         store,
         *execution_id,

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -60,19 +60,18 @@ use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::Duration;
 
 use colored::Colorize;
 use stella_core::{Engine, TurnOutcome};
 use stella_fleet::{
-    CiWatchOutcome, Fleet, FleetConfig, FleetRunReport, FleetWorker, GhCli, Ledger, Monitor,
-    MonitorError, Plan, SystemGhCli, SystemGitCli, Task, TaskId, TimeoutReason, WatchConfig,
-    WorkerControls, WorkerOutcome, WorktreeManager,
+    CiWatchOutcome, Fleet, FleetConfig, GhCli, Ledger, Monitor, MonitorError, Plan, SystemGhCli,
+    SystemGitCli, Task, TaskId, TimeoutReason, WatchConfig, WorkerControls, WorkerOutcome,
+    WorktreeManager,
 };
 use stella_protocol::{AgentEvent, PrStatus};
 use stella_tools::ToolRegistry;
 use stella_tools::hook_runner::HostHookRunner;
-use stella_tui::{FleetDashResult, FleetMsg, FleetStatus};
+use stella_tui::{FleetMsg, FleetStatus};
 use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::config::Config;
@@ -217,7 +216,7 @@ pub async fn run_fleet(
     // screen; the workers hold them here and the live arm below prints them
     // once the dashboard has restored the terminal (#3883).
     let held_reports = live.then(|| Arc::new(wrapped::HeldReports::default()));
-    let worker = EngineWorker {
+    let worker = engine_worker::EngineWorker {
         cfg: cfg.clone(),
         // Divide the aggregate cap across the concurrency width so one wave's
         // in-flight children can't collectively overshoot `--spend-limit`.
@@ -327,7 +326,7 @@ pub async fn run_fleet(
         );
         let report = run_result.map_err(|e| format!("fleet run failed: {e}"))?;
         if let Ok(res) = dash_result {
-            print_dash_summary(&res);
+            report::print_dash_summary(&res);
         }
         // The wrapper reports the workers held while the grid was up. Each
         // line already names its task, so printing them together after
@@ -345,7 +344,7 @@ pub async fn run_fleet(
             .map_err(|e| format!("fleet run failed: {e}"))?
     };
 
-    render_report(&plan, &report, &ledger_path);
+    report::render_report(&plan, &report, &ledger_path);
     if report.budget_aborted {
         return Err(format!(
             "budget cap reached after ${:.4} — remaining waves were not launched",
@@ -438,152 +437,6 @@ fn load_plan(prompts: &[String], plan_file: Option<&Path>) -> Result<Plan, Strin
             })
             .collect(),
     ))
-}
-
-/// The engine-backed [`FleetWorker`]: one turn per task — the raw
-/// `Engine::run_turn` step-loop — in the task's own workspace, with the
-/// standard (headless) tool registry.
-struct EngineWorker {
-    cfg: Config,
-    /// Per-child spend cap. Derived as `--spend-limit / max_concurrency` (not
-    /// the full `--spend-limit`), so a wave of concurrent children can't each spend the
-    /// whole cap and blow the aggregate — the parent fleet guard then enforces
-    /// the true total, stopping further launches once it is crossed.
-    per_child_budget: Option<f64>,
-    /// The fleet run id — combined with the task id it forms the worker's
-    /// lock-table identity (`<run>/<task>`), the SAME holder string the
-    /// fleet's declared-claim acquisition uses, so a task's tool-level
-    /// claim-on-first-write is re-entrant with its declared claims.
-    run_id: String,
-    /// The live-dashboard channel, present only when `stella fleet` runs on an
-    /// interactive TTY. When set, the worker announces its lifecycle
-    /// (Running → Done/Failed) and its `run_task` tees every `AgentEvent` to
-    /// the grid. `None` keeps the headless path untouched.
-    dash: Option<mpsc::UnboundedSender<FleetMsg>>,
-    /// The installed wrapper plugin every attempt runs under
-    /// (`--pipeline <variant>`, #3695), or `None` for the raw step-loop.
-    ///
-    /// The variant *name* rather than a bound wrapper: binding starts nothing,
-    /// but a [`stella_runtime::wrapper::WrapperDispatch`] is neither `Send` to
-    /// the worker's own OS thread nor shareable across concurrent attempts —
-    /// each holds one plugin conversation at a time. So each attempt binds its
-    /// own from this name, in its own tree, and `run_fleet`'s pre-flight has
-    /// already proven the name resolves.
-    wrapper_variant: Option<String>,
-    /// `--require-verdict` (#4543): each attempt's wrapper verdict gates that
-    /// attempt. Meaningless without `wrapper_variant`, and refused before the
-    /// fan-out in that case.
-    require_verdict: bool,
-    /// Where an attempt's wrapper report goes while the live grid owns the
-    /// terminal: held here and printed by [`run_fleet`] after teardown,
-    /// because an `eprintln!` onto the alternate screen is destroyed by the
-    /// next frame (#3883). `Some` exactly when `dash` is — both exist because
-    /// the run is live — and `None` keeps the headless path printing at
-    /// settle time, as it always has.
-    held_reports: Option<Arc<wrapped::HeldReports>>,
-}
-
-#[async_trait::async_trait]
-impl FleetWorker for EngineWorker {
-    async fn run(
-        &self,
-        task: &Task,
-        workspace_root: &Path,
-        controls: WorkerControls,
-    ) -> WorkerOutcome {
-        // The engine's turn future is deliberately not `Send` (it holds
-        // provider futures and the retry jitter RNG across awaits), but the
-        // fleet's worker port requires a `Send` future. Bridge the two by
-        // giving each task its own OS thread with a current-thread runtime —
-        // fleet workers are genuinely parallel — and awaiting the `Send`
-        // half of a oneshot from the async side.
-        let cfg = self.cfg.clone();
-        let per_child_budget = self.per_child_budget;
-        let wrapper_variant = self.wrapper_variant.clone();
-        let require_verdict = self.require_verdict;
-        let held_reports = self.held_reports.clone();
-        let task = task.clone();
-        let root = workspace_root.to_path_buf();
-        let claim_holder = format!("{}/{}", self.run_id, task.id);
-        let task_id = task.id.clone();
-        // Published by the worker the moment it opens an execution, so this
-        // side can still read the attempt's real spend if the worker never
-        // reports one (#1216).
-        let spend = crate::fleet_spend::SpendRecovery::default();
-
-        // Dispatch → the row flips to Running the instant the wave picks it up.
-        if let Some(d) = &self.dash {
-            let _ = d.send(FleetMsg::Status {
-                id: task_id.clone(),
-                status: FleetStatus::Running,
-            });
-        }
-
-        let worker_dash = self.dash.clone();
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        // The cancellation seam (#803): if this dispatch future is dropped
-        // (Ctrl-C, a `select!` losing the race), stella-fleet's `ClaimGuard`
-        // releases the task's durable file claims on the same unwind — but
-        // the worker below is a detached OS thread that would keep writing
-        // under claims it no longer holds. `abandon_tx` is held across the
-        // await, so that unwind closes this channel first (this future's
-        // state drops before the dispatch frame's earlier-declared guard),
-        // and `stop_or_abandoned` reads the closure as stop.
-        let (abandon_tx, abandon_rx) = tokio::sync::oneshot::channel::<()>();
-        let worker_spend = spend.clone();
-        std::thread::spawn(move || {
-            let result = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| format!("worker runtime failed to start: {e}"))
-                .and_then(|rt| {
-                    rt.block_on(run_task(
-                        &cfg,
-                        per_child_budget,
-                        &task,
-                        &root,
-                        &claim_holder,
-                        controls,
-                        abandon_rx,
-                        worker_dash,
-                        worker_spend,
-                        wrapper_variant.as_deref(),
-                        require_verdict,
-                        held_reports.as_deref(),
-                    ))
-                });
-            let _ = tx.send(result);
-        });
-        let outcome = match rx.await {
-            Ok(Ok(outcome)) => outcome,
-            // A worker that can't even start (provider, git) is a failed
-            // attempt with a named reason — never a panic, never a hang.
-            Ok(Err(e)) => {
-                crate::fleet_spend::unreported_outcome(&spend, format!("worker error: {e}"))
-            }
-            Err(_) => crate::fleet_spend::unreported_outcome(
-                &spend,
-                "worker thread died before reporting".into(),
-            ),
-        };
-        // Only now may the abandon line close: the worker has already
-        // reported, so the closure signals nothing.
-        drop(abandon_tx);
-        // The worker's own verdict is the authoritative terminal state — more
-        // reliable than inferring done/failed from the event stream.
-        if let Some(d) = &self.dash {
-            let status = if outcome.success {
-                FleetStatus::Done
-            } else {
-                FleetStatus::Failed
-            };
-            let _ = d.send(FleetMsg::Status {
-                id: task_id.clone(),
-                status,
-            });
-        }
-        outcome
-    }
 }
 
 /// `stella_core::ports::TurnGate` over the task's pause line: the worker's
@@ -1227,15 +1080,15 @@ async fn run_task(
         };
         match raced {
             Raced::Outcome(Ok(TurnOutcome::Completed { text, .. })) => {
-                (truncate(&text), true, "completed", false)
+                (report::truncate(&text), true, "completed", false)
             }
             Raced::Outcome(Ok(TurnOutcome::Aborted { reason, .. })) => {
-                (truncate(&reason), false, "aborted", false)
+                (report::truncate(&reason), false, "aborted", false)
             }
             // A wrapper that could not be driven fails the attempt by name —
             // never a silently successful one, and never a downgrade to the
             // raw loop the operator did not ask for.
-            Raced::Outcome(Err(reason)) => (truncate(&reason), false, "aborted", false),
+            Raced::Outcome(Err(reason)) => (report::truncate(&reason), false, "aborted", false),
             Raced::Stopped => (STOPPED.to_string(), false, "cancelled", true),
         }
     };
@@ -1368,124 +1221,11 @@ async fn git_stdout(root: &Path, args: &[&str]) -> Result<String, String> {
     Ok(output.stdout.trim().to_string())
 }
 
-fn truncate(s: &str) -> String {
-    let one_line = s.replace('\n', " ");
-    let mut out: String = one_line.chars().take(SUMMARY_CHARS).collect();
-    if one_line.chars().count() > SUMMARY_CHARS {
-        out.push('…');
-    }
-    out
-}
-
-/// The live grid's one-screen recap, printed on the normal screen after the
-/// dashboard restores it: each task's final status, wall-clock ELAPSED, and
-/// tool-call count, then the total SESSION time. The `render_report` below
-/// follows with the durable details (spend, commits, worktrees).
-fn print_dash_summary(res: &FleetDashResult) {
-    let fmt_elapsed = |d: Duration| {
-        let s = d.as_secs();
-        format!("{:02}:{:02}", s / 60, s % 60)
-    };
-    let fmt_session = |d: Duration| {
-        let s = d.as_secs();
-        format!("{:02}:{:02}:{:02}", s / 3600, (s % 3600) / 60, s % 60)
-    };
-    println!();
-    for t in &res.tasks {
-        let glyph = match t.status {
-            FleetStatus::Done => t.status.glyph().green(),
-            FleetStatus::Failed | FleetStatus::Killed => t.status.glyph().red(),
-            FleetStatus::Blocked => t.status.glyph().yellow(),
-            _ => t.status.glyph().normal(),
-        };
-        println!(
-            "  {glyph} {} — {} ({}, {} tool call{})",
-            t.id.bold(),
-            t.title,
-            fmt_elapsed(t.elapsed),
-            t.tool_calls,
-            if t.tool_calls == 1 { "" } else { "s" },
-        );
-    }
-    let tail = if res.detached {
-        " (detached — run continued to completion)"
-    } else {
-        ""
-    };
-    println!(
-        "  {} session {}{tail}",
-        "·".dimmed(),
-        fmt_session(res.session_elapsed).bold()
-    );
-}
-
-/// The end-of-run report: per task its outcome, spend, commits, and (when
-/// isolated) the worktree that holds the work, then the totals and where the
-/// receipts live.
-fn render_report(plan: &Plan, report: &FleetRunReport, ledger_path: &Path) {
-    println!();
-    for handle in &report.handles {
-        let ok = handle.outcome.success;
-        let mark = if ok { "✓".green() } else { "✗".red() };
-        let title = plan
-            .task(&handle.task_id)
-            .map(|t| t.title.as_str())
-            .unwrap_or("");
-        println!(
-            "  {mark} {} — {} (${:.4}, {} commit{})",
-            handle.task_id.bold(),
-            title,
-            handle.outcome.cost_usd,
-            handle.outcome.commits.len(),
-            if handle.outcome.commits.len() == 1 {
-                ""
-            } else {
-                "s"
-            },
-        );
-        if let Some(worktree) = &handle.worktree {
-            println!(
-                "      {} {} @ {}",
-                "↳".dimmed(),
-                worktree.branch.bright_magenta(),
-                worktree.path.display().to_string().dimmed()
-            );
-        }
-        if !handle.outcome.summary.is_empty() {
-            println!("      {}", handle.outcome.summary.dimmed());
-        }
-        // Durable-failure notices (a ledger close that failed after the
-        // worker settled, a dispatch lease lost mid-run) are composed in
-        // stella-fleet — this file is at its size ceiling (#1677).
-        for notice in stella_fleet::handle_notices(handle) {
-            println!("      {} {notice}", "!".yellow());
-        }
-    }
-    for (task_id, reason) in &report.dispatch_failures {
-        println!(
-            "  {} {} — dispatch failed: {}",
-            "✗".red(),
-            task_id.bold(),
-            reason.dimmed()
-        );
-    }
-    if !report.skipped.is_empty() {
-        println!(
-            "  {} skipped (dependency failed or budget stop): {}",
-            "○".yellow(),
-            report.skipped.join(", ").dimmed()
-        );
-    }
-    println!(
-        "\n  total ${:.4} · ledger {} · worktrees kept for review (`git worktree list`)\n",
-        report.total_cost_usd(),
-        ledger_path.display(),
-    );
-}
-
 mod branch_watch;
 mod durability;
+mod engine_worker;
 mod isolation_notice;
+mod report;
 mod steering;
 mod wrapped;
 

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -71,7 +71,7 @@ use stella_fleet::{
 use stella_protocol::{AgentEvent, PrStatus};
 use stella_tools::ToolRegistry;
 use stella_tools::hook_runner::HostHookRunner;
-use stella_tui::{FleetMsg, FleetStatus};
+use stella_tui::FleetMsg;
 use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::config::Config;

--- a/crates/stella-cli/src/fleet_cmd/branch_watch.rs
+++ b/crates/stella-cli/src/fleet_cmd/branch_watch.rs
@@ -12,6 +12,11 @@
 //! those have finished. The parent crossed the 1500-line ceiling (#4821) and
 //! this is the seam that was already there.
 
+// Imported here rather than inherited through `super::*`: the parent stopped
+// naming the run report when the report rendering moved to `report.rs`, so
+// this module and the tests are its only remaining users.
+use stella_fleet::FleetRunReport;
+
 use super::*;
 
 /// One fleet branch's post-fanout verdict: the capped CI watch outcome plus

--- a/crates/stella-cli/src/fleet_cmd/branch_watch.rs
+++ b/crates/stella-cli/src/fleet_cmd/branch_watch.rs
@@ -12,9 +12,8 @@
 //! those have finished. The parent crossed the 1500-line ceiling (#4821) and
 //! this is the seam that was already there.
 
-// Imported here rather than inherited through `super::*`: the parent stopped
-// naming the run report when the report rendering moved to `report.rs`, so
-// this module and the tests are its only remaining users.
+// Named here, not taken from `super::*`. The parent stopped using this type
+// when the report moved to `report.rs`.
 use stella_fleet::FleetRunReport;
 
 use super::*;

--- a/crates/stella-cli/src/fleet_cmd/engine_worker.rs
+++ b/crates/stella-cli/src/fleet_cmd/engine_worker.rs
@@ -1,0 +1,155 @@
+//! The fleet worker: one `Engine::run_turn` per task.
+//!
+//! Its own file. `fleet_cmd.rs` is at its size ceiling, and this piece
+//! stands alone: the dispatch settings, and the bridge from the engine's
+//! turn future onto the fleet's worker port. The attempt itself stays next
+//! door, in `run_task`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use stella_fleet::{FleetWorker, Task, WorkerControls, WorkerOutcome};
+use stella_tui::{FleetMsg, FleetStatus};
+use tokio::sync::mpsc;
+
+use super::{run_task, wrapped};
+use crate::config::Config;
+
+/// One turn per task: the raw `Engine::run_turn` step loop, in the task's
+/// own workspace, with the standard tool set and no terminal to ask at.
+pub(super) struct EngineWorker {
+    pub(super) cfg: Config,
+    /// What one child may spend: `--spend-limit` split across the width, not
+    /// the whole cap. Give each child the whole cap and one wave spends it
+    /// many times over. The fleet guard holds the true total, and stops
+    /// launching once it is crossed.
+    pub(super) per_child_budget: Option<f64>,
+    /// The fleet run id. With the task id it spells the worker's lock-table
+    /// name, `<run>/<task>`. The fleet takes a task's declared claims under
+    /// that same name, so a tool write inside the task re-enters its own
+    /// claims rather than blocking on them.
+    pub(super) run_id: String,
+    /// The live grid's channel, set only when `stella fleet` has a terminal.
+    /// The worker then says when it starts and how it ends, and `run_task`
+    /// tees every event to the grid. `None` is a run with no grid.
+    pub(super) dash: Option<mpsc::UnboundedSender<FleetMsg>>,
+    /// The plugin every attempt runs under (`--pipeline <name>`), or `None`
+    /// for the raw step loop.
+    ///
+    /// A name, not a bound wrapper. Binding starts nothing, but a bound
+    /// [`stella_runtime::wrapper::WrapperDispatch`] cannot cross to the
+    /// worker's own thread and cannot be shared by two attempts at once:
+    /// each holds one plugin talk at a time. So each attempt binds its own,
+    /// in its own tree. `run_fleet` has already proven the name resolves.
+    pub(super) wrapper_variant: Option<String>,
+    /// `--require-verdict`: the plugin's verdict gates the attempt. It says
+    /// nothing without `wrapper_variant`, and is refused before the fan-out
+    /// in that case.
+    pub(super) require_verdict: bool,
+    /// Where an attempt's plugin report waits while the grid owns the
+    /// terminal. `run_fleet` prints it once the grid gives the screen back.
+    /// A line written onto the grid's screen is wiped by the next frame.
+    /// `Some` exactly when `dash` is. A run with no grid prints at once.
+    pub(super) held_reports: Option<Arc<wrapped::HeldReports>>,
+}
+
+#[async_trait::async_trait]
+impl FleetWorker for EngineWorker {
+    async fn run(
+        &self,
+        task: &Task,
+        workspace_root: &Path,
+        controls: WorkerControls,
+    ) -> WorkerOutcome {
+        // The engine's turn future is not `Send`. It holds provider futures
+        // and the retry jitter across awaits. The fleet's worker port asks
+        // for a `Send` future. So each task gets its own thread with its own
+        // runtime, and this side awaits the `Send` half of a oneshot. Fleet
+        // workers run at the same time, so a thread each is right anyway.
+        let cfg = self.cfg.clone();
+        let per_child_budget = self.per_child_budget;
+        let wrapper_variant = self.wrapper_variant.clone();
+        let require_verdict = self.require_verdict;
+        let held_reports = self.held_reports.clone();
+        let task = task.clone();
+        let root = workspace_root.to_path_buf();
+        let claim_holder = format!("{}/{}", self.run_id, task.id);
+        let task_id = task.id.clone();
+        // The worker fills this in the moment it opens an execution. So this
+        // side can still read what the attempt spent when the worker dies
+        // before it reports.
+        let spend = crate::fleet_spend::SpendRecovery::default();
+
+        // Dispatch → the row flips to Running the instant the wave picks it up.
+        if let Some(d) = &self.dash {
+            let _ = d.send(FleetMsg::Status {
+                id: task_id.clone(),
+                status: FleetStatus::Running,
+            });
+        }
+
+        let worker_dash = self.dash.clone();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        // The cancel seam. Drop this future — Ctrl-C, or a `select!` that
+        // lost — and stella-fleet's `ClaimGuard` gives the task's file
+        // claims back on the same unwind. The worker is a loose thread and
+        // would keep writing under claims that are gone. `abandon_tx` is
+        // held across the await, so the unwind closes this line first: this
+        // future's state drops before the guard declared above it. The
+        // worker reads a closed line as a stop.
+        let (abandon_tx, abandon_rx) = tokio::sync::oneshot::channel::<()>();
+        let worker_spend = spend.clone();
+        std::thread::spawn(move || {
+            let result = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| format!("worker runtime failed to start: {e}"))
+                .and_then(|rt| {
+                    rt.block_on(run_task(
+                        &cfg,
+                        per_child_budget,
+                        &task,
+                        &root,
+                        &claim_holder,
+                        controls,
+                        abandon_rx,
+                        worker_dash,
+                        worker_spend,
+                        wrapper_variant.as_deref(),
+                        require_verdict,
+                        held_reports.as_deref(),
+                    ))
+                });
+            let _ = tx.send(result);
+        });
+        let outcome = match rx.await {
+            Ok(Ok(outcome)) => outcome,
+            // A worker that cannot start at all — no provider, no git — is a
+            // failed attempt with a named reason. Never a panic. Never a hang.
+            Ok(Err(e)) => {
+                crate::fleet_spend::unreported_outcome(&spend, format!("worker error: {e}"))
+            }
+            Err(_) => crate::fleet_spend::unreported_outcome(
+                &spend,
+                "worker thread died before reporting".into(),
+            ),
+        };
+        // Only now may the abandon line close. The worker has reported, so
+        // closing it signals nothing.
+        drop(abandon_tx);
+        // The worker's own verdict is the end state. Reading done or failed
+        // out of the event stream is a guess.
+        if let Some(d) = &self.dash {
+            let status = if outcome.success {
+                FleetStatus::Done
+            } else {
+                FleetStatus::Failed
+            };
+            let _ = d.send(FleetMsg::Status {
+                id: task_id.clone(),
+                status,
+            });
+        }
+        outcome
+    }
+}

--- a/crates/stella-cli/src/fleet_cmd/report.rs
+++ b/crates/stella-cli/src/fleet_cmd/report.rs
@@ -1,0 +1,129 @@
+//! What a finished fleet run prints.
+//!
+//! Its own file. `fleet_cmd.rs` is at its size ceiling. This half only
+//! reads: the grid recap, the per-task report, the totals. None of it runs
+//! while the fleet does.
+
+use std::path::Path;
+use std::time::Duration;
+
+use colored::Colorize;
+use stella_fleet::{FleetRunReport, Plan};
+use stella_tui::{FleetDashResult, FleetStatus};
+
+use super::SUMMARY_CHARS;
+
+/// One line, capped, with a mark where it was cut.
+pub(super) fn truncate(s: &str) -> String {
+    let one_line = s.replace('\n', " ");
+    let mut out: String = one_line.chars().take(SUMMARY_CHARS).collect();
+    if one_line.chars().count() > SUMMARY_CHARS {
+        out.push('…');
+    }
+    out
+}
+
+/// The grid's one-screen recap, printed once the dashboard gives the
+/// terminal back. Per task: status, time spent, tool calls. Then the whole
+/// session's time. [`render_report`] follows with spend, commits and
+/// worktrees.
+pub(super) fn print_dash_summary(res: &FleetDashResult) {
+    let fmt_elapsed = |d: Duration| {
+        let s = d.as_secs();
+        format!("{:02}:{:02}", s / 60, s % 60)
+    };
+    let fmt_session = |d: Duration| {
+        let s = d.as_secs();
+        format!("{:02}:{:02}:{:02}", s / 3600, (s % 3600) / 60, s % 60)
+    };
+    println!();
+    for t in &res.tasks {
+        let glyph = match t.status {
+            FleetStatus::Done => t.status.glyph().green(),
+            FleetStatus::Failed | FleetStatus::Killed => t.status.glyph().red(),
+            FleetStatus::Blocked => t.status.glyph().yellow(),
+            _ => t.status.glyph().normal(),
+        };
+        println!(
+            "  {glyph} {} — {} ({}, {} tool call{})",
+            t.id.bold(),
+            t.title,
+            fmt_elapsed(t.elapsed),
+            t.tool_calls,
+            if t.tool_calls == 1 { "" } else { "s" },
+        );
+    }
+    let tail = if res.detached {
+        " (detached — run continued to completion)"
+    } else {
+        ""
+    };
+    println!(
+        "  {} session {}{tail}",
+        "·".dimmed(),
+        fmt_session(res.session_elapsed).bold()
+    );
+}
+
+/// The end-of-run report. Per task: outcome, spend, commits, and the
+/// worktree that holds the work. Then the totals, and where the receipts
+/// live.
+pub(super) fn render_report(plan: &Plan, report: &FleetRunReport, ledger_path: &Path) {
+    println!();
+    for handle in &report.handles {
+        let ok = handle.outcome.success;
+        let mark = if ok { "✓".green() } else { "✗".red() };
+        let title = plan
+            .task(&handle.task_id)
+            .map(|t| t.title.as_str())
+            .unwrap_or("");
+        println!(
+            "  {mark} {} — {} (${:.4}, {} commit{})",
+            handle.task_id.bold(),
+            title,
+            handle.outcome.cost_usd,
+            handle.outcome.commits.len(),
+            if handle.outcome.commits.len() == 1 {
+                ""
+            } else {
+                "s"
+            },
+        );
+        if let Some(worktree) = &handle.worktree {
+            println!(
+                "      {} {} @ {}",
+                "↳".dimmed(),
+                worktree.branch.bright_magenta(),
+                worktree.path.display().to_string().dimmed()
+            );
+        }
+        if !handle.outcome.summary.is_empty() {
+            println!("      {}", handle.outcome.summary.dimmed());
+        }
+        // A ledger close that failed after the worker settled. A lease lost
+        // mid-run. stella-fleet writes those lines. It holds the facts.
+        for notice in stella_fleet::handle_notices(handle) {
+            println!("      {} {notice}", "!".yellow());
+        }
+    }
+    for (task_id, reason) in &report.dispatch_failures {
+        println!(
+            "  {} {} — dispatch failed: {}",
+            "✗".red(),
+            task_id.bold(),
+            reason.dimmed()
+        );
+    }
+    if !report.skipped.is_empty() {
+        println!(
+            "  {} skipped (dependency failed or budget stop): {}",
+            "○".yellow(),
+            report.skipped.join(", ").dimmed()
+        );
+    }
+    println!(
+        "\n  total ${:.4} · ledger {} · worktrees kept for review (`git worktree list`)\n",
+        report.total_cost_usd(),
+        ledger_path.display(),
+    );
+}

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -126,7 +126,7 @@ fn empty_input_and_unknown_extension_are_named_errors() {
 #[test]
 fn summaries_are_single_line_and_capped() {
     let long = "a\nb\n".repeat(200);
-    let out = truncate(&long);
+    let out = super::report::truncate(&long);
     assert!(!out.contains('\n'));
     assert!(out.chars().count() <= SUMMARY_CHARS + 1);
     assert!(out.ends_with('…'));

--- a/crates/stella-cli/src/fleet_cmd/tests.rs
+++ b/crates/stella-cli/src/fleet_cmd/tests.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use stella_fleet::CommitRecord;
+use stella_fleet::{CommitRecord, FleetRunReport};
 // Imported here rather than inherited through `super::*`: the parent stopped
 // building an opening transcript by hand when a fleet attempt gained its own
 // durable record (#3232), so this is the only remaining use of the type.

--- a/crates/stella-cli/src/issue_provider/github.toml
+++ b/crates/stella-cli/src/issue_provider/github.toml
@@ -45,8 +45,7 @@ parent = "parent"
 # labels. An issue in none of these lists is `Other`. A reader can see that.
 # A wrong class hides.
 #
-# The keys are Stella's own class names. §4.1 draws this block with `defect`
-# and `epic`. `IssueClass` is what shipped, so these follow the code.
+# The keys are Stella's own class names, and §4.1 draws the same three.
 # `#1281` owns the rest.
 [classes]
 bug = ["bug"]

--- a/crates/stella-cli/src/issue_provider/manifest.rs
+++ b/crates/stella-cli/src/issue_provider/manifest.rs
@@ -190,10 +190,19 @@ impl ProviderManifest {
     /// The path is what `[issues] manifest` names, or
     /// `.stella/issues/<provider>.toml`. A file that is missing or unreadable
     /// gives the shipped manifest, not an error.
+    ///
+    /// `provider = ""` means the same as saying nothing, so it resolves
+    /// `github`. Without that rule the empty name reaches the path template
+    /// and asks for `.stella/issues/.toml` — a name a workspace cannot write,
+    /// because the shell and most editors read a leading dot as the whole
+    /// stem — and the workspace's own `github.toml` is ignored with no word.
     pub(crate) fn resolve(root: &Path, issues: &IssuesSection) -> Self {
         let embedded = Self::embedded();
-        let provider = issues.provider.trim().to_ascii_lowercase();
-        if !provider.is_empty() && provider != super::GITHUB {
+        let mut provider = issues.provider.trim().to_ascii_lowercase();
+        if provider.is_empty() {
+            provider = super::GITHUB.to_owned();
+        }
+        if provider != super::GITHUB {
             eprintln!(
                 "warning: no built-in manifest for issue provider `{provider}`; using GitHub's. \
                  Declare it in `.stella/issues/{provider}.toml` to say how that tracker spells \
@@ -215,8 +224,7 @@ impl ProviderManifest {
             Err(error) => {
                 eprintln!(
                     "warning: {path} could not be read ({error}); using the built-in manifest \
-                     for `{}`",
-                    issues.provider
+                     for `{provider}`"
                 );
                 embedded
             }
@@ -377,6 +385,99 @@ feature = ["kind/enhancement"]
         let manifest = ProviderManifest::for_workspace(ws.path());
         assert!(manifest.vocabulary.is_open("triage"));
         assert_eq!(manifest.classes.class_of(&["bug"]), IssueClass::Bug);
+    }
+
+    /// The `[classes]` block of a rendered manifest, as text.
+    ///
+    /// From the `[classes]` header to the next table header, so the caller
+    /// gets exactly what a reader would copy.
+    fn classes_block(document: &str) -> String {
+        let start = document
+            .find("\n[classes]\n")
+            .expect("the document renders a [classes] block");
+        let body = &document[start + 1..];
+        let mut out = String::new();
+        for (index, line) in body.lines().enumerate() {
+            if index > 0 && line.starts_with('[') {
+                break;
+            }
+            out.push_str(line);
+            out.push('\n');
+        }
+        out
+    }
+
+    /// Every rendered `[classes]` block a reader can copy, by path.
+    fn rendered_class_blocks() -> Vec<(&'static str, String)> {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("the crate sits two levels under the workspace root")
+            .to_path_buf();
+        [
+            "docs/spec/agent-native-delivery.md",
+            "docs/spec/agent-native-delivery/provider.jira.toml",
+            "docs/spec/agent-native-delivery/provider.linear.toml",
+        ]
+        .into_iter()
+        .map(|rel| {
+            let raw = std::fs::read_to_string(root.join(rel))
+                .unwrap_or_else(|error| panic!("{rel} is readable ({error})"));
+            (rel, classes_block(&raw))
+        })
+        .collect()
+    }
+
+    /// **The doc-agreement witness.** Every `[classes]` block the spec renders
+    /// parses into a map this loader reads.
+    ///
+    /// Key a rendered block `defect` / `feature` / `epic` and this fails by
+    /// construction: `ClassMap` reads `bug` / `feature` / `task`, and
+    /// `#[serde(default)]` drops a key it does not know, so the map comes
+    /// back empty and every issue classes as `Other`. A reader who copies
+    /// such a block gets a mapping that does nothing and no word about it.
+    #[test]
+    fn every_rendered_classes_block_maps_a_bug() {
+        for (path, block) in rendered_class_blocks() {
+            let classes: ClassMap = toml::from_str(&block)
+                .unwrap_or_else(|error| panic!("{path}'s [classes] block parses ({error})"));
+            assert!(
+                !classes.is_empty(),
+                "{path} renders a [classes] block this loader reads as empty:\n{block}"
+            );
+            assert_eq!(
+                classes.class_of(&["Bug"]),
+                IssueClass::Bug,
+                "{path} must class the tracker's own bug type as a bug"
+            );
+        }
+    }
+
+    /// **The empty-name witness.** `provider = ""` reads the workspace's
+    /// `github.toml`.
+    ///
+    /// Let the empty name reach the path template and this fails by
+    /// construction: `resolve` opens `.stella/issues/.toml`, finds nothing,
+    /// and returns the shipped manifest — whose `open` word is `open`, not
+    /// `triage`.
+    #[test]
+    fn an_empty_provider_name_reads_the_github_manifest() {
+        let ws = workspace();
+        write(
+            ws.path(),
+            ".stella/issues/github.toml",
+            "open = [\"triage\"]\nclosed = [\"shipped\"]\n",
+        );
+
+        let manifest = ProviderManifest::resolve(
+            ws.path(),
+            &IssuesSection {
+                provider: String::new(),
+                manifest: None,
+            },
+        );
+        assert!(manifest.vocabulary.is_open("triage"));
+        assert!(!manifest.vocabulary.is_open("open"));
     }
 
     /// A workspace that set nothing gets the shipped manifest.

--- a/crates/stella-cli/src/issue_provider/manifest.rs
+++ b/crates/stella-cli/src/issue_provider/manifest.rs
@@ -387,18 +387,20 @@ feature = ["kind/enhancement"]
         assert_eq!(manifest.classes.class_of(&["bug"]), IssueClass::Bug);
     }
 
-    /// The `[classes]` block of a rendered manifest, as text.
+    /// The keys a rendered manifest's `[classes]` block sets, as text.
     ///
-    /// From the `[classes]` header to the next table header, so the caller
-    /// gets exactly what a reader would copy.
+    /// From the line after the `[classes]` header to the next table header.
+    /// The header itself is left out because [`ClassMap`] is the table's
+    /// value: keep the header and TOML nests the keys one level down, where a
+    /// root-level deserialize cannot see them.
     fn classes_block(document: &str) -> String {
         let start = document
             .find("\n[classes]\n")
             .expect("the document renders a [classes] block");
-        let body = &document[start + 1..];
+        let body = &document[start + "\n[classes]\n".len()..];
         let mut out = String::new();
-        for (index, line) in body.lines().enumerate() {
-            if index > 0 && line.starts_with('[') {
+        for line in body.lines() {
+            if line.starts_with('[') {
                 break;
             }
             out.push_str(line);

--- a/crates/stella-cli/src/memory/rules_mining/tests.rs
+++ b/crates/stella-cli/src/memory/rules_mining/tests.rs
@@ -344,6 +344,45 @@ fn mined_rules_land_where_the_loader_reads() {
     );
 }
 
+/// **The re-mining witness.** A published TOML record is recognised as
+/// already captured, so the same lesson is not mined a second time.
+///
+/// Hand the loader every file as markdown and this fails by construction. A
+/// record's `Rule::text` is then the whole TOML file. The dedup check
+/// compares shared words. A one-line claim shares few words with the file
+/// that holds it. So the rule on disk is proposed again on every pass.
+#[test]
+fn a_published_record_is_not_mined_again() {
+    let (_ctx, store) = store();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidate = RuleCandidate {
+        id: "already-abcd1234".into(),
+        text: LESSON.into(),
+        description: "d".into(),
+        occurrences: 3,
+        salient: false,
+        evidence: Vec::new(),
+        guard: None,
+        score: 30,
+    };
+    published_path(dir.path(), &candidate);
+
+    let existing = crate::rules::load_workspace_rules_unfiltered(dir.path());
+    assert!(!existing.is_empty(), "the published record must load");
+
+    let observations = across_turns(LESSON, &[1, 2, 3]);
+    let induced = induce_rule_proposals(&store, &observations, &existing, &MineConfig::default());
+
+    assert!(
+        induced.is_empty(),
+        "the lesson is already published and was mined again: {:?}",
+        induced
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
 /// **The hop out of the ledger** (#2782): a rule published from a proposal
 /// carries that proposal's evidence grade onto the record on disk.
 ///

--- a/crates/stella-cli/src/memory/skill_files.rs
+++ b/crates/stella-cli/src/memory/skill_files.rs
@@ -24,8 +24,8 @@ fn slash_path(path: &Path) -> String {
 struct FsSkillSource;
 
 impl SkillSource for FsSkillSource {
-    fn read_skill_files(&self, roots: &[String]) -> Vec<skills::SkillFile> {
-        let mut files = Vec::new();
+    fn read_skill_files(&self, roots: &[String]) -> skills::SkillFiles {
+        let mut found = skills::SkillFiles::default();
         for root in roots {
             // Flat layout: <root>/<slug>.md
             if let Ok(entries) = std::fs::read_dir(root) {
@@ -42,26 +42,41 @@ impl SkillSource for FsSkillSource {
                 paths.sort();
                 for path in paths {
                     if path.extension().is_some_and(|e| e == "md") {
-                        if let Ok(content) = std::fs::read_to_string(&path) {
-                            files.push(skills::SkillFile {
+                        match std::fs::read_to_string(&path) {
+                            Ok(content) => found.files.push(skills::SkillFile {
                                 path: slash_path(&path),
                                 content,
-                            });
+                            }),
+                            Err(error) => found.unreadable.push(skills::UnreadableSkillFile {
+                                path: slash_path(&path),
+                                reason: error.to_string(),
+                            }),
                         }
                     } else if path.is_dir() {
                         // Ecosystem layout: <root>/<slug>/SKILL.md
                         let nested = path.join("SKILL.md");
-                        if let Ok(content) = std::fs::read_to_string(&nested) {
-                            files.push(skills::SkillFile {
+                        match std::fs::read_to_string(&nested) {
+                            Ok(content) => found.files.push(skills::SkillFile {
                                 path: slash_path(&nested),
                                 content,
-                            });
+                            }),
+                            // A directory with no `SKILL.md` is not a skill
+                            // and never was — other agents keep working
+                            // directories here. One whose `SKILL.md` exists
+                            // and will not read is the loss this reports.
+                            Err(error) if nested.symlink_metadata().is_ok() => {
+                                found.unreadable.push(skills::UnreadableSkillFile {
+                                    path: slash_path(&nested),
+                                    reason: error.to_string(),
+                                });
+                            }
+                            Err(_) => {}
                         }
                     }
                 }
             }
         }
-        files
+        found
     }
 }
 
@@ -196,4 +211,79 @@ fn append_plugin_skills(workspace_root: &Path, loaded: &mut skills::LoadedSkills
 #[cfg(test)]
 pub(crate) fn load_workspace_skills(workspace_root: &Path) -> Vec<Skill> {
     load_workspace_skills_with_authority(workspace_root, true).skills
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `SKILL.md` in both layouts, one of them holding bytes that are not
+    /// UTF-8.
+    fn workspace_with_a_broken_skill() -> tempfile::TempDir {
+        let ws = tempfile::tempdir().expect("tmp");
+        let root = ws.path().join("skills");
+        std::fs::create_dir_all(root.join("nested")).expect("mkdir");
+        std::fs::write(
+            root.join("good.md"),
+            "---\nname: good\ndescription: d\n---\nbody",
+        )
+        .expect("write");
+        std::fs::write(root.join("flat-broken.md"), [0xffu8, 0xfe, 0xfd]).expect("write");
+        std::fs::write(root.join("nested/SKILL.md"), [0xffu8, 0xfe, 0xfd]).expect("write");
+        ws
+    }
+
+    /// **The unreadable-skill witness.** Both layouts report a file they
+    /// could not read, and the readable skill beside them still loads.
+    ///
+    /// Write either read site as `if let Ok(content)` and this fails by
+    /// construction: a file holding bad bytes is dropped inside the source
+    /// and `SkillFiles` has no second list for it to appear in. The reader
+    /// sees a short skill list and no word about the loss.
+    ///
+    /// Against `FsSkillSource` directly rather than
+    /// [`load_workspace_skills_with_authority`], which reads the user's real
+    /// `~/.stella/skills` and would make the result depend on the machine.
+    #[test]
+    fn an_unreadable_skill_file_is_reported_in_both_layouts() {
+        let ws = workspace_with_a_broken_skill();
+        let root = slash_path(&ws.path().join("skills"));
+
+        let found = FsSkillSource.read_skill_files(&[root]);
+
+        assert_eq!(found.files.len(), 1, "the readable skill still loads");
+        assert!(found.files[0].path.ends_with("good.md"));
+
+        let named: Vec<&str> = found
+            .unreadable
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect();
+        assert!(
+            named.iter().any(|path| path.ends_with("flat-broken.md")),
+            "the flat layout must name it: {named:?}"
+        );
+        assert!(
+            named.iter().any(|path| path.ends_with("nested/SKILL.md")),
+            "the nested layout must name it: {named:?}"
+        );
+        assert!(
+            found.unreadable.iter().all(|file| !file.reason.is_empty()),
+            "each one carries the reason the read gave"
+        );
+    }
+
+    /// A directory with no `SKILL.md` is not a skill and is not a loss.
+    /// Other agents keep working directories under `skills/`.
+    #[test]
+    fn a_directory_with_no_skill_file_reports_nothing() {
+        let ws = tempfile::tempdir().expect("tmp");
+        let root = ws.path().join("skills");
+        std::fs::create_dir_all(root.join("scratch")).expect("mkdir");
+
+        let found = FsSkillSource.read_skill_files(&[slash_path(&root)]);
+
+        assert!(found.files.is_empty());
+        assert!(found.unreadable.is_empty(), "{:?}", found.unreadable);
+    }
 }

--- a/crates/stella-cli/src/rules.rs
+++ b/crates/stella-cli/src/rules.rs
@@ -320,12 +320,62 @@ pub(crate) fn load_workspace_rules_unfiltered(workspace_root: &Path) -> Vec<Rule
         return Vec::new();
     }
     load_rules(
-        &FsRuleSource,
+        &StatementRuleSource,
         &LoadRulesOptions {
             cwd: workspace_root.display().to_string(),
             user_rules_dir: String::new(),
         },
     )
+}
+
+/// [`FsRuleSource`], with every TOML context record replaced by what it says.
+///
+/// The rule parser reads markdown. Without this, a `.toml` record loads with
+/// `Rule::text` set to the whole file: keys, quotes, hashes. The miner's
+/// dedup check compares shared words. A one-line claim shares few words with
+/// the file that holds it. So a rule already published is mined again on
+/// every pass.
+///
+/// Only this source projects. The record registry reads the same files as
+/// records and needs the file intact.
+struct StatementRuleSource;
+
+impl RuleSource for StatementRuleSource {
+    fn read_rule_files(&self, dirs: &[String]) -> Vec<RuleFile> {
+        FsRuleSource
+            .read_rule_files(dirs)
+            .into_iter()
+            .map(as_statements)
+            .collect()
+    }
+}
+
+/// A context record file as the statements it publishes, one per line.
+///
+/// A file may carry several records. The miner compares text, not structure,
+/// so every statement in the file counts. A file that will not load as a
+/// record is left as it was. The record registry reports a bad policy file,
+/// and one report is enough.
+fn as_statements(file: RuleFile) -> RuleFile {
+    if !file.path.ends_with(".toml") {
+        return file;
+    }
+    let Ok(records) = stella_records::records::load_context_file(&file.path, &file.contents) else {
+        return file;
+    };
+    let statements = records
+        .iter()
+        .map(|loaded| loaded.record.statement.trim())
+        .filter(|statement| !statement.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if statements.is_empty() {
+        return file;
+    }
+    RuleFile {
+        contents: statements,
+        ..file
+    }
 }
 
 /// [`load_workspace_rules`] over an explicit user rules directory — the seam

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -30,7 +30,10 @@ use crate::query_format::{QueryFormat, Rows};
 use super::config::LoopConfig;
 use super::state::LoopState;
 
+mod emergency;
 mod record;
+
+pub(super) use emergency::{EmergencyRead, open_base_breakage, open_deploy_breakage};
 
 /// How many open issues cross the port to produce one cycle's batch.
 ///
@@ -51,6 +54,17 @@ mod record;
 /// pins.
 pub(super) const QUEUE_READ_LIMIT: usize = 1_000;
 
+/// Whether a read of `total` issues filled its page.
+///
+/// One predicate behind four answers, so they cannot drift: the warning an
+/// operator reads, the word the queue listing puts on its count, the flag in
+/// the snapshot, and whether an emergency read can answer at all. A filled
+/// page makes the count a floor. The tracker held at least that many. The
+/// loop cannot say how many more.
+pub(super) fn read_filled_the_page(total: usize) -> bool {
+    total >= QUEUE_READ_LIMIT
+}
+
 /// What an operator is told when the queue read filled its page.
 ///
 /// A full page means the tracker held at least this many open issues, so the
@@ -62,16 +76,6 @@ pub(super) const QUEUE_READ_LIMIT: usize = 1_000;
 ///
 /// A function rather than an inline print, so what an operator is told can be
 /// asserted without running a loop.
-/// Whether a read of `total` issues filled its page.
-///
-/// One predicate behind three answers, so they cannot drift: the warning an
-/// operator reads, the word the queue listing puts on its count, and the flag
-/// in the snapshot. A filled page makes the count a floor. The tracker held
-/// at least that many. The loop cannot say how many more.
-pub(super) fn read_filled_the_page(total: usize) -> bool {
-    total >= QUEUE_READ_LIMIT
-}
-
 fn truncation_notice(total: usize, provider: &str) -> Option<String> {
     read_filled_the_page(total).then(|| {
         format!(
@@ -339,34 +343,6 @@ pub(super) fn unassessed(
 /// discovers that the emergency is already filed instead of filing it again.
 pub(super) const BASE_BREAKAGE_LABEL: &str = "main-red";
 
-/// The open base-breakage issue, if one exists.
-///
-/// Read through the port like everything else, and matched on
-/// [`BASE_BREAKAGE_LABEL`] rather than on words in the title. An unreachable
-/// tracker answers `None`, which reads as *nobody has filed it* — the loop
-/// then tries to file, the filing fails too, and it waits. That is the right
-/// shape: a forge outage should make it wait, not make it act on a guess.
-#[must_use]
-pub(super) fn open_base_breakage(provider: &dyn IssueProvider) -> Option<String> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .ok()?;
-    let issues = runtime
-        .block_on(provider.list_open(QUEUE_READ_LIMIT))
-        .ok()?;
-
-    issues
-        .into_iter()
-        .find(|issue| {
-            issue
-                .labels
-                .iter()
-                .any(|label| label.name == BASE_BREAKAGE_LABEL)
-        })
-        .map(|issue| issue.key.as_str().to_owned())
-}
-
 /// File the report that the base branch is broken.
 ///
 /// Deliberately **not** routed through [`file_finding`]. That path dedups on a
@@ -438,33 +414,6 @@ pub(super) fn file_base_breakage(
 /// emergency already filed instead of filing it again.
 pub(super) const DEPLOY_BREAKAGE_LABEL: &str = "release-red";
 
-/// The open deploy-breakage issue, if one exists.
-///
-/// Matched on [`DEPLOY_BREAKAGE_LABEL`] and read through the port. It
-/// degrades as [`open_base_breakage`] does. An unreachable tracker answers
-/// `None`, the filing that follows fails too, and the loop waits rather
-/// than acting on a guess.
-#[must_use]
-pub(super) fn open_deploy_breakage(provider: &dyn IssueProvider) -> Option<String> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .ok()?;
-    let issues = runtime
-        .block_on(provider.list_open(QUEUE_READ_LIMIT))
-        .ok()?;
-
-    issues
-        .into_iter()
-        .find(|issue| {
-            issue
-                .labels
-                .iter()
-                .any(|label| label.name == DEPLOY_BREAKAGE_LABEL)
-        })
-        .map(|issue| issue.key.as_str().to_owned())
-}
-
 /// File the report that the release workflow is red — once.
 ///
 /// The dedup lives in this function, not in the caller. The property that
@@ -483,7 +432,7 @@ pub(super) fn file_deploy_breakage(
     run_url: &str,
     attribution: &stella_autonomy::Attribution,
 ) -> Result<Option<String>, String> {
-    if open_deploy_breakage(provider).is_some() {
+    if open_deploy_breakage(provider).filed().is_some() {
         return Ok(None);
     }
 
@@ -701,7 +650,9 @@ pub(super) async fn comment(
 /// being worked is still `Open` and still in this read.
 ///
 /// A key that is not in the open queue is a typed refusal naming the two
-/// reasons a caller can act on: it is closed, or it does not exist.
+/// reasons a caller can act on: it is closed, or it does not exist. A read
+/// that filled its page cannot claim either, and says the weaker thing it
+/// knows instead.
 pub(super) fn resolve(
     provider: &dyn IssueProvider,
     key: &str,
@@ -714,16 +665,31 @@ pub(super) fn resolve(
         .block_on(provider.list_open(QUEUE_READ_LIMIT))
         .map_err(|error| error.to_string())?;
 
+    let filled = read_filled_the_page(issues.len());
     issues
         .into_iter()
         .find(|issue| issue.key.as_str() == key)
-        .ok_or_else(|| {
-            format!(
-                "#{key} is not in the open queue — it is closed, or it does not exist \
-                 (read {QUEUE_READ_LIMIT} open issues from `{}`)",
-                provider.id()
-            )
-        })
+        .ok_or_else(|| not_in_the_open_queue(key, provider.id(), filled))
+}
+
+/// Why one key did not resolve.
+///
+/// Two different statements, because a bounded read cannot make the stronger
+/// one. On a page with room left, everything open crossed, so an absent key
+/// is closed or was never filed. On a filled page the loop knows only that it
+/// did not see it, and saying more would be a false statement rather than a
+/// visibly partial one.
+fn not_in_the_open_queue(key: &str, provider: &str, filled: bool) -> String {
+    if filled {
+        return format!(
+            "#{key} is not in the {QUEUE_READ_LIMIT} open issues read from `{provider}`, and \
+             that read filled its page — so this says nothing about whether #{key} is open"
+        );
+    }
+    format!(
+        "#{key} is not in the open queue — it is closed, or it does not exist \
+         (read {QUEUE_READ_LIMIT} open issues from `{provider}`)"
+    )
 }
 
 /// Explain a filing that did not happen.
@@ -1225,6 +1191,69 @@ mod tests {
             OLD_PAGE + 1,
             "the reported backlog size counts every open issue, not one page \
              of them"
+        );
+    }
+
+    /// **Witness.** A filled page cannot answer "is the emergency already
+    /// filed", and says so instead of saying no.
+    ///
+    /// Collapse the three answers into `Option` and this fails by
+    /// construction: the label sits behind the page, the read returns `None`,
+    /// and every pass files a second `main-red` issue for a breakage that was
+    /// already reported. The label match is the interlock against exactly
+    /// that, and a bounded read defeats it.
+    ///
+    /// The choice on `Unknown` is to file anyway — see [`EmergencyRead::filed`]
+    /// for the cost of the other one.
+    #[test]
+    fn a_filled_page_cannot_say_the_emergency_is_unfiled() {
+        let mut open: Vec<Issue> = (0..QUEUE_READ_LIMIT)
+            .map(|n| {
+                issue(
+                    &format!("{}", n + 100),
+                    &["bug", "P2"],
+                    "2026-08-01T00:00:00Z",
+                )
+            })
+            .collect();
+        // Behind the page, which is where a freshly-filed emergency lands on a
+        // tracker that hands back its oldest first.
+        open.push(issue("9", &[BASE_BREAKAGE_LABEL], "2020-01-01T00:00:00Z"));
+
+        let provider = FixtureProvider::with(open);
+        assert_eq!(
+            open_base_breakage(&provider),
+            EmergencyRead::Unknown("the read filled its page"),
+            "a page with no room left is not evidence that nothing is filed"
+        );
+    }
+
+    /// The two answers a complete read can give, and `resolve`'s two
+    /// refusals. A page with room left saw everything open, so it may say a
+    /// key is closed. A filled page may not.
+    #[test]
+    fn a_complete_read_answers_and_a_bounded_one_says_less() {
+        let none = FixtureProvider::with(vec![issue("1", &["bug"], "2026-08-01T00:00:00Z")]);
+        assert_eq!(open_base_breakage(&none), EmergencyRead::NotFiled);
+        assert_eq!(open_deploy_breakage(&none), EmergencyRead::NotFiled);
+
+        let filed = FixtureProvider::with(vec![
+            issue("42", &[BASE_BREAKAGE_LABEL], "2026-08-02T00:00:00Z"),
+            issue("43", &[DEPLOY_BREAKAGE_LABEL], "2026-08-02T00:00:00Z"),
+        ]);
+        assert_eq!(open_base_breakage(&filed).filed().as_deref(), Some("42"));
+        assert_eq!(open_deploy_breakage(&filed).filed().as_deref(), Some("43"));
+
+        let complete = not_in_the_open_queue("7", "fixture", false);
+        assert!(
+            complete.contains("closed, or it does not exist"),
+            "{complete}"
+        );
+        let bounded = not_in_the_open_queue("7", "fixture", true);
+        assert!(
+            !bounded.contains("closed, or it does not exist")
+                && bounded.contains("filled its page"),
+            "a bounded read cannot claim the key is closed: {bounded}"
         );
     }
 

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -62,8 +62,18 @@ pub(super) const QUEUE_READ_LIMIT: usize = 1_000;
 ///
 /// A function rather than an inline print, so what an operator is told can be
 /// asserted without running a loop.
+/// Whether a read of `total` issues filled its page.
+///
+/// One predicate behind three answers, so they cannot drift: the warning an
+/// operator reads, the word the queue listing puts on its count, and the flag
+/// in the snapshot. A filled page makes the count a floor. The tracker held
+/// at least that many. The loop cannot say how many more.
+pub(super) fn read_filled_the_page(total: usize) -> bool {
+    total >= QUEUE_READ_LIMIT
+}
+
 fn truncation_notice(total: usize, provider: &str) -> Option<String> {
-    (total >= QUEUE_READ_LIMIT).then(|| {
+    read_filled_the_page(total).then(|| {
         format!(
             "warning: `{provider}` returned {total} open issues, which fills this read. \
              The ladder ranks that page alone, and the tracker chose it by its own order. \
@@ -147,11 +157,18 @@ pub(super) fn render_queue(
             .unwrap_or("");
         println!("{prio:>2}  #{:<6} {area:<18} {}", i.number, i.title);
     }
+    // "read", not "total". The number is one page. At the ceiling it is the
+    // ceiling, so "total" would name the read's own limit as the backlog.
     eprintln!(
-        "\n{} of {} ranked defects ({} open issues total, {} awaiting triage)",
+        "\n{} of {} ranked defects ({} open issues {}, {} awaiting triage)",
         picked.len(),
         defects.len(),
         total_issues,
+        if read_filled_the_page(total_issues) {
+            "read, and the page filled — there may be more"
+        } else {
+            "read"
+        },
         queue.unassessed.len()
     );
     Ok(())
@@ -1234,6 +1251,38 @@ mod tests {
         assert!(
             notice.contains(&QUEUE_READ_LIMIT.to_string()),
             "the notice names how many issues crossed: {notice}"
+        );
+    }
+
+    /// **Witness.** The count a surface draws is labelled as the read's size
+    /// at the page boundary, on both sides of it.
+    ///
+    /// Call the number "open issues total" and this fails. A backlog of ten
+    /// thousand and one of exactly a page both report the page. That figure
+    /// is the read's own ceiling under the tracker's name.
+    #[test]
+    fn the_page_boundary_is_the_same_answer_everywhere() {
+        assert!(
+            !read_filled_the_page(QUEUE_READ_LIMIT - 1),
+            "a page with room left is a complete read"
+        );
+        assert!(
+            read_filled_the_page(QUEUE_READ_LIMIT),
+            "a page exactly filled is a floor, not a total"
+        );
+        assert!(
+            read_filled_the_page(QUEUE_READ_LIMIT + 1),
+            "and so is anything past it"
+        );
+        assert_eq!(
+            read_filled_the_page(QUEUE_READ_LIMIT),
+            truncation_notice(QUEUE_READ_LIMIT, "github").is_some(),
+            "the warning and the label answer the same question"
+        );
+        assert_eq!(
+            read_filled_the_page(QUEUE_READ_LIMIT - 1),
+            truncation_notice(QUEUE_READ_LIMIT - 1, "github").is_some(),
+            "…on the other side of the boundary too"
         );
     }
 

--- a/crates/stella-cli/src/self_driving_cmd/backlog.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog.rs
@@ -33,7 +33,7 @@ use super::state::LoopState;
 mod emergency;
 mod record;
 
-pub(super) use emergency::{EmergencyRead, open_base_breakage, open_deploy_breakage};
+pub(super) use emergency::{open_base_breakage, open_deploy_breakage};
 
 /// How many open issues cross the port to produce one cycle's batch.
 ///
@@ -777,6 +777,9 @@ mod tests {
     use stella_protocol::issue::{Issue, IssueClass, IssueError, IssueKey, IssueLabel, IssueState};
 
     use super::*;
+    // Named here rather than re-exported above: the shipping code only ever
+    // calls `filed()` on this, so a re-export would be an unused import.
+    use super::emergency::EmergencyRead;
 
     /// A tracker that is not GitHub and is not a process.
     ///

--- a/crates/stella-cli/src/self_driving_cmd/backlog/emergency.rs
+++ b/crates/stella-cli/src/self_driving_cmd/backlog/emergency.rs
@@ -1,0 +1,95 @@
+//! Is this emergency already filed?
+//!
+//! The label on a `main-red` or `release-red` issue is the dedup key. It is
+//! how a restarted loop, or a second one, finds the emergency already
+//! filed. Without it, each pass files a new one. This is that read.
+//!
+//! Its own file because `backlog.rs` is at the size ceiling.
+
+use stella_protocol::issue::IssueProvider;
+
+use super::{BASE_BREAKAGE_LABEL, DEPLOY_BREAKAGE_LABEL, QUEUE_READ_LIMIT, read_filled_the_page};
+
+/// What a read for an already-filed emergency found.
+///
+/// Three answers, not two. "Not in the page I read" is not "not filed". The
+/// page is bounded. A backlog that fills it would make every emergency read
+/// as unfiled, and each pass would file one more.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum EmergencyRead {
+    /// The tracker answered and one is open, under this key.
+    Filed(String),
+    /// The tracker answered a page with room left, and none is in it.
+    NotFiled,
+    /// Nothing usable came back: the tracker could not be read, or the read
+    /// filled its page and the answer is not in what crossed.
+    Unknown(&'static str),
+}
+
+impl EmergencyRead {
+    /// The key of an emergency already filed, or `None`.
+    ///
+    /// `Unknown` answers `None`, so the loop files. Here is the cost of the
+    /// other choice. Refuse to file, and the base branch stays broken with
+    /// nothing on the tracker to say so. Every pull request stays red behind
+    /// a hold that never fires. A duplicate is one issue somebody closes.
+    /// The read says what it could not answer first, so the duplicate is
+    /// explained.
+    #[must_use]
+    pub(crate) fn filed(self) -> Option<String> {
+        match self {
+            Self::Filed(key) => Some(key),
+            Self::NotFiled => None,
+            Self::Unknown(why) => {
+                eprintln!(
+                    "warning: could not tell whether this emergency is already filed ({why}), \
+                     so it is being filed. Close the duplicate if there is one."
+                );
+                None
+            }
+        }
+    }
+}
+
+/// Scan one read for an issue carrying `label`.
+fn emergency_labelled(provider: &dyn IssueProvider, label: &str) -> EmergencyRead {
+    let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        return EmergencyRead::Unknown("no runtime for the issue provider");
+    };
+    let Ok(issues) = runtime.block_on(provider.list_open(QUEUE_READ_LIMIT)) else {
+        return EmergencyRead::Unknown("the tracker could not be read");
+    };
+
+    let filled = read_filled_the_page(issues.len());
+    match issues
+        .into_iter()
+        .find(|issue| issue.labels.iter().any(|carried| carried.name == label))
+    {
+        Some(issue) => EmergencyRead::Filed(issue.key.as_str().to_owned()),
+        None if filled => EmergencyRead::Unknown("the read filled its page"),
+        None => EmergencyRead::NotFiled,
+    }
+}
+
+/// The open base-breakage issue, if one exists.
+///
+/// Read through the port like everything else, and matched on
+/// [`BASE_BREAKAGE_LABEL`] rather than on words in the title. An unreachable
+/// tracker answers [`EmergencyRead::Unknown`], and so does a read that filled
+/// its page — see that type for what the caller does with it.
+#[must_use]
+pub(crate) fn open_base_breakage(provider: &dyn IssueProvider) -> EmergencyRead {
+    emergency_labelled(provider, BASE_BREAKAGE_LABEL)
+}
+
+/// The open deploy-breakage issue, if one exists.
+///
+/// Matched on [`DEPLOY_BREAKAGE_LABEL`] and read through the port. It
+/// degrades as [`open_base_breakage`] does, and on the same terms.
+#[must_use]
+pub(crate) fn open_deploy_breakage(provider: &dyn IssueProvider) -> EmergencyRead {
+    emergency_labelled(provider, DEPLOY_BREAKAGE_LABEL)
+}

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -237,20 +237,43 @@ fn read_toml(root: &Path) -> LoopDocument {
 /// agent. The name is taken up to the closing bracket rather than off the
 /// end of the line, so a trailing comment does not hide the header.
 ///
-/// A quoted key (`[self_driving."worker"]`) is not recognised. That spelling
-/// fails toward refusing a worker this cannot read rather than toward
-/// running one the operator did not name, which is the direction that is
-/// safe to be wrong in.
+/// A quoted key is TOML-legal too, and it is dropped for the same reason the
+/// whitespace is: `[self_driving."worker"]` opens the table
+/// `[self_driving.worker]` opens. Every miss here fails in one direction, and
+/// it is the unsafe one — `names_a_worker: false` resolves
+/// [`WorkerKind::default`](crate::settings::toml_config::WorkerKind), which is
+/// `Stella`, so a spelling this does not recognise runs the default agent
+/// under a file that named a different one rather than refusing the turn.
+///
+/// Splitting on the dots before unquoting is what keeps the normalization from
+/// widening: `["self_driving.worker"]` is one quoted key holding a dot, a
+/// different table, and it must not match. Nor may `[[self_driving.worker]]`,
+/// an array of tables, which cannot carry a `kind`.
 fn declares_a_worker(raw: &str) -> bool {
     raw.lines().map(str::trim).any(|line| {
         line.strip_prefix('[')
             .and_then(|rest| rest.split_once(']'))
             .is_some_and(|(name, _)| {
-                name.chars()
-                    .filter(|c| !c.is_whitespace())
-                    .eq("self_driving.worker".chars())
+                let mut keys = name.split('.').map(|key| unquote(key.trim()));
+                keys.next() == Some("self_driving")
+                    && keys.next() == Some("worker")
+                    && keys.next().is_none()
             })
     })
+}
+
+/// One table-header key with its TOML quoting removed, if it carried any.
+///
+/// Both quote characters, because TOML spells a key as a basic string
+/// (`"worker"`) or a literal one (`'worker'`).
+fn unquote(key: &str) -> &str {
+    key.strip_prefix('"')
+        .and_then(|rest| rest.strip_suffix('"'))
+        .or_else(|| {
+            key.strip_prefix('\'')
+                .and_then(|rest| rest.strip_suffix('\''))
+        })
+        .unwrap_or(key)
 }
 
 #[cfg(test)]
@@ -477,6 +500,9 @@ kind = "clade"
             "[ self_driving.worker ]",
             "[self_driving . worker]",
             "[self_driving.worker] # the agent this loop drives",
+            "[self_driving.\"worker\"]",
+            "[\"self_driving\".worker]",
+            "[self_driving.'worker']",
         ] {
             let ws = workspace();
             write(
@@ -491,6 +517,32 @@ kind = "clade"
                 load(ws.path()).worker.kind,
                 crate::settings::toml_config::WorkerKind::Unreadable,
                 "`{header}` names the worker table, so it must refuse like the bare spelling"
+            );
+        }
+    }
+
+    /// The negative control for the test above. Dropping whitespace and quotes
+    /// must not widen the match into a header naming a different table:
+    /// `["self_driving.worker"]` is one quoted key holding a dot, and
+    /// `[[self_driving.worker]]` is an array of tables that cannot carry a
+    /// `kind`. Either one matching would refuse a turn over a document that
+    /// names no worker at all.
+    #[test]
+    fn a_lookalike_header_is_not_read_as_the_worker_table() {
+        for header in ["[\"self_driving.worker\"]", "[[self_driving.worker]]"] {
+            let ws = workspace();
+            write(
+                ws.path(),
+                "stella.toml",
+                &format!(
+                    "[meta]\nschema_version = 1\nscope = \"project\"\n\n{header}\nkind = \"clade\"\n"
+                ),
+            );
+
+            assert_eq!(
+                load(ws.path()).worker.kind,
+                crate::settings::toml_config::WorkerKind::Stella,
+                "`{header}` does not open [self_driving.worker]"
             );
         }
     }

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -228,10 +228,29 @@ fn read_toml(root: &Path) -> LoopDocument {
 /// tree to ask. A table header is the whole line, so a scan of the line
 /// starts answers exactly: a `[` in the middle of a value cannot reach here,
 /// and a header split across lines is not TOML.
+///
+/// Whitespace inside the brackets and around the dot is TOML-legal and
+/// carries no meaning, so it is dropped before the comparison rather than
+/// matched literally — `[ self_driving . worker ]` names the same table as
+/// `[self_driving.worker]`, and reading the spaced spelling as "no worker
+/// named" is what would hand an unparsable document back to the default
+/// agent. The name is taken up to the closing bracket rather than off the
+/// end of the line, so a trailing comment does not hide the header.
+///
+/// A quoted key (`[self_driving."worker"]`) is not recognised. That spelling
+/// fails toward refusing a worker this cannot read rather than toward
+/// running one the operator did not name, which is the direction that is
+/// safe to be wrong in.
 fn declares_a_worker(raw: &str) -> bool {
-    raw.lines()
-        .map(str::trim)
-        .any(|line| line.starts_with("[self_driving.worker]"))
+    raw.lines().map(str::trim).any(|line| {
+        line.strip_prefix('[')
+            .and_then(|rest| rest.split_once(']'))
+            .is_some_and(|(name, _)| {
+                name.chars()
+                    .filter(|c| !c.is_whitespace())
+                    .eq("self_driving.worker".chars())
+            })
+    })
 }
 
 #[cfg(test)]
@@ -439,6 +458,41 @@ kind = "clade"
             crate::settings::toml_config::WorkerKind::Unreadable,
             "a worker the file cannot express must not resolve to one the operator did not name"
         );
+    }
+
+    /// **The witness for the spaced header.** TOML lets a table header carry
+    /// whitespace inside its brackets and around its dots, and lets a comment
+    /// follow it. Each of those spellings names `[self_driving.worker]`, so
+    /// each must fail closed the same way.
+    ///
+    /// Matching the header literally fails here by construction: none of
+    /// these three lines starts with `[self_driving.worker]`, so the document
+    /// reads as naming no worker, `load` hands back `LoopConfig::default()`,
+    /// and the operator who wrote `kind = "clade"` gets `WorkerKind::Stella`
+    /// — the substitution the whole fail-closed path exists to stop, reached
+    /// through the one spelling nothing checked.
+    #[test]
+    fn a_spaced_or_commented_worker_header_still_fails_closed() {
+        for header in [
+            "[ self_driving.worker ]",
+            "[self_driving . worker]",
+            "[self_driving.worker] # the agent this loop drives",
+        ] {
+            let ws = workspace();
+            write(
+                ws.path(),
+                "stella.toml",
+                &format!(
+                    "[meta]\nschema_version = 1\nscope = \"project\"\n\n{header}\nkind = \"clade\"\n"
+                ),
+            );
+
+            assert_eq!(
+                load(ws.path()).worker.kind,
+                crate::settings::toml_config::WorkerKind::Unreadable,
+                "`{header}` names the worker table, so it must refuse like the bare spelling"
+            );
+        }
     }
 
     /// A document that does not parse and names no worker keeps today's

--- a/crates/stella-cli/src/self_driving_cmd/config.rs
+++ b/crates/stella-cli/src/self_driving_cmd/config.rs
@@ -125,13 +125,38 @@ impl Default for LoopConfig {
 /// are edited in, and requiring a second file beside it to make the first one
 /// count would make the manifest unreachable for the workspace that has
 /// configured nothing else — which is the workspace it exists for.
+///
+/// The worker is the exception, and it fails closed. A document that does not
+/// parse but does declare `[self_driving.worker]` resolves
+/// [`crate::settings::toml_config::WorkerKind::Unreadable`], and the work path
+/// refuses the turn. Falling back to the default there would run stella under
+/// a file that asked for Claude Code, which is the one substitution the typed
+/// setting exists to stop, and `stella self-driving drive` runs unattended, so
+/// a warning on stderr is not a stop.
 #[must_use]
 pub(crate) fn load(root: &Path) -> LoopConfig {
-    let Some(parsed) = read_toml(root) else {
-        return LoopConfig {
-            manifest: ProviderManifest::for_workspace(root),
-            ..LoopConfig::default()
-        };
+    let parsed = match read_toml(root) {
+        LoopDocument::Parsed(parsed) => parsed,
+        LoopDocument::Absent => {
+            return LoopConfig {
+                manifest: ProviderManifest::for_workspace(root),
+                ..LoopConfig::default()
+            };
+        }
+        LoopDocument::Unparsed { names_a_worker } => {
+            return LoopConfig {
+                manifest: ProviderManifest::for_workspace(root),
+                worker: crate::settings::toml_config::WorkerSection {
+                    kind: if names_a_worker {
+                        crate::settings::toml_config::WorkerKind::Unreadable
+                    } else {
+                        crate::settings::toml_config::WorkerKind::default()
+                    },
+                    ..crate::settings::toml_config::WorkerSection::default()
+                },
+                ..LoopConfig::default()
+            };
+        }
     };
 
     LoopConfig {
@@ -167,16 +192,46 @@ fn default_container_labels() -> Vec<String> {
         .collect()
 }
 
-fn read_toml(root: &Path) -> Option<TomlConfig> {
+/// What a workspace's `stella.toml` gave the loop.
+enum LoopDocument {
+    /// No file, or one this process cannot read.
+    Absent,
+    /// The document parsed.
+    Parsed(Box<TomlConfig>),
+    /// The document did not parse. Every setting falls back to its default
+    /// except the worker, which fails closed when the file declared one.
+    Unparsed {
+        /// Whether the raw text opens a `[self_driving.worker]` table.
+        names_a_worker: bool,
+    },
+}
+
+fn read_toml(root: &Path) -> LoopDocument {
     let path = crate::settings::toml_config::project_toml_path(root);
-    let raw = std::fs::read_to_string(&path).ok()?;
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return LoopDocument::Absent;
+    };
     match TomlConfig::parse(&raw, &path) {
-        Ok(parsed) => Some(parsed),
+        Ok(parsed) => LoopDocument::Parsed(Box::new(parsed)),
         Err(error) => {
             eprintln!("warning: {error}; self-driving is using its defaults");
-            None
+            LoopDocument::Unparsed {
+                names_a_worker: declares_a_worker(&raw),
+            }
         }
     }
+}
+
+/// Whether the text opens a `[self_driving.worker]` table.
+///
+/// Read from the raw text because the document did not parse, so there is no
+/// tree to ask. A table header is the whole line, so a scan of the line
+/// starts answers exactly: a `[` in the middle of a value cannot reach here,
+/// and a header split across lines is not TOML.
+fn declares_a_worker(raw: &str) -> bool {
+    raw.lines()
+        .map(str::trim)
+        .any(|line| line.starts_with("[self_driving.worker]"))
 }
 
 #[cfg(test)]
@@ -352,6 +407,56 @@ dangerously_skip_permissions = true
         assert_eq!(worker.model.as_deref(), Some("opus"));
         assert_eq!(worker.max_turns, Some(40));
         assert!(worker.dangerously_skip_permissions);
+    }
+
+    /// **The fail-closed witness.** A document that names a worker and does
+    /// not parse resolves no worker at all.
+    ///
+    /// Fall back to the defaults here and this fails by construction: the
+    /// whole-document parse fails, `load` returns `LoopConfig::default()`,
+    /// and the operator who wrote `kind = "clade"` gets `WorkerKind::Stella`
+    /// — the substitution the typed setting was chosen to stop. Every `match`
+    /// on the enum has to answer for `Unreadable`, so the work path refuses
+    /// instead.
+    #[test]
+    fn an_unreadable_worker_kind_resolves_no_worker() {
+        let ws = workspace();
+        write(
+            ws.path(),
+            "stella.toml",
+            r#"
+[meta]
+schema_version = 1
+scope = "project"
+
+[self_driving.worker]
+kind = "clade"
+"#,
+        );
+
+        assert_eq!(
+            load(ws.path()).worker.kind,
+            crate::settings::toml_config::WorkerKind::Unreadable,
+            "a worker the file cannot express must not resolve to one the operator did not name"
+        );
+    }
+
+    /// A document that does not parse and names no worker keeps today's
+    /// recovery: the loop says so and runs its default agent. Only the key
+    /// that selects an executing agent fails closed.
+    #[test]
+    fn an_unparsable_document_with_no_worker_table_keeps_the_default() {
+        let ws = workspace();
+        write(
+            ws.path(),
+            "stella.toml",
+            "[meta]\nschema_version = 1\nscope = \"project\"\n\n[self_driving]\ntriage = 7\n",
+        );
+
+        assert_eq!(
+            load(ws.path()).worker.kind,
+            crate::settings::toml_config::WorkerKind::Stella
+        );
     }
 
     /// The default is unchanged by the seam existing: a workspace that says

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -1439,7 +1439,7 @@ fn observe(
         };
     }
 
-    let filed = super::backlog::open_base_breakage(provider);
+    let filed = super::backlog::open_base_breakage(provider).filed();
     let contention = filed
         .as_ref()
         .map(|key| super::contention::for_base_fix(root, key))

--- a/crates/stella-cli/src/self_driving_cmd/parallel.rs
+++ b/crates/stella-cli/src/self_driving_cmd/parallel.rs
@@ -67,6 +67,14 @@ fn refuse_unsupported_worker(
              issues one at a time with the worker you chose, or set worker.kind = \
              \"stella\" for the wave."
             .to_owned()),
+        // A wave under an unreadable worker would run stella across every
+        // issue at once, which is the swap this function exists to stop —
+        // and at width, not one issue at a time.
+        WorkerKind::Unreadable => Err("stella.toml declares [self_driving.worker] and could not \
+                                       be read, so which agent you asked for is unknown. Fix the \
+                                       document — the parse error is on stderr above — and run \
+                                       again."
+            .to_owned()),
     }
 }
 

--- a/crates/stella-cli/src/self_driving_cmd/state.rs
+++ b/crates/stella-cli/src/self_driving_cmd/state.rs
@@ -303,6 +303,10 @@ impl LoopState {
     /// `rank` is the rung label an issue carries (`P0`, `P1`, …) or
     /// `untriaged` for one nobody has placed — the same split the loop
     /// claims by, spelled so a reader needs no ladder to interpret it.
+    ///
+    /// `open_total` is what one read returned, and the read is one page. The
+    /// document says so beside it, so a reader can tell a backlog of exactly
+    /// the page size from a backlog the page could not hold.
     pub fn write_queue_snapshot(
         &self,
         queue: &stella_autonomy::priority::Queue,
@@ -340,6 +344,12 @@ impl LoopState {
         let doc = json!({
             "at": crate::timefmt::rfc3339_utc_now(),
             "open_total": open_total,
+            // `open_total` is the size of one read, and the read is one page.
+            // When the page filled, the count is a floor: the tracker held at
+            // least that many and the loop cannot say how many more. A reader
+            // that draws the number as the backlog's size needs this to know
+            // when it is drawing a ceiling instead.
+            "open_total_is_a_full_page": super::backlog::read_filled_the_page(open_total),
             "ranked": queue.ranked.len(),
             "untriaged": queue.unassessed.len(),
             "items": items,
@@ -1175,6 +1185,10 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(tmp.path().join("queue.json")).unwrap())
                 .unwrap();
         assert_eq!(doc["open_total"], 3);
+        assert_eq!(
+            doc["open_total_is_a_full_page"], false,
+            "three issues left the page room, so the count is the backlog"
+        );
         assert_eq!(doc["ranked"], 2);
         assert_eq!(doc["untriaged"], 1);
         let items = doc["items"].as_array().unwrap();

--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -760,6 +760,15 @@ pub(crate) fn start(
             budget.cap().unwrap_or_default(),
         )),
         WorkerKind::Claude => super::claude_worker::run_claude(&created.path, &prompt, worker),
+        // The file named a worker and did not parse. Running the default
+        // agent here is the substitution the typed setting exists to stop,
+        // and this loop runs unattended, so the warning the config reader
+        // already printed is not a stop.
+        WorkerKind::Unreadable => Err("stella.toml declares [self_driving.worker] and could not \
+                                       be read, so which agent you asked for is unknown. Fix the \
+                                       document — the parse error is on stderr above — and run \
+                                       again."
+            .to_owned()),
     };
     let change = tree_change(&created.path, &base);
     let outcome = classify(turn, change, &wt);

--- a/crates/stella-cli/src/settings/toml_config.rs
+++ b/crates/stella-cli/src/settings/toml_config.rs
@@ -615,6 +615,19 @@ pub enum WorkerKind {
     Stella,
     /// Claude Code, run non-interactively in the same isolated worktree.
     Claude,
+    /// The file asked for a worker and this build could not read which one.
+    ///
+    /// No spelling produces it — `#[serde(skip)]`, so it is not a value an
+    /// operator can write — and the loop's config reader is the only thing
+    /// that sets it. Every `match` on this enum has to answer for it, which
+    /// is the point: the loop refuses the turn instead of running the
+    /// default agent under a file that named a different one.
+    ///
+    /// It exists because a `stella.toml` is parsed whole. One typo anywhere
+    /// in the document failed the parse, the loop fell back to its defaults,
+    /// and `kind = "clade"` quietly ran stella.
+    #[serde(skip)]
+    Unreadable,
 }
 
 /// `[self_driving.merge]` — which checks may block a merge.

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -861,11 +861,13 @@ pub(crate) fn spawn(
         });
         // A panic unwound past the worker's own closeout, so its claims are
         // still held — release them here or they block rivals until the
-        // age-based sweep.
-        if matches!(&end, WorkerEnd::Failed(reason) if reason.starts_with(PANIC_FAILURE_PREFIX))
-            && let Some(store) = agent::open_store(&cfg.workspace_root)
-        {
-            let _ = store.release_file_locks_for_holder(&format!("{session_id}/{lane}"));
+        // age-based sweep. The lane's terminal frame is skipped the same way,
+        // so it is written here too.
+        if matches!(&end, WorkerEnd::Failed(reason) if reason.starts_with(PANIC_FAILURE_PREFIX)) {
+            if let Some(store) = agent::open_store(&cfg.workspace_root) {
+                let _ = store.release_file_locks_for_holder(&format!("{session_id}/{lane}"));
+            }
+            terminal_frame::settle_panicked_lane(&cfg.workspace_root, &session_id, &lane, &end);
         }
 
         // Terminal lane status. On failure the Error event (already on the

--- a/crates/stella-cli/src/subsession/closeout.rs
+++ b/crates/stella-cli/src/subsession/closeout.rs
@@ -67,6 +67,12 @@ pub(crate) fn close_worker_execution(
     let Some((store, id)) = execution else {
         return cost_usd;
     };
+    // The SQLite code behind a refused write goes unread here, and the reason
+    // is the signature above: this closeout takes no channel, so it has
+    // nowhere to send a line. The deck owns the terminal while a worker runs,
+    // so stderr is wiped by the next frame. A caller that wants the detail on
+    // a lane reads it the way `command_deck::lead_turn` does, off the
+    // `ExecutionEndOutcome` this discards.
     let _ = agent::record_execution_end(
         store,
         *id,

--- a/crates/stella-cli/src/subsession/terminal_frame.rs
+++ b/crates/stella-cli/src/subsession/terminal_frame.rs
@@ -17,6 +17,45 @@ use super::{WorkerEnd, lane_journal_key};
 use crate::durability::SessionDurability;
 use crate::lane_frame::{LaneEnd, TerminalFrame, report_line};
 
+/// Write the terminal frame a panicked lane owes its lead.
+///
+/// `run_worker` settles its own recorder on every path it returns through.
+/// An unwind is not one of them. The lane's last step is still on disk with
+/// nothing to turn it into a frame, so the lead's report says nothing about
+/// the loudest way a lane can die.
+///
+/// This binds its own handle to the same lane key. The worker's went with the
+/// frame that unwound. A lane that reached no end of a turn is framed from
+/// the checkpoint standing at its tip, which is what a panic leaves, so a
+/// second handle over the same key reads the same state.
+///
+/// A bind warning is dropped, for the reason `run_worker` drops its own: the
+/// worker is dead and the lane has already said so.
+pub(super) fn settle_panicked_lane(
+    workspace_root: &std::path::Path,
+    session_id: &str,
+    lane: &str,
+    end: &WorkerEnd,
+) {
+    let durability = SessionDurability::default();
+    let _ = crate::durability::bind_session(
+        &durability,
+        workspace_root,
+        &lane_journal_key(session_id, lane),
+    );
+    settle_bound_lane(&durability, lane, end);
+}
+
+/// [`settle_panicked_lane`] over a handle the caller has already bound.
+///
+/// The split is the one `durability::bind_session_in` argues for. The global
+/// form finds its store through `data_dir()`, which reads `STELLA_HOME`. A
+/// test that used it would write into the developer's own store.
+pub(super) fn settle_bound_lane(durability: &SessionDurability, lane: &str, end: &WorkerEnd) {
+    crate::lane_frame::LaneRecorder::new(durability, lane)
+        .settle(&crate::lane_frame::LaneEnd::from(end));
+}
+
 impl From<&WorkerEnd> for LaneEnd {
     fn from(end: &WorkerEnd) -> Self {
         match end {

--- a/crates/stella-cli/src/subsession/tests.rs
+++ b/crates/stella-cli/src/subsession/tests.rs
@@ -325,6 +325,74 @@ fn a_panicking_worker_body_ends_as_failed_never_silence() {
     assert!(matches!(end, WorkerEnd::Done(answer) if answer == "done"));
 }
 
+/// **The panicked-lane witness.** A lane whose worker thread panicked leaves
+/// the terminal frame its lead reads, naming the last step it committed.
+///
+/// Settle only from inside `run_worker` and this fails by construction: the
+/// unwind skips that call, the lane's checkpoint sits on disk with nothing to
+/// turn it into a frame, and the lead's report says nothing at all about the
+/// loudest way a lane can die.
+#[test]
+fn a_panicked_lane_still_leaves_its_lead_a_frame() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    // Its own store, never the shared `data_dir()` — see
+    // `durability::bind_session_in`.
+    let store = tempfile::tempdir().expect("store");
+
+    let durability = crate::durability::SessionDurability::default();
+    assert!(
+        crate::durability::bind_session_in(
+            &durability,
+            store.path(),
+            workspace.path(),
+            &lane_journal_key("ses-1", "sub:9"),
+        )
+        .is_none(),
+        "the lane binds"
+    );
+
+    let recorder = crate::lane_frame::LaneRecorder::new(&durability, "sub:9");
+    let sink = recorder.sink().expect("the lane's sink");
+    sink.persist(
+        &stella_core::step::Checkpoint {
+            version: stella_core::step::CHECKPOINT_VERSION,
+            step: 2,
+            messages: vec![
+                stella_protocol::CompletionMessage::user("do the task"),
+                stella_protocol::CompletionMessage::assistant("on it"),
+            ],
+            budget: stella_core::step::BudgetSnapshot {
+                mode: stella_protocol::BudgetMode::Observed,
+                turn_limit_usd: None,
+                session_limit_usd: None,
+                turn_spent_usd: 0.0,
+                session_spent_usd: 0.0,
+            },
+            total_cost_usd: 0.0,
+            calibration_model: None,
+            loop_steered: false,
+            loop_steered_pattern: Vec::new(),
+            loop_steered_inputs: None,
+            transcript_rewrites: 0,
+            loop_steers_spent: 0,
+        }
+        .to_json()
+        .expect("the fixture encodes"),
+    );
+
+    // What a panic leaves: the checkpoint standing at the lane's tip, and no
+    // end of a turn at all.
+    let (_, _, end) = run_caught(|| panic!("tool blew up"));
+    terminal_frame::settle_bound_lane(&durability, "sub:9", &end);
+
+    let frame = crate::lane_frame::TerminalFrame::read(&durability)
+        .expect("a panicked lane leaves a frame");
+    assert_eq!(frame.lane, "sub:9");
+    assert_eq!(frame.committed_steps, 2);
+    assert_eq!(frame.ending, crate::lane_frame::Ending::Failed);
+    assert!(frame.reason.contains("worker panicked"), "{}", frame.reason);
+}
+
 #[tokio::test]
 async fn quit_shutdown_stops_workers_and_reaps_their_endings() {
     // Quit-time teardown: every live worker sees its stop signal and the

--- a/crates/stella-cli/src/tool_foundry/adopt.rs
+++ b/crates/stella-cli/src/tool_foundry/adopt.rs
@@ -297,6 +297,23 @@ fn finish_adoption(
     Ok(record)
 }
 
+/// What `stella tools --enable` says when there is no terminal to ask at.
+///
+/// Not "the one approval a machine never grants for itself": ADR 0023 makes
+/// that false, because with `foundry.autonomy = "auto"` the foundry adopts
+/// and enables a tool by itself, inside the sandbox that path requires.
+/// `--enable` is the draft-only path — the one taken when autonomy is off, or
+/// when the sandbox is not available — and the message says so.
+fn no_terminal_to_ask(name: &str) -> String {
+    format!(
+        "nothing here can ask you to approve `{name}` — no terminal is attached. \
+         This is the draft-only path, which `stella tools --enable` takes when \
+         `foundry.autonomy` is off or the sandbox the automatic path needs is \
+         missing, so the approval has to come from you; re-run with --yes if you \
+         have read the declaration above and accept it."
+    )
+}
+
 /// The consent gate and the ledger write. The testable core of
 /// [`run_tools_enable`]: no cwd, no reporting.
 ///
@@ -324,12 +341,7 @@ pub(crate) fn run_tools_enable_in(
         // `true` for the first input: this is a plain text command, so the only
         // questions are whether stdio is a terminal.
         if !crate::interactive::human_is_present(true) {
-            return Err(format!(
-                "nothing here can ask you to approve `{name}` — no terminal is attached. \
-                 Enabling a self-authored tool is the one approval in this protocol a machine \
-                 never grants itself; re-run with --yes if you have read the declaration above \
-                 and accept it."
-            ));
+            return Err(no_terminal_to_ask(name));
         }
         if !confirm_enable(name)? {
             return Ok(false);

--- a/crates/stella-cli/src/tool_foundry/adopt/tests.rs
+++ b/crates/stella-cli/src/tool_foundry/adopt/tests.rs
@@ -538,3 +538,53 @@ fn the_consent_text_names_the_script_and_the_witness() {
         "and what the witness does NOT establish: {text}"
     );
 }
+
+/// **The retired-claim witness.** The no-terminal refusal describes the
+/// draft-only path, and no source file in this crate still carries the claim
+/// it replaced.
+///
+/// Call enabling a self-authored tool the one approval in this protocol a
+/// machine never grants for itself and this fails by construction. ADR 0023
+/// makes that claim false: `foundry.autonomy = "auto"` has the foundry enable
+/// a tool with no human in the loop. The scan is what stops the sentence
+/// coming back somewhere else in the crate.
+#[test]
+fn the_no_terminal_refusal_describes_draft_only_mode() {
+    let message = no_terminal_to_ask("cat");
+    assert!(message.contains("draft-only"), "{message}");
+    assert!(message.contains("foundry.autonomy"), "{message}");
+    assert!(message.contains("--yes"), "{message}");
+
+    // Split so this file's own source does not match the scan below.
+    let retired = [concat!("never grants", " itself")];
+    for path in rust_sources(Path::new(env!("CARGO_MANIFEST_DIR")).join("src")) {
+        let body = std::fs::read_to_string(&path).expect("a source file is readable");
+        for claim in retired {
+            assert!(
+                !body.contains(claim),
+                "{} still claims `{claim}`; autonomy = \"auto\" grants it",
+                path.display()
+            );
+        }
+    }
+}
+
+/// Every `.rs` file under a directory.
+fn rust_sources(root: std::path::PathBuf) -> Vec<std::path::PathBuf> {
+    let mut found = Vec::new();
+    let mut pending = vec![root];
+    while let Some(dir) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                found.push(path);
+            }
+        }
+    }
+    found
+}

--- a/crates/stella-learn/src/skills.rs
+++ b/crates/stella-learn/src/skills.rs
@@ -167,7 +167,33 @@ pub struct SkillFile {
 /// [`skill_search_dirs`], where the workspace directory comes last so it wins
 /// over a user-global skill of the same name.
 pub trait SkillSource: Send + Sync {
-    fn read_skill_files(&self, roots: &[String]) -> Vec<SkillFile>;
+    fn read_skill_files(&self, roots: &[String]) -> SkillFiles;
+}
+
+/// What one walk of the skill directories found.
+///
+/// Two lists, because a file that will not read is not a skill file with
+/// empty contents. Drop it inside the source and a `SKILL.md` holding bad
+/// bytes stops being offered with nothing anywhere to say so — the reader
+/// sees a short skill list and reads it as complete.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SkillFiles {
+    /// Every file that was read, in discovery order.
+    pub files: Vec<SkillFile>,
+    /// Every file the source found and could not read, by path, with the
+    /// reason as the source spells it. The loader turns each one into a
+    /// [`SkillProblem::Unreadable`] diagnostic.
+    pub unreadable: Vec<UnreadableSkillFile>,
+}
+
+/// A skill file that is on disk and cannot be read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnreadableSkillFile {
+    /// The file's path, spelled the way [`SkillFile::path`] is.
+    pub path: String,
+    /// Why, as the source's own error reads — bad bytes, no permission, or a
+    /// directory where a file belongs.
+    pub reason: String,
 }
 
 /// Why one skill file could not be loaded — a skill needs a name, a
@@ -181,6 +207,10 @@ pub enum SkillProblem {
     MissingDescription,
     /// The markdown body is empty — a skill with no procedure is useless.
     EmptyBody,
+    /// The file is on disk and the source could not read it — bad bytes, no
+    /// permission, or a directory where a file belongs. The reason rides in
+    /// [`SkillDiagnostic::detail`].
+    Unreadable,
 }
 
 /// A malformed skill file, skipped during loading (never fatal).
@@ -188,6 +218,12 @@ pub enum SkillProblem {
 pub struct SkillDiagnostic {
     pub path: String,
     pub problem: SkillProblem,
+    /// What the source said, when the problem alone does not say enough.
+    ///
+    /// A field rather than a payload on [`SkillProblem`], which stays `Copy`
+    /// so the callers that match on it keep doing arithmetic with a value
+    /// instead of a borrow.
+    pub detail: Option<String>,
 }
 
 /// The result of a load: the merged skills plus every file that was skipped
@@ -288,6 +324,7 @@ pub fn skill_from_file_with_origin(
     let diag = |problem| SkillDiagnostic {
         path: path.to_string(),
         problem,
+        detail: None,
     };
 
     let name = fm
@@ -372,8 +409,8 @@ pub fn load_skills_with_diagnostics(
     opts: &LoadSkillsOptions,
 ) -> LoadedSkills {
     let dirs = skill_search_dirs(opts);
-    let files = source.read_skill_files(&dirs);
-    merge_by_name(files, |path| default_origin_for(path, opts))
+    let found = source.read_skill_files(&dirs);
+    merge_by_name(found, |path| default_origin_for(path, opts))
 }
 
 /// Load every skill in one directory, tagged with the `origin` the caller
@@ -390,20 +427,28 @@ pub fn load_skills_from_dir(
     dir: &str,
     origin: SkillOrigin,
 ) -> LoadedSkills {
-    let files = source.read_skill_files(&[dir.to_string()]);
-    merge_by_name(files, |_| origin)
+    let found = source.read_skill_files(&[dir.to_string()]);
+    merge_by_name(found, |_| origin)
 }
 
 /// Parse each file with the origin `origin_of` gives it and merge by skill
 /// name: a later file overrides an earlier one of the same name but keeps the
 /// first-seen ordering position (JS `Map.set` semantics), and a file that does
 /// not parse becomes a diagnostic instead of a skill.
-fn merge_by_name(files: Vec<SkillFile>, origin_of: impl Fn(&str) -> SkillOrigin) -> LoadedSkills {
+fn merge_by_name(found: SkillFiles, origin_of: impl Fn(&str) -> SkillOrigin) -> LoadedSkills {
     let mut order: Vec<String> = Vec::new();
     let mut by_name: HashMap<String, Skill> = HashMap::new();
-    let mut diagnostics: Vec<SkillDiagnostic> = Vec::new();
+    let mut diagnostics: Vec<SkillDiagnostic> = found
+        .unreadable
+        .into_iter()
+        .map(|file| SkillDiagnostic {
+            path: file.path,
+            problem: SkillProblem::Unreadable,
+            detail: Some(file.reason),
+        })
+        .collect();
 
-    for file in files {
+    for file in found.files {
         match skill_from_file_with_origin(&file.path, &file.content, origin_of(&file.path)) {
             Ok(skill) => {
                 if !by_name.contains_key(&skill.name) {

--- a/crates/stella-learn/src/skills/tests.rs
+++ b/crates/stella-learn/src/skills/tests.rs
@@ -108,14 +108,28 @@ fn origin_marker_auto_and_installed_are_read_back() {
 
 struct FakeSkillSource {
     by_dir: HashMap<String, Vec<SkillFile>>,
+    /// Files this source finds and refuses to read, by directory.
+    unreadable: HashMap<String, Vec<UnreadableSkillFile>>,
+}
+
+impl FakeSkillSource {
+    fn new(by_dir: HashMap<String, Vec<SkillFile>>) -> Self {
+        Self {
+            by_dir,
+            unreadable: HashMap::new(),
+        }
+    }
 }
 
 impl SkillSource for FakeSkillSource {
-    fn read_skill_files(&self, roots: &[String]) -> Vec<SkillFile> {
-        let mut out = Vec::new();
+    fn read_skill_files(&self, roots: &[String]) -> SkillFiles {
+        let mut out = SkillFiles::default();
         for root in roots {
             if let Some(files) = self.by_dir.get(root) {
-                out.extend(files.iter().cloned());
+                out.files.extend(files.iter().cloned());
+            }
+            if let Some(broken) = self.unreadable.get(root) {
+                out.unreadable.extend(broken.iter().cloned());
             }
         }
         out
@@ -149,7 +163,7 @@ fn loads_a_skill_end_to_end_with_workspace_origin() {
             "---\nname: prefer-tables\ndescription: Prefer tables over prose for comparisons\n---\nWhen comparing options, render a table.",
         )],
     );
-    let source = FakeSkillSource { by_dir };
+    let source = FakeSkillSource::new(by_dir);
     let skills = load_skills(&source, &o);
     assert_eq!(skills.len(), 1);
     assert_eq!(skills[0].name, "prefer-tables");
@@ -177,7 +191,7 @@ fn workspace_beats_user_global_on_a_name_collision() {
             "---\nname: s\ndescription: workspace version\n---\nworkspace body",
         )],
     );
-    let source = FakeSkillSource { by_dir };
+    let source = FakeSkillSource::new(by_dir);
     let skills = load_skills(&source, &o);
     let s = skills.iter().find(|s| s.name == "s").unwrap();
     assert_eq!(s.description, "workspace version");
@@ -200,13 +214,55 @@ fn load_with_diagnostics_surfaces_skipped_files() {
             skill_file(&dirs[1], "bad.md", "---\nname: bad\n---\nbody"), // no description
         ],
     );
-    let source = FakeSkillSource { by_dir };
+    let source = FakeSkillSource::new(by_dir);
     let loaded = load_skills_with_diagnostics(&source, &o);
     assert_eq!(loaded.skills.len(), 1);
     assert_eq!(loaded.diagnostics.len(), 1);
     assert_eq!(
         loaded.diagnostics[0].problem,
         SkillProblem::MissingDescription
+    );
+}
+
+/// **The unreadable-file witness.** A file the source could not read becomes
+/// a diagnostic, and the readable skills beside it still load.
+///
+/// Have `read_skill_files` return only the files it managed to read and this
+/// fails by construction: there is then nothing here for a lost file to be
+/// reported through.
+#[test]
+fn a_file_the_source_could_not_read_becomes_a_diagnostic() {
+    let o = opts();
+    let dirs = skill_search_dirs(&o);
+    let mut by_dir = HashMap::new();
+    by_dir.insert(
+        dirs[1].clone(),
+        vec![skill_file(
+            &dirs[1],
+            "ok.md",
+            "---\nname: ok\ndescription: d\n---\nbody",
+        )],
+    );
+    let mut source = FakeSkillSource::new(by_dir);
+    source.unreadable.insert(
+        dirs[1].clone(),
+        vec![UnreadableSkillFile {
+            path: format!("{}/bad.md", dirs[1]),
+            reason: "stream did not contain valid UTF-8".to_owned(),
+        }],
+    );
+
+    let loaded = load_skills_with_diagnostics(&source, &o);
+    assert_eq!(loaded.skills.len(), 1, "the readable skill still loads");
+    let named = loaded
+        .diagnostics
+        .iter()
+        .find(|diag| diag.problem == SkillProblem::Unreadable)
+        .expect("the unreadable file is reported");
+    assert!(named.path.ends_with("bad.md"), "{named:?}");
+    assert_eq!(
+        named.detail.as_deref(),
+        Some("stream did not contain valid UTF-8")
     );
 }
 

--- a/crates/stella-parity/src/evolution.rs
+++ b/crates/stella-parity/src/evolution.rs
@@ -397,8 +397,8 @@ evolution_surfaces! {
         "`stella tools --rollback <name> [--to <version>]` restores a prior version's exact \
          bytes from the append-only history and re-digests them; `--disable <name>` stops \
          offering a tool while keeping its proof on file; `foundry.autonomy = \"off\"` is \
-         the kill switch; `forget_foundry_tool` removes an adoption and its approval \
-         outright";
+         the kill switch. Outright removal of an adoption and its approval is a store \
+         call with no verb behind it, so it is not a rollback an operator can reach";
 
     /// How Stella configures its own runs.
     Workflow => "workflow",

--- a/crates/stella-parity/src/evolution/tests.rs
+++ b/crates/stella-parity/src/evolution/tests.rs
@@ -184,6 +184,33 @@ fn every_row_explains_its_mechanism_and_its_rollback() {
     }
 }
 
+/// **The reachable-rollback witness.** No row offers an undo an operator
+/// cannot perform.
+///
+/// A rollback column is read by a person deciding whether to let a surface
+/// change itself, so a library call listed beside three real flags reads as a
+/// fourth flag. The Tool row named `forget_foundry_tool`, which
+/// `crates/stella-store/src/foundry.rs` exposes and no `stella` verb reaches:
+/// a search of the workspace for it finds the definition, its own tests, and
+/// this ledger. Wiring the verb is the other answer, and it needs the same
+/// consent posture `--enable` has.
+///
+/// The list is what a search of the workspace turned up, so a second name
+/// joins it the same way. It fails by construction on the string it names.
+#[test]
+fn no_rollback_offers_a_call_with_no_verb_behind_it() {
+    const UNREACHABLE: &[&str] = &["forget_foundry_tool"];
+    for row in EVOLUTION_SURFACES {
+        for name in UNREACHABLE {
+            assert!(
+                !row.rollback.contains(name),
+                "the {} row offers `{name}` as a rollback, and no `stella` verb calls it",
+                row.surface.as_str()
+            );
+        }
+    }
+}
+
 /// **The two ledgers cannot drift**, because this one does not restate the
 /// other. A row declares its impact and reads the grade out of #2782's policy,
 /// so there is no second copy of the requirement to disagree with the first.

--- a/crates/stella-transcript/src/html.rs
+++ b/crates/stella-transcript/src/html.rs
@@ -49,12 +49,29 @@ pub fn escape(text: &str) -> String {
     out
 }
 
+/// The policy this page declares about itself.
+///
+/// The document is built from model output and tool output — text the
+/// workspace influenced — and every interpolation goes through [`escape`].
+/// This is the backstop under that: the page says it loads nothing and talks
+/// to nobody. Inline style only, its own; no script at any origin, because
+/// there is none to run; no frames, no forms, no fetches.
+///
+/// It is a whole page's policy, so it belongs beside the page rather than at
+/// one caller. The archive `stella export` writes has no server to set a
+/// header, and the Observatory sends a wider header of its own — a browser
+/// enforces every policy it is given, so the narrower one here still holds.
+pub const CSP: &str = "default-src 'none'; style-src 'unsafe-inline'; img-src data:; \
+                       base-uri 'none'; form-action 'none'; frame-ancestors 'none'; \
+                       connect-src 'none'";
+
 /// Render a complete standalone page.
 #[must_use]
 pub fn render_page(run: &Run, state: &FoldState) -> String {
     format!(
         "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"UTF-8\">\
          <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\
+         <meta http-equiv=\"Content-Security-Policy\" content=\"{CSP}\">\n\
          <title>{}</title>\n<style>\n{STYLE}\n</style>\n</head>\n<body>\n\
          <div class=\"wrap\">{}</div>\n</body>\n</html>\n",
         escape(&run.name),

--- a/crates/stella-transcript/src/tests.rs
+++ b/crates/stella-transcript/src/tests.rs
@@ -935,6 +935,42 @@ fn html_escapes_model_output_that_looks_like_markup() {
     assert!(markup.contains("&lt;script&gt;"));
 }
 
+/// **The policy witness.** The standalone page declares what it may load,
+/// beside the escaping rather than instead of it.
+///
+/// Emit a head with only a charset and a viewport and this fails. The page is
+/// built from model and tool text. Escaping is then all that stands between
+/// that text and a browser. The export file has no server to send a header,
+/// so the page says it itself.
+#[test]
+fn the_standalone_page_declares_a_content_security_policy() {
+    let call = bash(
+        "echo",
+        &["</script><img src=x onerror=alert(1)>"],
+        Status::Ok,
+    );
+    let run = run_with(vec![step(call, 0)]);
+    let mut state = FoldState::new();
+    state.set_zoom(Zoom::Everything);
+
+    let page = html::render_page(&run, &state);
+
+    assert!(
+        page.contains(&format!(
+            "<meta http-equiv=\"Content-Security-Policy\" content=\"{}\">",
+            html::CSP
+        )),
+        "the page carries no policy: {page}"
+    );
+    assert!(
+        html::CSP.contains("default-src 'none'"),
+        "a page with no script and no fetches starts from nothing: {}",
+        html::CSP
+    );
+    assert!(!page.contains("<img src=x"), "the escaping still holds");
+    assert!(page.contains("&lt;/script&gt;"), "the escaping still holds");
+}
+
 #[test]
 fn the_word_tint_reaches_the_ansi_encoder_as_a_background_span() {
     let run = run_with(vec![step(edit("main.tex", "{15pt}\n", "{12pt}\n"), 0)]);

--- a/docs/spec/agent-native-delivery.md
+++ b/docs/spec/agent-native-delivery.md
@@ -174,18 +174,29 @@ pub enum Readiness {
 /// The only semantic distinctions the delivery policy (§6) can key on.
 pub enum IssueClass {
     /// Something is broken. Implies a regression obligation (§6.2).
-    Defect,
-    /// New behavior.
+    Bug,
+    /// Something should exist that does not.
     Feature,
-    /// A group of features carrying shared intent — the spec anchor (§5).
-    Epic,
-    /// Mapped to none of the above. Workable only if policy says so.
+    /// Work that is neither — a migration, a cleanup, a chore.
+    Task,
+    /// The provider's vocabulary had no mapping for this one. Workable only
+    /// if policy says so.
     Other,
 }
 ```
 
 That is the whole model. Four states, four classes, a title, a description,
 comments, and a parent edge.
+
+**These are the shipped names**, copied from
+`crates/stella-protocol/src/issue.rs`. An earlier draft of this section spelled
+them `Defect`, `Feature`, `Epic`, `Other`, and GitHub's shipped manifest
+(`crates/stella-cli/src/issue_provider/github.toml`) keys the kernel's names
+instead — so a manifest written from the draft classed every issue as `Other`,
+silently. The draft's `Epic` is not a class here: a container issue is one
+carrying a container label, which
+`stella_autonomy::ready::DEFAULT_CONTAINER_LABELS` spells `epic`, and §5 works
+it that way rather than through the type.
 
 **What is absent, and why:** priority (a human steering signal
 Stella reads but never acts on unilaterally — it enters ordering via the
@@ -225,11 +236,19 @@ user_email_env = "JIRA_USER_EMAIL"
 api_key_env    = "JIRA_API_TOKEN"   # the NAME of an env var, never a secret
 
 # ── The whole point: customer vocabulary → Stella's four classes (§3) ──
+# The keys are the kernel's own class names, lowercased. A key the loader does
+# not read is skipped, so a misspelled one costs the whole mapping.
 [classes]
-defect  = ["Bug", "Defect", "Incident", "Production Issue"]
-feature = ["Story", "Task", "Improvement", "Spike"]
-epic    = ["Epic", "Initiative"]
-# Unlisted types → IssueClass::Other. Policy decides whether Other is workable.
+bug     = ["Bug", "Defect", "Incident", "Production Issue"]
+feature = ["Story", "Improvement", "Spike"]
+task    = ["Task", "Chore", "Migration"]
+# A type in none of the lists reads as `IssueClass::Other`, never as `Task`.
+# `Other` says "not mapped" out loud; a wrong class hides. Policy decides
+# whether `Other` may be worked.
+#
+# A container issue is not a class. It is an issue carrying a container label
+# (`stella_autonomy::ready::DEFAULT_CONTAINER_LABELS` ships `epic`), and §5
+# works it through that label.
 
 # ── Every reachable status maps to exactly one of three buckets ──
 [states]

--- a/docs/spec/agent-native-delivery/provider.jira.toml
+++ b/docs/spec/agent-native-delivery/provider.jira.toml
@@ -59,12 +59,17 @@ api_key_env    = "JIRA_API_TOKEN"
 # to `Feature` would apply the wrong delivery policy quietly, which is worse
 # than refusing loudly.
 [classes]
-# `Defect` carries the regression obligation (§6.2) — a witness test that
+# The keys are the kernel's own class names, lowercased — `bug`, `feature`,
+# `task`. A key the loader does not read is skipped, so a misspelled one costs
+# the whole mapping.
+#
+# `Bug` carries the regression obligation (§6.2) — a witness test that
 # fails at the commit the defect was reported against, not merely at HEAD.
-defect  = ["Bug", "Defect", "Incident", "Production Issue"]
-feature = ["Story", "Task", "Improvement", "Spike"]
-# `Epic` is the spec anchor (§5) and is never worked directly.
-epic    = ["Epic", "Initiative"]
+bug     = ["Bug", "Defect", "Incident", "Production Issue"]
+feature = ["Story", "Improvement", "Spike"]
+task    = ["Task", "Chore"]
+# A container issue is not a class. `Epic` and `Initiative` carry the container
+# label instead (§5), and are never worked directly.
 
 
 # ── STATES ───────────────────────────────────────────────────────────────────

--- a/docs/spec/agent-native-delivery/provider.linear.toml
+++ b/docs/spec/agent-native-delivery/provider.linear.toml
@@ -48,10 +48,15 @@ team_key    = "ENG"
 # class, which is precisely why it cannot apply a per-class delivery policy
 # (§6) to a Linear workspace. The manifest is what makes that possible.
 [classes]
+# The keys are the kernel's own class names, lowercased — `bug`, `feature`,
+# `task`. A key the loader does not read is skipped, so a misspelled one costs
+# the whole mapping.
 source  = "label"                      # label | issue_type | none
-defect  = ["Bug", "bug", "defect"]
-feature = ["Feature", "feature", "Improvement", "Chore"]
-epic    = ["Epic", "epic"]
+bug     = ["Bug", "bug", "defect"]
+feature = ["Feature", "feature", "Improvement"]
+task    = ["Chore", "chore", "Migration"]
+# A container issue is not a class. An `Epic` label is a container label (§5),
+# read through `stella_autonomy::ready::DEFAULT_CONTAINER_LABELS`.
 
 
 # ── STATES ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Batch fix for `area:cli`, folding #6306 in. Seventeen members, each a separate
defect with its own witness. The members that could not ride are listed at the
end with the case that stopped them; each of those has been **reopened**,
because folding closed them and a member that did not ride must not disappear
with the batch. None was re-filed.

Tests deleted: None

## What each member fixes, and its witness

### #6276 — an empty issue provider name looks for a file nobody can name

`ProviderManifest::resolve` put `[issues] provider` straight into the path
template, so `provider = ""` opened `.stella/issues/.toml` — a name a shell
and most editors read as a dotfile with no stem — and the workspace's own
`github.toml` was ignored with no word. An empty name now means the same as
saying nothing and resolves `github`.

Witness: `an_empty_provider_name_reads_the_github_manifest`
(`crates/stella-cli/src/issue_provider/manifest.rs`). It writes
`.stella/issues/github.toml` whose `open` word is `triage` and resolves with
`provider: String::new()`. Without the normalization the read misses the file
and the shipped manifest answers, whose `open` word is `open`.

### #6275 — the manifest spec and the shipped loader used different class names

`doc:agent-native-delivery` §4.1 and both rendered manifests keyed `[classes]`
by `defect` / `feature` / `epic`. `ClassMap` reads `bug` / `feature` / `task`,
and `#[serde(default)]` drops a key it does not know, so a reader who copied
either block got a class map that classed every issue as `Other`. The doc is
repointed at the code — the issue's cheaper option, and the direction
CLAUDE.md's "a local convention that contradicts the shipped tree is a bug in
the convention" names. §3's `IssueClass` block shows the shipped names, §4.1
says what an unlisted type falls to, the container case is named as a label
rather than a class, and `github.toml`'s comment about the divergence is gone.

Witness: `every_rendered_classes_block_maps_a_bug` reads the `[classes]` block
out of §4.1 and both rendered `provider.*.toml` files and parses each one
through `ClassMap`. On the old keys the map deserializes empty and the
assertion fails.

### #5553 — `adopt.rs` printed a retired claim about who may enable a tool

The no-terminal refusal on `stella tools --enable` said enabling a
self-authored tool is the one approval a machine never grants for itself. ADR
0023 makes that false: `foundry.autonomy = "auto"` has the foundry adopt and
enable a tool with no human in the loop. The message now describes the
draft-only path, and the same claim is gone from the clap help.

Witness: `the_no_terminal_refusal_describes_draft_only_mode`. It asserts the
message text and then scans every `.rs` file under `crates/stella-cli/src` for
the retired sentence, so the claim cannot come back somewhere else in the
crate. The needle is built with `concat!` so the test file does not match
itself.

### #5593 — the file-lock coverage note contradicted `mutating_path`

`mutating_path`'s own doc said no built-in carried these names. `write_file`,
`edit_file` and `delete_file` are rows in `stella_tools::catalog`, so
claim-on-first-write is live for the file CRUD surface — a reader who trusted
the note would read the whole mechanism as dead, which is what nearly happened
once. The doc now points at the match as the coverage list, says it keys on the
tool name, and places `apply_edits` as a retired name kept because nothing
reserves one.

Witness: `the_declared_route_only_names_tools_the_catalog_knows` asserts every
declared mutator is in `ALL_NAMES` or `RETIRED_TOOL_NAMES`, that the three file
tools are live, and that no other catalog tool takes the declared route.

### #5755 — `stella commands convert` could write TOML that will not parse

`to_toml` pasted the prompt body into a multi-line literal string unchecked. A
literal string has no escapes, so a control character in the body has no
spelling at all: the converter returned `Ok`, reported a success, and left a
file that failed to parse the next time anything read it. `quote` had the same
hole for the basic-string fields. The body is now refused by name, and `quote`
escapes everything TOML bars raw — the C0 range plus delete, rather than
`char::is_control`, which would also refuse U+0080–U+009F that TOML accepts.

Witnesses: `a_body_containing_a_control_character_is_rejected` (bell, vertical
tab, lone carriage return, delete), `tabs_and_newlines_still_convert` (the
three TOML does take), and
`a_description_carrying_a_control_character_is_escaped`, which parses the
emitted document back.

### #5765 and #5821 — an unreadable skill file was dropped with no diagnostic

Both read sites in `FsSkillSource::read_skill_files` were `if let Ok(content)`,
so a `SKILL.md` holding bad bytes stopped being offered and nothing said so.
`SkillSource::read_skill_files` now returns `SkillFiles { files, unreadable }`,
`merge_by_name` turns each unreadable file into a `SkillProblem::Unreadable`
diagnostic carrying the read error, and `Extensions::problems_report` — which
both chat surfaces already print — names it. `SkillDiagnostic` gains a `detail`
field so `SkillProblem` stays `Copy`.

Witnesses: `a_file_the_source_could_not_read_becomes_a_diagnostic`
(`crates/stella-learn`), `an_unreadable_skill_file_is_reported_in_both_layouts`
and `a_directory_with_no_skill_file_reports_nothing` (`crates/stella-cli`). The
CLI witness runs against `FsSkillSource` directly rather than through the
authority-aware loader, which would read the developer's real
`~/.stella/skills`.

### #5602 — a mistyped worker kind ran the agent the operator did not name

`TomlConfig::parse` is a whole-document parse, so `kind = "clade"` failed the
file, `config::load` returned `LoopConfig::default()`, and the loop ran stella
under a document that asked for Claude Code — the substitution the typed
`WorkerKind` was chosen to prevent, on a path that runs unattended.

**The decision, per the issue's first DoD item: only the key that selects an
executing agent fails closed.** Every other setting keeps today's recovery,
because the leniency is right for a file whose other keys tune a loop that was
going to run either way. `WorkerKind` gains a `#[serde(skip)] Unreadable` value
— no spelling produces it — which `config::load` sets when the document does
not parse and its raw text opens a `[self_driving.worker]` table. Every `match`
on the enum has to answer for it, so the refusal is compiler-enforced rather
than a check someone can forget: `work.rs`'s worker branch and `parallel.rs`'s
`refuse_unsupported_worker` both refuse. `drive.rs` sits two lines under the
ceiling and gains none.

Witnesses: `an_unreadable_worker_kind_resolves_no_worker`, the negative control
`an_unparsable_document_with_no_worker_table_keeps_the_default`, and — for the
TOML spellings a literal prefix match misses —
`a_spaced_or_commented_worker_header_still_fails_closed` and
`a_lookalike_header_is_not_read_as_the_worker_table`.

### #2314 — the rule loader parsed TOML context records as markdown

`load_workspace_rules_unfiltered` feeds the miner's dedup, and it parsed every
file as markdown, so a published record's `Rule::text` was the whole TOML
document. The dedup compares shared words, and a one-line statement shares few
with the file that serializes it, so a rule already on disk was proposed again
on every pass. `StatementRuleSource` wraps `FsRuleSource` and projects each
`.toml` through `stella_records::records::load_context_file`. The record
registry reads the same files and still sees the document intact.

Witness: `a_published_record_is_not_mined_again` publishes a record and mines
the same lesson across three turns, asserting nothing is induced.
`mined_rules_land_where_the_loader_reads` keeps passing, now because the text is
the statement rather than because it is raw TOML.

### #5251 — palette recents did not follow the state root

The path was joined by hand, so a session in a throwaway worktree wrote its
list where the worktree would take it — and agents in this repository run under
`.claude/worktrees/`. It resolves through
`stella_store::workspace_private_state_path` now, the tier that already holds
`reflections.jsonl`: `0700`, checked for symlinks, gitignored by construction,
and redirected by `STELLA_WORKSPACE_STATE_ROOT`.

The issue's second DoD item asked that the list travel over the deck channel
rather than through `DeckOptions`. That is a means to an end, and the end it
names is "`stella-tui` still takes no dependency on `stella-store`" — which
resolving CLI-side already satisfies. The tier's guarantees are properties of
where the file is, not of who resolved the path, so the channel reshape buys
nothing here and is not done.

Witness: `palette_recents_follow_the_workspace_state_root`.

### #6009 — the exported transcript document carried no CSP backstop

Taken the issue's first way: `render_page` declares the policy itself, so the
export archive and the Observatory both get it. The Observatory sends a wider
header of its own and a browser enforces every policy it is given, so the
narrower meta tag still holds there. The page has no script and fetches
nothing, so `default-src 'none'` is the honest start.

Witness: `the_standalone_page_declares_a_content_security_policy`, which
renders a hostile string and asserts both the policy and the escaping.

### #5888 (from #6306) — `fleet_cmd.rs` sat five lines under the ceiling

The next change there would have failed the gate, and the answer the gate gives
is "split it" — to whoever happens to be holding an unrelated change.
`EngineWorker` and its `FleetWorker` impl move to `fleet_cmd/engine_worker.rs`;
`truncate`, `print_dash_summary` and `render_report` to `fleet_cmd/report.rs`.
The parent drops to under 1240 lines. No baseline entry.

A refactor, so no witness: nothing changes behaviour, and `make file-size` is
the check that had no headroom and now has it.

### #5683 — the deck and fleet close-outs reported a failed audit write with no code

`record_execution_end` returns each dropped write with its typed `StoreError`,
and only `turn_close.rs` read it. A deck lane said the audit record was
incomplete and stopped there, which is a fact nobody can act on.
`dropped_write_report` is reachable from the deck (which has no stderr) and
`forwarder::AuditWriteDetail` carries the two facts a lane needs, so the lane
and the cancelled-turn close-out both name the SQLite code, the retries and the
database file. The fleet attempt and the sub-session close-out say in a comment
why their surface cannot: both settle while something else owns the terminal,
and neither holds a channel to send a line down.

Witnesses: `a_refused_deck_audit_write_names_the_sqlite_code` (a real refusal —
the MCP usage table turns away a second row at a `seq` it holds) and
`a_close_out_with_no_refused_write_says_only_that_much`.

### #5877 — a panicked sub-session lane left no terminal frame

`LaneRecorder::settle` runs inside `run_worker`, and the unwind skips it, so
the lane's last committed step sat on disk with nothing to turn it into a
frame. `spawn`'s catching arm settles it, beside the claim release it already
performs there for the same reason. The settle is split into a bound form so
the test writes into its own store rather than the developer's.

Witness: `a_panicked_lane_still_leaves_its_lead_a_frame`.

### #5333 — the Tool row's removal rollback named a function no operator can invoke

Census done: `forget_foundry_tool` appears in `crates/stella-store/src/foundry.rs`,
its own tests, and the ledger. Nothing in `stella-cli` calls it. Rewording the
row is the cheaper of the issue's two answers, and it is the honest one for a
column a person reads when deciding whether to let a surface change itself.

Witness: `no_rollback_offers_a_call_with_no_verb_behind_it`.

### #5601 — the queue's "open issues total" was the read's size

Taken the second option the issue names — labelled rather than counted,
because a true count needs a port method `IssueProvider` does not have and
paginating to exhaustion on every claim pass is the cost the issue says is not
obviously right. One predicate, `read_filled_the_page`, answers for the
warning, the listing's wording and the snapshot's flag, so those three cannot
drift. `open_total` keeps its name and meaning; `open_total_is_a_full_page`
joins it, so the Observatory's reader is unchanged and can tell a floor from a
total.

Witness: `the_page_boundary_is_the_same_answer_everywhere`, on both sides of
the boundary and at it.

### #5603 — a filled page said an emergency was unfiled

`open_base_breakage` and `open_deploy_breakage` scanned one bounded page and
returned `None` for a miss, which defeats the interlock those labels exist to
be: the label sits behind the page, the read says nothing is filed, the filing
succeeds, and every pass opens another `main-red` issue.

`EmergencyRead` gives the read three answers. **The choice on `Unknown` is to
report and file**, and the cost of the other one is written on the type:
refusing leaves the base branch broken with nothing on the tracker saying so,
and every pull request stays red behind a hold that never fires, while a
duplicate is one issue somebody closes. `resolve`'s refusal splits the same
way — a page with room left may say a key is closed, a filled page may say only
that it did not see it.

The read moves to `backlog/emergency.rs`, because `backlog.rs` is at the
ceiling.

Witnesses: `a_filled_page_cannot_say_the_emergency_is_unfiled` (a full page
with the label behind it) and
`a_complete_read_answers_and_a_bounded_one_says_less`.

## Could not ride

Reopened, not re-filed.

- **#6236** — the split is small; what it obligates is not. `make prose` holds
  a newly created file to a 6.00 reading grade, and every split of `recall.rs`
  moves several hundred lines of inherited architectural commentary into a new
  file. Rewriting that to grade 6 with care is larger than the session, and
  rewriting it in a hurry would lose the reasoning those comments carry. This
  PR does the same split twice at a tenth the size (`fleet_cmd.rs`,
  `backlog.rs`) and paid that price both times.
- **#6183** — serving `SweepRegress`/`SweepMeta` adds an argument and a result
  shape to the wrapper wire contract, so `docs/wire/wrapper.wire.json` has to
  be regenerated. That is a schema-exporter build this session's machine rules
  forbid running here, and a hand-edited generated schema is what
  `wire-schema.yml` exists to reject.
- **#6002** — a new scope setting is nine artifacts in this workspace (the
  section, its default, the three-scope merge, the docs page, the schema, the
  parity row…). Larger than the session.
- **#2721**, **#5787**, **#2284**, **#6111**, **#6103**, **#6076**, **#5852**,
  **#5695**, **#5676**, **#5895**, **#5962**, **#5721**, **#5703** — the batch
  was sized at thirty-four members and one session landed seventeen with
  witnesses. These are the remainder. Nothing in them is blocked or undecided:
  they are open work the next session can take, and each keeps its own handoff.
- **#6134**, **#4507**, **#5474**, **#5938**, **#6106**, **#6189**, **#6162**,
  **#2321**, **#2595**, **#2592**, **#5722**, **#5396** — carried over from the
  batch issue's own list, unchanged: each is blocked on another issue, needs a
  maintainer decision, or is an open-ended investigation.

Closes #6308, Closes #6306

## Summary by Sourcery

Harden Stella CLI configuration, issue handling, persistence diagnostics, exports, and unattended execution paths across the audited defects.

New Features:
- Add fail-closed handling for malformed self-driving worker configuration so the requested agent is never silently replaced by the default.
- Report unreadable skill files and persist diagnostic details for both flat and nested skill layouts.
- Add CSP declarations to standalone transcript exports.
- Preserve emergency issue deduplication and distinguish complete queue reads from bounded pages.

Bug Fixes:
- Correct empty issue-provider normalization, TOML command conversion for control characters, rule mining of published context records, workspace-root handling for palette recents, panic lane close-outs, and audit-write diagnostics.
- Align issue-class manifests and documentation with the shipped class vocabulary.
- Update tool-adoption messaging to reflect automatic autonomy support.
- Clarify queue and emergency-read behavior when bounded pages may omit issues.

Enhancements:
- Make declared file-mutating tool coverage explicit and test it against the tool catalog.
- Split fleet worker and reporting code into dedicated modules to restore file-size headroom.
- Improve deck close-out errors with actionable database failure details.

Documentation:
- Align the agent-native delivery specification and provider examples with the implemented issue-class names and container-label behavior.

Tests:
- Add regression coverage for provider resolution, manifest class mappings, control-character TOML conversion, unreadable skills, malformed worker configuration, record re-mining, queue page boundaries, emergency reads, panic lane frames, audit-write diagnostics, palette state roots, transcript CSPs, and reachable rollback claims.

Chores:
- Reopen batch members that could not be completed in this pull request while retaining their handoff context.