### PR TITLE
fix(scripts): stand issue-claim down on a closed issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,7 +400,9 @@ is a dead attempt — reported, not blocking, because that is the state where
 the next session most needs to proceed. A `Refs #N` PR — the carrier when a
 fix uses no closing keyword so `dod-check` does not hold an unrelated
 issue's checklist against it — is named too, but only as a weaker signal
-that never blocks by itself. Then the claim comments,
+that never blocks by itself. Then the issue's own state: a closed issue
+stands the session down and names the reason, because an audit that folds
+an issue into a batch leaves no PR and no claim behind. Then the claim comments,
 on the red-`main` rules — the tracker is the table so a peer in another
 worktree can see it, a comment carries its author and timestamp, a claim
 lapses so a crashed session cannot hold an issue shut, and every unknown

--- a/scripts/issue-claim.sh
+++ b/scripts/issue-claim.sh
@@ -63,6 +63,16 @@
 # It also does not replace reading the open PRs. A merged or open PR closing
 # the issue is a stronger signal than any claim, and this prints one when it
 # finds it — that is the check that would have saved this session twice.
+#
+# ── A closed issue is not work to claim ──────────────────────────────────────
+#
+# The pull requests say who finished; the claims say who started. Neither
+# says whether the issue is still open. An audit can fold an issue into a
+# batch and close it, leaving no PR and no claim behind. On 2026-09-06 a
+# session claimed an issue two minutes after such a fold and spent an hour
+# on it. So the check reads the issue's own state and stands down on a
+# closed one, naming the reason. An unreadable state proceeds, like every
+# other unknown here.
 
 set -uo pipefail
 
@@ -84,6 +94,8 @@ fixture_session=""
 fixture_claims=""
 fixture_prs=""
 fixture_prs_failed=0
+fixture_issue_state="OPEN"
+fixture_issue_state_failed=0
 select_now=""
 use_fixture=0
 
@@ -134,6 +146,20 @@ while [ $# -gt 0 ]; do
   # this — a failed query has no rows to fake.
   --fixture-prs-failed)
     fixture_prs_failed=1
+    use_fixture=1
+    shift
+    ;;
+  # Test-only: the issue's own state as `gh issue view --json state,stateReason`
+  # would report it, `STATE` or `STATE:REASON`. Defaults to OPEN, so a fixture
+  # that says nothing about the state models an ordinary open issue.
+  --fixture-issue-state)
+    fixture_issue_state="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  # Test-only: the state query itself failing, as opposed to answering.
+  --fixture-issue-state-failed)
+    fixture_issue_state_failed=1
     use_fixture=1
     shift
     ;;
@@ -325,6 +351,48 @@ if [ -n "$refs_hits" ]; then
   echo "      the live fix can sit in a Refs-only PR while the one that would" >&2
   echo "      close the issue is dead." >&2
   printf '     %s\n' "$refs_hits" >&2
