### PR TITLE
fix(stella-runtime): fix five candidate-fanout and arbitration defects

### DIFF
--- a/crates/stella-cli/src/wrapper_plugin/planes.rs
+++ b/crates/stella-cli/src/wrapper_plugin/planes.rs
@@ -90,14 +90,15 @@ pub(crate) fn child_turn_plane(
 /// capability whose unit is a *writing* worker turn rather than a read:
 ///
 /// - **Only `worker` may be fanned out to, and this host binds no extra
-///   tier.** [`CandidateFanouts`] keeps its own tier table and refuses every
-///   tier that does not resolve to the worker's seat, which is the inverse of
-///   the child plane's rule and the reason both exist: a child turn is
-///   evidence *about* the work and must not be graded by the model that did
-///   it, while a candidate **is** the work and must not be booked to a
-///   responsibility that wrote nothing. Nothing is bound here, so that rule
-///   stands as core wrote it. Moving this plane onto the grant
-///   [`child_turn_plane`] reads has its own issue.
+///   tier.** [`CandidateFanouts`] resolves an unbound tier to the worker's
+///   seat by default. Whether this plugin may fan out at all is a separate
+///   check, done first: `HostCallGate` reads `[loop] calls` for
+///   `candidate_fanout` before this plane is ever asked to resolve a tier. So
+///   no core-owned word list decides the tier here. This is the child plane's
+///   rule, inverted: a child turn is evidence *about* the work and must not
+///   be graded by the model that did it, while a candidate **is** the work
+///   and must not be booked to a responsibility that wrote nothing. Nothing
+///   is bound here, so every declared tier resolves to the worker.
 /// - **No per-fan-out USD carve is requested.** `None` asks for the whole
 ///   headroom, divided by the clamped width, and each share is clamped again
 ///   by the substrate against the session's sub-agent pool

--- a/crates/stella-cli/src/wrapper_plugin/report.rs
+++ b/crates/stella-cli/src/wrapper_plugin/report.rs
@@ -14,8 +14,9 @@
 
 use std::sync::Arc;
 
+use stella_protocol::StampAssessment;
 use stella_runtime::wrapper::{
-    CandidateFanoutSpend, ChildTurnSpend, DispatchReport, HostCallGate, TestRunRecord,
+    CandidateFanoutSpend, ChildTurnSpend, DispatchReport, HostCallGate, TestRunRecord, seat_token,
 };
 
 use crate::OutputFormat;
@@ -83,6 +84,25 @@ pub(super) fn report_lines(
                 "arbiter {} did not answer — recorded as inconclusive, and nothing was held open",
                 row.author
             ),
+        ));
+    }
+    // Rule 1 of `wrapper::arbitration`: a red test is never talked round. A
+    // claim of `done` can sit beside a rung that says the evidence still
+    // fails, and `report.met()` alone reads that as an ordinary pass — it
+    // answers from the verdict, not from whether anything here disagreed
+    // with it. Printed only when both halves are true, so an abstention or a
+    // rule with nothing declared never trips this line.
+    if report.arbitration.refutes_done()
+        && report
+            .arbitration
+            .rows
+            .iter()
+            .any(|row| row.assessment == StampAssessment::Done)
+    {
+        lines.push(wrapper_line(
+            scope,
+            &"a claim says the work is done, and the rung says otherwise — the rung's evidence \
+              wins",
         ));
     }
     // Every member's refusals, in selection order: a composition has one gate
@@ -218,8 +238,14 @@ pub(super) fn fanout_spend_lines(spends: &[CandidateFanoutSpend]) -> Vec<String>
                 format!(" — it asked for {}", spend.requested_width)
             };
             format!(
-                "fanned out {} candidate turn(s) at \"{}\" (seat {:?}, {} finished, ${:.4}){clamped}",
-                spend.width, spend.role, spend.seat, spend.completed, spend.cost_usd,
+                "{} fanned out {} candidate turn(s) at \"{}\" (seat {}, {} finished, \
+                 ${:.4}){clamped}",
+                spend.plugin,
+                spend.width,
+                spend.role,
+                seat_token(spend.seat),
+                spend.completed,
+                spend.cost_usd,
             )
         })
         .collect()

