### PR TITLE
docs: fix batch — 9 small defects (audit 2026-09-06)

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -6,13 +6,14 @@ name: guard-self-tests
 # Two questions, one workflow, because both are answered by the same
 # toolchain-free runner in seconds.
 #
-# **`gate-steps`** — `prose`, `hue-separation` and `transcript-surfaces` are
-# `GATE_STEPS` members, and `rg 'check-prose|check-hue-separation|check-transcript-surfaces'
+# **`gate-steps`** — `prose`, `line-citations`, `hue-separation` and
+# `transcript-surfaces` are `GATE_STEPS` members, and
+# `rg 'check-prose|check-line-citations|check-hue-separation|check-transcript-surfaces'
 # .github/workflows/` was empty: ci.yml runs the guards individually rather
-# than `make gate`, so those three ran only on a contributor's machine. The
+# than `make gate`, so those four ran only on a contributor's machine. The
 # pre-push hook is advisory, per-clone and bypassable, and on the maintainer's
 # laptop the gate is not run at all (CLAUDE.md, "CI builds and tests; this
-# laptop does not") — so for these three there was no check to complement.
+# laptop does not") — so for these four there was no check to complement.
 # `tokens` sat in the same hole from #4066 until #4086, red on `main` for
 # twenty PRs that were all otherwise green. They live here rather than in
 # ci.yml's guards job because that job is skipped for a prose-only diff, which
@@ -84,7 +85,7 @@ jobs:
 
       # Each step carries `!cancelled()` so a red one reports independently
       # instead of masking the next — ci.yml's guards job explains the trade at
-      # length, and the three below are verdicts about disjoint subjects.
+      # length, and the four below are verdicts about disjoint subjects.
       - name: no content-free prose was added
         if: ${{ !cancelled() }}
         run: python3 ./scripts/check-prose.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,8 @@ workspace at all: the only verification path left is an **installed
 verification plugin** — `stella run --pipeline <plugin-id>` hands the turn to
 that plugin, whose evidence is self-reported. Stella evaluates that evidence
 against the plugin's declared rule and never re-runs or re-checks it itself
-(#3511; `doc:pipeline-as-plugins` is the extraction plan, and Oxagen's Vera is
-the reference verification plugin, private and not shipped in this
-repository).
+(#3511; `doc:pipeline-as-plugins` is the extraction plan; `plugins/stella-witness`
+ships here as the open reference plugin, and Vera is the paid superset).
 Neither path runs by default — a plain `stella run` is the raw step-loop
 with no verification stage over it. It is the open-source reference
 implementation of