+fi
+
+# ── A closed issue is not work to claim ──────────────────────────────────────
+#
+# After the pull requests, since a MERGED closing PR is the clearer report of
+# the same fact, and before the identity read, since a closed issue is closed
+# for every session alike. `state_ok` is whether the tracker answered at all:
+# "OPEN" is a claim about a state that was read, and a query that failed to
+# ask must never be reported in that shape.
+issue_state=""
+issue_reason=""
+state_ok=1
+if [ "$use_fixture" -eq 1 ]; then
+  if [ "$fixture_issue_state_failed" -eq 1 ]; then
+    state_ok=0
+  else
+    state_line="$fixture_issue_state"
+  fi
+elif ! state_line="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh issue view "$issue" \
+  --json state,stateReason --jq '"\(.state):\(.stateReason // "")"' 2>/dev/null)"; then
+  state_ok=0
+fi
+if [ "$state_ok" -eq 1 ]; then
+  issue_state="${state_line%%:*}"
+  issue_reason="${state_line#*:}"
+  [ "$issue_reason" = "$state_line" ] && issue_reason=""
+fi
+
+if [ "$state_ok" -eq 0 ]; then
+  echo "note: could not read #$issue's state, so this run cannot tell an open" >&2
+  echo "      issue from a closed one. Proceeding (fail-open); the claim check" >&2
+  echo "      below still runs." >&2
+elif [ "$issue_state" = "CLOSED" ]; then
+  echo "STAND DOWN  #$issue is closed (${issue_reason:-no reason recorded})." >&2
+  echo "" >&2
+  echo "     A closed issue is not work to claim. COMPLETED means the work" >&2
+  echo "     landed and the issue is stale. NOT_PLANNED is usually a fold: an" >&2
+  echo "     audit moved it into a batch issue, and the closing comment names" >&2
+  echo "     which one. Read that comment, then the batch's member list. If" >&2
+  echo "     the member is still unticked there, claim the batch and say" >&2
+  echo "     which member you are taking." >&2
+  exit 1
 fi
 
 if [ "$use_fixture" -eq 1 ]; then

--- a/scripts/test-issue-claim.sh
+++ b/scripts/test-issue-claim.sh
@@ -36,13 +36,19 @@ bad() { printf '  \033[31m✗\033[0m %s\n' "$*"; fail=$((fail + 1)); }
 # One assertion shape: run with every seam pinned and compare the exit code.
 # An expected block must also name its reason, because "exit 1" is satisfied by
 # a typo in the script just as well as by the case's own subject.
-want() { # want <name> <expect-proceed|expect-block> <want-substring> <mode> <login> <claims> <prs>
+want() { # want <name> <expect-proceed|expect-block> <want-substring> <mode> <login> <claims> <prs> [state] [extra flags...]
   local name="$1" expect="$2" want_text="$3" mode="$4" login="$5" claims="$6" prs="$7"
+  # The issue's own state, `STATE` or `STATE:REASON`; an empty eighth argument
+  # keeps the script's default (OPEN). Anything after it is passed through.
+  local state="${8:-}"
+  shift 7
+  [ $# -gt 0 ] && shift
   local out rc
   out="$("$SCRIPT" "$mode" 5045 \
     --fixture-login "$login" \
     --fixture-claims "$claims" \
-    --fixture-prs "$prs" 2>&1)"
+    --fixture-prs "$prs" \
+    ${state:+--fixture-issue-state "$state"} "$@" 2>&1)"
   rc=$?
   if [ "$expect" = "expect-proceed" ] && [ "$rc" -ne 0 ]; then
     bad "$name — expected proceed, got exit $rc: $out"
@@ -120,7 +126,53 @@ esac
 want "a Refs-only pull request does not stand this session down, but is named" \
   expect-proceed "6203 OPEN" check "ada" "" "6203 OPEN refs"
 
+# ── a closed issue is not work to claim ──────────────────────────────────────
+
+# The fold shape: an audit closed the issue into a batch, so no PR and no
+# claim names it, and the unfixed script called it unclaimed. The report has
+# to say the reason and point at the batch, or a reader takes the stand-down
+# for a stale claim and works it anyway.
+out="$("$SCRIPT" check 5045 \
+  --fixture-login ada --fixture-claims "" --fixture-prs "" \
+  --fixture-issue-state "CLOSED:NOT_PLANNED" 2>&1)"
+rc=$?
+case "$rc,$out" in
+1,*"is closed (NOT_PLANNED)"*"batch"*)
+  ok "a closed issue stands this session down and names the reason"
+  ;;
+*)
+  bad "expected exit 1 naming 'is closed (NOT_PLANNED)' and the batch, got exit $rc: $out"
+  ;;
+esac
+
+want "a closed issue also refuses to take a claim" \
+  expect-block "is closed" claim "ada" "" "" "CLOSED:COMPLETED"
+
+# An explicit OPEN state is the default the other cases run under, spelled
+# out once so the seam is shown to reach the comparison.
+want "an open issue proceeds" \
+  expect-proceed "is unclaimed" check "ada" "" "" "OPEN:REOPENED"
+
 # ── the negative controls: every unknown proceeds ────────────────────────────
+
+# An unreadable state proceeds, and the claim check still runs after it: a
+# peer's live claim must block even when the tracker would not say whether
+# the issue is open.
+out="$("$SCRIPT" check 5045 \
+  --fixture-login ada --fixture-claims "grace - 300" --fixture-prs "" \
+  --fixture-issue-state-failed 2>&1)"
+rc=$?
+case "$rc,$out" in
+1,*"state, so this run cannot tell an open"*"claimed by @grace"*)
+  ok "an unreadable issue state proceeds to the claim check, which still blocks"
+  ;;
+*)
+  bad "expected the state note and then a stand-down on @grace, got exit $rc: $out"
+  ;;
+esac
+
+want "an unreadable issue state proceeds when nothing else blocks" \
+  expect-proceed "is unclaimed" check "ada" "" "" "" --fixture-issue-state-failed
 
 want "an unclaimed issue proceeds" \
   expect-proceed "is unclaimed" check "ada" "" ""