--- a/crates/stella-cli/src/wrapper_plugin/tests.rs
+++ b/crates/stella-cli/src/wrapper_plugin/tests.rs
@@ -194,13 +194,12 @@ fn the_deprecation_notice_fires_only_when_no_pipeline_was_passed() {
 /// after `WrapperDispatch::run` had already billed
 /// `1 + DEFAULT_HOST_MAX_HOLDS` worker turns inside one judged round
 /// (`report.rounds != 1`, `goal_wrapped::run_goal_wrapped_turn`) — every one
-/// of those turns paid for before the whole run was discarded. This
-/// assertion fails on the pre-fix code (no such pre-flight check exists, so
-/// `reject_arbiter_wrapper_on_goal` is not even a name in scope / always
-/// returns `Ok`) and passes on this one: the arbiter grade is refused at
-/// resolve/bind time, before any provider is ever built and before a single
-/// paid call — mirrored end to end (no cost, no provider reached) by
-/// `crates/stella-cli/tests/goal_arbiter_wrapper_refusal_cli.rs`.
+/// of those turns paid for before the whole run was discarded. Without the
+/// fix, no such check exists: `reject_arbiter_wrapper_on_goal` is not even a
+/// name in scope, or it always returns `Ok`. With the fix, the arbiter grade
+/// is refused at resolve/bind time — before any provider is built and
+/// before a single paid call. `crates/stella-cli/tests/goal_arbiter_wrapper_refusal_cli.rs`
+/// mirrors it end to end: no cost, no provider reached.
 #[test]
 fn an_arbiter_grade_wrapper_is_refused_on_goal() {
     let mut warn = |_: String| {};
@@ -879,58 +878,6 @@ async fn a_stella_run_host_serves_candidate_fanout() {
     assert!(
         leaked.is_empty(),
         "the sweep must take every workspace: {leaked:?}"
-    );
-}
-
-/// A fan-out's spend is printed, and the clamp is printed with it (#3892).
-///
-/// The largest spend a plugin can cause on one host call — N *writing* worker
-/// turns — so a run that reported child turns and stayed silent here would be
-/// visible about the cheap spend and quiet about the expensive one. The
-/// requested width appears only when it differs from what ran, because "asked
-/// 5, ran 3" and "asked 3, ran 3" are different facts about a plugin and only
-/// the host knows which one happened.
-#[test]
-fn a_fanout_reports_what_it_bought_and_names_a_clamp() {
-    use stella_protocol::event::ModelCallRole;
-    use stella_runtime::wrapper::CandidateFanoutSpend;
-
-    let clamped = super::fanout_spend_lines(&[CandidateFanoutSpend {
-        role: "attempt".into(),
-        seat: ModelCallRole::Worker,
-        requested_width: 5,
-        width: 3,
-        cost_usd: 0.4200,
-        completed: 2,
-    }])
-    .remove(0);
-    assert!(clamped.contains("3 candidate turn(s)"), "{clamped}");
-    assert!(clamped.contains("attempt"), "{clamped}");
-    assert!(clamped.contains("0.4200"), "the money is named: {clamped}");
-    assert!(clamped.contains("2 finished"), "{clamped}");
-    assert!(
-        clamped.contains("asked for 5"),
-        "a clamp the plugin could not see is a clamp it will report as its \
-         own choice: {clamped}"
-    );
-
-    let unclamped = super::fanout_spend_lines(&[CandidateFanoutSpend {
-        role: "attempt".into(),
-        seat: ModelCallRole::Worker,
-        requested_width: 3,
-        width: 3,
-        cost_usd: 0.1,
-        completed: 3,
-    }])
-    .remove(0);
-    assert!(
-        !unclamped.contains("asked for"),
-        "nothing was clamped, so nothing is said about it: {unclamped}"
-    );
-
-    assert!(
-        super::fanout_spend_lines(&[]).is_empty(),
-        "a plugin that never fanned out keeps a silent run silent"
     );
 }
 

--- a/crates/stella-cli/src/wrapper_plugin/tests/report.rs
+++ b/crates/stella-cli/src/wrapper_plugin/tests/report.rs
@@ -110,6 +110,131 @@ fn an_arbiter_that_did_not_answer_gets_a_line_of_its_own() {
     );
 }
 
+/// **Witness.** A claim of `done` beside a rung that says a real test still
+/// fails prints a line saying so, rather than reading like an ordinary pass.
+///
+/// A build that never hands `fold_stamps` the round's rung leaves
+/// `Arbitration::rung` at `None` always, so `refutes_done` can never answer
+/// `true` there and this line can never print. This report is built the way a
+/// real dispatch builds one when it does pass the rung through — a `Done`
+/// claim sitting beside a rung `deterministic_failure` reads as a real
+/// failure — so the assertion below distinguishes the two.
+#[test]
+fn a_done_claim_beside_a_failing_rung_says_the_rung_wins() {
+    use stella_runtime::wrapper::{ArbiterClaim, TurnHoldBudget, fold_stamps};
+
+    let grant = stella_plugin::LoopGrant {
+        participation: stella_plugin::Participation::Arbiter,
+        ..stella_plugin::LoopGrant::default()
+    };
+    let verdict = stella_plugin::Verdict::Met {
+        evidence: stella_plugin::EvidenceProvenance::PluginReported,
+    };
+    let arbitration = fold_stamps(
+        Some(stella_protocol::LadderRung::Revise),
+        &[ArbiterClaim::from_verdict("vera", &verdict, &grant, 0)],
+        TurnHoldBudget {
+            turn_holds_spent: 0,
+            host_max_holds: 2,
+        },
+    );
+    let report = stella_runtime::wrapper::DispatchReport {
+        verdict: verdict.clone(),
+        outcome: stella_plugin::Outcome::Met {
+            evidence: stella_plugin::EvidenceProvenance::PluginReported,
+        },
+        snapshot: stella_runtime::wrapper::stamp::snapshot(
+            &stella_plugin::VerdictRule::default(),
+            &stella_plugin::EvidenceSet::unobserved(),
+            &verdict,
+        ),
+        faults: Vec::new(),
+        arbitration,
+        ..faulted_report()
+    };
+
+    let lines = super::report_lines(None, OutputFormat::Text, &report, &[], &[], &[], &[]);
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("the rung's evidence wins")),
+        "a done claim beside a failing rung must not read as an ordinary pass: {lines:#?}"
+    );
+}
+
+/// A fan-out's spend is printed, and the clamp is printed with it.
+///
+/// The largest spend a plugin can cause on one host call — N *writing* worker
+/// turns — so a run that reported child turns and stayed silent here would be
+/// visible about the cheap spend and quiet about the expensive one. The
+/// requested width appears only when it differs from what ran, because "asked
+/// 5, ran 3" and "asked 3, ran 3" are different facts about a plugin and only
+/// the host knows which one happened.
+///
+/// **Also asserts the line names the plugin that spent it**, and prints the
+/// seat in the wire vocabulary telemetry carries — a lowercase `"worker"` —
+/// never `{:?}`'s `"Worker"`. A build that prints `seat Worker` with no
+/// plugin fails both assertions.
+#[test]
+fn a_fanout_reports_what_it_bought_and_names_a_clamp() {
+    use stella_protocol::event::ModelCallRole;
+    use stella_runtime::wrapper::CandidateFanoutSpend;
+
+    let clamped = super::fanout_spend_lines(&[CandidateFanoutSpend {
+        plugin: "candidates-wrapper".into(),
+        role: "attempt".into(),
+        seat: ModelCallRole::Worker,
+        requested_width: 5,
+        width: 3,
+        cost_usd: 0.4200,
+        completed: 2,
+    }])
+    .remove(0);
+    assert!(clamped.contains("3 candidate turn(s)"), "{clamped}");
+    assert!(clamped.contains("attempt"), "{clamped}");
+    assert!(clamped.contains("0.4200"), "the money is named: {clamped}");
+    assert!(clamped.contains("2 finished"), "{clamped}");
+    assert!(
+        clamped.contains("candidates-wrapper"),
+        "the line names the plugin that spent it, matching the child-turn line beside it: \
+         {clamped}"
+    );
+    assert!(
+        clamped.contains("seat worker"),
+        "the seat prints in the wire vocabulary telemetry carries, not a Rust identifier: \
+         {clamped}"
+    );
+    assert!(
+        !clamped.contains("Worker"),
+        "no Debug rendering of the enum survives to the report: {clamped}"
+    );
+    assert!(
+        clamped.contains("asked for 5"),
+        "a clamp the plugin could not see is a clamp it will report as its \
+         own choice: {clamped}"
+    );
+
+    let unclamped = super::fanout_spend_lines(&[CandidateFanoutSpend {
+        plugin: "candidates-wrapper".into(),
+        role: "attempt".into(),
+        seat: ModelCallRole::Worker,
+        requested_width: 3,
+        width: 3,
+        cost_usd: 0.1,
+        completed: 3,
+    }])
+    .remove(0);
+    assert!(
+        !unclamped.contains("asked for"),
+        "nothing was clamped, so nothing is said about it: {unclamped}"
+    );
+
+    assert!(
+        super::fanout_spend_lines(&[]).is_empty(),
+        "a plugin that never fanned out keeps a silent run silent"
+    );
+}
+
 /// **Witness (#3883).** Every line a wrapper's report prints names the lane it
 /// came from, when there is more than one lane to confuse.
 ///