@@ -183,7 +182,8 @@ leaving `main` red for everyone (#1883).
 
 CI enforces the same steps split across four workflows:
 `/.github/workflows/ci.yml`'s required job runs everything except `invariants`,
-`doc-links`, `prose`, `hue-separation` and `transcript-surfaces`, and adds a
+`doc-links`, `prose`, `line-citations`, `hue-separation` and
+`transcript-surfaces`, and adds a
 `Cargo.lock` sync check, `stella context
 validate`, a release smoke build (thin LTO), and the deleted-test guard
 (`scripts/check-deleted-tests.sh`);
@@ -201,15 +201,16 @@ of the other two (#1439) — and `doc-warnings-schema` beside it, because
 `ci.yml`'s `cargo doc --workspace` runs with default features and every module
 that describes the wire format sits behind an off-by-default `schema` one, so
 rustdoc compiled none of them anywhere (#4584); this workflow already builds
-those three crates with the feature on; and `guard-self-tests.yml` runs the three steps
-ci.yml's job cannot — it is skipped for a prose-only diff, which is the diff
-`prose` exists to judge — alongside the hermetic suites that prove a guard can
-still fail (#3820, #4427). Which workflow runs a step is a judgement; *that*
-one does is checked, by `gate-parity` against every `run:` in
-`.github/workflows/`. That check stops at "does some workflow run it" — it
+those three crates with the feature on; and `guard-self-tests.yml` runs the
+gate steps ci.yml's job cannot — `prose`, `line-citations`, `hue-separation`
+and `transcript-surfaces`; it is skipped for a prose-only diff, which is the
+diff `prose` exists to judge — alongside the hermetic suites that prove a
+guard can still fail (#3820, #4427). Which workflow runs a step is a
+judgement; *that* one does is checked, by `gate-parity` against every `run:`
+in `.github/workflows/`. That check stops at "does some workflow run it" — it
 says nothing about which files reach it, so a `paths:` filter narrowing
 `guard-self-tests.yml`'s `pull_request:` trigger to `docs/**` would still read
-as green, and the three steps would run nowhere for a scripts-only pull
+as green, and those gate steps would run nowhere for a scripts-only pull
 request. Nothing held that absence in place except a comment.
 `guard-trigger-coverage` reads the trigger back: each watched guard must run,
 in some workflow, from a job with no `paths:`/`paths-ignore:` filter above it
@@ -976,9 +977,10 @@ described has been deleted from this workspace (#3865, the last slice of
 `docs/spec/pipeline-as-plugins.md` §7's extraction plan; see this branch's
 history for the deletion itself). It is kept here, rewritten to the
 post-removal state, because the *shape* it names — a demand-driven witness
-stage, a flip oracle, a terminal verify ladder — is exactly what
-`doc:pipeline-as-plugins` §8 ports into Vera, Oxagen's private reference
-verification plugin, rather than reinventing.** Host-run verification is no
+stage, a flip oracle, a terminal verify ladder — is what
+`doc:pipeline-as-plugins` §8 ports into `plugins/stella-witness`, the open
+plugin shipped here, rather than reinventing. Vera is the paid superset
+built on it.** Host-run verification is no
 longer something Stella ships in-tree: `stella run --pipeline classic` is
 refused outright (`crates/stella-cli/src/wrapper_plugin.rs`'s
 `PipelineChoice::resolve`), and the three verification flags split two ways
@@ -1013,9 +1015,10 @@ does not, and that is decided by running it. Everything downstream of a
 plugin's evidence is meant to stay deterministic on the plugin's own side:
 `ladder_decision`'s terminality — no arm escalates to a model — was the
 built-in pipeline's own invariant (`LadderDecision`'s doc comment, historical
-now that the enum shipped in the deleted crate) and is exactly what
-`doc:pipeline-as-plugins` §8 asks Vera to preserve as it ports the logic
-rather than copies it. This file deliberately does not restate a variant
+now that the enum shipped in the deleted crate) and is what
+`doc:pipeline-as-plugins` §8 asks `plugins/stella-witness`, and Vera's paid
+superset, to preserve as it ports the logic rather than copies it. This file
+deliberately does not restate a variant
 count for a type it no longer hosts, because a number copied into a second
 file drifts — that happened once already while `LadderDecision` still lived
 here (#3473) and is the reason to name the risk rather than repeat the
@@ -1113,7 +1116,7 @@ the files you must plan around (see below).
 | Touch shared types crossing a crate boundary | [`stella-protocol`](crates/stella-protocol/README.md) | **Zero logic, zero I/O — types only.** |
 | Resolve where `~/.stella` is — home dir, stella home, the user-tier data dir | [`stella-home`](crates/stella-home/README.md) | **A leaf with NO dependencies at all**, which is what lets `stella-store`, `stella-observatory`, `stella-cli`, `stella-model` and `stella-tools` all share it (the observatory must not link the store). Every resolver has a pure `resolve_*` half that reads no environment. |
 | Parse/validate a plugin's manifest, or change the wrapper socket's **wire contract** — the request/response types a non-Rust plugin speaks (`before_turn`/`after_turn`, `EvidenceSet`, `VerdictRule`) | [`stella-plugin`](crates/stella-plugin/README.md) | **Near-leaf: `stella-protocol` is its only workspace dependency** (#3245 slice A; #3310) — pure parsing/validation over borrowed text, plus `src/wire.rs`'s serialized shapes (#3380, `doc:wrapper-socket` §2). The engine never learns plugins exist: the host binds these grants to the engine's gates, and `stella-core` must never depend on it. The one edge it does take is what lets it share `HookEvent` with the engine instead of mirroring it by hand. |
-| Change the wrapper socket's **trait** — `TurnWrapper`, `admissible`, `judge`/`again`, the in-process/subprocess transports | [`stella-runtime`](crates/stella-runtime/README.md) | `src/wrapper/` (#3380, landed #3479, `doc:wrapper-socket`). Lives one layer above `stella-core` because `before_turn`/`after_turn` do I/O, which invariant 2 bans in the engine; consumes `stella-plugin`'s wire types rather than redefining them. No live turn dispatches through it yet — see the crate's own README. |
+| Change the wrapper socket's **trait** — `TurnWrapper`, `admissible`, `judge`/`again`, the in-process/subprocess transports | [`stella-runtime`](crates/stella-runtime/README.md) | `src/wrapper/` (#3380, landed #3479, `doc:wrapper-socket`). Lives one layer above `stella-core` because `before_turn`/`after_turn` do I/O, which invariant 2 bans in the engine; consumes `stella-plugin`'s wire types rather than redefining them. It is reached four ways now: a `--pipeline` run, a goal round, a fleet attempt, and an auto-resolved plugin — see the crate's own README. |
 | Change how a plugin is **installed, listed, removed, or trusted** — `.stella/plugins/` and `~/.stella/plugins/` resolution, install consent, the project-tier trust gate | [`stella-cli`](crates/stella-cli/README.md) | `src/plugin_cmd.rs` + `src/plugin_cmd/{roster,process}.rs` — renders `stella_plugin::consent_text` before anything executes, gates a cloned repository's plugins on `project_code_execution_trusted()` (#3509), and is the one place `LoopGrant::permits_hook`/`permits_point` get consulted against an installed manifest. |
 | Decide whether a human is present to see/answer a mid-run prompt | [`stella-tty`](crates/stella-tty/README.md) | **A leaf with NO dependencies at all** (#3036) — one pure `human_can_answer(interactive_output, stdin_is_terminal, prompt_is_visible)`, which is what lets `stella-cli`'s approval prompts and `stella-model`'s credential prompt share one derivation without `stella-model` depending on `stella-cli` (invariant 1). |
 | Emit a diagnostic — a record explaining *why* the program did something | [`stella-diag`](crates/stella-diag/README.md) | **A leaf: `serde` only, so anything may depend on it.** Field values cannot hold a `String`, a `Path`, or model output — that is a compile error, not a review question. Design: [`docs/spec/diagnostics.md`](docs/spec/diagnostics.md). |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,8 @@
     built-in staged pipeline that once ran the check itself is deleted from
     this workspace (#3865), so host-run verification no longer exists here
     at all. The only path left is an installed verification plugin's
-    self-reported evidence (Oxagen's Vera is the private reference one),
+    self-reported evidence (`plugins/stella-witness` is the open reference
+    one shipped here; Oxagen's Vera is the paid superset built on it),
     which Stella evaluates against the plugin's declared rule and never
     re-runs or re-checks. Neither relaxes this rule: it is about how *this
     repository* reviews *its own* changes.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,8 +145,9 @@ CI enforces the same steps, split across `ci.yml` (plus a release smoke build);
 and `*.md` paths that `ci.yml` deliberately skips; `wire-schema.yml`, for the
 same reason in the other direction — a PR that only hand-edits a generated
 schema under `docs/wire/` starts neither of the others (#1439); and
-`guard-self-tests.yml`, which runs `prose`, `hue-separation` and
-`transcript-surfaces` — `ci.yml`'s job skips itself for a prose-only diff,
+`guard-self-tests.yml`, which runs `prose`, `line-citations`,
+`hue-separation` and `transcript-surfaces` — `ci.yml`'s job skips itself for
+a prose-only diff,
 which is the diff `prose` is about — beside the hermetic suites that prove a
 guard can still fail (#3820, #4427). `gate-parity` now also fails when a gate
 step is named in the `Makefile` and run by no workflow at all.

--- a/Makefile
+++ b/Makefile
@@ -538,6 +538,10 @@ prose-test: ## Test the prose ratchet's direction (hermetic; not part of `gate`)
 deck-fit-all-test: ## Test the deck enumeration and its skip/fail accounting (#3404)
 	@./scripts/test-deck-fit-all.sh
 
+.PHONY: deck-fit-math-test
+deck-fit-math-test: ## Test the overflow-unit fix so a slide's overflow reads the same at every viewport (hermetic; not part of `gate`)
+	node ./scripts/test-deck-fit-math.mjs
+
 .PHONY: deck-fit-all
 deck-fit-all: ## Measure every deck under website/public/presentations/ (needs node + a browser)
 	./scripts/deck-fit-all.sh

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ exist in no default install. Written in Rust as a workspace of focused crates.
   to an installed verification plugin whose oracle authors a test that fails on
   the old code and passes on the new, and tracks that flip. A green suite alone
   is not accepted. The evidence is self-reported: Stella judges it against the
-  plugin's declared rule and never re-runs it. Oxagen's Vera is the reference
-  plugin, private and not shipped here.
+  plugin's declared rule and never re-runs it. `plugins/stella-witness` is the open
+  reference plugin, shipped here; Vera is the paid superset.
 - **Embeddable** — link `stella-core` and supply the `Provider` and
   `ToolExecutor` ports in process. Or drive
   [`stella-serve`](crates/stella-serve/README.md) over HTTP/SSE. Every model

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,9 @@ is the only door this workspace ships today, and verification is opt-in only
 through an installed wrapper plugin (`stella run --pipeline <plugin-id>`).
 No proposal below executes against this workspace. The design shape — flip
 oracle, evidence ladder, witness authoring, revise/evidence-demand — is what
-a verification plugin ports rather than reinvents (Oxagen's Vera is the
-private reference one, `doc:pipeline-as-plugins` §8), and this roadmap stays
+a verification plugin ports rather than reinvents (`plugins/stella-witness`
+is the open reference one, `doc:pipeline-as-plugins` §8; Vera is the paid
+superset), and this roadmap stays
 as the record of that design and which parts of it were built before the
 extraction.
 

--- a/docs/spec/filesystem-layout.md
+++ b/docs/spec/filesystem-layout.md
@@ -60,7 +60,11 @@ it, and `.stella/.gitignore` enforces the line.
     │
     │   ── Content the agent reads. All markdown-with-frontmatter. Commit these. ──
     ├── rules/
-    │   └── <name>.md ........... enforceable guardrails
+    │   ├── <name>.md ........... enforceable guardrails
+    │   ├── <name>.toml ......... a published context record (ADR 0011/0012)
+    │   ├── governance.toml ..... which governance mode this repo runs under
+    │   └── promotions.jsonl .... hash-chained ledger of enforcement grants
+    │                             and record lifecycle events
     ├── skills/
     │   └── <slug>/SKILL.md ..... know-how selected into context automatically
     ├── commands/
@@ -81,7 +85,8 @@ it, and `.stella/.gitignore` enforces the line.
     ├── attachments/ ............ files pasted into the TUI
     ├── screenshots/ ............ page/CI captures
     ├── explorations/ ........... exploration map bundles (rendered by `stella observe`'s filesystem view)
-    ├── proposals/ .............. pending context-record proposals awaiting review
+    ├── proposals/
+    │   └── <name>.toml ......... an ingest proposal awaiting `stella context keep`
     ├── exports/ ................ `stella export` output
     ├── context/packs/ .......... assembled context packs
     ├── worktrees/ .............. git worktrees for isolated fleet tasks
@@ -94,6 +99,9 @@ it, and `.stella/.gitignore` enforces the line.
     │   ├── codegraph.db ........ the code graph built by `stella init`
     │   ├── context.db .......... embeddings + recall index for adaptive context
     │   ├── fleet.db ............ fleet attempts, commits, and dollars
+    │   ├── context-sweep.json .. cached verdicts for due context-record probes
+    │   ├── context-decisions.jsonl  the fail-closed record of human approvals
+    │   │                         that let a TOML context record block a tool call
     │   ├── reflections.jsonl ... per-execution reflections (mined into skills)
     │   ├── mcp_oauth.json ...... OAuth tokens for MCP servers — SECRET
     │   └── mcp_auth_probes.json  connect-time 401 cache (auth-probe

--- a/scripts/deck-fit-math.mjs
+++ b/scripts/deck-fit-math.mjs
@@ -1,0 +1,33 @@
+// The deck-fit overflow normalization, as source text rather than a plain
+// function, and in its own leaf module with no side effects.
+//
+// `scripts/deck-fit.mjs` runs this INSIDE the browser via `page.evaluate`,
+// which can only receive JSON-serializable arguments — a function defined
+// out here cannot be called from in there directly, but a string can be
+// shipped across and turned back into a function with `new Function`. That
+// is what buys a single source of truth: `scripts/test-deck-fit-math.mjs`
+// calls this same string the same way, from plain node, with no browser at
+// all. It lives in its own file (rather than inside deck-fit.mjs) so
+// importing it never runs deck-fit.mjs's top-level launch-a-browser script.
+//
+// `fit()` transform-scales the whole stage by k = min(w/1600, h/900), so
+// `scrollDelta` (scrollHeight/Width minus clientHeight/Width) is LAYOUT px —
+// the transform never touches it — while `extreme` comes from a descendant's
+// `getBoundingClientRect()`, which returns the SCALED box: k times the
+// layout value. Taking `Math.max(scrollDelta, extreme - boxSize)` therefore
+// mixed units: at k < 1 the layout reading won and the number was layout px,
+// at k > 1 the sweep won and the number was visual px, so one real overflow
+// printed a different magnitude at every viewport (#2475). Dividing the
+// sweep back down to layout px before the max keeps both terms in the same
+// unit.
+//
+// `clientSize` is 0 for a display:none slide — deck-fit.mjs activates one
+// slide at a time, so that never happens today, but a future refactor that
+// measures an inactive one hits the guard below instead of dividing by zero.
+// The fallback is the layout reading alone, never NaN: NaN compares false
+// against `> 0` and would silently pass a slide that may genuinely overflow.
+export const OVERFLOW_MATH_SRC = `function computeOverflow(scrollDelta, boxSize, clientSize, extreme) {
+  const k = clientSize === 0 ? 0 : boxSize / clientSize;
+  const sweep = k === 0 ? 0 : Math.round((extreme - boxSize) / k);
+  return Math.max(scrollDelta, sweep);
+}`;

--- a/scripts/deck-fit.mjs
+++ b/scripts/deck-fit.mjs
@@ -44,6 +44,8 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { OVERFLOW_MATH_SRC } from "./deck-fit-math.mjs";
+
 const DECK = resolve(process.argv[2] ?? "website/public/presentations/investor-deck.html");
 
 // The canvas the deck is authored against, and the viewports it is shown on.
@@ -132,7 +134,9 @@ for (const vp of VIEWPORTS) {
   await page.goto(pathToFileURL(DECK).href);
   await page.waitForLoadState("networkidle");
 
-  const rows = await page.evaluate(() => {
+  const rows = await page.evaluate((mathSrc) => {
+    // eslint-disable-next-line no-new-func -- see OVERFLOW_MATH_SRC's comment
+    const computeOverflow = new Function(`return (${mathSrc});`)();
     const out = [];
     const slides = [...document.querySelectorAll(".slide")];
     slides.forEach((slide, i) => {
@@ -153,8 +157,8 @@ for (const vp of VIEWPORTS) {
         lowest = Math.max(lowest, r.bottom - box.top);
         widest = Math.max(widest, r.right - box.left);
       }
-      const overH = Math.max(frame.scrollHeight - frame.clientHeight, Math.round(lowest - box.height));
-      const overW = Math.max(frame.scrollWidth - frame.clientWidth, Math.round(widest - box.width));
+      const overH = computeOverflow(frame.scrollHeight - frame.clientHeight, box.height, frame.clientHeight, lowest);
+      const overW = computeOverflow(frame.scrollWidth - frame.clientWidth, box.width, frame.clientWidth, widest);
       out.push({
         n: i + 1,
         label: (slide.getAttribute("aria-label") || "").slice(0, 44),
@@ -169,7 +173,7 @@ for (const vp of VIEWPORTS) {
       y: document.documentElement.scrollHeight - document.documentElement.clientHeight,
     };
     return { out, docOverflow };
-  });
+  }, OVERFLOW_MATH_SRC);
 
   const bad = rows.out.filter((r) => r.overH > 0 || r.overW > 0);
   const docBad = rows.docOverflow.x > 0 || rows.docOverflow.y > 0;

--- a/scripts/diagnostic-codes.py
+++ b/scripts/diagnostic-codes.py
@@ -52,6 +52,13 @@ same grounds as check-invariants.sh's greps: the reviewable convention is that
 codes reach a record through these three doors, and a PR inventing a fourth
 has to touch this script or ship an undocumented code past review.
 
+**Keep every `.with(name, value)` chained straight onto the `emit` call.**
+`field_names` (below) reads field names off that chain, and it hedges when a
+helper hides some of them — but a hedge is a worse reference than an exact
+one. Pulling two `.with` calls into a shared function, the way
+`crates/stella-cli/src/diag_bridge/memory.rs` once did, is the shape that
+loses names silently; inlining them back is what fixed it.
+
 ## The website's table, and what is checked about it (#3045)
 
 `website/content/docs/diagnostics.mdx` carries a second table: a dozen codes

--- a/scripts/diagnostic-codes.py
+++ b/scripts/diagnostic-codes.py
@@ -336,20 +336,91 @@ def split_args(argtext: str) -> list[str]:
 
 # ── Extraction ───────────────────────────────────────────────────────────────
 
+# Every `.with(` in a fields-building expression, so each one's RECEIVER —
+# whatever call sits immediately to its left — can be checked.
+_WITH_CALL = re.compile(r"\.with\(")
+
+
+def _has_opaque_call(joined: str) -> bool:
+    """Whether some `.with(...)` in `joined` is chained directly onto a call
+    this scanner does not recognize, which may be contributing field names of
+    its own that never reach [`WITH_FIELD`].
+
+    Narrow on purpose: only the call IMMEDIATELY before a `.with(` counts.
+    A field-building chain reads `<receiver>.with(a, x).with(b, y)…`, so that
+    receiver — `Fields::new()`, `self.at_seq()`, or a prior `.with(...)` link
+    in the same chain — is the only place another field source could hide.
+    Anything else in the expression (a `match` scrutinee choosing which arm's
+    chain to build, an argument's own helper call) is not in that position,
+    so it is not asked whether it looks like a call, only whether it sits
+    right there. `fields(bridge.at_seq(), class, confidence).with("decays",
+    decays)` fails this test on `fields(...)`; `match x.kind() { … =>
+    self.at_seq().with("stage", …), … }` never asks about `x.kind()` at all,
+    because nothing chains a `.with(` onto it.
+    """
+    for m in _WITH_CALL.finditer(joined):
+        dot = m.start()  # the '.' in this '.with('
+        k = dot
+        while k > 0 and joined[k - 1] in " \t\n":
+            k -= 1
+        if k == 0 or joined[k - 1] != ")":
+            continue  # nothing callable immediately precedes this `.with(`
+        # Find the '(' that opens this ')'. That way a receiver with its
+        # own nested parens, like `fields(bridge.at_seq(), …)`, is read as
+        # one call, not cut short at its first ')'.
+        depth = 0
+        p = k - 1
+        while p >= 0:
+            if joined[p] == ")":
+                depth += 1
+            elif joined[p] == "(":
+                depth -= 1
+                if depth == 0:
+                    break
+            p -= 1
+        if p < 0:
+            continue  # unbalanced text; nothing safe to conclude here
+        # The call's name: the word or path right before that '(', plus
+        # whether a '.' comes right before it (a method call, like `.with`
+        # or `.at_seq`).
+        h = p
+        while h > 0 and (joined[h - 1].isalnum() or joined[h - 1] in "_:"):
+            h -= 1
+        head = joined[h:p]
+        dotted = h > 0 and joined[h - 1] == "."
+        segments = head.split("::")
+        if segments[-1] == "with" and dotted:
+            continue  # a link in the same chain — already covered
+        if segments[-1] == "at_seq":
+            continue  # zero-arg, whether called bare or through a path
+        if segments[-2:] == ["Fields", "new"]:
+            continue  # `Fields::new()`, however qualified (`crate::Fields::new()`)
+        return True
+    return False
+
 
 def field_names(exprs: list[str]) -> tuple[dict[str, None], bool]:
     """Statically visible field names in a fields-building expression, plus
-    whether anything opaque contributes fields this scanner cannot name."""
+    whether anything opaque contributes fields this scanner cannot name.
+
+    The two are independent. A call this scanner cannot see inside may sit
+    beside `.with(...)` calls that DID resolve to names — `names` is
+    non-empty and `dynamic` is still true — and that is the case a reader
+    most needs the hedge for, because a partial list is the one that looks
+    complete.
+    """
     names: dict[str, None] = {}
-    dynamic = False
     joined = " ".join(exprs)
     if "at_seq()" in joined:
         names["seq"] = None  # the bridge's Fields::new().with("seq", …) helper
     for name in WITH_FIELD.findall(joined):
         names[name] = None
-    if not names and joined and "Fields::new()" not in joined:
-        # Something like `Parsed::report(clause)`: fields exist, names do not.
-        dynamic = True
+    # A `Fields` value can arrive by name, with no `.with` in sight — the
+    # old check's own case. Or a helper this scanner cannot read sits right
+    # before a `.with` that DID find some names. Either way, hedge: a
+    # partial list looks whole and is not.
+    no_names_and_opaque_source = not names and bool(joined) and "Fields::new()" not in joined
+    dynamic = no_names_and_opaque_source or _has_opaque_call(joined)
     return names, dynamic
 
 

--- a/scripts/test-deck-fit-math.mjs
+++ b/scripts/test-deck-fit-math.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+//
+// Witness for the deck-fit overflow-unit bug (#2475): one overflow reported
+// three different numbers because the two readings `overH`/`overW` take the
+// max of were in different coordinate spaces.
+//
+//   node scripts/test-deck-fit-math.mjs
+//
+// Hermetic: reconstructs `computeOverflow` from `OVERFLOW_MATH_SRC`
+// (`scripts/deck-fit-math.mjs`), the same string `scripts/deck-fit.mjs` ships
+// into the browser via `page.evaluate`, so this test and the shipped code can
+// never drift apart silently. Importing the math from its own leaf module
+// (rather than from deck-fit.mjs itself) means this test never runs
+// deck-fit.mjs's top-level launch-a-browser script. No browser, no network --
+// plain node, which is why this can run as a witness in a sandbox that can't
+// launch Chromium.
+//
+// The buggy formula this replaces took Math.max of a LAYOUT-px reading
+// (scrollHeight - clientHeight) and a VISUAL-px reading (a descendant's
+// getBoundingClientRect() minus the frame's own box, unscaled) at whatever
+// scale k the viewport happened to produce. One real 25px overflow then
+// printed 25, 30, or 40 depending on k -- reproduced below at the four k
+// values measured on 2026-08-09 against the investor deck.
+
+import { OVERFLOW_MATH_SRC } from "./deck-fit-math.mjs";
+
+let pass = 0;
+let fail = 0;
+
+function ok(name) {
+  pass += 1;
+  console.log(`ok   ${name}`);
+}
+
+function no(name, detail) {
+  fail += 1;
+  console.log(`FAIL ${name}`);
+  if (detail) console.log(`  ${detail}`);
+}
+
+// eslint-disable-next-line no-new-func -- see OVERFLOW_MATH_SRC's comment
+const computeOverflow = new Function(`return (${OVERFLOW_MATH_SRC});`)();
+
+// The buggy formula this fix replaced: Math.max of the two readings taken
+// AS THEY STOOD, with no unit normalization. Kept here, inline, only so this
+// witness can demonstrate the fix actually changes the answer -- it is not
+// the thing under test.
+function buggyOverflow(scrollDelta, boxSize, extreme) {
+  return Math.max(scrollDelta, Math.round(extreme - boxSize));
+}
+
+// A layout box of height 900 with a real ~25px layout overflow (925 tall
+// laid out), scaled by k. `box.height` (the frame's own rect) and `extreme`
+// (a descendant's rect) are both k times their layout value; scrollHeight/
+// clientHeight are never scaled, so the layout overflow reading is fixed.
+const LAYOUT_HEIGHT = 900;
+const LAYOUT_OVERFLOW = 25;
+const LAYOUT_DELTA = LAYOUT_OVERFLOW; // scrollHeight - clientHeight, unscaled
+
+const CASES = [
+  { name: "1440x900 · laptop", k: 0.9 },
+  { name: "1280x800 · small laptop", k: 0.8 },
+  { name: "1920x1080 · projector", k: 1.2 },
+  { name: "2560x1440 · large display", k: 1.6 },
+];
+
+// 1. The bug: at k != 1, the buggy formula reports a different magnitude for
+//    the SAME layout overflow -- this is what made one overflow read as
+//    three numbers across four viewports.
+const buggyReadings = CASES.map(({ k }) => {
+  const boxHeight = LAYOUT_HEIGHT * k;
+  const extreme = (LAYOUT_HEIGHT + LAYOUT_OVERFLOW) * k;
+  return buggyOverflow(LAYOUT_DELTA, boxHeight, extreme);
+});
+const buggyDistinct = new Set(buggyReadings).size;
+if (buggyDistinct > 1) {
+  ok("demonstrates the bug: the old formula disagrees across viewports");
+} else {
+  no(
+    "demonstrates the bug: the old formula disagrees across viewports",
+    `expected more than one distinct reading, got ${JSON.stringify(buggyReadings)} -- the repro no longer demonstrates the defect`,
+  );
+}
+
+// 2. The fix: computeOverflow (the shipped math) reports the SAME layout-px
+//    magnitude at every k, including k > 1 and k < 1.
+const fixedReadings = CASES.map(({ k }) => {
+  const boxHeight = LAYOUT_HEIGHT * k;
+  const clientHeight = LAYOUT_HEIGHT; // clientHeight is never scaled
+  const extreme = (LAYOUT_HEIGHT + LAYOUT_OVERFLOW) * k;
+  return computeOverflow(LAYOUT_DELTA, boxHeight, clientHeight, extreme);
+});
+if (fixedReadings.every((v) => v === LAYOUT_OVERFLOW)) {
+  ok("one overflow reports one number at every viewport");
+} else {
+  no(
+    "one overflow reports one number at every viewport",
+    `expected every reading to equal ${LAYOUT_OVERFLOW}, got ${JSON.stringify(
+      fixedReadings.map((v, i) => `${CASES[i].name}=${v}`),
+    )}`,
+  );
+}
+
+// 3. No overflow stays no overflow at every k -- the fix must never turn a
+//    passing slide into a failing one.
+const zeroReadings = CASES.map(({ k }) => {
+  const boxHeight = LAYOUT_HEIGHT * k;
+  const clientHeight = LAYOUT_HEIGHT;
+  const extreme = LAYOUT_HEIGHT * k; // the descendant never exceeds the box
+  return computeOverflow(0, boxHeight, clientHeight, extreme);
+});
+if (zeroReadings.every((v) => v === 0)) {
+  ok("no overflow still reads zero at every viewport");
+} else {
+  no("no overflow still reads zero at every viewport", JSON.stringify(zeroReadings));
+}
+
+// 4. The divide-by-zero guard: a display:none slide (clientHeight 0) must
+//    fail toward reporting the layout delta, never toward NaN/Infinity --
+//    a NaN would compare false against `> 0` and silently pass the slide.
+const guarded = computeOverflow(12, 0, 0, 30);
+if (guarded === 12 && Number.isFinite(guarded)) {
+  ok("clientSize=0 falls back to the layout reading, not NaN/Infinity");
+} else {
+  no("clientSize=0 falls back to the layout reading, not NaN/Infinity", `got ${guarded}`);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-diagnostic-codes.sh
+++ b/scripts/test-diagnostic-codes.sh
@@ -237,6 +237,47 @@ EOF
 want "D6d an emptied table is a failure, not a skip" \
   expect-fail "$t" "emptied or restructured"
 
+# ── 7. A partly-opaque emit expression is hedged, not silently short ────────
+#
+# The generator's `field_names` set its "fields built at runtime" flag only
+# when NO name was found at all. A call that mixes a helper this scanner
+# cannot see inside with visible `.with(...)`s -- `helper(dx.at_seq(), class,
+# confidence).with("decays", decays)` -- found `decays` (and `seq`, from the
+# `at_seq()` substring check) and stopped there: `class` and `confidence`
+# vanished from the generated reference with no hedge warning a reader that
+# the list is short. This exercises `write` mode directly rather than
+# `check-diagnostic-codes.sh`, because the defect is in what gets generated,
+# not in whether a committed file matches it.
+mixed_tree() {
+  local dir="$TMP/mixed"
+  mkdir -p "$dir/crates/fixture-one/src"
+  cat >"$dir/crates/fixture-one/src/lib.rs" <<'EOF'
+pub fn logged(dx: &Dx, class: &str, confidence: u32, decays: bool) {
+    dx.emit(
+        Level::Debug,
+        "fixture.thing.mixed",
+        helper(dx.at_seq(), class, confidence).with("decays", decays),
+    );
+}
+EOF
+  echo "$dir"
+}
+
+t="$(mixed_tree)"
+python3 "$GENERATOR" write "$t" >/dev/null
+fields_line="$(grep '\*\*Fields:\*\*' "$t/docs/reference/diagnostics.md")"
+case "$fields_line" in
+*"seq"*"decays"*"plus fields built at runtime"*)
+  pass=$((pass + 1))
+  echo "ok   D9 a partly-opaque emit expression is hedged, not silently short"
+  ;;
+*)
+  fail=$((fail + 1))
+  echo "FAIL D9 a partly-opaque emit expression is hedged, not silently short — got:"
+  echo "$fields_line"
+  ;;
+esac
+
 # ── The two files themselves ─────────────────────────────────────────────────
 #
 # Both fail closed. A registry whose reference has been deleted has documented

--- a/stella.example.toml
+++ b/stella.example.toml
@@ -634,6 +634,11 @@ min_steps = 3       # open steps that raise a card
 # takes. Absent means "on"; filing stated follow-up work is the default.
 residue_gate = "on"
 
+# Whether the drive loop also watches the release workflow's latest run and
+# files on red. Absent means "on"; a red release stays missed only if an
+# operator turns this off on purpose.
+deploy_watch = "on"
+
 # The dedup those checks use is not a setting, and it is what an operator asks
 # about first: why was this finding not filed? The loop keeps every digest it
 # has filed in `seen.txt`, under `~/.stella/self-driving/<repo>/`, and drops a

--- a/website/content/docs/api-providers/index.mdx
+++ b/website/content/docs/api-providers/index.mdx
@@ -343,20 +343,16 @@ slug the gateway serves works exactly as written, and a typo fails with OpenRout
 
 #### The default posture
 
-One key reaches every vendor, so on OpenRouter the interesting question isn't which
-model, but which model for which role, since each role wants genuinely different things.
-With no configuration at all, an OpenRouter instance runs:
+One key reaches every vendor, so an OpenRouter instance can afford a stronger
+posture than a single-vendor one costs nothing extra to configure. With no
+configuration at all, `provider_engine_baseline` sets one thing: the `default`
+agent runs at `xhigh` effort with reasoning on, driving `moonshotai/kimi-k3`,
+a long-context agentic model. Core has one role today, so that is the whole
+posture — no model is picked for a verifier or a triage role on your behalf.
 
-| Role | Model | Why |
-| --- | --- | --- |
-| default | `moonshotai/kimi-k3` | long-context agentic driver, at `xhigh` effort with thinking on |
-| verifier | `anthropic/claude-opus-5` | a different vendor's strongest reasoner — not the worker grading itself |
-| triage | `z-ai/glm-5.2` | fast and cheap, and it runs on every turn |
-
-Note the verifier is a different family from the driver. stella already treats
-cross-family judging as the goal (see `stella goal`'s
-`resolve_cross_family_verifier`) — this default just does that without asking
-you to configure anything.
+A second model still runs in one place: `stella goal`'s
+`resolve_cross_family_verifier`, which groups by family at the point of use
+and has never read this baseline.
 
 This is a starting point, not a lock. It sits underneath the whole
 [`agent_engine_config`](/docs/configuration/agent-engine-config) scope chain, so any

--- a/website/content/docs/configuration/stella-toml.mdx
+++ b/website/content/docs/configuration/stella-toml.mdx
@@ -760,6 +760,16 @@ different ladders.
     `Blocked by:` lines say. Sits under `[self_driving]`, not `[self_driving.triage]`:
     the backlog reader is a different queue and needs its own copy of this rule.
   </OptionCard>
+  <OptionCard name="self_driving.residue_gate" defaultValue="on">
+    Whether the end-of-turn residue gate files a turn's stated leftover work as
+    issues. Sits under `[self_driving]`. Off skips the scan and the filing;
+    on is the default, so filing stated follow-up work needs no setting at all.
+  </OptionCard>
+  <OptionCard name="self_driving.deploy_watch" defaultValue="on">
+    Whether the drive loop also watches the release workflow's latest run and
+    files on red. Sits under `[self_driving]`. On unless an operator turns it
+    off, so a red release is never missed just because nobody thought to ask.
+  </OptionCard>
 </CardGrid>
 
 Each list defaults on its own, and declaring one **replaces** it wholesale rather than


### PR DESCRIPTION
Nine independently-verifiable docs/scripts fixes, riding one PR per the fix-over-file rule.

## Members

- **#6269** — AGENTS.md's `stella-runtime` row and witness-test section said the wrapper socket drove no live turn; four call sites already dispatch through it (`stella run --pipeline`, a goal round, a fleet attempt, and a resolved plugin). Named the doors instead of the stale claim, and confirmed `crates/stella-runtime/README.md` already agrees.
- **#5418** — AGENTS.md and CONTRIBUTING.md said `guard-self-tests.yml` runs three steps; it runs four (`line-citations` was missing from both lists and from the workflow's own header comment). Named every step (`prose`, `line-citations`, `hue-separation`, `transcript-surfaces`) instead of a count that can go stale again.
- **#5645** — `self_driving.residue_gate` and `self_driving.deploy_watch` had no `OptionCard` on the `stella.toml` reference page; `deploy_watch` was also missing from `stella.example.toml`. Added both, matching the `container_labels` entry's pattern.
- **#6206** — AGENTS.md, CLAUDE.md, README.md and ROADMAP.md still called Oxagen's Vera the only verification plugin, private and unshipped. `plugins/stella-witness` ships in this repo as the open reference plugin (graded on every PR by `witness_plugin_conformance.rs`); updated all four to say so, with Vera as the paid superset.
- **#2285** — `docs/spec/filesystem-layout.md`'s `.stella/rules/` entry predated the TOML context-record surface. Added `rules/*.toml`, `governance.toml`, `promotions.jsonl`, `proposals/*.toml`, and the two `private/` sweep/decision files, matching AGENTS.md's table and `context_records.rs`'s path constants.
- **#2475** — `scripts/deck-fit.mjs`'s `overH`/`overW` mixed layout px and transform-scaled visual px in one `Math.max`, so one real overflow printed a different number at every viewport (25/25/30/40 across the four viewports, per the issue's own repro). Normalized the sweep reading to layout px before the max, with a divide-by-zero guard for a `display:none` slide.
- **#6034** — the website's OpenRouter default-models table still showed a verifier/triage row pair retired with #3908. Rewrote the section to match `provider_engine_baseline`'s actual behavior (effort + reasoning on the one `default` agent only); confirmed no other doc still names the retired GLM triage model.
- **#5372** — `diagnostic-codes.py`'s `field_names` only hedged "fields built at runtime" when NO name was found at all, so a call mixing a visible `.with(...)` chain with an opaque helper (`fields(bridge.at_seq(), class, confidence).with("decays", decays)`) published the visible subset as if complete, silently dropping `class`/`confidence` with no hedge.

## Witnesses

- **#2475**: `scripts/test-deck-fit-math.mjs` reconstructs the *exact* pre-fix formula inline and shows it disagrees across k=0.9/0.8/1.2/1.6 (25/25/30/40 — the issue's own numbers), then shows the shared `OVERFLOW_MATH_SRC` (now in its own `scripts/deck-fit-math.mjs` leaf module, imported by both the script and the test — a single source of truth between the in-browser `page.evaluate` code and the plain-node test) reports one number at every k. No browser needed. Confirmed by hand: swapping in the old formula makes the test fail with the exact issue-reported numbers; the shipped formula passes.
- **#5372**: a new case (`D9`) in `scripts/test-diagnostic-codes.sh` builds exactly the mixed-opacity shape from the bug report and asserts the generated reference hedges it. Confirmed by hand (`git stash` on `diagnostic-codes.py` alone): the old scanner reports `` `seq`, `decays` `` with no hedge (test fails); the fix reports the hedge (test passes). Also confirmed `make diag-reference` leaves `docs/reference/diagnostics.md` byte-identical on the real tree — no live entry was wrong, only the scanner's blind spot, per the issue's own DoD.
- #6269, #5418, #5645, #6206, #2285, #6034 are docs-only changes; per AGENTS.md ("Pure refactors, docs, and CI changes don't need a witness"), verification was a side-by-side read-back against the cited ground truth (source doc comments, the workflow file's own steps, the struct fields, `plugins/stella-witness`'s own README/plugin.toml).

## Could not ride

None — all nine members shipped in this PR.

Tests deleted: None

Closes #6269
Closes #5418
Closes #5645
Closes #6206
Closes #2285
Closes #2475
Closes #6034
Closes #5372
Closes #6295

## Summary by Sourcery

Align documentation and validation tooling with current behavior while fixing viewport-dependent deck-fit measurements and incomplete diagnostic field reporting.

Bug Fixes:
- Correct overflow measurement so deck-fit reports consistent layout-space values across viewports and safely handles hidden slides.
- Ensure diagnostic documentation generation flags partially opaque field expressions instead of publishing incomplete field lists without a hedge.
- Update documentation and examples to reflect current verification plugins, CI guard coverage, context-record filesystem layout, OpenRouter defaults, and self-driving options.

Enhancements:
- Centralize deck-fit overflow math and add hermetic coverage for viewport normalization and divide-by-zero handling.
- Improve diagnostic field extraction to detect opaque helper calls alongside statically visible fields.

Build:
- Add a Makefile target for the deck-fit math test.

CI:
- Document and test the complete four-step guard-self-tests workflow coverage.

Documentation:
- Refresh repository, contribution, roadmap, API-provider, configuration, and filesystem-layout documentation to match current behavior and available settings.

Tests:
- Add regression coverage for deck-fit overflow calculations and mixed opaque/static diagnostic fields.