### PR TITLE
fix(ci): stop dod-recheck reporting an unread check as a passing one

### DIFF
--- a/scripts/dod-recheck.sh
+++ b/scripts/dod-recheck.sh
@@ -162,18 +162,40 @@ elif ! open_prs="$(gh pr list --state open --limit "$limit" \
   exit 0
 fi
 
-# The last `dod-check` run on this head, and only if it failed. A re-run
-# updates the run in place, so `[0]` is that run, and its conclusion is the
-# verdict the branch rules read.
+# The last `dod-check` run on this head. A re-run updates the run in place, so
+# `[0]` is that run, and its conclusion is the verdict the branch rules read.
+#
+# Three answers, because "nothing failed" and "the lookup did not answer" are
+# different facts. One empty string for both lets the caller read an
+# unanswered lookup as a passing check and print `its dod check is not
+# failing` about a check it never read — which is how a pull request with
+# every box ticked stayed red through three sweeps that each reported success.
+# Prints the run id when the last run failed, `none` when it did not, and `?`
+# when the question went unanswered.
 failed_run_for() {
   head="$1"
   if [ "$use_fixture" -eq 1 ]; then
+    # No entry for this head is the green case, matching the live `none`. A
+    # fixture entry of `?` is how a test drives the unanswered branch.
     printf '%s\n' "$fixture_failed_runs" |
-      awk -v head="$head" '$1 == head { print $2; exit }'
+      awk -v head="$head" '$1 == head { print $2; hit = 1; exit }
+                           END { if (!hit) print "none" }'
     return 0
   fi
-  gh api "repos/{owner}/{repo}/actions/workflows/$workflow/runs?head_sha=$head&per_page=20" \
-    --jq '.workflow_runs[0] | select(.conclusion == "failure") | .id' 2>/dev/null || true
+  if ! run_answer="$(gh api \
+    "repos/{owner}/{repo}/actions/workflows/$workflow/runs?head_sha=$head&per_page=20" \
+    --jq '.workflow_runs[0] | if .conclusion == "failure" then .id else "none" end' \
+    2>/dev/null)"; then
+    printf '?\n'
+    return 0
+  fi
+  # An empty body from a call that exited 0 is the same unknown: the filter
+  # above yields `none` for a head with no runs at all, so nothing legitimate
+  # comes back blank.
+  case "$run_answer" in
+  "") printf '?\n' ;;
+  *) printf '%s\n' "$run_answer" ;;
+  esac
 }
 
 rerun=0
@@ -186,10 +208,19 @@ while read -r pr head rest; do
   printf '%s' "$rest" | grep -Eq "#${issue}([^0-9]|\$)" || continue
   named=$((named + 1))
   run="$(failed_run_for "$head")"
-  if [ -z "$run" ]; then
+  case "$run" in
+  "?" | "")
+    # Fail open, out loud. Reporting this as a passing check would say the
+    # checklist is met on evidence this never read.
+    note "could not read the dod check on PR #$pr (head $head), so nothing was"
+    note "run again for it. A push to the branch still re-runs it."
+    continue
+    ;;
+  none)
     say "PR #$pr names the issue and its dod check is not failing — left alone."
     continue
-  fi
+    ;;
+  esac
   if [ "$dry_run" -eq 1 ]; then
     say "would re-run the dod check on PR #$pr (head $head, run $run)"
     rerun=$((rerun + 1))

--- a/scripts/test-dod-recheck.sh
+++ b/scripts/test-dod-recheck.sh
@@ -119,6 +119,26 @@ says "the summary counts what it swept" \
   "named by 3 open pull request(s); ran the dod check again on 2" 6079 \
   "$open_prs" "$failed_runs"
 
+# Third negative control: the unanswered lookup. A 403, a rate limit or a
+# renamed workflow file leaves the run unread, and spelling that the way a
+# green check is spelled makes the sweep announce a verdict it never read. So
+# the seam gives it an answer of its own, `?`, and this pins that the sweep
+# neither claims the check passed nor counts it as swept.
+unread_runs="aaaaaaa ?
+ddddddd 33952811235"
+
+lacks "a lookup that did not answer is not reported as a passing check" \
+  "6046 names the issue and its dod check is not failing" 6079 \
+  "$open_prs" "$unread_runs"
+
+says "...it says the check went unread, so the gap is visible" \
+  "(head aaaaaaa), so nothing was" 6079 \
+  "$open_prs" "$unread_runs"
+
+says "...and it is not counted as swept, while its siblings still are" \
+  "named by 3 open pull request(s); ran the dod check again on 1" 6079 \
+  "$open_prs" "$unread_runs"
+
 # An issue no open pull request names is a state, not an error.
 says "an issue nothing references says so and stops" \
   "named by 0 open pull request(s); ran the dod check again on 0" 4242 \


