### PR TITLE
fix(settings): trust notices name the standing remedy, not just the env var

### DIFF
--- a/crates/stella-cli/src/settings/merge.rs
+++ b/crates/stella-cli/src/settings/merge.rs
@@ -702,8 +702,9 @@ impl Settings {
 
         if announce && !trust.code_execution_trusted() && project.hooks.is_some() {
             eprintln!(
-                "  ! project hooks in {} were NOT loaded — set STELLA_PROJECT_HOOKS=1 \
-                 (or STELLA_TRUST_PROJECT=1) to trust this repo's hooks",
+                "  ! project hooks in {} were NOT loaded — set run.auto_trust_project = true \
+                 in ~/.stella/stella.toml to trust repos' hooks from now on, or \
+                 STELLA_PROJECT_HOOKS=1 (or STELLA_TRUST_PROJECT=1) for this launch alone",
                 project_path.display()
             );
         }
@@ -711,9 +712,10 @@ impl Settings {
         if announce && !trust.code_execution_trusted() && !project.context_providers.is_empty() {
             eprintln!(
                 "  ! project context providers in {} were NOT loaded — set \
-                 STELLA_TRUST_PROJECT=1 to let this repo run its context sources \
-                 (a stdio source runs a command on your machine; an http one can \
-                 send workspace content off it)",
+                 run.auto_trust_project = true in ~/.stella/stella.toml to let repos run \
+                 their context sources from now on, or STELLA_TRUST_PROJECT=1 for this \
+                 launch alone (a stdio source runs a command on your machine; an http one \
+                 can send workspace content off it)",
                 project_path.display()
             );
         }

--- a/crates/stella-cli/src/settings/withheld.rs
+++ b/crates/stella-cli/src/settings/withheld.rs
@@ -204,11 +204,8 @@ impl WithheldNotice {
     /// The human channel's line: the workspace, the inventory, and the
     /// remedy that works on the arm it is actually on.
     ///
-    /// The untrusted arm names two routes, standing one first. A reader
-    /// hitting this notice is hitting it on every launch in every repo, so
-    /// the env var alone answers the wrong question — it is a one-launch
-    /// remedy offered for a permanent condition, and a reader told only
-    /// about it reasonably concludes no permanent remedy exists.
+    /// The untrusted arm names the config key first, then the env var.
+    /// The env var lasts one launch. The notice comes back every launch.
     pub(crate) fn line(&self, workspace_root: &Path) -> String {
         let remedy = match self.by {
             Withholder::ProjectUntrusted => {

--- a/crates/stella-cli/src/settings/withheld.rs
+++ b/crates/stella-cli/src/settings/withheld.rs
@@ -201,13 +201,20 @@ pub(crate) struct WithheldNotice {
 }
 
 impl WithheldNotice {
-    /// The human channel's line: the workspace, the inventory, and the one
+    /// The human channel's line: the workspace, the inventory, and the
     /// remedy that works on the arm it is actually on.
+    ///
+    /// The untrusted arm names two routes, standing one first. A reader
+    /// hitting this notice is hitting it on every launch in every repo, so
+    /// the env var alone answers the wrong question — it is a one-launch
+    /// remedy offered for a permanent condition, and a reader told only
+    /// about it reasonably concludes no permanent remedy exists.
     pub(crate) fn line(&self, workspace_root: &Path) -> String {
         let remedy = match self.by {
             Withholder::ProjectUntrusted => {
-                "set STELLA_TRUST_PROJECT=1 to let this repo's memories, rules, skills, commands \
-                 and agents steer this session"
+                "set run.auto_trust_project = true in ~/.stella/stella.toml to let repos' \
+                 memories, rules, skills, commands and agents steer sessions from now on, or \
+                 STELLA_TRUST_PROJECT=1 for this session alone"
             }
             Withholder::ManagedCeiling => {
                 "your org's managed settings set authority.project_prompts = \"off\", so no \

--- a/crates/stella-cli/tests/settings_warnings_cli.rs
+++ b/crates/stella-cli/tests/settings_warnings_cli.rs
@@ -220,6 +220,12 @@ fn an_untrusted_checkouts_withheld_steering_is_named_on_stderr() {
         "a notice that does not name the opt-in leaves the user stuck: {stderr}"
     );
     assert!(
+        stderr.contains("auto_trust_project"),
+        "the env var alone is a one-launch answer to a condition that recurs every \
+         launch; a reader told only about it concludes no standing remedy exists, \
+         which is how this notice got read as unfixable: {stderr}"
+    );
+    assert!(
         !stderr.contains("SECRET-MARKER-BODY") && !stderr.contains("00-marker"),
         "counts, never content or filenames — a refusal that echoed repository \
          text would be the exfiltration channel it exists to prevent: {stderr}"

--- a/crates/stella-tui/src/render/tests/steering.rs
+++ b/crates/stella-tui/src/render/tests/steering.rs
@@ -72,6 +72,12 @@ fn the_remedy_names_the_authority_that_can_actually_lift_it() {
         untrusted.contains("STELLA_TRUST_PROJECT=1"),
         "an untrusted checkout is the user's to trust: {untrusted}"
     );
+    assert!(
+        untrusted.contains("auto_trust_project"),
+        "and trusts it for good, not for one launch: this row recurs on every \
+         launch of every untrusted repo, so a remedy that expires when the \
+         process does is the wrong shape of answer: {untrusted}"
+    );
 
     let managed = rows(Withholder::ManagedCeiling);
     assert!(

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -207,8 +207,6 @@ pub fn budget_tick(spent_usd: f64, limit_usd: Option<f64>) -> EventLine {
 /// The remedy differs by authority and that is the whole reason the event
 /// carries one: `STELLA_TRUST_PROJECT=1` printed against an org-managed
 /// ceiling tells a user who has already set that flag to set it again.
-/// The untrusted arm leads with `run.auto_trust_project`, because this row
-/// recurs every launch and only the config key ends it for good.
 pub fn steering_withheld(withheld_by: Withholder, counts: &[(usize, &str, &str)]) -> EventLine {
     let parts: Vec<String> = counts
         .iter()

--- a/crates/stella-tui/src/textline.rs
+++ b/crates/stella-tui/src/textline.rs
@@ -207,6 +207,8 @@ pub fn budget_tick(spent_usd: f64, limit_usd: Option<f64>) -> EventLine {
 /// The remedy differs by authority and that is the whole reason the event
 /// carries one: `STELLA_TRUST_PROJECT=1` printed against an org-managed
 /// ceiling tells a user who has already set that flag to set it again.
+/// The untrusted arm leads with `run.auto_trust_project`, because this row
+/// recurs every launch and only the config key ends it for good.
 pub fn steering_withheld(withheld_by: Withholder, counts: &[(usize, &str, &str)]) -> EventLine {
     let parts: Vec<String> = counts
         .iter()
@@ -221,7 +223,8 @@ pub fn steering_withheld(withheld_by: Withholder, counts: &[(usize, &str, &str)]
         detail: Some(
             match withheld_by {
                 Withholder::ProjectUntrusted => {
-                    "set STELLA_TRUST_PROJECT=1 to let this repo steer the session"
+                    "set run.auto_trust_project = true in ~/.stella/stella.toml to let repos \
+                     steer sessions from now on, or STELLA_TRUST_PROJECT=1 for this one"
                 }
                 Withholder::ManagedCeiling => {
                     "your org's managed settings forbid it; STELLA_TRUST_PROJECT does not lift it"


### PR DESCRIPTION
## The defect

Every notice the project-trust gate prints offers exactly one remedy: `STELLA_TRUST_PROJECT=1`.

That is a **one-launch** flag, and the condition it answers is **permanent** — an untrusted checkout is untrusted on every launch, in every repo, forever. So a reader is handed a per-launch fix for a standing problem, and reasonably concludes no standing fix exists.

One does. `run.auto_trust_project = true` in `~/.stella/stella.toml` has been the supported answer all along — `settings::resolve_project_trust` reads it as the default and lets the env var override in either direction, and `merge::trusted_scope_auto_trust_project` honors it from the user/managed scope. The notices simply never mentioned it.

**Observed:** a user reading the steering notice on every launch concluded the key could not be set in `stella.toml` at all, and asked for a feature that already ships.

## The change

All four notices now lead with the config key and offer the env var as the explicit one-launch alternative:

| Notice | File |
|---|---|
| project steering withheld | `settings/withheld.rs` |
| project hooks not loaded | `settings/merge.rs` |
| project context providers not loaded | `settings/merge.rs` |
| TUI steering-withheld row | `stella-tui/src/textline.rs` |

**Behavior is unchanged — only the advice is.** In particular:

- The managed-ceiling arm keeps its own distinct remedy, which correctly states that `STELLA_TRUST_PROJECT` does not lift it.
- The trust boundary itself is untouched: a project's own `stella.toml` still cannot grant itself trust (`merge.rs` discards it), which is what `docs/spec/threat-model.md` exists to protect.
- Every notice still names `STELLA_TRUST_PROJECT=1`, so the existing assertions on that substring continue to hold.

## Tests

The entire defect was a missing sentence, so the regression cover asserts the sentence is present:

- `settings_warnings_cli` — the stderr notice names `auto_trust_project`
- `render::tests::steering` — the TUI row names `auto_trust_project`

## Verification

`rustfmt --check` passes on all five touched files. The local `cargo test -p stella-tui --lib steering` run could not complete: `~/Projects/stella/target` had a build lock held continuously by a fleet of concurrent agent test runs, so the run starved rather than failing. Leaving compile + test verification to CI, which is the authoritative gate.

## Summary by Sourcery

Clarify project-trust notices by presenting the persistent configuration option alongside the one-launch environment override.

Bug Fixes:
- Update project-trust notices to identify the persistent `run.auto_trust_project = true` configuration as the standing remedy while retaining environment variables for one-launch trust.

Enhancements:
- Align CLI and TUI guidance for withheld project steering, hooks, and context providers without changing trust enforcement behavior.

Tests:
- Add regression assertions that CLI and TUI untrusted-project notices mention `auto_trust_project`.