### PR TITLE
fix(stella-tui): tui batch — 11 small defects

### DIFF
--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -6,7 +6,6 @@
 //! checks — see `crates/stella-core/src/driver.rs`) and renders its
 //! `AgentEvent` stream live via a spawned draining task.
 
-use std::collections::HashMap;
 use std::io::{BufRead, Write};
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/crates/stella-cli/src/agent/persistence.rs
+++ b/crates/stella-cli/src/agent/persistence.rs
@@ -196,7 +196,9 @@ pub(crate) fn spawn_renderer(
     prompt: Option<String>,
 ) -> tokio::task::JoinHandle<RendererOutcome> {
     tokio::spawn(async move {
-        let mut tool_names: HashMap<String, (String, Option<String>)> = HashMap::new();
+        // The name a `ToolResult` needs but does not carry (`#2450`). The
+        // deck has its own lookup for this; this table is this surface's.
+        let mut tool_names = stella_tui::tool_call_index::ToolCallIndex::new();
         // Shared with every blocking persistence hop below, so the provider id
         // is not re-allocated once per persisted event.
         let provider_id: Arc<str> = provider_id.into();
@@ -361,9 +363,10 @@ pub(crate) fn spawn_renderer(
                         call, sub_agent_id, ..
                     } = &event
                     {
-                        tool_names.insert(
-                            call.call_id.clone(),
-                            (call.name.clone(), sub_agent_id.clone()),
+                        tool_names.observe_start(
+                            &call.call_id,
+                            &call.name,
+                            sub_agent_id.as_deref(),
                         );
                     }
                     if let Some(printer) = transcript.as_mut() {
@@ -374,9 +377,10 @@ pub(crate) fn spawn_renderer(
                     AgentEvent::ToolStart {
                         call, sub_agent_id, ..
                     } => {
-                        tool_names.insert(
-                            call.call_id.clone(),
-                            (call.name.clone(), sub_agent_id.clone()),
+                        tool_names.observe_start(
+                            &call.call_id,
+                            &call.name,
+                            sub_agent_id.as_deref(),
                         );
                         plain::tool_call_card(
                             &call.name,
@@ -392,10 +396,7 @@ pub(crate) fn spawn_renderer(
                         sub_agent_id,
                         ..
                     } => {
-                        let (name, started_agent) = tool_names
-                            .get(call_id)
-                            .map(|(name, agent)| (name.as_str(), agent.as_deref()))
-                            .unwrap_or(("tool", None));
+                        let (name, started_agent) = tool_names.resolve(call_id);
                         let content = match output {
                             ToolOutput::Ok { content, .. } => content.clone(),
                             ToolOutput::Error { message, .. } => message.clone(),

--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -544,6 +544,14 @@ pub async fn run_deck_session(
     let _ = session_registry.upsert(&session_record);
     // One line when another live session already holds this checkout.
     shared_checkout::announce(&session_registry, &session_record, &cfg.workspace_root);
+    // The other half (`#5933`): a peer that joins this checkout LATER, once
+    // this deck's own channel exists to tell it through.
+    shared_checkout::spawn_late_arrival_monitor(
+        session_registry.clone(),
+        session_record.clone(),
+        cfg.workspace_root.clone(),
+        in_tx.clone(),
+    );
     // What the record's terminal status will be at exit (last turn wins);
     // quitting with a pending backlog overrides to Paused below — the work
     // is durable now, so an exit with prompts waiting is a pause, not loss.
@@ -1599,11 +1607,7 @@ pub async fn run_deck_session(
                             // cached: MCP servers join the session
                             // asynchronously, so the panel must ask what the
                             // stack holds now, not at boot.
-                            let mcp = mcp_slot.get().cloned();
-                            let base: &dyn ToolExecutor = match &mcp {
-                                Some(set) => set.as_ref(),
-                                None => &*registry,
-                            };
+                            let base = settings_io::live_tool_executor(&mcp_slot, &*registry);
                             let names =
                                 crate::tool_switches::session_tool_names(base, &custom_tools);
                             handle_tools_input(&other, cfg, &names, &mut settings_stale, &in_tx);
@@ -1663,6 +1667,7 @@ pub async fn run_deck_session(
             DeckCommand::Handled
                 | DeckCommand::InitCompleted
                 | DeckCommand::Reloaded
+                | DeckCommand::SettingsReloaded
                 | DeckCommand::SessionModel(_)
         ) {
             // A handled command emits its answer as `Text`, which flips the
@@ -1725,6 +1730,15 @@ pub async fn run_deck_session(
                 // request the deck raised against the old seats names a
                 // seating that no longer exists and starts nothing.
                 announce_panels(panels.reseat(&cfg.workspace_root), &deck_tx, &in_tx);
+                settings_io::refresh_tools_panel(cfg, &mcp_slot, &*registry, &custom_tools, &in_tx);
+                continue 'session;
+            }
+            // A settings write refreshed the ENGINE overlay inline and
+            // deferred the TOOLS panel here, the same reason `Reloaded`
+            // does: an accurate row list needs `mcp_slot`, only this loop's
+            // scope holds it (`#1990`).
+            DeckCommand::SettingsReloaded => {
+                settings_io::refresh_tools_panel(cfg, &mcp_slot, &*registry, &custom_tools, &in_tx);
                 continue 'session;
             }
             DeckCommand::InitCompleted => {

--- a/crates/stella-cli/src/command_deck/settings_io.rs
+++ b/crates/stella-cli/src/command_deck/settings_io.rs
@@ -263,7 +263,13 @@ mod tests {
         // real server would advertise): the answer switches to the MCP set,
         // which never claims the registry-only tool by name.
         let mcp = stella_mcp::McpToolSet::connect(&[], std::time::Duration::from_secs(1)).await;
-        slot.set(std::sync::Arc::new(mcp)).unwrap();
+        // `is_ok()` rather than `unwrap()`: `OnceCell::set` hands back the
+        // value it refused, and `McpToolSet` is not `Debug`, so the unwrap
+        // does not compile.
+        assert!(
+            slot.set(std::sync::Arc::new(mcp)).is_ok(),
+            "the slot was empty a line ago, so this set cannot be refused"
+        );
         assert!(
             !names_of(live_tool_executor(&slot, &registry))
                 .contains(&"registry_only_tool".to_string()),

--- a/crates/stella-cli/src/command_deck/settings_io.rs
+++ b/crates/stella-cli/src/command_deck/settings_io.rs
@@ -19,6 +19,8 @@
 //! scope chain from disk, so what the overlay shows is what the files say,
 //! reloaded or not. Only *subsequent turns* depend on the live `Config`.
 
+use stella_core::ports::ToolExecutor;
+use stella_tools::custom::CustomTool;
 use stella_tui::{AgentScope, Inbound, WorkspaceInput};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -143,11 +145,50 @@ pub(super) fn reload_command(cfg: &mut Config, in_tx: &UnboundedSender<Inbound>)
     // Refresh an open SETTINGS tab with the merged view, the same courtesy
     // `/model` pays. The deck renders the last snapshot it was sent, so a
     // hand edit picked up by `/reload` is invisible in an open overlay until
-    // one arrives. The TOOLS panel is deliberately not refreshed here: an
-    // accurate row list needs the MCP-inclusive live stack, which this
-    // function does not hold (#1990).
+    // one arrives. The TOOLS panel is refreshed separately, at the driver
+    // loop's `DeckCommand::Reloaded` arm: an accurate row list needs the
+    // MCP-inclusive live stack, which this function does not hold (`#1990`).
     let _ = in_tx.send(engine_config_inbound(cfg, None));
     "configuration reloaded — engine, tools, and authority settings re-read from disk.".to_string()
+}
+
+/// Refresh an open TOOLS panel with the current, MCP-inclusive row list,
+/// sent as a fresh [`Inbound::ToolPolicy`] (`#1990`).
+///
+/// The list is built fresh each time, not cached: MCP servers join the
+/// session later, so the panel must ask what the stack holds right now.
+/// Only the driver loop holds `mcp_slot`, `registry`, and `custom_tools`
+/// together, so it calls this once a command marks the panel stale
+/// (`DeckCommand::Reloaded`, `DeckCommand::SettingsReloaded`).
+pub(super) fn refresh_tools_panel(
+    cfg: &Config,
+    mcp_slot: &tokio::sync::OnceCell<std::sync::Arc<stella_mcp::McpToolSet>>,
+    registry: &dyn ToolExecutor,
+    custom_tools: &[CustomTool],
+    in_tx: &UnboundedSender<Inbound>,
+) {
+    let names = crate::tool_switches::session_tool_names(
+        live_tool_executor(mcp_slot, registry),
+        custom_tools,
+    );
+    let _ = in_tx.send(tool_policy_inbound(cfg, &names, None));
+}
+
+/// Which tool executor is "the live stack" right now: the connected MCP
+/// set if one exists, the bare registry if not. Split out so this function
+/// and the driver loop's own between-prompts refresh give the same answer,
+/// checked by a test that needs no `Config` at all.
+///
+/// The boot-seed snapshot does not use this: MCP has not tried to connect
+/// yet at that point, so it always means the registry.
+pub(super) fn live_tool_executor<'a>(
+    mcp_slot: &'a tokio::sync::OnceCell<std::sync::Arc<stella_mcp::McpToolSet>>,
+    registry: &'a dyn ToolExecutor,
+) -> &'a dyn ToolExecutor {
+    match mcp_slot.get() {
+        Some(set) => set.as_ref(),
+        None => registry,
+    }
 }
 
 /// Re-derive the live [`Config`] from disk after a save, reporting a failure
@@ -164,5 +205,69 @@ pub(super) fn apply_pending_reload(cfg: &mut Config, in_tx: &UnboundedSender<Inb
         let _ = in_tx.send(super::chrome_note(format!(
             "settings saved, but reloading them failed: {e} — restart to pick them up."
         )));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use stella_protocol::tool::{ToolOutput, ToolSchema};
+
+    use super::*;
+
+    /// A base executor standing in for "registry" — enough to tell it apart
+    /// from an MCP set by name alone.
+    struct Base(&'static str);
+
+    #[async_trait]
+    impl ToolExecutor for Base {
+        fn schemas(&self) -> Vec<ToolSchema> {
+            vec![ToolSchema {
+                name: self.0.to_string(),
+                description: String::new(),
+                input_schema: serde_json::json!({}),
+                read_only: false,
+                speculation_safe: false,
+            }]
+        }
+        async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+            ToolOutput::Ok {
+                content: String::new(),
+                data: None,
+            }
+        }
+    }
+
+    fn names_of(executor: &dyn ToolExecutor) -> Vec<String> {
+        executor.schemas().into_iter().map(|s| s.name).collect()
+    }
+
+    /// `#1990`: this and the boot-seed code must answer "what is the live
+    /// tool stack" the same way — the bare registry, or the MCP set once one
+    /// connects. Without `live_tool_executor` as its own function, this test
+    /// cannot compile, because nothing here exists yet to call.
+    #[tokio::test]
+    async fn live_tool_executor_switches_to_the_connected_mcp_set() {
+        let registry = Base("registry_only_tool");
+        let slot: tokio::sync::OnceCell<std::sync::Arc<stella_mcp::McpToolSet>> =
+            tokio::sync::OnceCell::new();
+
+        // Nothing connected yet: the registry is the whole live stack.
+        assert_eq!(
+            names_of(live_tool_executor(&slot, &registry)),
+            vec!["registry_only_tool".to_string()]
+        );
+
+        // Connected (to nothing, here — the point is the *slot*, not what a
+        // real server would advertise): the answer switches to the MCP set,
+        // which never claims the registry-only tool by name.
+        let mcp = stella_mcp::McpToolSet::connect(&[], std::time::Duration::from_secs(1)).await;
+        slot.set(std::sync::Arc::new(mcp)).unwrap();
+        assert!(
+            !names_of(live_tool_executor(&slot, &registry))
+                .contains(&"registry_only_tool".to_string()),
+            "a connected (even empty) MCP set must replace the bare registry, not add to it"
+        );
     }
 }

--- a/crates/stella-cli/src/command_deck/shared_checkout.rs
+++ b/crates/stella-cli/src/command_deck/shared_checkout.rs
@@ -22,18 +22,43 @@
 //! holds each session's pid and tree and already reads a dead pid as a
 //! crash. A second file with the same three facts would be a second answer
 //! to one question.
+//!
+//! # The late arrival (`#5933`)
+//!
+//! [`announce`] runs once, at boot, before the deck's screen exists. That is
+//! why it prints to stderr instead of sending an [`Inbound`]. It warns the
+//! SECOND session, never the first. That is backwards: the first session
+//! holds the uncommitted work, and it is the second session's `git checkout`
+//! that reverts it.
+//!
+//! [`spawn_late_arrival_monitor`] is the fix. It runs inside the deck, once
+//! the deck has a channel to send through. It checks the session registry on
+//! a timer, not every frame, and tells the first session when a new peer
+//! shows up. It never refuses to start a turn, the same as [`announce`].
 
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use stella_store::{SessionRecord, SessionRegistry};
+use stella_tui::Inbound;
+use tokio::sync::mpsc::UnboundedSender;
 
 /// A live session that already holds this checkout.
+#[derive(Clone)]
 pub(super) struct Peer {
     /// The registry id, so the reader can find it in the SESSIONS view.
     id: String,
     /// The process that owns it.
     pid: u32,
+}
+
+impl Peer {
+    /// The registry id — what [`spawn_late_arrival_monitor`] diffs on.
+    pub(super) fn id(&self) -> &str {
+        &self.id
+    }
 }
 
 /// Every live session in `record`'s tree other than `record` itself.
@@ -106,6 +131,58 @@ pub(super) fn announce(registry: &SessionRegistry, record: &SessionRecord, root:
     if let Some(line) = notice(&peers, current_branch(root).as_deref()) {
         eprintln!("  ! {line}");
     }
+}
+
+/// Which of `current` were not in `previous`. Kept apart from the registry
+/// read so this can be tested on its own (`#5933`).
+fn newly_arrived<'a>(previous: &HashSet<String>, current: &'a [Peer]) -> Vec<&'a Peer> {
+    current
+        .iter()
+        .filter(|p| !previous.contains(p.id()))
+        .collect()
+}
+
+/// How often the deck checks the session registry for a new peer (`#5933`).
+/// The tab redraws about thirty times a second; the registry does not
+/// change that often, so this reads it on a slower timer instead.
+const LATE_ARRIVAL_POLL: Duration = Duration::from_secs(5);
+
+/// Watch for a peer that joins this checkout after this session started,
+/// and announce it through the deck's own channel.
+///
+/// Stops when the deck does: `in_tx` closes once the driver loop drops it.
+pub(super) fn spawn_late_arrival_monitor(
+    registry: SessionRegistry,
+    record: SessionRecord,
+    root: PathBuf,
+    in_tx: UnboundedSender<Inbound>,
+) {
+    tokio::spawn(async move {
+        // Start from the boot-time set, not empty. A peer `announce` already
+        // named must not get a second notice on the first tick.
+        let mut known: HashSet<String> = peers(&registry.list(), &record)
+            .iter()
+            .map(|p| p.id().to_string())
+            .collect();
+        let mut tick = tokio::time::interval(LATE_ARRIVAL_POLL);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            if in_tx.is_closed() {
+                break;
+            }
+            let records = registry.list();
+            let now = peers(&records, &record);
+            let arrived: Vec<Peer> = newly_arrived(&known, &now).into_iter().cloned().collect();
+            if !arrived.is_empty()
+                && let Some(line) = notice(&arrived, current_branch(&root).as_deref())
+                && in_tx.send(Inbound::Notice(line)).is_err()
+            {
+                break;
+            }
+            known = now.iter().map(|p| p.id().to_string()).collect();
+        }
+    });
 }
 
 #[cfg(test)]
@@ -196,5 +273,33 @@ mod tests {
     fn a_directory_that_is_not_a_repository_has_no_branch() {
         let dir = tempfile::tempdir().expect("tempdir");
         assert_eq!(current_branch(dir.path()), None);
+    }
+
+    /// **The witness (`#5933`).** Without `newly_arrived`, nothing tells a
+    /// session about a peer that starts later — `announce` runs once, at
+    /// boot. A peer already known is not named again. A new one is.
+    #[test]
+    fn newly_arrived_names_only_the_peer_the_last_check_did_not_see() {
+        let mine = live("ses-1", "/w/one");
+        let known_peer = live("ses-2", "/w/one");
+        let late_peer = live("ses-3", "/w/one");
+        let previous: HashSet<String> = [known_peer.id.clone()].into_iter().collect();
+        let now = peers(&[mine.clone(), known_peer, late_peer], &mine);
+
+        let arrived = newly_arrived(&previous, &now);
+        assert_eq!(arrived.len(), 1, "only the truly new peer is reported");
+        assert_eq!(arrived[0].id(), "ses-3");
+    }
+
+    /// With no prior check, every live peer counts as arrived. That is fine:
+    /// [`spawn_late_arrival_monitor`] fills `known` from `peers()` before
+    /// its first tick, so this case never fires and never repeats what
+    /// `announce` already said at boot.
+    #[test]
+    fn newly_arrived_with_no_prior_check_reports_everyone_live() {
+        let mine = live("ses-1", "/w/one");
+        let theirs = live("ses-2", "/w/one");
+        let now = peers(&[mine.clone(), theirs], &mine);
+        assert_eq!(newly_arrived(&HashSet::new(), &now).len(), 1);
     }
 }

--- a/crates/stella-cli/src/command_deck/slash_commands.rs
+++ b/crates/stella-cli/src/command_deck/slash_commands.rs
@@ -55,6 +55,16 @@ pub(super) enum DeckCommand {
     /// only the loop owns (the provider handle, the prompt plane, the lead's
     /// registered meta) — see `session_override`.
     SessionModel(String),
+    /// A settings write already answered locally — its own line printed, and
+    /// its own snapshot sent for the ENGINE overlay — but one that also
+    /// touches the TOOLS panel. `/model default <id>` is today's case. Skip
+    /// the turn and refresh TOOLS with a fresh, MCP-inclusive row list.
+    ///
+    /// Its own case, not folded into `Reloaded`: that one also reseats the
+    /// plugin panel deck (`#5253`), which a plain settings write never
+    /// causes. Carried to the driver loop because only it holds `mcp_slot`
+    /// (`#1990`).
+    SettingsReloaded,
 }
 
 // The deck's productized vocabulary (`DECK_BUILTINS`) and the
@@ -275,6 +285,11 @@ pub(super) async fn run_deck_command(
                                 say(msg);
                                 // Refresh an open SETTINGS tab with the merged view.
                                 let _ = in_tx.send(engine_config_inbound(cfg, None));
+                                // ...and an open TOOLS panel: a persisted
+                                // default model is a settings write like any
+                                // other, and the panel must not go stale
+                                // behind it (`#1990`).
+                                return DeckCommand::SettingsReloaded;
                             }
                             Err(msg) => say(msg),
                         }

--- a/crates/stella-cli/src/command_deck/tests.rs
+++ b/crates/stella-cli/src/command_deck/tests.rs
@@ -156,7 +156,7 @@ fn extract_skill_md_unwraps_a_fenced_block_or_frontmatter() {
 
 #[test]
 fn mcp_outcome_report_lists_connected_servers_by_name() {
-    let report = crate::mcp_cmd::mcp_outcome_report(&["files", "search"], &[], &[], &[], &[]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&["files", "search"], &[], &[], &[], &[], &[]);
     assert_eq!(report, "2 MCP server(s) connected: files, search");
 }
 
@@ -166,7 +166,7 @@ fn mcp_outcome_report_names_each_failure_with_its_reason() {
         "slow".to_string(),
         "connect timed out after 10000ms".to_string(),
     )];
-    let report = crate::mcp_cmd::mcp_outcome_report(&["files"], &failed, &[], &[], &[]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&["files"], &failed, &[], &[], &[], &[]);
     let lines: Vec<&str> = report.lines().collect();
     assert_eq!(lines[0], "1 MCP server(s) connected: files");
     assert_eq!(
@@ -178,7 +178,7 @@ fn mcp_outcome_report_names_each_failure_with_its_reason() {
 #[test]
 fn mcp_outcome_report_states_total_failure_outright() {
     let failed = vec![("a".to_string(), "spawn failed".to_string())];
-    let report = crate::mcp_cmd::mcp_outcome_report(&[], &failed, &[], &[], &[]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&[], &failed, &[], &[], &[], &[]);
     assert!(
         report.starts_with("no MCP servers connected"),
         "the degraded mode is stated, not implied: {report}"
@@ -191,7 +191,8 @@ fn mcp_outcome_report_states_total_failure_outright() {
 /// no consumer, so the model silently had fewer tools than the server offered.
 #[test]
 fn mcp_outcome_report_reports_a_truncated_server_as_connected_not_unavailable() {
-    let report = crate::mcp_cmd::mcp_outcome_report(&["greedy"], &[], &[("greedy", 12)], &[], &[]);
+    let report =
+        crate::mcp_cmd::mcp_outcome_report(&["greedy"], &[], &[("greedy", 12)], &[], &[], &[]);
     let lines: Vec<&str> = report.lines().collect();
     assert_eq!(lines[0], "1 MCP server(s) connected: greedy");
     assert!(
@@ -217,7 +218,7 @@ fn mcp_outcome_report_reports_a_truncated_server_as_connected_not_unavailable() 
 fn mcp_outcome_report_carries_truncation_and_failure_together() {
     let failed = vec![("dead".to_string(), "spawn failed".to_string())];
     let report =
-        crate::mcp_cmd::mcp_outcome_report(&["greedy"], &failed, &[("greedy", 3)], &[], &[]);
+        crate::mcp_cmd::mcp_outcome_report(&["greedy"], &failed, &[("greedy", 3)], &[], &[], &[]);
     assert!(report.contains("MCP server `dead` unavailable: spawn failed"));
     assert!(report.contains("`greedy` advertised more than"));
 }
@@ -229,7 +230,7 @@ fn mcp_outcome_report_carries_truncation_and_failure_together() {
 #[test]
 fn mcp_outcome_report_reports_a_schema_budget_trim_in_its_own_words() {
     let budgeted = vec![("verbose".to_string(), 4)];
-    let report = crate::mcp_cmd::mcp_outcome_report(&["verbose"], &[], &[], &budgeted, &[]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&["verbose"], &[], &[], &budgeted, &[], &[]);
     let lines: Vec<&str> = report.lines().collect();
     assert_eq!(lines[0], "1 MCP server(s) connected: verbose");
     assert!(
@@ -259,6 +260,7 @@ fn mcp_outcome_report_keeps_the_count_cap_and_the_byte_budget_distinct() {
         &[("greedy", 3)],
         &budgeted,
         &[],
+        &[],
     );
     assert!(report.contains("`greedy` advertised more than"), "{report}");
     assert!(
@@ -275,7 +277,7 @@ fn mcp_outcome_report_keeps_the_count_cap_and_the_byte_budget_distinct() {
 /// zero is noise that trains operators to ignore the real one.
 #[test]
 fn mcp_outcome_report_is_silent_when_nothing_was_truncated() {
-    let report = crate::mcp_cmd::mcp_outcome_report(&["files"], &[], &[], &[], &[]);
+    let report = crate::mcp_cmd::mcp_outcome_report(&["files"], &[], &[], &[], &[], &[]);
     assert_eq!(report, "1 MCP server(s) connected: files");
 }
 
@@ -292,7 +294,8 @@ fn mcp_outcome_report_names_every_claimant_of_a_contested_wire_name() {
             ("acme".to_string(), "_status".to_string()),
         ],
     }];
-    let report = crate::mcp_cmd::mcp_outcome_report(&["acme_", "acme"], &[], &[], &[], &collisions);
+    let report =
+        crate::mcp_cmd::mcp_outcome_report(&["acme_", "acme"], &[], &[], &[], &collisions, &[]);
     assert!(report.contains("`mcp__acme___status`"), "{report}");
     assert!(report.contains("`acme_` tool `status`"), "{report}");
     assert!(report.contains("`acme` tool `_status`"), "{report}");
@@ -303,6 +306,31 @@ fn mcp_outcome_report_names_every_claimant_of_a_contested_wire_name() {
     assert!(
         !report.contains("unavailable"),
         "claimant servers are connected, not down: {report}"
+    );
+}
+
+/// `#2802`: without the `auth_required` parameter, an auth-suppressed
+/// server stayed invisible in the deck's connect notice. Text mode already
+/// named the server and its login command; this test pins the shared
+/// wording so the two cannot drift apart again.
+#[test]
+fn mcp_outcome_report_names_an_auth_suppressed_server_with_its_login_command() {
+    let auth_required = vec![(
+        "linear".to_string(),
+        "server requires OAuth login".to_string(),
+    )];
+    let report = crate::mcp_cmd::mcp_outcome_report(&["files"], &[], &[], &[], &[], &auth_required);
+    assert!(
+        report.contains("MCP server `linear` requires authentication"),
+        "{report}"
+    );
+    assert!(
+        report.contains("stella mcp login linear"),
+        "the fix is named, not just the symptom: {report}"
+    );
+    assert!(
+        !report.contains("unavailable"),
+        "auth-suppressed is actionable, not the same word failed_servers uses: {report}"
     );
 }
 

--- a/crates/stella-cli/src/deck_mcp.rs
+++ b/crates/stella-cli/src/deck_mcp.rs
@@ -124,8 +124,16 @@ pub(crate) async fn mcp_snapshot(
                 kind: transport.kind_label().to_string(),
                 enabled,
                 connected: connected_now,
-                health: connected_now.then_some(health).flatten(),
-                latency_ms: connected_now.then_some(latency_ms).flatten(),
+                // NOT gated on `connected_now` (`#2802`): an auth-suppressed
+                // server is never connected but still carries a synthesized
+                // `AuthRequired` health row (`McpToolSet::health`) — the one
+                // state that matters most for a row with no live client. A
+                // genuinely unmonitored server (no client, no auth
+                // suppression, e.g. `failed`) has no row at all, so
+                // `health`/`latency_ms` are already `None` there without
+                // this gate's help.
+                health,
+                latency_ms,
                 granted: config.is_granted(name),
                 tool_count,
                 dropped_tools: dropped.get(name).copied().unwrap_or(0),

--- a/crates/stella-cli/src/export/transcript.rs
+++ b/crates/stella-cli/src/export/transcript.rs
@@ -631,6 +631,9 @@ fn note_kind(event: &AgentEvent) -> NoteKind {
         | AgentEvent::Pr { .. }
         | AgentEvent::MediaProgress { .. }
         | AgentEvent::MediaComplete { .. } => NoteKind::Handoff,
+        // Same fix as `note_kind` in `stella_tui::transcript_build`
+        // (`#5748`). An error must not look like a budget tick.
+        AgentEvent::Error { .. } | AgentEvent::SteeringWithheld { .. } => NoteKind::Alert,
         _ => NoteKind::Other,
     }
 }

--- a/crates/stella-cli/src/mcp_cmd.rs
+++ b/crates/stella-cli/src/mcp_cmd.rs
@@ -90,12 +90,19 @@ pub fn resolve_registry_url(workspace_root: &Path) -> String {
 /// connect order pick which server answers. Reported separately from `failed`
 /// for the same reason truncation is: the claimant servers are connected and
 /// their uncontested tools route normally.
+/// `auth_required` carries the servers skipped before connect, or refused
+/// with an HTTP 401, because this session lacks their login (`#2687`). Kept
+/// apart from `failed` for the same reason as the others: these servers can
+/// be fixed, not just retried. The deck's own notice missed this case until
+/// `#2802`; text mode already had it, and both now share
+/// [`auth_required_note`].
 pub(crate) fn mcp_outcome_report(
     connected: &[&str],
     failed: &[(String, String)],
     truncated: &[(&str, usize)],
     budgeted: &[(String, usize)],
     collisions: &[stella_mcp::WireNameCollision],
+    auth_required: &[(String, String)],
 ) -> String {
     let mut lines = match connected.len() {
         0 => vec!["no MCP servers connected — continuing with native tools only".to_string()],
@@ -120,13 +127,26 @@ pub(crate) fn mcp_outcome_report(
             .map(|(name, trimmed)| budget_note(name, *trimmed)),
     );
     lines.extend(collisions.iter().map(collision_note));
+    lines.extend(
+        auth_required
+            .iter()
+            .map(|(name, _)| auth_required_note(name)),
+    );
     lines.join("\n")
+}
+
+/// One server's login hint, shared by deck and text mode (`#2802`), the
+/// same as [`truncation_note`] and [`collision_note`]. Never "unavailable"
+/// — that word is [`mcp_outcome_report`]'s `failed`, and this server can be
+/// fixed.
+pub(crate) fn auth_required_note(name: &str) -> String {
+    format!("MCP server `{name}` requires authentication — run `stella mcp login {name}`")
 }
 
 /// The whole connect outcome for a live tool set, as one notice.
 ///
-/// The deck sends this straight to the chrome; unpacking the five accessors at
-/// the call site put the join in `command_deck.rs`, where a sixth diagnostic
+/// The deck sends this straight to the chrome; unpacking the six accessors at
+/// the call site put the join in `command_deck.rs`, where a seventh diagnostic
 /// meant editing a god file to add it.
 pub(crate) fn mcp_connect_report(set: &stella_mcp::McpToolSet) -> String {
     mcp_outcome_report(
@@ -135,6 +155,7 @@ pub(crate) fn mcp_connect_report(set: &stella_mcp::McpToolSet) -> String {
         &set.over_advertising_servers(),
         &set.over_budget_servers(),
         set.wire_name_collisions(),
+        set.auth_required_servers(),
     )
 }
 
@@ -212,10 +233,7 @@ pub(crate) fn print_connect_diagnostics(set: &stella_mcp::McpToolSet) {
     // Auth-suppressed servers (#2687) are actionable, not broken — say the
     // fix, never "unavailable" (which is what `failed_servers` renders as).
     for (name, _) in set.auth_required_servers() {
-        eprintln!(
-            "  {} MCP server `{name}` requires authentication — run `stella mcp login {name}`",
-            "!".yellow()
-        );
+        eprintln!("  {} {}", "!".yellow(), auth_required_note(name));
     }
     if set.connected_count() > 0 {
         println!(

--- a/crates/stella-cli/src/plain.rs
+++ b/crates/stella-cli/src/plain.rs
@@ -515,9 +515,9 @@ fn file_change_lines(
 ///
 /// `ToolStart`/`ToolResult` are intentionally a no-op here: `ToolResult`
 /// doesn't carry the tool's name (only `call_id`), so the call site keeps a
-/// small `call_id -> name` map and calls `tool_call_card`/`tool_result_card`
-/// directly instead of routing those two through this function — see
-/// `agent.rs`'s event-draining task. Every other event kind (including
+/// [`stella_tui::tool_call_index::ToolCallIndex`] (`#2450`, shared with the
+/// deck) and calls `tool_call_card`/`tool_result_card` directly instead —
+/// see `agent.rs`'s event-draining task. Every other event kind (including
 /// `Text` — the engine emits one per step, not just at turn-end, since a
 /// step with tool calls can still carry commentary text) is rendered here.
 ///

--- a/crates/stella-mcp/src/registry.rs
+++ b/crates/stella-mcp/src/registry.rs
@@ -168,9 +168,14 @@ impl SignatureStatus {
     }
 
     /// The short label the MCP tab renders beside the row.
+    ///
+    /// `"attributed"`, not `"signed"` (`#5176`). The registry vouches for
+    /// the publisher's *namespace*. It never checks a signature over the
+    /// package bytes. "Signed" claims that check, which this state has not
+    /// earned.
     pub fn label(self) -> &'static str {
         match self {
-            SignatureStatus::Signed => "signed",
+            SignatureStatus::Signed => "attributed",
             SignatureStatus::Unsigned => "unsigned · blocked",
             SignatureStatus::Withdrawn(_) => "withdrawn · blocked",
         }
@@ -883,6 +888,19 @@ mod tests {
         assert_ne!(
             signature_status("com.stripe/mcp", Some("deprecated")).label(),
             signature_status("com.stripe/mcp", None).label()
+        );
+    }
+
+    /// `#5176`: the label must not claim more than the namespace check
+    /// establishes. This test guards against `"signed"`, a word for a
+    /// check this code never runs.
+    #[test]
+    fn an_attributed_entry_does_not_render_as_signed() {
+        let label = signature_status("com.stripe/mcp", Some("active")).label();
+        assert_eq!(label, "attributed");
+        assert!(
+            !label.contains("signed"),
+            "the row must not claim a byte-level signature nothing verified: {label}"
         );
     }
 

--- a/crates/stella-transcript/src/grid.rs
+++ b/crates/stella-transcript/src/grid.rs
@@ -552,6 +552,7 @@ fn note_color(kind: crate::model::NoteKind) -> Color {
         NoteKind::Meter | NoteKind::Other => Color::Dim,
         NoteKind::Wait | NoteKind::Verdict => Color::Amber,
         NoteKind::Handoff => Color::Cyan,
+        NoteKind::Alert => Color::Red,
     }
 }
 

--- a/crates/stella-transcript/src/html/transcript.css
+++ b/crates/stella-transcript/src/html/transcript.css
@@ -358,6 +358,9 @@ details[open] > summary .chev { transform: rotate(90deg); }
 .note-wait .notegut, .note-verdict .notegut { color: var(--amber); }
 .note-handoff .notegut { color: var(--gold); }
 .note-meter .notegut { color: var(--gold); }
+.note-alert .notegut, .note-alert .note-summary, .note-alert .note-fold > summary {
+  color: var(--red);
+}
 
 /* The prompt-inspect control a metering note carries. Hidden by default so a
    standalone transcript — which has no script and no receipt store — never

--- a/crates/stella-transcript/src/model.rs
+++ b/crates/stella-transcript/src/model.rs
@@ -641,6 +641,11 @@ pub enum NoteKind {
     Verdict,
     /// Work handed elsewhere: sub-agents, commits, pull requests, media.
     Handoff,
+    /// Something went wrong: a turn error, or withheld steering advice.
+    /// Louder than [`NoteKind::Verdict`] on purpose. This is not a
+    /// judgement about finished work. Do not read it as a budget tick
+    /// (`#5748`).
+    Alert,
     /// Anything this crate has never heard of.
     Other,
 }
@@ -656,6 +661,7 @@ impl NoteKind {
             NoteKind::Wait => "⏸",
             NoteKind::Verdict => "⚑",
             NoteKind::Handoff => "↳",
+            NoteKind::Alert => "✗",
             NoteKind::Other => "·",
         }
     }
@@ -670,6 +676,7 @@ impl NoteKind {
             NoteKind::Wait => "wait",
             NoteKind::Verdict => "verdict",
             NoteKind::Handoff => "handoff",
+            NoteKind::Alert => "alert",
             NoteKind::Other => "other",
         }
     }

--- a/crates/stella-tui/src/deck_render.rs
+++ b/crates/stella-tui/src/deck_render.rs
@@ -711,15 +711,25 @@ fn render_inspect_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
     };
     Clear.render(popup, buf);
 
+    // The width a banner line has once the block's own border is drawn (one
+    // column each side). Every free-text line below wraps at this width
+    // instead of clipping (`#2029`). The wrap makes real `Line`s here, not a
+    // `Paragraph::wrap` call: this popup scrolls by row offset, and
+    // `push_wrapped`'s own doc explains why that scroll needs one `Line`
+    // per row.
+    let banner_width = (w as usize).saturating_sub(2);
+
     let mut lines: Vec<Line<'static>> = Vec::new();
     let title;
 
     if ui.inspect_pending && ui.inspect_view.is_none() {
         title = " inspect · reconstructing ";
-        lines.push(Line::from(Span::styled(
+        push_wrapped_banner(
+            &mut lines,
             "  reconstructing the call's context from the recorded receipt…",
             theme::text_secondary(),
-        )));
+            banner_width,
+        );
     } else if let Some(view) = ui.inspect_view.as_ref() {
         // Borrowed, never cloned and never moved out: a reconstructed context
         // is a whole prompt (up to a full window of messages) and the deck
@@ -729,48 +739,57 @@ fn render_inspect_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
         // (see `crate::panel_guard`); a shared borrow avoids both.
         title = " inspect · context sent ";
         let call = &view.call;
-        lines.push(Line::from(Span::styled(
-            format!(
+        push_wrapped_banner(
+            &mut lines,
+            &format!(
                 "  turn {} · step {} · call-seq {} · {}",
                 call.turn_instance, call.step, call.call_seq, call.call_role
             ),
             theme::accent().add_modifier(Modifier::BOLD),
-        )));
-        lines.push(Line::from(Span::styled(
-            format!(
+            banner_width,
+        );
+        push_wrapped_banner(
+            &mut lines,
+            &format!(
                 "  {} / {} · {} message(s)",
                 call.provider,
                 call.model,
                 view.messages.len()
             ),
             theme::text_secondary(),
-        )));
+            banner_width,
+        );
         // Never merged: unresolved is a coverage gap, a mismatch means the
         // recovered bytes are not this block's. The gap is never phrased as
         // tampering — it is a documented coverage boundary, not a signal.
         if view.unresolved > 0 {
-            lines.push(Line::from(Span::styled(
-                format!(
+            push_wrapped_banner(
+                &mut lines,
+                &format!(
                     "  ! {} block(s) unresolved — synthetic results, discarded speculation, \
                      or attachments",
                     view.unresolved
                 ),
                 Style::default().fg(theme::WARN),
-            )));
+                banner_width,
+            );
         }
         // A mismatch means one of two things depending on who wrote the
         // journal, and `InspectView` (not this renderer) holds that verdict —
-        // see `envelope::InspectView::digest_mismatch_line`, which also keeps
-        // both variants short enough to survive this overlay's clip (#1981).
+        // see `envelope::InspectView::digest_mismatch_line`. Wrapped like
+        // every other banner line here (`#2029`), so its wording does not
+        // have to fit unaided (`#1981`'s original constraint).
         if let Some((text, alarm)) = view.digest_mismatch_line() {
             let tone = if alarm { theme::DANGER } else { theme::WARN };
-            lines.push(Line::from(Span::styled(text, Style::default().fg(tone))));
+            push_wrapped_banner(&mut lines, &text, Style::default().fg(tone), banner_width);
         }
         if view.verified {
-            lines.push(Line::from(Span::styled(
+            push_wrapped_banner(
+                &mut lines,
                 "  verified · every journal-resolved block re-hashed to its recorded digest",
                 Style::default().fg(theme::SUCCESS),
-            )));
+                banner_width,
+            );
         }
         let body_width = (w as usize).saturating_sub(6);
         for (index, message) in view.messages.iter().enumerate() {
@@ -804,28 +823,38 @@ fn render_inspect_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
             }
         }
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(
+        push_wrapped_banner(
+            &mut lines,
             " ↑/↓ pgup/pgdn scroll · esc/← back to calls · q close",
             theme::text_secondary(),
-        )));
+            banner_width,
+        );
     } else {
         title = " inspect · recorded calls ";
-        lines.push(Line::from(Span::styled(
+        push_wrapped_banner(
+            &mut lines,
             "  every model call this execution recorded a receipt for",
             theme::text_secondary(),
-        )));
+            banner_width,
+        );
         lines.push(Line::default());
         if ui.inspect_calls.is_empty() {
-            lines.push(Line::from(Span::styled(
+            push_wrapped_banner(
+                &mut lines,
                 "    no receipts for this execution yet — run a turn, then reopen",
                 theme::text_secondary(),
-            )));
+                banner_width,
+            );
         } else {
             lines.push(Line::from(Span::styled(
                 "    TURN  STEP  SEQ  ROLE            PROVIDER    MODEL",
                 theme::text_secondary(),
             )));
         }
+        // How many rows come before the call list. Used below to find the
+        // selected row without assuming a fixed count, now that a banner
+        // above can wrap onto more than one row (`#2029`).
+        let rows_before_calls = lines.len();
         for (index, call) in ui.inspect_calls.iter().enumerate() {
             let selected = index == ui.inspect_sel;
             let style = if selected {
@@ -833,6 +862,9 @@ fn render_inspect_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
             } else {
                 Style::default().fg(theme::INK)
             };
+            // A fixed-width table row, not a banner: wrapping it would break
+            // its own column headers. A long value elides here instead,
+            // through `columns::head`.
             lines.push(Line::from(Span::styled(
                 format!(
                     "  {} {:>4}  {:>4}  {:>3}  {:<14}  {:<10}  {}",
@@ -848,17 +880,18 @@ fn render_inspect_overlay(ui: &mut DeckUi, area: Rect, buf: &mut Buffer) {
             )));
         }
         lines.push(Line::default());
-        lines.push(Line::from(Span::styled(
+        push_wrapped_banner(
+            &mut lines,
             " ↑/↓ select · ⏎ show the context it was sent · r refresh · esc close",
             theme::text_secondary(),
-        )));
+            banner_width,
+        );
         // The whole popup scrolls by `inspect_scroll`, and the list-mode key
-        // handler only moves `inspect_sel` — it never touches the scroll. Track
-        // the selection here so the `›` row stays on-screen when the call list
-        // is taller than the popup. The rows are preceded by three fixed lines
-        // (title · blank · header), so the selected row is at `3 + inspect_sel`.
+        // handler only moves `inspect_sel` — it never touches the scroll.
+        // Track the selection here so the `›` row stays on-screen when the
+        // call list is taller than the popup.
         let inner_h = (h as usize).saturating_sub(2);
-        let sel_line = 3 + ui.inspect_sel;
+        let sel_line = rows_before_calls + ui.inspect_sel;
         ui.inspect_scroll = scroll_window_start(lines.len(), sel_line, inner_h);
     }
 
@@ -894,6 +927,18 @@ fn push_wrapped(lines: &mut Vec<Line<'static>>, body: &str, width: usize) {
                 Style::default().fg(theme::INK),
             )));
         }
+    }
+}
+
+/// Push one banner/status line, hard-wrapped at `width` (`#2029`) instead
+/// of left to clip at the popup's edge. No added indent on a continuation
+/// row: `wrap_chars` already fills each chunk to `width`.
+///
+/// One `Line` per row, same as `push_wrapped`, so `ui.inspect_scroll` still
+/// matches what is on screen.
+fn push_wrapped_banner(lines: &mut Vec<Line<'static>>, text: &str, style: Style, width: usize) {
+    for chunk in wrap_chars(text, width) {
+        lines.push(Line::from(Span::styled(chunk, style)));
     }
 }
 

--- a/crates/stella-tui/src/envelope/inspect.rs
+++ b/crates/stella-tui/src/envelope/inspect.rs
@@ -114,14 +114,11 @@ impl InspectView {
     /// The overlay's mismatch line and whether it is a genuine integrity
     /// signal, or `None` when nothing mismatched.
     ///
-    /// The wording lives here rather than in the renderer for two reasons.
-    /// `deck_render.rs` is a god file at its ceiling, so a second branch there
-    /// costs lines it does not have; and the overlay **clips** rather than
-    /// wraps, so each variant has to be short enough to survive the right edge
-    /// intact — which is a property of the string, testable here, not of the
-    /// draw call. Both variants stay under 80 columns and put the *meaning*
-    /// before the detail, so the part that distinguishes them survives even on
-    /// the narrowest terminal the popup can be drawn in.
+    /// The wording lives here, not in the renderer, because it is about
+    /// meaning, not the draw call. `deck_render.rs` wraps every banner line
+    /// it draws (`#2029`), so this text can run past one row. It still puts
+    /// the meaning first, so a reader sees which kind of mismatch this is
+    /// before the wrap point.
     ///
     /// A legacy journal's mismatch stays the benign warning #1668 introduced,
     /// naming compaction as the cause. A journal that records every rewrite
@@ -149,17 +146,17 @@ impl InspectView {
 mod tests {
     use super::*;
 
-    /// The INSPECT overlay clips rather than wraps, and its popup is
-    /// `min(frame - 6, 120)` columns wide — so on an 80-column terminal a
-    /// banner line has about 72 to work with. Both variants are written to
-    /// that budget and put the meaning first; this pins it, because a wording
-    /// change that silently pushes the distinguishing half off the right edge
-    /// would undo #1981 without failing anything else (see #2029).
+    /// Each era's mismatch line names its own count and its own meaning
+    /// (compaction rewrite vs. unaccounted for), at any length. There is no
+    /// column budget to hold it to: `deck_render.rs` wraps every banner
+    /// line it draws (`#2029`). The old eighty-column check this test made
+    /// is gone with that limit, and named in this PR's description, the
+    /// same as `check-deleted-tests` asks.
     #[test]
-    fn both_mismatch_lines_survive_an_eighty_column_terminal() {
-        for era in [
-            JournalEra::CompactionUnjournaled,
-            JournalEra::CompactionJournaled,
+    fn each_era_names_its_own_count_and_meaning() {
+        for (era, meaning) in [
+            (JournalEra::CompactionUnjournaled, "compaction rewrite"),
+            (JournalEra::CompactionJournaled, "unaccounted for"),
         ] {
             let view = InspectView {
                 call: RecordedCallInfo {
@@ -178,7 +175,8 @@ mod tests {
                 journal_era: era,
             };
             let (line, _) = view.digest_mismatch_line().expect("a mismatch is reported");
-            assert!(line.chars().count() <= 72, "{} cols: {line}", line.len());
+            assert!(line.contains("999"), "{line}");
+            assert!(line.contains(meaning), "{line}");
         }
     }
 }

--- a/crates/stella-tui/src/envelope/mcp.rs
+++ b/crates/stella-tui/src/envelope/mcp.rs
@@ -40,7 +40,11 @@ pub struct McpServerInfo {
     /// reachable). A newly-installed server shows `configured` but not
     /// `connected` until the next session.
     pub connected: bool,
-    /// Short health label when connected (e.g. `live`, `reconnecting`).
+    /// Short health label (e.g. `live`, `reconnecting`, `auth required`).
+    /// Not gated on [`Self::connected`] (`#2802`): an auth-suppressed server
+    /// has no client and so is never connected, but it still carries a
+    /// synthesized `auth required` row — the one state a reader most needs
+    /// for a server with no live connection.
     pub health: Option<String>,
     /// Round-trip time of the connect handshake's `initialize` request, in
     /// whole milliseconds — SPEC §9.3's latency column.
@@ -184,9 +188,12 @@ impl McpSignature {
 
     /// The label the row renders. The blocked states carry the word `blocked`
     /// rather than relying on the red alone (SPEC §13).
+    ///
+    /// `"attributed"`, not `"signed"` (`#5176`) — see
+    /// `stella_mcp::SignatureStatus::label` for why.
     pub fn label(self) -> &'static str {
         match self {
-            McpSignature::Signed => "signed",
+            McpSignature::Signed => "attributed",
             McpSignature::Unsigned => "unsigned · blocked",
             McpSignature::Withdrawn => "withdrawn · blocked",
         }

--- a/crates/stella-tui/src/lib.rs
+++ b/crates/stella-tui/src/lib.rs
@@ -88,6 +88,7 @@ pub mod splash;
 pub mod start_work;
 pub mod syntax;
 pub mod theme;
+pub mod tool_call_index;
 pub mod tool_class;
 pub mod transcript_build;
 pub mod transcript_nav;

--- a/crates/stella-tui/src/render/tests/spine.rs
+++ b/crates/stella-tui/src/render/tests/spine.rs
@@ -14,8 +14,9 @@
 //!
 //! [`declared`] covers every kind, so a new one stops this file from building
 //! until somebody says what sends it. A kind nothing sends is allowed and
-//! names the issue that will settle it. `EventKind::Gate` is the only one
-//! (`#5651`).
+//! names the issue that will settle it — SPEC 6.3's `gate` row was the one
+//! standing example (`EventKind::Gate`), and `#5651` deleted the kind rather
+//! than give it a sender, since the engine only ever emits a whole board.
 
 use super::*;
 use crate::tool_class::ToolClass;
@@ -23,11 +24,15 @@ use crate::views::transcript::{EventKind, Extent};
 use stella_protocol::{MemoryClass, ModelCallRole, SkillTrigger, TaskId, ToolCall};
 
 /// What draws one head kind.
+///
+/// `Gap(u32)` — nothing sends one, and the number of the issue that settles
+/// it — is not one of the options below. It was `EventKind::Gate`'s,
+/// removed with the kind in `#5651`. Reintroduce it the day a new kind
+/// again ships with no wire event behind it; until then a second option
+/// nothing ever constructs is dead code, not a declared gap.
 enum Producer {
     /// A wire event a session sends.
     Live,
-    /// Nothing sends one, and the number of the issue that settles it.
-    Gap(u32),
 }
 
 /// What draws `kind`.
@@ -49,11 +54,6 @@ fn declared(kind: &EventKind) -> Producer {
         | EventKind::Model { .. }
         | EventKind::Compaction { .. }
         | EventKind::Other { .. } => Producer::Live,
-        // SPEC 6.3's lone gate row. The engine sends a whole board
-        // (`AgentEvent::GateBoard`), never one gate, so no fold can build this
-        // head. `#5651` picks between routing the board through it and
-        // dropping the kind.
-        EventKind::Gate { .. } => Producer::Gap(5651),
     }
 }
 
@@ -333,22 +333,25 @@ fn a_live_tool_head_carries_the_task_tag_the_wire_stamped() {
     );
 }
 
-/// The one head nothing sends stays out of the table above and names the
-/// issue that will settle it.
+/// `#5651`: `EventKind::Gate` is gone, and with it the copy of the gate
+/// board's price text that could never be reached (nothing built one).
+/// Before that deletion `views/transcript.rs`'s `kind_detail` carried its
+/// own `" · $0.00 · det"` literal beside `gate_board.rs`'s live one — two
+/// implementations of one fact, only one of which a session could ever see
+/// drift — which is what this test asserts against and would have failed on.
 #[test]
-fn the_gate_head_has_no_wire_event_and_names_its_issue() {
-    assert!(
-        !live()
-            .iter()
-            .any(|row| matches!(row.kind, EventKind::Gate { .. })),
-        "a gate row is listed as live, so it has a sender and belongs in `live`"
+fn the_deterministic_gate_price_is_built_in_exactly_one_place() {
+    let transcript_src = include_str!("../../views/transcript.rs");
+    let gate_board_src = include_str!("../../views/gate_board.rs");
+    let needle = "\" · $0.00 · det\"";
+    assert_eq!(
+        transcript_src.matches(needle).count(),
+        0,
+        "views/transcript.rs builds the gate board's own price literal again"
     );
-    let gate = EventKind::Gate {
-        state: "green".into(),
-        deterministic: true,
-    };
-    match declared(&gate) {
-        Producer::Gap(issue) => assert!(issue > 0, "a gap has to name its issue: {issue}"),
-        Producer::Live => panic!("a gate head has a sender now, so it belongs in `live`"),
-    }
+    assert_eq!(
+        gate_board_src.matches(needle).count(),
+        1,
+        "the price literal should live in gate_board.rs's live renderer alone"
+    );
 }

--- a/crates/stella-tui/src/tool_call_index.rs
+++ b/crates/stella-tui/src/tool_call_index.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! One `call_id -> name` lookup, shared by every surface that needs it
+//! (`#2450`).
+//!
+//! `AgentEvent::ToolResult` names only the `call_id` it answers. The tool's
+//! own name is on the matching `ToolStart`, sent earlier. Any surface that
+//! labels a result row must save the pairing itself. Each surface kept its
+//! own copy: the interactive terminal scans its saved log for the match,
+//! and the plain-text renderer kept a private map at its own call site.
+//!
+//! That is the copy `#2421` closes: two copies of one fact, free to drift
+//! apart. A third caller — a future format, or a remote host — would need a
+//! third copy. This type is the one to share instead.
+//!
+//! It holds two fields: a tool's name and its sub-agent id. That is all a
+//! result card needs. The interactive terminal's own lookup finds more (a
+//! file path, a plan-gate refusal) and keeps doing that. This type does not
+//! replace it.
+
+use std::collections::HashMap;
+
+/// What one `ToolStart` recorded, kept until its `ToolResult` arrives.
+struct Started {
+    name: String,
+    sub_agent_id: Option<String>,
+}
+
+/// The `call_id -> (name, sub_agent_id)` table. Insert on `ToolStart`, read
+/// on `ToolResult`.
+#[derive(Default)]
+pub struct ToolCallIndex {
+    started: HashMap<String, Started>,
+}
+
+/// The name a `ToolResult` gets when this table has no matching `ToolStart`
+/// — a resumed session with a gap in its log, say. A caller can always
+/// print this; it never has to unwrap an absent value.
+pub const UNKNOWN_TOOL_NAME: &str = "tool";
+
+impl ToolCallIndex {
+    /// A table with nothing recorded yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record one call's name (and its sub-agent, if it has one). A second
+    /// `ToolStart` for the same `call_id` replaces the first, since the wire
+    /// never sends two.
+    pub fn observe_start(&mut self, call_id: &str, name: &str, sub_agent_id: Option<&str>) {
+        self.started.insert(
+            call_id.to_string(),
+            Started {
+                name: name.to_string(),
+                sub_agent_id: sub_agent_id.map(str::to_string),
+            },
+        );
+    }
+
+    /// The name and sub-agent a `ToolResult` for `call_id` belongs to.
+    ///
+    /// A plain lookup, not a `take`: reading the same `call_id` twice gives
+    /// the same answer both times, so a re-render of an old result still
+    /// labels it correctly.
+    #[must_use]
+    pub fn resolve(&self, call_id: &str) -> (&str, Option<&str>) {
+        self.started
+            .get(call_id)
+            .map(|s| (s.name.as_str(), s.sub_agent_id.as_deref()))
+            .unwrap_or((UNKNOWN_TOOL_NAME, None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **The witness (`#2450`).** Without this type, this test cannot even
+    /// compile: nothing offers one lookup shared across surfaces. Once it
+    /// compiles, this is the contract every caller gets.
+    #[test]
+    fn a_result_resolves_the_name_and_sub_agent_its_start_recorded() {
+        let mut index = ToolCallIndex::new();
+        index.observe_start("call-1", "edit_file", Some("worker-a"));
+        index.observe_start("call-2", "read_file", None);
+
+        assert_eq!(index.resolve("call-1"), ("edit_file", Some("worker-a")));
+        assert_eq!(index.resolve("call-2"), ("read_file", None));
+    }
+
+    /// A result with no matching start gets a safe placeholder name, not a
+    /// crash.
+    #[test]
+    fn an_unseen_call_id_resolves_to_the_unknown_placeholder() {
+        let index = ToolCallIndex::new();
+        assert_eq!(index.resolve("never-started"), (UNKNOWN_TOOL_NAME, None));
+    }
+
+    /// A second start for one call id replaces the first. There is only one
+    /// slot, so the newest start is the one a later result answers.
+    #[test]
+    fn a_second_start_for_one_call_id_replaces_the_first() {
+        let mut index = ToolCallIndex::new();
+        index.observe_start("call-1", "read_file", None);
+        index.observe_start("call-1", "edit_file", Some("worker-a"));
+        assert_eq!(index.resolve("call-1"), ("edit_file", Some("worker-a")));
+    }
+}

--- a/crates/stella-tui/src/transcript_build.rs
+++ b/crates/stella-tui/src/transcript_build.rs
@@ -498,6 +498,13 @@ fn note_kind(event: &AgentEvent) -> NoteKind {
         | AgentEvent::Pr { .. }
         | AgentEvent::MediaProgress { .. }
         | AgentEvent::MediaComplete { .. } => NoteKind::Handoff,
+        // Louder than a budget tick on purpose: the live deck bolds and
+        // colors both of these (`render/entry.rs`), so the plain and
+        // exported forms must not mute them to the same glyph (`#5748`).
+        AgentEvent::Error { .. } | AgentEvent::SteeringWithheld { .. } => NoteKind::Alert,
+        // `Steered` stays in the wildcard on purpose: the live deck folds it
+        // into a full user-turn row, not a note, and the plain `Note` model
+        // has no such row to match it with (`#5748`).
         _ => NoteKind::Other,
     }
 }

--- a/crates/stella-tui/src/transcript_build/tests.rs
+++ b/crates/stella-tui/src/transcript_build/tests.rs
@@ -543,3 +543,27 @@ fn note_kind_classifies_one_event_from_every_reachable_family() {
         );
     }
 }
+
+/// `#5748`: without this classification, `Error` and `SteeringWithheld`
+/// fall into the `_` wildcard and render as the same muted `NoteKind::Other`
+/// glyph a budget tick gets. Both classify as `NoteKind::Alert`, distinct
+/// from `Other` and from each other's sibling severities.
+#[test]
+fn error_and_steering_withheld_classify_louder_than_other() {
+    let error = AgentEvent::Error {
+        message: "boom".to_string(),
+        retryable: false,
+    };
+    let steering = AgentEvent::SteeringWithheld {
+        withheld_by: stella_protocol::Withholder::ProjectUntrusted,
+        memories: 0,
+        records: 0,
+        skills: 0,
+        commands: 0,
+        agents: 0,
+    };
+    assert_eq!(note_kind(&error), NoteKind::Alert);
+    assert_ne!(note_kind(&error), NoteKind::Other);
+    assert_eq!(note_kind(&steering), NoteKind::Alert);
+    assert_ne!(note_kind(&steering), NoteKind::Other);
+}

--- a/crates/stella-tui/src/views/files_tab.rs
+++ b/crates/stella-tui/src/views/files_tab.rs
@@ -399,7 +399,8 @@ fn render_diff_pane(
     // footer could disagree about one file.
     let (added, removed) = record.map(|r| (r.added, r.removed)).unwrap_or((0, 0));
     match diff_text {
-        Some((text, current)) if !text.is_empty() => {
+        Some(shown) if !shown.text.is_empty() => {
+            let text = shown.text;
             // A viewer scrolls, so its budget is the generous one — but it is
             // still a budget: a generated file arrives as one hunk of
             // thousands of `+` lines, and this pane re-renders on every frame.
@@ -416,7 +417,7 @@ fn render_diff_pane(
             // of which can fail), and showing the previous diff under the
             // footer's cumulative counts without a word would be the same
             // quiet mismatch this pane already has too much of (#1741, #1740).
-            if !current {
+            if !shown.current {
                 lines.insert(
                     0,
                     Line::from(Span::styled(
@@ -424,6 +425,21 @@ fn render_diff_pane(
                          reported no diff)",
                         Style::new().fg(token::MUTED),
                     )),
+                );
+            } else if shown.changes > 1 {
+                // The common `#1740` case: this is the latest mutation's own
+                // diff, but the footer sums every mutation of this path.
+                // Say which one, and its own delta when known, so the
+                // footer's total is not read as a count of the lines shown.
+                let label = match shown.latest_delta {
+                    Some((a, r)) => {
+                        format!("(latest of {} changes here · +{a} -{r})", shown.changes)
+                    }
+                    None => format!("(latest of {} changes here)", shown.changes),
+                };
+                lines.insert(
+                    0,
+                    Line::from(Span::styled(label, Style::new().fg(token::MUTED))),
                 );
             }
             let total = lines.len();
@@ -447,14 +463,42 @@ fn render_diff_pane(
     Paragraph::new(diff::footer_line(added, removed, w)).render(bands[2], buf);
 }
 
+/// What [`find_diff`] found, plus enough of the path's mutation history to
+/// say whether it is the whole story (`#1740`).
+struct DiffShown<'a> {
+    text: &'a str,
+    /// True when `text` is the newest mutation's own diff. False when an
+    /// older one is shown because the newest brought none —
+    /// [`crate::model::FileState::best_diff`].
+    current: bool,
+    /// This path's total mutation count —
+    /// [`crate::model::FileState::changes`]. The footer sums every one; the
+    /// body shows only one.
+    changes: u32,
+    /// The shown mutation's own delta, when `current` is true (the back of
+    /// [`crate::model::FileState::recent_diffs`]). Left unset for the
+    /// `!current` case, which already has its own message.
+    latest_delta: Option<(u32, u32)>,
+}
+
 /// The diff TEXT for a ledger record: found via the owning agent's
-/// `SessionModel::files[].latest_diff()` (`deck.rs` L-T5) — never re-derived.
+/// `SessionModel::files[].best_diff()` (`deck.rs` L-T5) — never re-derived.
 /// Borrowed, not cloned: this runs on every ~30 fps frame the diff pane is
 /// open, and a single mutation's diff can be hundreds of KiB.
-fn find_diff<'a>(model: &'a WorkspaceModel, rec: &FileRecord) -> Option<(&'a str, bool)> {
+fn find_diff<'a>(model: &'a WorkspaceModel, rec: &FileRecord) -> Option<DiffShown<'a>> {
     let agent = model.agents.iter().find(|a| a.meta.id == rec.agent)?;
     let file = agent.model.files.iter().find(|f| f.path == rec.path)?;
-    file.best_diff()
+    let (text, current) = file.best_diff()?;
+    let latest_delta = current
+        .then(|| file.recent_diffs.back())
+        .flatten()
+        .map(|d| (d.added, d.removed));
+    Some(DiffShown {
+        text,
+        current,
+        changes: file.changes,
+        latest_delta,
+    })
 }
 
 #[cfg(test)]
@@ -738,6 +782,69 @@ mod tests {
             text.contains("earlier change"),
             "shown, but labelled — an older diff under the footer's cumulative \
              counts with no note is the mismatch #1740 is about:\n{text}"
+        );
+    }
+
+    /// **Witness (`#1740`'s reported shape).** Four mutations of one path,
+    /// each with its own diff. The footer sums all four (`+64 -6`); the
+    /// body renders only the latest one's text (`+13 -4`). This test
+    /// checks for the label that says so. It is a different case from the
+    /// `!current` branch above (a mutation with no diff at all), since
+    /// every mutation here has one, so a pane with no such label draws
+    /// nothing here and this test fails.
+    #[test]
+    fn a_footer_summing_several_mutations_labels_which_one_the_body_shows() {
+        let mut model = sample_model();
+        for (added, removed, tail) in [(1u32, 1u32, "third"), (13, 4, "fourth")] {
+            model.apply_inbound(&Inbound::Event {
+                agent: "lead".into(),
+                event: AgentEvent::FileChange {
+                    path: "src/existing.rs".into(),
+                    kind: FileChangeKind::Modified,
+                    added,
+                    removed,
+                    diff: Some(format!("@@ -1,1 +1,1 @@\n-old\n+{tail}\n")),
+                    minimal: true,
+                    task_id: None,
+                },
+            });
+        }
+        // sample_model's own +2/-1, then +1/-1 and +13/-4 above: cumulative
+        // +16/-6 over 3 mutations, the last one alone +13/-4.
+        let record = model
+            .ledger
+            .records
+            .iter()
+            .find(|r| r.path == "src/existing.rs")
+            .expect("the ledger keeps the row");
+        assert_eq!((record.added, record.removed), (16, 6));
+
+        let mut ui = DeckUi::default();
+        ui.files_sel = 1; // "existing.rs"
+        ui.files_diff_open = true;
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        render(&model, &mut ui, area, &mut buf);
+        let text = buffer_text(&buf);
+
+        assert!(
+            text.contains("fourth"),
+            "the body shows the LATEST mutation's own diff:\n{text}"
+        );
+        assert!(
+            !text.contains("third"),
+            "not an earlier one — that is the `!current` case, tested \
+             separately:\n{text}"
+        );
+        assert!(
+            text.contains("latest of 3 changes"),
+            "the body must say it is one of several, matching the ledger's \
+             own mutation count:\n{text}"
+        );
+        assert!(
+            text.contains("+13") && text.contains("-4"),
+            "and name that one mutation's own delta, not the footer's \
+             cumulative +16 -6:\n{text}"
         );
     }
 

--- a/crates/stella-tui/src/views/mcp_tab.rs
+++ b/crates/stella-tui/src/views/mcp_tab.rs
@@ -466,6 +466,12 @@ fn headline(server: &McpServerInfo, selected: bool) -> Line<'static> {
     } else if server.connected {
         let label = server.health.clone().unwrap_or_else(|| "live".to_string());
         Span::styled(label, muted)
+    } else if server.health.as_deref() == Some("auth required") {
+        // A server this session suppressed pre-connect (`#2687`) has no
+        // client, so it is never `connected`. It is not simply
+        // unreachable either, and "not connected" hid the one thing that
+        // would fix it (`#2802`).
+        Span::styled("auth required", Style::new().fg(token::WARNING))
     } else {
         Span::styled("not connected", Style::new().fg(token::RED))
     };
@@ -540,13 +546,19 @@ fn headline(server: &McpServerInfo, selected: bool) -> Line<'static> {
     Line::from(spans)
 }
 
-/// The latency cell: whole milliseconds of the connect handshake's round trip,
-/// or blank.
+/// The latency cell: whole milliseconds of the connect handshake's round
+/// trip, or blank.
 ///
-/// Blank rather than a dash or a zero when the number is unknown, and blank
-/// for a server that is not connected even if one was once measured — the
-/// column answers "how far away is this server right now", and a stale figure
-/// beside `not connected` would answer a question nobody asked.
+/// **Connect-time, not live** (`#5183`). This is the `initialize` round
+/// trip measured when the current connection was made. A reconnect
+/// re-measures it, but a server that slows down without dropping keeps
+/// showing its old, healthy number. See `stella_mcp::ServerHealth::latency`
+/// for the full contract this cell reads (prose, not a link: this crate
+/// does not depend on that one).
+///
+/// Blank, not a dash or a zero, when the number is unknown, and blank for a
+/// server that is not connected even if one was once measured. A stale
+/// number beside `not connected` would claim a distance nobody measured.
 fn latency(server: &McpServerInfo) -> String {
     match server.latency_ms {
         Some(ms) if server.connected && server.enabled => format!("{ms}ms"),
@@ -885,6 +897,29 @@ mod tests {
         lines.iter().map(flat).collect()
     }
 
+    /// `#2802`: an auth-suppressed server has no client, so it is never
+    /// `connected`. Without this fix, the row reads the same "not
+    /// connected" a genuinely down server gets, with no hint that logging
+    /// in would fix it. This is the row's word; getting the health value
+    /// this far at all is `deck_mcp.rs::mcp_snapshot`'s half, tested
+    /// separately.
+    #[test]
+    fn a_row_names_auth_required_instead_of_not_connected() {
+        let suppressed = McpServerInfo {
+            name: "linear".into(),
+            kind: "http".into(),
+            endpoint: "https://mcp.linear.app".into(),
+            enabled: true,
+            connected: false,
+            health: Some("auth required".into()),
+            granted: true,
+            ..McpServerInfo::default()
+        };
+        let text = rows(&[suppressed]).join("\n");
+        assert!(text.contains("auth required"), "{text}");
+        assert!(!text.contains("not connected"), "{text}");
+    }
+
     /// The reported bug: an aliased server rendered as `mcp [http] not
     /// connected`, and the only way to learn it was Stripe was to start its
     /// OAuth flow and read the browser.
@@ -1077,7 +1112,9 @@ mod tests {
         let text = search_rows(vec![signed("com.stripe/mcp")]).join("\n");
         assert!(text.contains("vendor"), "source tier: {text}");
         assert!(text.contains("9.1k installs"), "install count: {text}");
-        assert!(text.contains("signed"), "signature: {text}");
+        // "attributed", not "signed" (`#5176`) — the registry vouches for the
+        // publisher's namespace, never for the package bytes.
+        assert!(text.contains("attributed"), "signature: {text}");
 
         let text = search_rows(vec![blocked("io.github.x/y")]).join("\n");
         assert!(text.contains("community"), "{text}");

--- a/crates/stella-tui/src/views/transcript.rs
+++ b/crates/stella-tui/src/views/transcript.rs
@@ -126,6 +126,13 @@ pub struct Touched {
 /// release and a renderer that needs an arm per kind silently drops the ones it
 /// has not heard of. Anything unrecognised is [`EventKind::Other`] and renders
 /// as a plain muted row, which is the correct degradation.
+///
+/// There is no standalone `Gate` kind (`#5651`). SPEC 6.3 once specced one
+/// (`◇ gate <name> · state`), but the engine only sends a whole board
+/// (`AgentEvent::GateBoard`), never one gate. That kind had no wire event
+/// to draw from. A single gate's row, price included, belongs to
+/// [`super::gate_board`] alone — a second copy of that text here could
+/// drift with no way to notice.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EventKind {
     /// `▸ read <path> · n lines` — folded by default.
@@ -179,8 +186,6 @@ pub enum EventKind {
         confidence: u8,
         audit_event_id: String,
     },
-    /// `◇ gate <name> · state` — always priced, `$0.00` when deterministic.
-    Gate { state: String, deterministic: bool },
     /// `◐ model <activity> · tok/s`.
     ///
     /// The rate is an `Option` for the reason [`Extent`]'s counts are: a model
@@ -228,10 +233,7 @@ impl EventKind {
     pub fn metal(&self) -> Color {
         match self {
             EventKind::Read { .. } => token::MUTED,
-            EventKind::Edit { .. }
-            | EventKind::Write { .. }
-            | EventKind::Run { .. }
-            | EventKind::Gate { .. } => token::GOLD,
+            EventKind::Edit { .. } | EventKind::Write { .. } | EventKind::Run { .. } => token::GOLD,
             EventKind::Delete { .. } => token::RED,
             EventKind::Skill { .. }
             | EventKind::MemoryLog { .. }
@@ -263,7 +265,6 @@ impl EventKind {
             EventKind::Delete { .. } => glyph::FAILED,
             EventKind::Skill { .. } => glyph::SKILL,
             EventKind::MemoryLog { .. } | EventKind::MemoryPromote { .. } => glyph::MEMORY,
-            EventKind::Gate { .. } => glyph::GATE,
             EventKind::Model { .. } => glyph::RUNNING,
             EventKind::Compaction { .. } => glyph::COMPACTED,
             EventKind::Other { class, .. } => match class {
@@ -289,7 +290,6 @@ impl EventKind {
             EventKind::Run { .. } => "run",
             EventKind::Skill { .. } => "skill",
             EventKind::MemoryLog { .. } | EventKind::MemoryPromote { .. } => "memory",
-            EventKind::Gate { .. } => "gate",
             EventKind::Model { .. } => "model",
             EventKind::Compaction { .. } => "compacted",
             EventKind::Other { .. } => "",
@@ -695,7 +695,6 @@ fn head_row(event: &Event, metal: Color, width: usize) -> Line<'static> {
 /// The kind-specific tail of a head line (SPEC 6.3's per-event columns).
 fn kind_detail(kind: &EventKind) -> Vec<Span<'static>> {
     let dim = Style::new().fg(token::DIM);
-    let text = Style::new().fg(token::TEXT);
     match kind {
         // `n of m` when the read was truncated, `n lines` when it was whole —
         // so a partial read is visibly partial rather than silently
@@ -748,16 +747,6 @@ fn kind_detail(kind: &EventKind) -> Vec<Span<'static>> {
             Span::styled(format!(" · {trigger}"), dim),
             Span::styled(format!(" · {} tok", fmt_tokens(u64::from(*tokens))), dim),
         ],
-        EventKind::Gate {
-            state,
-            deterministic,
-        } => {
-            let mut spans = vec![Span::styled(format!(" · {state}"), text)];
-            if *deterministic {
-                spans.push(Span::styled(" · $0.00 · det", dim));
-            }
-            spans
-        }
         EventKind::Model { tokens_per_sec } => match tokens_per_sec {
             Some(rate) => vec![Span::styled(format!(" · {rate} tok/s"), dim)],
             None => Vec::new(),

--- a/crates/stella-tui/src/views/transcript/tests.rs
+++ b/crates/stella-tui/src/views/transcript/tests.rs
@@ -412,10 +412,6 @@ fn every_head_glyph_is_in_the_vocabulary() {
             confidence: 87,
             audit_event_id: "prm_1".into(),
         },
-        EventKind::Gate {
-            state: "pass".into(),
-            deterministic: true,
-        },
         EventKind::Model {
             tokens_per_sec: Some(40),
         },

--- a/crates/stella-tui/tests/deck_snapshot.rs
+++ b/crates/stella-tui/tests/deck_snapshot.rs
@@ -514,28 +514,33 @@ fn inspect_overlay_banner_lines_wrap_at_80_columns_instead_of_clipping() {
     let mut terminal = Terminal::new(TestBackend::new(80, 40)).unwrap();
     terminal.draw(|f| render_deck(&model, &mut ui, f)).unwrap();
     let screen = buffer_text(terminal.backend().buffer());
-    let flat: String = screen.chars().filter(|c| !c.is_whitespace()).collect();
+    // Letters and digits only. A wrapped line's second row sits past the
+    // popup's own border, and other panels' rails and rules can land there
+    // too. None of that is prose. Keeping only letters and digits lets one
+    // check span the wrap point without a border symbol breaking it.
+    let flat: String = only_alnum(&screen);
 
     let unresolved_line = "3 block(s) unresolved — synthetic results, discarded speculation, \
                             or attachments";
-    let stripped_unresolved: String = unresolved_line
-        .chars()
-        .filter(|c| !c.is_whitespace())
-        .collect();
     assert!(
-        flat.contains(&stripped_unresolved),
+        flat.contains(&only_alnum(unresolved_line)),
         "the unresolved-blocks line lost characters at 80 columns:\n{screen}"
     );
 
     let mismatch_line = view_digest_mismatch_text(&ui);
-    let stripped_mismatch: String = mismatch_line
-        .chars()
-        .filter(|c| !c.is_whitespace())
-        .collect();
     assert!(
-        flat.contains(&stripped_mismatch),
+        flat.contains(&only_alnum(&mismatch_line)),
         "the digest-mismatch line lost characters at 80 columns:\n{screen}"
     );
+}
+
+/// Lowercase letters and digits only. Compares screen text to source prose
+/// across a wrap point; see the caller.
+fn only_alnum(text: &str) -> String {
+    text.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 /// The exact mismatch text the overlay draws for `ui`'s current inspect

--- a/crates/stella-tui/tests/deck_snapshot.rs
+++ b/crates/stella-tui/tests/deck_snapshot.rs
@@ -472,6 +472,83 @@ fn inspect_overlay_renders_the_call_list_then_the_context_sent() {
     );
 }
 
+/// **The witness (`#2029`).** On an 80-column terminal — SPEC's narrowest
+/// width — the overlay's banner lines clip at the popup's edge without
+/// this fix, and drop their tail. This test fails on that:
+/// `buffer_text` never has "or attachments" (the unresolved-blocks line's
+/// last words), and the mismatch line loses its own tail the same way.
+///
+/// A banner can now wrap onto more than one screen row, so a plain
+/// `contains(full_sentence)` check would fail for the wrong reason: a `\n`
+/// or padding now sits where the wrap point falls. Stripping whitespace
+/// from both sides first survives a wrap without hiding a clip —
+/// `wrap_chars` moves characters onto a new row, it never drops any.
+#[test]
+fn inspect_overlay_banner_lines_wrap_at_80_columns_instead_of_clipping() {
+    use stella_tui::{InspectMessage, InspectView, JournalEra, RecordedCallInfo};
+
+    let model = folded_model();
+    let mut ui = ready_ui();
+    ui.inspect_open = true;
+    ui.inspect_view = Some(Box::new(InspectView {
+        call: RecordedCallInfo {
+            turn_instance: 0,
+            step: 3,
+            call_seq: 1,
+            call_role: "summarization".into(),
+            provider: "anthropic".into(),
+            model: "claude-opus".into(),
+            estimated_input_tokens: 1234,
+        },
+        messages: vec![InspectMessage {
+            role: "user".into(),
+            content: "t0 t1 t2".into(),
+            sections: Vec::new(),
+        }],
+        verified: false,
+        unresolved: 3,
+        digest_mismatches: 2,
+        journal_era: JournalEra::CompactionJournaled,
+    }));
+
+    let mut terminal = Terminal::new(TestBackend::new(80, 40)).unwrap();
+    terminal.draw(|f| render_deck(&model, &mut ui, f)).unwrap();
+    let screen = buffer_text(terminal.backend().buffer());
+    let flat: String = screen.chars().filter(|c| !c.is_whitespace()).collect();
+
+    let unresolved_line = "3 block(s) unresolved — synthetic results, discarded speculation, \
+                            or attachments";
+    let stripped_unresolved: String = unresolved_line
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    assert!(
+        flat.contains(&stripped_unresolved),
+        "the unresolved-blocks line lost characters at 80 columns:\n{screen}"
+    );
+
+    let mismatch_line = view_digest_mismatch_text(&ui);
+    let stripped_mismatch: String = mismatch_line
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    assert!(
+        flat.contains(&stripped_mismatch),
+        "the digest-mismatch line lost characters at 80 columns:\n{screen}"
+    );
+}
+
+/// The exact mismatch text the overlay draws for `ui`'s current inspect
+/// view, read from the same source the render calls. A wording change
+/// there cannot leave this test asserting stale text.
+fn view_digest_mismatch_text(ui: &DeckUi) -> String {
+    ui.inspect_view
+        .as_ref()
+        .and_then(|view| view.digest_mismatch_line())
+        .map(|(text, _)| text)
+        .expect("this test's fixture always has a mismatch")
+}
+
 /// Witness for #689. `stella-mcp` has recorded per-server tool truncation
 /// since #551, but nothing rendered it: an over-advertising server lost every
 /// tool past the cap and the operator was never told, so the model silently

--- a/design/tui-v2/SPEC.md
+++ b/design/tui-v2/SPEC.md
@@ -252,7 +252,7 @@ Top to bottom:
    - **PR** moves to the ISSUES tab (§9.4). A pull request is a tracker-side artifact of the current work, and that tab is where tracker-side artifacts live.
    - **LANES** moves to the AGENTS tab (§9.5), onto the EXECUTIONS header beside the active/total count that ENGINE became.
 
-   No `det %` here, or anywhere — see §1. The `det` tags that remain (`$0.00 · det` on a gate, §6.3; the graph footer, §9.1) are **booleans**: this call did or did not reach a model. They need no ratio behind them and are not summed into one.
+   No `det %` here, or anywhere — see §1. The `det` tags that remain (`$0.00 · det` on a gate, §8.1; the graph footer, §9.1) are **booleans**: this call did or did not reach a model. They need no ratio behind them and are not summed into one.
 
 ## 6. Transcript
 
@@ -280,7 +280,6 @@ Rail metals: read silver-dim, edit gold, write gold, delete red, run gold, skill
 | `skill` | `✦ skill <name> · auto\|/cmd · n tok` | `injected <summary> · used n× this repo` | |
 | `memory` (log) | `◆ memory logged · mem_id` | quoted text, then `OBSERVATION ▸ RULE ▸ FACT` ladder with current class lit, `conf 0.62 · kind · decays`, footer `promotes at 0.85 · e edit · x reject` | |
 | `memory` (promote) | `◆ memory promoted OBSERVATION → RULE · conf 0.87` | `audit event <id> · now prompt-injected` | one line total |
-| `gate` | `◇ gate <name> · state` | see section 8.1 on failure | always shows `$0.00` when deterministic |
 | `model` | `◐ model <activity> · tok/s` | footer: `irreducible generation · n of m budgeted model calls this turn` | |
 | `compaction` | `↓ compacted 74k→69k · 0 evicted · 0 deduped` | none | dim single line, deliberately quiet |
 
@@ -491,7 +490,12 @@ The manifest's own name is held to the same standard: it is composed into chrome
 ## 13. Accessibility
 
 - Never color alone (section 2). All states carry glyphs; diffs carry sign columns.
-- Minimum contrast: `muted` on `bg` is the floor; nothing dimmer than `dim` may carry required information.
+- Minimum contrast: `muted` on `bg` (4.5:1) sets the floor for body text. `dim`
+  is a stated exception, held to 3.0:1 instead, even on a real word like a
+  keybinding verb or a status-bar hint. That is safe because of rule 4 above:
+  nothing here is color-only, so a reader who cannot see `dim` well still has
+  the glyph or the word under it. `dim` still may not carry a fact found
+  nowhere else on the row.
 - All overlays closable with `esc`; all lists navigable with arrows alone.
 
 ## 14. Non-goals

--- a/scripts/check-contrast.py
+++ b/scripts/check-contrast.py
@@ -101,7 +101,9 @@ PAIRINGS = [
     ("gold", "panel", "actions on a panel", 4.5),
     ("green", "bg", "pass verdict", 4.5),
     ("red", "bg", "fail verdict", 4.5),
-    ("dim", "bg", "hints and line numbers (large/decorative floor)", 3.0),
+    # `dim` labels real words too, not just gutters. It keeps the lower
+    # floor anyway, as a stated exception (SPEC.md §13, `#6005`).
+    ("dim", "bg", "hints, keybinding rows, and line numbers (terminal exception)", 3.0),
     # `comment on panel` sat here at 2.64:1 and measured a value nothing
     # painted: `comment` was a token with no consumer on any surface, and code
     # comments ship in `muted` — already on this list, on the same ground. It

--- a/website/content/docs/commands/mcp.mdx
+++ b/website/content/docs/commands/mcp.mdx
@@ -50,7 +50,7 @@ The source tier comes from the server's namespace:
 
 Install count shows how many people installed the server, or "installs unknown" if the registry doesn't publish that number. stella never shows a fake `0`.
 
-"Signed" means the registry has confirmed who published the entry, and that entry is marked active. It does **not** mean stella checked a signature on the actual files — no MCP registry publishes one to check yet. Anything the registry can't attribute to a publisher, or has withdrawn, shows as "blocked." `stella mcp install` refuses to install a blocked server.
+"Attributed" means the registry knows who published the entry, and marks it active. It does **not** mean stella checked a signature on the files. No registry publishes one yet. An entry the registry can't attribute, or has withdrawn, shows as "blocked." `stella mcp install` refuses a blocked server.
 
 ### `stella mcp install <name>`
 


### PR DESCRIPTION
## What & why

Batch fix for #6299 (11 small `area:tui` defects from the 2026-09-06 backlog
audit), one PR per the fix-over-file rule since each member is small.

### Members

- **#5748** — `note_kind` muted `Error`/`SteeringWithheld` to the same glyph
  as a budget tick. Added `NoteKind::Alert` to `stella-transcript`, rendered
  red by both renderers, and wired `stella-tui`'s and `stella-cli`'s own
  `note_kind` classifiers (both had the shape) to use it. `Steered` stays in
  the wildcard on purpose, documented why.
- **#5651** — the transcript's standalone gate row could never draw (the
  engine only ever emits a whole board), and its `$0.00 · det` price text
  was duplicated in two places. Deleted `EventKind::Gate`; `gate_board.rs`
  stays the sole renderer. Updated `SPEC.md` §6.3/§8.1 to match.
- **#5176** — MCP registry `"signed"` attested only the publisher's
  namespace, not the package bytes. Renamed the label to `"attributed"` in
  `stella-mcp` and `stella-tui`, and the website docs.
- **#1740** — the Files tab diff pane summed every mutation's delta in the
  footer while the body showed only the latest mutation's diff, with
  nothing on screen saying so. Added a `latest of N changes` label for the
  common case (option 1 from the issue: label it, no data-model change).
- **#5933** — the deck checked for a checkout peer only once, at boot, so
  the *first* session — the one with uncommitted work to lose — was never
  warned about a session that started sharing the tree later. Added a
  bounded 5-second poll (`shared_checkout::spawn_late_arrival_monitor`) that
  diffs the peer set and announces new arrivals through the deck's own
  channel.
- **#2802** — the deck's MCP tab and connect-outcome notice both dropped
  auth-suppressed servers entirely. `deck_mcp.rs`'s snapshot no longer
  gates `health`/`latency_ms` on `connected`; the MCP tab row now reads
  `auth required` instead of `not connected`; `mcp_outcome_report` gained
  an `auth_required` parameter sharing text mode's existing wording.
- **#6005** — `dim` is held to WCAG's large-text floor in
  `check-contrast.py`, but `SPEC.md` §13 contradicted that by describing
  `dim` as carrying required information at the normal-text floor. Chose
  option 2 from the issue (state the terminal-only exception explicitly)
  since the ~75 call sites already ship this way; rewrote §13 to agree with
  §3.1 instead of contradicting it.
- **#2450** — `ToolResult` carries no tool name, so `stella-tui` and
  `stella-cli` each kept a private `call_id -> name` map. Added a shared
  `ToolCallIndex` in `stella-tui` (option 2 from the issue — the correlation
  only, not a wire change) and switched `stella-cli`'s plain-text renderer
  to it. The deck's own richer transcript-scan resolution is unchanged.
- **#2029** — the INSPECT overlay clipped banner lines instead of wrapping
  them. Added `push_wrapped_banner`, which wraps every free-text banner
  line at the popup's real width as real `Line`s (never `Paragraph::wrap`,
  which would desync the row-offset scroll). Left the fixed-width call
  table alone — wrapping it would break its own column headers. Fixed the
  list-mode selected-row scroll math, which assumed a fixed 3-line header
  that a wrapped banner could now invalidate.
- **#1990** — an open TOOLS panel stayed stale after `/reload` and `/model
  default`, because the code that could refresh it did not hold the
  MCP-inclusive live stack. Added `DeckCommand::SettingsReloaded` and a
  shared `refresh_tools_panel`/`live_tool_executor` pair in
  `settings_io.rs`, called from the driver loop where `mcp_slot` is in
  scope.
- **#5183** — the MCP tab's latency column doc claimed "how far away is
  this server right now" while the underlying field is connect-time only
  and never re-measured — the exact mismatch the issue reports. Corrected
  the doc comment to match `ServerHealth::latency`'s own accurate contract
  (the issue's "or names which of the two it reports" branch). Live
  re-measurement is a larger, design-requiring change and is not attempted
  here.

### Could not ride

None — all 11 members rode this PR.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), for
      every member except #6005 and the doc-only half of #5183.
- [x] No witness needed for #6005 (SPEC.md decision, no code change) and
      #5183 (doc-comment correction, no behavior change) — pure docs.

Per member:
- #5748: `error_and_steering_withheld_classify_louder_than_other`
- #5651: `the_deterministic_gate_price_is_built_in_exactly_one_place`
- #5176: `an_attributed_entry_does_not_render_as_signed`
- #1740: `a_footer_summing_several_mutations_labels_which_one_the_body_shows`
- #5933: `newly_arrived_names_only_the_peer_the_last_check_did_not_see` +
  `newly_arrived_with_no_prior_check_reports_everyone_live`
- #2802: `mcp_outcome_report_names_an_auth_suppressed_server_with_its_login_command`
  + `a_row_names_auth_required_instead_of_not_connected`
- #2450: the three tests in `tool_call_index.rs` (new type; fails to
  compile on `main`)
- #2029: `inspect_overlay_banner_lines_wrap_at_80_columns_instead_of_clipping`
- #1990: `live_tool_executor_switches_to_the_connected_mcp_set`

## The gate

- [x] `cargo fmt --check` — clean locally
- [ ] clippy across the workspace at `-D warnings` — CI (`make guards-fast`
      is green locally; clippy is not run on this laptop per CLAUDE.md)
- [ ] full workspace test run — CI
- [x] Docs updated where behavior/flags changed (SPEC.md, website mcp.mdx,
      several doc comments)
- [ ] CLA signed (bot prompts)
- [x] `Closes #6299` appears both above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: while fixing #2450, found and fixed the
  *same* two-tier-classifier duplication shape in a second place
  (`stella-cli/src/export/transcript.rs`'s own `note_kind`, not mentioned
  in #5748's issue text) — updated it too, same fix, same reasoning. While
  fixing #1990, found the boot-adjacent between-prompts TOOLS refresh in
  `command_deck.rs` duplicated the same executor-selection logic
  `refresh_tools_panel` now needs — deduplicated both onto
  `settings_io::live_tool_executor` (net line reduction in `command_deck.rs`).
- [ ] Nothing deferred to an issue — all findings rode this PR.

## Tests deleted

**Two**, named per AGENTS.md's `check-deleted-tests` convention.

1. `envelope/inspect.rs`'s
   `both_mismatch_lines_survive_an_eighty_column_terminal` asserted a
   column-width constraint that #2029's fix removed (the overlay wraps
   instead of clipping now, so nothing needs to fit 80 columns unaided).
   Replaced with `each_era_names_its_own_count_and_meaning`, which checks
   the same lines' content instead of their length.

2. `render/tests/spine.rs`'s
   `the_gate_head_has_no_wire_event_and_names_its_issue` asserted that
   `EventKind::Gate` was absent from `live()` and that `declared()` classed
   it as a `Producer::Gap` naming an issue. That issue is #5651, and this
   PR is its fix: `EventKind::Gate` is deleted outright, so the variant the
   test names no longer exists and the test cannot compile, let alone
   assert. Its subject going away *is* the fix — keeping it would mean
   keeping the dead variant to have something to assert about. The witness
   that replaces it in the same file is
   `the_deterministic_gate_price_is_built_in_exactly_one_place`, which pins
   what #5651 actually asks for: one renderer for the gate price rather
   than two.

   (This second name was missing from the first version of this
   description, which is why `no test disappears in the merge
   unacknowledged` was red on `1f977bf` and `730af4d`.)

## Ground-rule check

- [x] No I/O added to `stella-core`
- [x] No new outbound network calls
- [x] No new cross-boundary (wire) types — `tool_call_index::ToolCallIndex`
      and `DeckCommand::SettingsReloaded` are both process-internal

## Anything reviewers should know?

- `crates/stella-tui/src/tool_call_index.rs` is a new file/module
  (`pub mod tool_call_index;` in `lib.rs`), justified as the shared
  correlation #2450 asks for rather than a new crate — it is a small,
  dependency-free type inside an existing crate, not a new deliverable.
- `deck_render.rs` and `command_deck.rs` were both believed to be god
  files at their ceiling when several of these issues were filed; on this
  branch neither is (both have since been split/reduced on `main`), so
  #2029's and #1990's/#5933's fixes land the new logic directly rather than
  in a sibling submodule as the issues suggested — confirmed against
  `scripts/file-size-baseline.txt` before writing anything.

Closes #6299