### PR DESCRIPTION
## What & why

`scripts/issue-claim.sh check <n>` asked the pull requests and the claim comments, but never the issue's own state. An issue that an audit had folded into a batch and closed as not planned read as `ok #n is unclaimed`. That is exactly what happened to this session on 2026-09-06: #6102 was folded into batch #6308 at 19:20 UTC, claimed at 19:22, and worked for an hour. The work was still wanted that time; the same hour spent on an issue closed as done is lost.

The check now reads `gh issue view --json state,stateReason` after the pull-request check (a merged closing PR is the clearer report of the same fact) and before the identity read (a closed issue is closed for every session alike). A closed issue stands the session down, names the state reason, and tells the reader to check the batch's member list before writing. An unreadable state proceeds with a note, and the claim check still runs after it, like every other unknown in the script.

Verified live before opening this PR: `issue-claim.sh check 6276` (a folded member with no closing PR) now prints `STAND DOWN #6276 is closed (NOT_PLANNED)` and exits 1; `check 6102` still stands down on its merged PR first, which is the intended order.

Closes #6343

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

In `scripts/test-issue-claim.sh`, driven through the new paired `--fixture-issue-state` / `--fixture-issue-state-failed` seams:

- `a closed issue stands this session down and names the reason` (positive control; fails on `main`, where the script has no such seam and prints `is unclaimed`)
- `a closed issue also refuses to take a claim`
- `an open issue proceeds` (the seam reaches the comparison)
- `an unreadable issue state proceeds to the claim check, which still blocks` (fail-open does not skip the rest)
- `an unreadable issue state proceeds when nothing else blocks`

`./scripts/test-issue-claim.sh`: 38 passed. `make shellcheck`, `make prose`, `make guards-fast` green.

## The gate

- [x] `cargo fmt --check` (no Rust touched)
- [x] `make guards-fast` locally; the workspace run is CI's
- [x] Docs updated: AGENTS.md's paragraph on the script names the state check
- [x] CLA signed
- [x] `Closes #N` appears both above and as a commit trailer

## Nothing left behind

- [x] There is nothing: everything I noticed is fixed in this PR

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls (one more `gh` read against the same tracker)

## Anything reviewers should know?

- The `want` helper in the test file gained an optional eighth argument (the state) and passes any further arguments through; every existing call is unchanged.

## Summary by Sourcery

Stand down issue-claim sessions when the tracked issue is closed while preserving claim checks when state information is unavailable.

Bug Fixes:
- Prevent issue-claim checks from proceeding on issues that are already closed, including issues folded into batches without a closing pull request.
- Fail open when the issue state cannot be read while continuing subsequent claim checks.

Enhancements:
- Report the issue's closure reason and direct contributors to review the associated batch member list before claiming work.
- Add fixture seams and witness coverage for open, closed, and unreadable issue states.

Documentation:
- Document the issue-state check in the contributor guidance for issue claiming.

Tests:
- Expand issue-claim script coverage to verify closed-issue stand-downs, closure reasons, fail-open behavior, and continued claim enforcement.