### PR DESCRIPTION
## What & why

`scripts/dod-recheck.sh`'s `failed_run_for` asked GitHub for the last `dod-check` run on a head and returned the empty string in two different situations: the run did not fail, and the lookup never answered. `gh api`'s failure was swallowed by `2>/dev/null || true`, so a 403, a rate limit or a renamed workflow file reached the caller spelled exactly like a green check. The caller then printed

```
PR #N names the issue and its dod check is not failing — left alone.
```

a claim about a check it had not read, and the summary counted that pull request as handled.

That fired. On 2026-09-06 a pull request whose three linked issues had every DoD box ticked stayed red on `dod / dod`; three sweeps ran against those edits, each reported success, and none re-ran the failing check. Asked by hand, the API answers correctly for that head — the failing run is `workflow_runs[0]` and the script's own jq selects its id — so the empty result came from inside the lookup, which is the half nothing could tell apart. `rerun-failed-jobs` needs `actions: write`, a scope an agent session does not hold, so this workflow is the only thing that can clear such a check, and the pull request had no event left to correct it.

`failed_run_for` now gives three answers: the run id when the last run failed, `none` when it did not, and `?` when the question went unanswered. An unanswered lookup prints what it could not read and stays out of the swept count — the fail-open-out-loud contract the script's own header already promised. The fixture seam grows the same third answer, so the branch is reachable hermetically.

This is the same discipline `shellcheck: UNAVAILABLE — THIS STEP DID NOT RUN` already applies one rung down: a check that did not run must not read as a check that found nothing.

`Refs #6079` — the re-check trigger this repairs. No closing keyword: that issue's own checklist is not this PR's to satisfy.

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

A third negative control in `scripts/test-dod-recheck.sh`, beside the two already there. Against the old script two of its three assertions fail:

```
✗ ...it says the check went unread, so the gap is visible
    — wanted '(head aaaaaaa), so nothing was':
      dod-recheck: would re-run the dod check on PR #6046 (head aaaaaaa, run ?)
✗ ...and it is not counted as swept, while its siblings still are
    — wanted 'ran the dod check again on 1'
test-dod-recheck: FAILED — 17 passed, 2 failed
```

and all three pass on this branch (19/19). Checked the artisanal way, by restoring `scripts/dod-recheck.sh` from `origin/main` under the new test file and running it.

The first of the three assertions passes either way, and that is worth stating rather than counting as a win: the old fixture seam had no spelling for an unanswered lookup at all, which is exactly why the defect had no test. The live path's empty-string conflation cannot be driven hermetically without the `?` answer this adds.

## The gate

- [x] `shellcheck` — clean on both changed files
- [x] `make prose` — `check-prose: OK`, none added
- [x] `make line-citations` — OK, none added
- [x] `./scripts/test-dod-recheck.sh` — 19/19
- [x] `bash -n` on both files
- [ ] `cargo fmt --check` / clippy / `cargo test --workspace` — CI's job; this diff is two shell scripts and reaches no crate
- [x] Docs updated where behavior changed — the function's own header states the three answers; AGENTS.md's description of this sweep is unchanged, because what it promised is what this restores
- [ ] CLA signed
- [x] No closing keyword, so nothing has to appear as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: none — the fixture seam's third answer is part of the same fix, not a second one
- [x] Nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls — the one `gh api` call is the same call, with its failure now read
- [x] No new cross-boundary types

## Anything reviewers should know?

**Which error fired is not established, and this does not guess.** The evidence shows the lookup returned nothing while the same query answers correctly for that head today; it does not distinguish a 403 from a rate limit from a transient fault. The fix is the conflation, which is a defect under every one of those causes — and the new `note` is what will name the cause the next time it happens, which no surface could do before.

Found while working the routine PR sweep: `#6330` was red on `dod / dod` alone with every box ticked, and tracing why the designed remedy had not cleared it led here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012v3WC2AiYLmSNBj8Pc1AyY

---
_Generated by [Claude Code](https://claude.ai/code/session_012v3WC2AiYLmSNBj8Pc1AyY)_

## Summary by Sourcery

Prevent DoD rechecks from reporting unread checks as passing and falsely counting affected pull requests as handled.

Bug Fixes:
- Distinguish failed, successful, and unanswered DoD check lookups so unread GitHub API results are no longer treated as passing checks.
- Leave pull requests out of the swept count when their DoD check cannot be read, while reporting the lookup gap explicitly.

Enhancements:
- Extend the test fixture interface and coverage for unanswered DoD check lookups.

Tests:
- Add regression coverage confirming unread checks are surfaced and not counted as rerun.