@@ -136,6 +261,7 @@ fn a_scoped_report_names_its_task_on_every_line() {
         completed: true,
     }];
     let fanouts = [CandidateFanoutSpend {
+        plugin: "budget-keeper".to_string(),
         role: "attempt".to_string(),
         seat: ModelCallRole::Worker,
         requested_width: 2,

--- a/crates/stella-runtime/src/wrapper.rs
+++ b/crates/stella-runtime/src/wrapper.rs
@@ -111,7 +111,7 @@ pub use arbitration::{
 pub use candidate_fanout::{
     CandidateFanoutError, CandidateFanoutPlane, CandidateFanoutSpend, CandidateFanouts,
     CandidateReport, CandidateWork, CandidateWorkspace, CandidateWorkspaces,
-    DEFAULT_HOST_MAX_FANOUT_WIDTH, DEFAULT_HOST_MAX_FANOUTS,
+    DEFAULT_HOST_MAX_FANOUT_WIDTH, DEFAULT_HOST_MAX_FANOUTS, seat_token,
 };
 pub use child_turn::{ChildTurnPlane, ChildTurnSpend, ChildTurns, DEFAULT_HOST_MAX_CHILD_TURNS};
 pub use dispatch::{

--- a/crates/stella-runtime/src/wrapper/candidate_fanout.rs
+++ b/crates/stella-runtime/src/wrapper/candidate_fanout.rs
@@ -303,6 +303,13 @@ pub trait CandidateWorkspaces: Send + Sync {
 /// can account for.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CandidateFanoutSpend {
+    /// Which plugin caused the fan-out.
+    ///
+    /// [`ChildTurnSpend::plugin`](super::ChildTurnSpend::plugin)'s sibling, for
+    /// the same reason: two lines in one report naming a spend must both say
+    /// whose it was, or a reader can price the child-turn line and not this
+    /// one.
+    pub plugin: String,
     /// The role intent the plugin named.
     pub role: String,
     /// The responsibility the host resolved it to — always
@@ -379,41 +386,6 @@ impl<W> std::fmt::Debug for CandidateFanouts<W> {
     }
 }
 
-/// The tiers this host resolves a fan-out's role intent from, before a caller
-/// binds any of its own.
-///
-/// The same four [`ChildTurns`](super::ChildTurns) serves, and shipping the
-/// three a fan-out may **not** use is the point — it is that module's own
-/// argument for keeping `worker` in *its* table, read from the other end. A
-/// tier that resolves to nothing answers [`HostCallRefusal::Unavailable`]
-/// ("this host binds it to no responsibility"), which sends a plugin author to
-/// ask their host operator for a binding; a tier that resolves to a non-worker
-/// seat answers [`HostCallRefusal::Forbidden`] ("a candidate is the work, and
-/// this seat did not do it"), which sends them to change one line of their own
-/// manifest. Collapsing the second into the first would hide a rule behind the
-/// weaker of the two answers, and a rule discovered that way comes to be read
-/// as an accident of configuration.
-///
-/// A host that serves some other tier says so with
-/// [`CandidateFanouts::with_seat`]; binding one to anything but
-/// [`ModelCallRole::Worker`] only changes which word gets refused, because the
-/// check below compares the resolved seat and never the spelling.
-fn default_seats() -> BTreeMap<String, ModelCallRole> {
-    [
-        ("worker", ModelCallRole::Worker),
-        // Three tiers a manifest still names. Each is bound to a plugin's
-        // own seat, so naming one is answered `Forbidden` — "a candidate is
-        // the work" — and not `Unavailable`, which sends a plugin author to
-        // their host operator over a rule no operator can lift.
-        ("triage", ModelCallRole::Plugin),
-        ("research", ModelCallRole::Plugin),
-        ("plan", ModelCallRole::Plugin),
-    ]
-    .into_iter()
-    .map(|(tier, seat)| (tier.to_string(), seat))
-    .collect()
-}
-
 // Unbounded on `W`: every method here decides, clamps or reports, and not one
 // of them touches the substrate — the `Debug` impl above included, which is
 // what a host prints when it cannot work out why a plugin was refused.
@@ -442,7 +414,16 @@ impl<W> CandidateFanouts<W> {
             plugin: manifest.name.clone(),
             workspaces,
             roles,
-            seats: default_seats(),
+            // Empty, not a table of words core happens to know: whether this
+            // plugin may fan out at all is decided upstream, by
+            // `LoopGrant::permits_call(HostCall::CandidateFanout)` before this
+            // plane is ever asked to resolve anything. Once that grant is
+            // read, a candidate is the work, so every declared tier resolves
+            // to the worker's seat by default (below) — a plugin naming a
+            // tier core has never heard of is served exactly as one naming
+            // `worker` is. A host that wants a tier refused anyway still
+            // binds it here with `with_seat`.
+            seats: BTreeMap::new(),
             declared_width: manifest.loop_grant.max_fanout_width,
             width_ceiling: DEFAULT_HOST_MAX_FANOUT_WIDTH,
             fanout_ceiling: DEFAULT_HOST_MAX_FANOUTS,
@@ -565,10 +546,13 @@ impl<W> CandidateFanouts<W> {
     ///
     /// # Errors
     ///
-    /// [`HostCallRefusal::Undeclared`] when the manifest declares no such role,
-    /// [`HostCallRefusal::Unavailable`] when its tier names no seat this host
-    /// serves, and [`HostCallRefusal::Forbidden`] when it resolves anywhere but
-    /// the worker's seat.
+    /// [`HostCallRefusal::Undeclared`] when the manifest declares no such
+    /// role, and [`HostCallRefusal::Forbidden`] when a host has explicitly
+    /// bound its tier somewhere other than the worker's seat with
+    /// [`Self::with_seat`]. There is no `Unavailable` case here: whether this
+    /// plugin may fan out at all is `LoopGrant::permits_call`'s question,
+    /// asked upstream before this plane is asked to resolve anything, so a
+    /// declared role always resolves to a seat.
     pub fn resolve(&self, role: &str) -> Result<ModelCallRole, HostCallFailure> {
         let Some(tier) = self.roles.get(role) else {
             let declared = if self.roles.is_empty() {
@@ -585,24 +569,26 @@ impl<W> CandidateFanouts<W> {
                 ),
             ));
         };
-        let Some(&seat) = self.seats.get(tier) else {
-            return Err(HostCallFailure::new(
-                HostCallRefusal::Unavailable,
-                format!(
-                    "role intent \"{role}\" asks for the \"{tier}\" tier, which this host binds \
-                     to no responsibility; served tiers: {}",
-                    self.seats.keys().cloned().collect::<Vec<_>>().join(", ")
-                ),
-            ));
-        };
+        // A candidate is the work, so an unbound tier defaults to the
+        // worker's own seat rather than to nothing — the tier word itself is
+        // never core's to know or refuse. `with_seat` is the one way a host
+        // can still bind a tier elsewhere, and doing so is answered exactly
+        // as it always was: `Forbidden`, on the resolved seat rather than the
+        // spelling.
+        let seat = self
+            .seats
+            .get(tier)
+            .copied()
+            .unwrap_or(ModelCallRole::Worker);
         if seat != ModelCallRole::Worker {
             return Err(HostCallFailure::new(
                 HostCallRefusal::Forbidden,
                 format!(
-                    "role intent \"{role}\" resolves to the \"{}\" seat, and a candidate is the \
-                     work rather than evidence about it — booking a writing turn anywhere but \
-                     the worker's seat would attribute it to a responsibility that wrote \
-                     nothing; name a tier that resolves to the worker",
+                    "role intent \"{role}\" is bound by this host to the \"{}\" seat, and a \
+                     candidate is the work rather than evidence about it — booking a writing \
+                     turn anywhere but the worker's seat would attribute it to a responsibility \
+                     that wrote nothing; ask your host operator to bind the \"{tier}\" tier to \
+                     the worker instead",
                     seat_token(seat)
                 ),
             ));
@@ -781,6 +767,7 @@ impl<W: CandidateWorkspaces> CandidateFanoutPlane for CandidateFanouts<W> {
         }
 
         self.record(CandidateFanoutSpend {
+            plugin: self.plugin.clone(),
             role: args.role.clone(),
             seat,
             requested_width: args.width,
@@ -849,15 +836,25 @@ impl<W: CandidateWorkspaces> CandidateFanoutPlane for CandidateFanouts<W> {
         // landing" is a different fact from "landed, and its scratch copy
         // cleaned up".
         //
-        // A removal that fails is left to `discard_all`'s contract rather than
-        // raised here: the adoption succeeded, and failing the call now would
-        // tell the plugin its winner did not land when it did.
+        // A removal that fails is not raised here — the adoption already
+        // succeeded, and failing the call now would tell the plugin its
+        // winner did not land when it did — and it is not dropped either: the
+        // workspace goes back into `live()`, unreported as discarded, so the
+        // end-of-run sweep (`discard_all`) still holds a handle it can retry.
         let mut discarded = Vec::with_capacity(held.len().saturating_sub(1));
-        for (at, workspace) in held.iter().enumerate() {
-            let _ = self.workspaces.remove(workspace).await;
-            if at != index {
-                discarded.push(workspace.handle.clone());
+        let mut not_removed = Vec::new();
+        for (at, workspace) in held.into_iter().enumerate() {
+            match self.workspaces.remove(&workspace).await {
+                Ok(()) => {
+                    if at != index {
+                        discarded.push(workspace.handle.clone());
+                    }
+                }
+                Err(_) => not_removed.push(workspace),
             }
+        }
+        if !not_removed.is_empty() {
+            self.register(not_removed);
         }
 
         Ok(AdoptCandidateResult {
@@ -894,7 +891,13 @@ impl<P: CandidateFanoutPlane + ?Sized> CandidateFanoutPlane for std::sync::Arc<P
 /// A seat's wire token, as `step_usage` records it — through `serde_json`
 /// rather than a second hand-written table, for [`super::child_turn`]'s reason:
 /// a second copy of a closed enum's spellings is a rule in two places.
-fn seat_token(seat: ModelCallRole) -> String {
+///
+/// Public so a report renderer outside this crate — `stella-cli`'s
+/// `wrapper_plugin::report` — can print [`CandidateFanoutSpend::seat`] in the
+/// same vocabulary the child-turn line beside it already uses, rather than
+/// `{:?}`'s Rust identifier.
+#[must_use]
+pub fn seat_token(seat: ModelCallRole) -> String {
     serde_json::to_value(seat)
         .ok()
         .and_then(|value| value.as_str().map(ToString::to_string))

--- a/crates/stella-runtime/src/wrapper/candidate_fanout.rs
+++ b/crates/stella-runtime/src/wrapper/candidate_fanout.rs
@@ -889,8 +889,11 @@ impl<P: CandidateFanoutPlane + ?Sized> CandidateFanoutPlane for std::sync::Arc<P
 }
 
 /// A seat's wire token, as `step_usage` records it — through `serde_json`
-/// rather than a second hand-written table, for [`super::child_turn`]'s reason:
+/// rather than a second hand-written table, for `super::child_turn`'s reason:
 /// a second copy of a closed enum's spellings is a rule in two places.
+/// That module name is a code span, not a link: this item is public and the
+/// module is not, so a link here is a `rustdoc::private_intra_doc_links`
+/// error under `-D warnings`.
 ///
 /// Public so a report renderer outside this crate — `stella-cli`'s
 /// `wrapper_plugin::report` — can print [`CandidateFanoutSpend::seat`] in the

--- a/crates/stella-runtime/src/wrapper/dispatch.rs
+++ b/crates/stella-runtime/src/wrapper/dispatch.rs
@@ -754,10 +754,18 @@ impl WrapperDispatch {
                         &verdict,
                         input.candidate.as_ref().map(|c| c.handle.to_string()),
                     );
+                    // The arbiter's own id — the plugin whose `[requirements]`
+                    // and `[oracle]` `self.rule` actually is, so it is the
+                    // thing that decided (`super::compose::merge_rule`). A
+                    // stamp names the same decider `ArbiterClaim` does, rather
+                    // than the whole composition's joined id: see
+                    // `stamp::author`'s doc for the rule and why.
+                    let arbiter_id = self.arbiter_id();
                     let snapshot = self.stamp_round(
                         &evidence,
                         &verdict,
                         &pipeline_id,
+                        &arbiter_id,
                         input.candidate.as_ref(),
                         timing,
                         &mut faults,
@@ -768,19 +776,17 @@ impl WrapperDispatch {
                     // loop.
                     let mut claims = faults.claims.clone();
                     claims.push(ArbiterClaim::from_verdict(
-                        self.arbiter_id(),
+                        arbiter_id,
                         &verdict,
                         &self.hold_grant,
                         holds_spent,
                     ));
-                    // The rung stays `None`, as it was before the stamp
-                    // producer landed. `snapshot.rung` is an answer this
-                    // dispatch now holds, and feeding it here would arm
-                    // `Arbitration::refutes_done` on the live path for the
-                    // first time. That is a decision of its own, with its
-                    // own tests, and it is not what this change is.
+                    // `snapshot.rung` is the same answer the stamp above just
+                    // recorded, so the fold judges this round against the
+                    // evidence the stamp itself carries rather than against a
+                    // gap the two disagree about.
                     let arbitration = fold_stamps(
-                        None,
+                        snapshot.rung,
                         &claims,
                         TurnHoldBudget {
                             turn_holds_spent: holds_spent,
@@ -984,9 +990,13 @@ impl WrapperDispatch {
 
     /// The round as the ladder's own record, with one stamp on it.
     ///
-    /// The name on the stamp comes from the manifests this dispatch was bound
-    /// to, so a plugin cannot sign another one's name. `super::stamp` holds the
-    /// rest of the rule.
+    /// The name on the stamp is `author_id` — the arbiter's id, per
+    /// `stamp::author`'s rule — and never a payload the manifests' processes
+    /// sent, so a plugin cannot sign another one's name. `pipeline_id` names
+    /// the composition instead, for the one place that still means "the run",
+    /// not "the decider": [`WrapperError::Unstampable`], where a person is
+    /// told which `--pipeline` selection produced an unhashable record.
+    /// `super::stamp` holds the rest of the rule.
     ///
     /// A record that cannot be hashed keeps its answer and loses its stamp.
     /// The hash is taken after the verdict is settled and can change nothing
@@ -998,6 +1008,7 @@ impl WrapperDispatch {
         evidence: &EvidenceSet,
         verdict: &Verdict,
         pipeline_id: &str,
+        author_id: &str,
         candidate: Option<&CandidateGrant>,
         timing: StampTiming,
         faults: &mut Faults,
@@ -1009,7 +1020,7 @@ impl WrapperDispatch {
             .iter()
             .map(|grant| format!("candidate:{}", grant.handle))
             .collect();
-        match stamp::stamped(&self.rule, evidence, verdict, pipeline_id, refs, timing) {
+        match stamp::stamped(&self.rule, evidence, verdict, author_id, refs, timing) {
             Ok(snapshot) => snapshot,
             Err(source) => {
                 faults.push_host(WrapperError::Unstampable {

--- a/crates/stella-runtime/src/wrapper/dispatch.rs
+++ b/crates/stella-runtime/src/wrapper/dispatch.rs
@@ -764,8 +764,10 @@ impl WrapperDispatch {
                     let snapshot = self.stamp_round(
                         &evidence,
                         &verdict,
-                        &pipeline_id,
-                        &arbiter_id,
+                        RoundNames {
+                            author: &arbiter_id,
+                            pipeline: &pipeline_id,
+                        },
                         input.candidate.as_ref(),
                         timing,
                         &mut faults,
@@ -990,14 +992,6 @@ impl WrapperDispatch {
 
     /// The round as the ladder's own record, with one stamp on it.
     ///
-    /// The name on the stamp is `author_id` — the arbiter's id, per
-    /// `stamp::author`'s rule — and never a payload the manifests' processes
-    /// sent, so a plugin cannot sign another one's name. `pipeline_id` names
-    /// the composition instead, for the one place that still means "the run",
-    /// not "the decider": [`WrapperError::Unstampable`], where a person is
-    /// told which `--pipeline` selection produced an unhashable record.
-    /// `super::stamp` holds the rest of the rule.
-    ///
     /// A record that cannot be hashed keeps its answer and loses its stamp.
     /// The hash is taken after the verdict is settled and can change nothing
     /// about it, so failing the whole run over one would throw away a good
@@ -1007,8 +1001,7 @@ impl WrapperDispatch {
         &self,
         evidence: &EvidenceSet,
         verdict: &Verdict,
-        pipeline_id: &str,
-        author_id: &str,
+        names: RoundNames<'_>,
         candidate: Option<&CandidateGrant>,
         timing: StampTiming,
         faults: &mut Faults,
@@ -1020,17 +1013,33 @@ impl WrapperDispatch {
             .iter()
             .map(|grant| format!("candidate:{}", grant.handle))
             .collect();
-        match stamp::stamped(&self.rule, evidence, verdict, author_id, refs, timing) {
+        match stamp::stamped(&self.rule, evidence, verdict, names.author, refs, timing) {
             Ok(snapshot) => snapshot,
             Err(source) => {
                 faults.push_host(WrapperError::Unstampable {
-                    wrapper: pipeline_id.to_string(),
+                    wrapper: names.pipeline.to_string(),
                     source,
                 });
                 stamp::snapshot(&self.rule, evidence, verdict)
             }
         }
     }
+}
+
+/// The two names a stamped round carries. They are both `&str` and they mean
+/// different things, so passing them positionally is one transposition away
+/// from signing a record with the wrong name — the defect class the arbiter-id
+/// fix was itself about.
+///
+/// `author` is the arbiter's id, per `stamp::author`'s rule, and never a
+/// payload the manifests' processes sent, so a plugin cannot sign another
+/// one's name. `pipeline` names the composition, for the one place that still
+/// means "the run" rather than "the decider": [`WrapperError::Unstampable`],
+/// where a person is told which `--pipeline` selection produced an unhashable
+/// record. `super::stamp` holds the rest of the rule.
+struct RoundNames<'a> {
+    author: &'a str,
+    pipeline: &'a str,
 }
 
 /// The verdict a report carries, as the one-line answer a surface prints.

--- a/crates/stella-runtime/src/wrapper/stamp.rs
+++ b/crates/stella-runtime/src/wrapper/stamp.rs
@@ -65,6 +65,22 @@ pub struct StampTiming {
 /// A plugin gets the id from the manifest the host loaded. Nothing else can
 /// reach this field, so no plugin can sign another one's name. Evidence the
 /// host concluded for itself is [`HOST_AUTHOR`].
+///
+/// # Whose id, in a composition
+///
+/// `manifest_id` is a single id, and a composition can run several plugins in
+/// one dispatch. The rule is the **arbiter's** id — the one plugin whose
+/// `[requirements]` and `[oracle]` became `self.rule` at bind time
+/// (`WrapperDispatch::bind_composed`'s `super::compose::merge_rule`), because
+/// that rule is what `judge` actually read to reach the verdict this stamp
+/// records. It is the same id [`super::ArbiterClaim::from_verdict`] carries,
+/// on purpose: a stamp and the claim beside it on one report must name the
+/// same decider, or a reader has no way to tell which one to trust
+/// (`doc:pipeline-as-plugins` §4). The composition's own joined id (every
+/// member's, comma-separated) is a record of what *ran*, not of what
+/// *decided*, and stays on [`super::DispatchReport::variant`] instead. A
+/// composition with no arbiter has nothing this rule can single out, so the
+/// caller falls back to that same joined id — the two already agree there.
 #[must_use]
 pub fn author(provenance: EvidenceProvenance, manifest_id: &str) -> &str {
     match provenance {

--- a/crates/stella-runtime/tests/wrapper_candidate_fanout.rs
+++ b/crates/stella-runtime/tests/wrapper_candidate_fanout.rs
@@ -105,6 +105,9 @@ struct Substrate {
     /// When true, `adopt` refuses. The user's tree stays untouched, and the
     /// losing candidates must survive.
     adoption_fails: bool,
+    /// When true, `remove` refuses for every workspace, so a test can drive
+    /// the disk-left-behind case: a workspace that could not be removed.
+    removal_fails: bool,
 }
 
 impl Substrate {
@@ -185,6 +188,12 @@ impl CandidateWorkspaces for Substrate {
     }
 
     async fn remove(&self, workspace: &CandidateWorkspace) -> Result<(), CandidateFanoutError> {
+        if self.removal_fails {
+            return Err(CandidateFanoutError::NotRemoved {
+                handle: workspace.handle.clone(),
+                reason: "disk is full".to_string(),
+            });
+        }
         self.record(Op::Removed(workspace.handle.to_string()));
         Ok(())
     }
@@ -336,6 +345,7 @@ async fn a_plugin_asks_for_three_attempts_scores_them_and_the_host_lands_the_win
         1,
         "the fan-out's spend is visible, not hidden"
     );
+    assert_eq!(spends[0].plugin, "candidates-wrapper");
     assert_eq!(spends[0].role, "attempt");
     assert_eq!(spends[0].seat, ModelCallRole::Worker);
     assert_eq!(spends[0].requested_width, 3);
@@ -354,19 +364,25 @@ async fn a_plugin_asks_for_three_attempts_scores_them_and_the_host_lands_the_win
     );
 }
 
-/// The three refusals, each a different question and each reaching the plugin
-/// as a value it can branch on — `child_turn.rs`'s shape, at the capability
-/// whose seat rule is inverted.
+/// The two remaining refusals, each a different question. Each reaches the
+/// plugin as a value it can act on — `child_turn.rs`'s shape, for the
+/// capability whose seat rule runs the other way.
 ///
-/// `nowhere` is the interesting one: its tier is declared, so the manifest
-/// check passes, and it still resolves to no seat this host serves. Telling a
-/// plugin author "undeclared" there would send them to edit a manifest that is
-/// already correct.
+/// **The witness.** `nowhere` names a tier core has no fixed word for:
+/// `"archivist"`. It still resolves, at the worker's seat. `HostCallGate`
+/// checks `[loop] calls` for `candidate_fanout` first, before this plane
+/// resolves any tier at all. So no tier word list decides it here. A build
+/// with a core-owned tier table would refuse `"archivist"` instead.
+///
+/// `scout`'s tier (`"research"`) is refused only once a host binds it away
+/// from the worker with `with_seat`. The check reads the *bound* seat, not
+/// the spelling. The assertion below is what exercises that.
 #[tokio::test]
-async fn the_three_refusals_are_distinguishable_and_none_of_them_creates_a_workspace() {
+async fn an_unbound_tier_resolves_to_the_worker_and_a_bound_one_is_still_forbidden() {
     let manifest = manifest();
     let substrate = Substrate::default();
-    let plane = CandidateFanouts::declare(&manifest, substrate.clone());
+    let plane = CandidateFanouts::declare(&manifest, substrate.clone())
+        .with_seat("research", ModelCallRole::Plugin);
 
     let undeclared = plane
         .resolve("auditor")
@@ -377,18 +393,17 @@ async fn the_three_refusals_are_distinguishable_and_none_of_them_creates_a_works
         "the refusal names what the manifest did declare: {undeclared}"
     );
 
-    let unavailable = plane
-        .resolve("nowhere")
-        .expect_err("a tier this host binds to no responsibility");
-    assert_eq!(unavailable.refusal, HostCallRefusal::Unavailable);
-    assert!(
-        unavailable.detail.contains("archivist"),
-        "the refusal names the tier that resolved nowhere: {unavailable}"
+    assert_eq!(
+        plane
+            .resolve("nowhere")
+            .expect("a tier core has never heard of still resolves to the worker"),
+        ModelCallRole::Worker,
+        "the fanout grant, not a core-owned word list, decides whether this plugin may fan out"
     );
 
     let forbidden = plane
         .resolve("scout")
-        .expect_err("a writing turn booked anywhere but the worker's seat");
+        .expect_err("a writing turn this host bound anywhere but the worker's seat");
     assert_eq!(forbidden.refusal, HostCallRefusal::Forbidden);
     assert!(
         forbidden.detail.contains("plugin"),
@@ -403,6 +418,63 @@ async fn the_three_refusals_are_distinguishable_and_none_of_them_creates_a_works
         substrate.ops().is_empty(),
         "a refusal the plugin could never have bought creates nothing: {:?}",
         substrate.ops()
+    );
+}
+
+/// **The witness.** A workspace whose removal fails during adoption is not
+/// reported as discarded. It is not lost either: it stays in `live()`, so
+/// the end-of-run sweep can still retry it.
+///
+/// A build that ignores the removal error would report the workspace as
+/// discarded anyway, and never put it back in `live()`. The first assertion
+/// below catches that: `discard_all` would find nothing left to retry, and
+/// the directory would stay on disk with nothing telling the operator.
+#[tokio::test]
+async fn a_removal_that_fails_during_adoption_stays_live_for_the_sweep_to_retry() {
+    use stella_runtime::wrapper::CandidateFanoutPlane;
+
+    let manifest = manifest();
+    let substrate = Substrate {
+        removal_fails: true,
+        ..Substrate::default()
+    };
+    let plane = CandidateFanouts::declare(&manifest, substrate.clone());
+    plane
+        .fanout(stella_plugin::CandidateFanoutArgs {
+            role: "attempt".to_string(),
+            instruction: "try it".to_string(),
+            width: 2,
+        })
+        .await
+        .expect("the fan-out runs");
+
+    let result = plane
+        .adopt(stella_plugin::AdoptCandidateArgs {
+            candidate: CandidateHandle::new("candidate-1"),
+        })
+        .await
+        .expect("the winner still lands even though nothing could be removed");
+    assert!(
+        result.discarded.is_empty(),
+        "a workspace that could not be removed must not be reported as discarded: {:?}",
+        result.discarded
+    );
+    assert_eq!(
+        plane.live().len(),
+        2,
+        "both workspaces stay live so the end-of-run sweep can retry them: {:?}",
+        plane.live()
+    );
+
+    let failures = plane.discard_all().await;
+    assert_eq!(
+        failures.len(),
+        2,
+        "the sweep reaches both workspaces the adoption could not clear: {failures:?}"
+    );
+    assert!(
+        plane.live().is_empty(),
+        "the sweep takes the table either way"
     );
 }
 

--- a/crates/stella-runtime/tests/wrapper_verdict_stamp.rs
+++ b/crates/stella-runtime/tests/wrapper_verdict_stamp.rs
@@ -24,7 +24,7 @@ use stella_protocol::hash::record_hash;
 use stella_protocol::{CandidateHandle, StampAssessment};
 use stella_runtime::wrapper::{
     DEFAULT_WRAPPER_TIMEOUT, DispatchReport, DrivenTurn, RoundInput, SubprocessWrapper, TurnDriver,
-    TurnPrelude, WrapperDispatch,
+    TurnPrelude, TurnWrapper, WrapperDispatch,
 };
 
 /// A plugin that holds the turn open until the test flips red to green.
@@ -57,6 +57,22 @@ id = "witness-v1"
 name = "verify"
 "#;
 
+/// A second, steering member. It has no oracle and no say over the round.
+/// It is here only to make the composed id longer than the arbiter's own id.
+const STEERING_MANIFEST: &str = r#"
+name = "witness-reader"
+description = "reads the round and claims nothing"
+
+[loop]
+participation = "steering"
+points = ["before_turn"]
+
+[wrapper]
+id = "reader-v1"
+[[wrapper.stages]]
+name = "recall"
+"#;
+
 const FIXTURE: &str = env!("CARGO_BIN_EXE_wrapper-plugin-fixture");
 
 /// A clock this file owns. Both times on the claim are then values it names.
@@ -80,6 +96,39 @@ fn dispatch(mode: &str) -> WrapperDispatch {
         Arc::new(admitted.wrapper),
     )
     .expect("it declares a [wrapper]")
+    .with_clock(Arc::new(PinnedClock))
+}
+
+/// The same arbiter, now composed beside the steering member above. It
+/// never answers `after_turn`, so the arbiter's rule still decides alone.
+fn composed_dispatch(mode: &str) -> WrapperDispatch {
+    let reader = SubprocessWrapper::declare(
+        vec![
+            FIXTURE.to_string(),
+            "echo-stage".to_string(),
+            "reader".to_string(),
+        ],
+        Vec::new(),
+        DEFAULT_WRAPPER_TIMEOUT,
+    )
+    .expect("the transport is declared with a program and a budget");
+    let arbiter = SubprocessWrapper::declare(
+        vec![FIXTURE.to_string(), mode.to_string()],
+        Vec::new(),
+        DEFAULT_WRAPPER_TIMEOUT,
+    )
+    .expect("the transport is declared with a program and a budget");
+    WrapperDispatch::bind_composed(vec![
+        (
+            PluginManifest::from_toml_str(STEERING_MANIFEST).expect("the manifest loads"),
+            Arc::new(reader.wrapper) as Arc<dyn TurnWrapper>,
+        ),
+        (
+            PluginManifest::from_toml_str(MANIFEST).expect("the manifest loads"),
+            Arc::new(arbiter.wrapper) as Arc<dyn TurnWrapper>,
+        ),
+    ])
+    .expect("a steering member and an arbiter member compose")
     .with_clock(Arc::new(PinnedClock))
 }
 
@@ -201,5 +250,41 @@ async fn the_stamp_points_at_the_workspace_it_judged() {
     assert_eq!(
         report.snapshot.stamps[0].evidence_refs,
         vec!["candidate:host-tree".to_string()]
+    );
+}
+
+/// **The witness.** A composed run's stamp names the arbiter. It does not
+/// name the whole composition.
+///
+/// Naming the whole composition would read `"reader-v1,witness-v1"`. That
+/// name would not match the `ArbiterClaim` next to it on the same report.
+/// The stamp below reads `"witness-v1"` instead.
+#[tokio::test]
+async fn a_composed_stamp_names_the_arbiter_not_the_whole_composition() {
+    let input = RoundInput {
+        goal: "make the flaky test deterministic".into(),
+        signals: signals(),
+        candidate: Some(granted("/tmp/workspace")),
+    };
+    let report = composed_dispatch("flip-if-granted")
+        .run(input, &mut Host)
+        .await
+        .expect("a validated composition resolves");
+
+    let stamp = &report.snapshot.stamps[0];
+    assert_eq!(
+        stamp.author, "witness-v1",
+        "the stamp names the arbiter whose rule decided the round, not the whole composition"
+    );
+
+    let arbiter_claim = report
+        .arbitration
+        .rows
+        .iter()
+        .find(|row| row.assessment == StampAssessment::Done)
+        .expect("the arbiter's own claim is in the fold");
+    assert_eq!(
+        stamp.author, arbiter_claim.author,
+        "the stamp and the claim beside it on one report must name the same decider"
     );
 }

--- a/docs/spec/roleless-core.md
+++ b/docs/spec/roleless-core.md
@@ -142,8 +142,9 @@ booked, and whether it may be spent there at all, come from
 `stella_runtime::wrapper::SeatGrant` — the manifest a person read at install.
 The two rules the table carried survive on the grant: no plugin spends at the
 seat the session's own turns use, and a seat that decides whether the work is
-done needs a manifest declaring an `[oracle]`. One table is left in that crate,
-in `candidate_fanout.rs`, whose rule is the inverse; it has its own issue.
+done needs a manifest declaring an `[oracle]`. The one other table in that
+crate, in `candidate_fanout.rs`, carried the inverse rule and is gone too
+(§6's Slice 1 note).
 
 ## 5. The four gaps
 
@@ -190,12 +191,18 @@ reference to any role name.
 
 **Landed.** The witness is
 `a_tier_core_has_never_heard_of_runs_at_the_grants_own_seat` in
-`crates/stella-runtime/src/wrapper/child_turn.rs`. The done check was written
-as a whole-crate one and could not be met as written: `candidate_fanout.rs`
-keeps its own table for the inverted rule, tracked as its own issue, and prose
-that explains the rule still names the worker. What holds instead is that the
-child-turn plane carries no role-word table and no role-word literal outside
-its tests.
+`crates/stella-runtime/src/wrapper/child_turn.rs`.
+
+**The one table left behind is also gone.** `candidate_fanout.rs`'s
+own `default_seats()` — the same four words, bound the other way round — kept
+this whole-crate check from being met as written. Whether a plugin may fan out
+at all is now `[loop] calls` containing `candidate_fanout`, checked by
+`HostCallGate` before the plane resolves anything, so a declared tier core has
+never heard of resolves to the worker's seat exactly as `reviewer` does for a
+child turn; a host that still wants a tier refused binds it away with
+`CandidateFanouts::with_seat`, and that binding is what is checked, never the
+spelling. The done check now holds as written: no role-word table and no
+role-word literal remain in `crates/stella-runtime/` outside a test.
 
 ### Slice 2 — receipts carry the name (gap C)
 


### PR DESCRIPTION
## What / why, per member

- **#5759 — failed candidate-workspace removal reported as a successful discard.** `CandidateFanouts::adopt` iterated `held` with `let _ = self.workspaces.remove(...).await;`, discarding the error and still pushing the workspace's handle into the `discarded` list — even when the underlying removal failed. `discard_all`'s contract (retrying whatever is still in `live()`) never saw it, because the workspace was never put back. **Fix:** `adopt` now matches on `remove`'s result; a failed removal is left out of `discarded` and the workspace is put back into `live()` so the end-of-run sweep can retry it. **Witness:** `a_removal_that_fails_during_adoption_stays_live_for_the_sweep_to_retry` drives a `Substrate` whose `remove()` always fails; it asserts `result.discarded.is_empty()` and `plane.live().len() == 2` after `adopt`. On the old code `discarded` contained the loser's handle and `live()` was empty, so both assertions fail there.

- **#5822 — the candidate fan-out plane owned a core-owned table of plugin role words.** `candidate_fanout::default_seats()` hardcoded `worker`/`triage`/`research`/`plan`, so a manifest naming a candidate tier core had never heard of (e.g. `"builder"`) was refused `Unavailable`. Whether a plugin may fan out at all is already checked upstream by `HostCallGate::declared.permits_call(HostCall::CandidateFanout)` (i.e. `[loop] calls` containing `candidate_fanout`), before `CandidateFanouts::fanout`/`resolve` is ever invoked — so the tier-word table was deciding a question already settled elsewhere. **Fix:** `default_seats()` is deleted; `resolve()` now defaults every unbound tier to the worker's seat, and `with_seat` still lets a host bind a tier to a non-worker seat, which is still refused `Forbidden` on the resolved seat. This is exactly the fix `#3905` already made to `ChildTurns`. **Witness:** `an_unbound_tier_resolves_to_the_worker_and_a_bound_one_is_still_forbidden` resolves `"nowhere"` (tier `"archivist"`, a word core never knew) and asserts it now succeeds at `Worker`; on the old code it was refused `Unavailable`.

- **#5920 — a stamp and an arbiter claim named the decider two different ways.** `WrapperDispatch::run` passed `pipeline_id` (every composed member's id, joined) as the stamp's `author`, while `ArbiterClaim::from_verdict` used `self.arbiter_id()` (the one arbiter whose rule actually decided). The two agree for a single-member dispatch and disagree for a composition. **Fix:** the rule is written down on `stamp::author`'s doc — the arbiter's id, because `self.rule` (what `judge` actually reads) is `compose::merge_rule`'s union of requirements plus the *one* oracle, i.e. the arbiter's. `WrapperDispatch::run` now stamps with `self.arbiter_id()` instead of `pipeline_id`; `pipeline_id` still names `WrapperError::Unstampable`'s `wrapper` field, since that error is about which `--pipeline` selection ran, not who decided. **Witness:** `a_composed_stamp_names_the_arbiter_not_the_whole_composition` composes a steering member (`reader-v1`) with the arbiter (`witness-v1`) and asserts `report.snapshot.stamps[0].author == "witness-v1"`; on the old code it read `"reader-v1,witness-v1"`.

- **#5919 — a wrapper report printed a fan-out's seat as a Rust enum name, with no plugin.** `CandidateFanoutSpend` had no `plugin` field, and `fanout_spend_lines` printed `spend.seat` with `{:?}` (`"seat Worker"`), while the child-turn line beside it already names its plugin and prints its seat as a lowercase wire token. **Fix:** `CandidateFanoutSpend` gains a `plugin: String` field, filled from the plane's own name at record time; the module's existing `seat_token` helper (already used for the `Forbidden` refusal message) is now `pub` and re-exported from `stella_runtime::wrapper`, and `fanout_spend_lines` renders through it. **Witness:** `a_fanout_reports_what_it_bought_and_names_a_clamp` (moved into `wrapper_plugin::tests::report`, alongside the other report-rendering tests) asserts the line contains `"candidates-wrapper"` and `"seat worker"` and does **not** contain `"Worker"`; the old code printed `"seat Worker"` with no plugin name.

- **#5918 — the completion gate never learned the rung, so its red-test rule never fired.** `WrapperDispatch::run` called `fold_stamps(None, &claims, ...)`, so `Arbitration::rung` was always `None` and `Arbitration::refutes_done()` could never observe a deterministic failure on a live run — rule 1 ("a red test is never talked round") was proven only in `wrapper_arbitration.rs`'s own unit tests, never exercised end to end. **Fix:** `WrapperDispatch::run` now passes `snapshot.rung` (the same rung the stamp just recorded) into `fold_stamps`. Per the issue's third bullet ("every consumer of `refutes_done` is checked"): today nothing in `stella-cli` actually called it, so `wrapper_plugin::report::report_lines` now does — it prints a line when `refutes_done()` is true *and* some claim asserts `Done`, so a plugin's optimistic claim next to a real `Revise` rung no longer reads like an ordinary pass. **Witness:** `a_done_claim_beside_a_failing_rung_says_the_rung_wins` builds a report with a `Done` claim and a `Revise` rung and asserts the new line prints; on the old always-`None` wiring `refutes_done()` can never be `true`, so it can't.

## Could not ride (from the batch issue, not re-filed)

- **#6270** — needs a new telemetry path across five files with an open design decision (reuse `ContextRecall` vs. a new `AgentEvent` variant) — larger than this session.
- **#5871** — needs either a full store migration or a new `AgentEvent` + `consumers.rs` row, plus a hash round-trip witness — larger than this session.

## Verification

- `cargo test -p stella-runtime` (whole crate, all suites green) and `cargo test -p stella-cli --bin stella wrapper_plugin` (52 tests green) run locally, scoped per SCR-001.
- `cargo check -p stella-runtime -p stella-cli --all-targets` clean.
- `make guards-fast` green (prose ratchet included — see below).
- CI (`ci.yml`) is the authority for the full workspace build/test/lint/doc gates; this laptop does not run them.

Tests deleted: `the_three_refusals_are_distinguishable_and_none_of_them_creates_a_workspace`
(`crates/stella-runtime/tests/wrapper_candidate_fanout.rs`).

Deleted deliberately, because #5822 removes the behaviour its central assertion
pinned. That test asserted an unbound tier resolves to `HostCallRefusal::Unavailable`
(`plane.resolve("nowhere")` — "a tier this host binds to no responsibility"), and the
whole point of #5822 is that an unbound tier now resolves to the worker's seat instead.
Keeping it would have meant asserting the defect. Its replacement is
`an_unbound_tier_resolves_to_the_worker_and_a_bound_one_is_still_forbidden`, which keeps
the half that survives — a tier a host bound elsewhere with `with_seat` is still
`Forbidden` — beside the new resolution.

Closes #6292

## Summary by Sourcery

Correct candidate fan-out cleanup, tier resolution, arbitration identity, completion reporting, and spend telemetry across the wrapper runtime.

Bug Fixes:
- Preserve candidate workspaces after failed removal so end-of-run cleanup can retry them instead of reporting them as discarded.
- Resolve unbound candidate tiers to the worker seat while retaining explicit host bindings and forbidden-seat checks.
- Align composed-run stamp authors with the arbiter that decided the verdict.
- Propagate ladder rungs into arbitration and report when rung evidence contradicts a Done claim.
- Include the originating plugin and wire-format seat name in candidate fan-out spend reports.

Enhancements:
- Remove the candidate fan-out plane's core-owned tier-name table and rely on upstream capability checks plus explicit host bindings.

Documentation:
- Update role-resolution specification documentation to reflect removal of the candidate fan-out tier table.

Tests:
- Add coverage for retryable workspace-removal failures, unknown-tier resolution, composed stamp authorship, contradictory Done claims, and enriched fan-out reporting.

---
_Generated by [Claude Code](https://claude.ai/code)_