### PR TITLE
docs(scr): describe the AGENTS.md summary as part of the corpus contract

### DIFF
--- a/docs/scr/README.md
+++ b/docs/scr/README.md
@@ -41,6 +41,33 @@ the corpus is replicated.
 **Editing the corpus is therefore a five-repo change.** Land it everywhere in
 the same sitting; the check will notice within a day if you do not.
 
+## Keeping each repo's compiled summary honest
+
+`docs/scr/` is the record. What an agent actually holds in context at session
+start is the compiled **summary** of it: every repo's `AGENTS.md` carries the
+same directives, restated under a "## Standing decisions" heading, one bullet
+per record. That summary is part of the corpus contract too, and the same
+`scr-corpus-check` workflow checks it — but not byte-for-byte, because it is
+not meant to be byte-identical. At least SCR-001's compiled bullet names each
+repo's own toolchain command (`cargo test -p <crate>` in the Rust repos,
+`pnpm --filter <package> test` here, `uv run pytest` in arenabench), so a
+literal-bytes comparison would fail on correct, legitimately differing
+content.
+
+What the check compares instead is structure and titles: every repo's summary
+has exactly one bullet per `docs/scr/` record, and the short title naming that
+record — the text between the id link and the colon, e.g. "Tests/builds
+(inner loop)" — is expected to read the same in every repo, even where the
+sentence after it does not. This is what would have caught oxagen#2673: the
+record and the corpus check were both back in sync after
+`docs/scr/SCR-004-residue-becomes-issues.md` was rewritten, but one repo's
+`AGENTS.md` still summarized the directive it replaced, and nothing looked at
+that file to notice.
+
+**Editing a record's directive is therefore also an `AGENTS.md` edit, in the
+same five-repo change** — update the compiled bullet's title (and body, where
+it isn't repo-specific) alongside the record it summarizes.
+
 ## The autonomy ladder
 
 Each SCR carries an `autonomy` field naming its current rung:

--- a/docs/scr/README.md
+++ b/docs/scr/README.md
@@ -49,16 +49,17 @@ same directives, restated under a "## Standing decisions" heading, one bullet
 per record. That summary is part of the corpus contract too, and the same
 `scr-corpus-check` workflow checks it — but not byte-for-byte, because it is
 not meant to be byte-identical. At least SCR-001's compiled bullet names each
-repo's own toolchain command (`cargo test -p <crate>` in the Rust repos,
-`pnpm --filter <package> test` here, `uv run pytest` in arenabench), so a
-literal-bytes comparison would fail on correct, legitimately differing
-content.
+repo's own toolchain command, so a literal-bytes comparison would fail on
+correct, legitimately differing content. Each repo's own bullet carries the
+command it uses, and this document does not repeat them: a list copied into
+five files is four copies that can go stale.
 
 What the check compares instead is structure and titles: every repo's summary
-has exactly one bullet per `docs/scr/` record, and the short title naming that
-record — the text between the id link and the colon, e.g. "Tests/builds
-(inner loop)" — is expected to read the same in every repo, even where the
-sentence after it does not. A check of `docs/scr/` alone misses that drift.
+has one bullet per numbered record (`SCR-*.md`; this README carries none, and
+the check keys each bullet by the `SCR-NNN` id it names), and the short title
+naming that record — the text between the id link and the colon, e.g.
+"Tests/builds (inner loop)" — is expected to read the same in every repo, even
+where the sentence after it does not. A check of `docs/scr/` alone misses that drift.
 `docs/scr/SCR-004-residue-becomes-issues.md` was rewritten. The record and the
 corpus check went back in sync. One repo's `AGENTS.md` still gave the old
 directive, and nothing read the summary to catch it.

--- a/docs/scr/README.md
+++ b/docs/scr/README.md
@@ -41,7 +41,7 @@ the corpus is replicated.
 **Editing the corpus is therefore a five-repo change.** Land it everywhere in
 the same sitting; the check will notice within a day if you do not.
 
-## Keeping each repo's compiled summary honest
+## Keeping each repo's compiled summary in sync with the record
 
 `docs/scr/` is the record. What an agent actually holds in context at session
 start is the compiled **summary** of it: every repo's `AGENTS.md` carries the
@@ -58,11 +58,10 @@ What the check compares instead is structure and titles: every repo's summary
 has exactly one bullet per `docs/scr/` record, and the short title naming that
 record — the text between the id link and the colon, e.g. "Tests/builds
 (inner loop)" — is expected to read the same in every repo, even where the
-sentence after it does not. This is what would have caught oxagen#2673: the
-record and the corpus check were both back in sync after
-`docs/scr/SCR-004-residue-becomes-issues.md` was rewritten, but one repo's
-`AGENTS.md` still summarized the directive it replaced, and nothing looked at
-that file to notice.
+sentence after it does not. A check of `docs/scr/` alone misses that drift.
+`docs/scr/SCR-004-residue-becomes-issues.md` was rewritten. The record and the
+corpus check went back in sync. One repo's `AGENTS.md` still gave the old
+directive, and nothing read the summary to catch it.
 
 **Editing a record's directive is therefore also an `AGENTS.md` edit, in the
 same five-repo change** — update the compiled bullet's title (and body, where


### PR DESCRIPTION
## What & Why

`docs/scr/README.md` is itself part of the corpus replicated identically
across the five org repos. macanderson/oxagen#2690 extends
`scr-corpus-check` to also compare each repo's compiled `AGENTS.md`
"Standing decisions" summary of that corpus — not byte-for-byte (SCR-001's
compiled bullet legitimately names each repo's own toolchain command), but
by structure and per-SCR title, which is what would have caught
oxagen#2673 (a repo's summary still describing a directive the record had
already replaced).

This PR is the docs-only half of that change: it adds the section to this
repo's copy of `docs/scr/README.md`, verified byte-identical to the other
four copies before pushing. No issue of its own — tracked by
oxagen#2684, whose PR is macanderson/oxagen#2690.

Docs-only; no tests to run.

Refs oxagen#2684

## Summary by Sourcery

Document the cross-repository contract for keeping compiled SCR summaries synchronized with their source records.

Enhancements:
- Document the compiled `AGENTS.md` standing-decisions summary as part of the replicated SCR corpus contract, including cross-repository synchronization requirements and title-based consistency checks.

Documentation:
- Explain how record directives and their compiled summaries must be updated together across all five repositories.