### PR TITLE
fix(ci): give guard-self-tests.yml's prose job a resolvable base

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -81,7 +81,16 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      # Two, not one (#6273). `check-prose.py`'s base-tree allowances read
+      # `HEAD^1` on a `refs/pull/N/merge` checkout the same way
+      # `check-file-size.sh`'s do — see that job's checkout in file-size.yml
+      # for the full argument. At the default depth of 1 the parent is not in
+      # the clone, `resolve_base_commit` returns "", and every allowance
+      # collapses to the strict whole-tree check: inherited drift this PR did
+      # not cause then fails it anyway, which is what happened to #6266.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 2
 
       # Each step carries `!cancelled()` so a red one reports independently
       # instead of masking the next — ci.yml's guards job explains the trade at

--- a/scripts/check-prose.py
+++ b/scripts/check-prose.py
@@ -1322,11 +1322,24 @@ def main() -> int:
         return 1
 
     total = sum(per_pair.values())
+    # Say which mode ran, mirroring check-file-size.sh's mode_note. The
+    # base-relative rule is silent by nature -- it only shows itself when
+    # something drifts -- so a checkout too shallow to resolve a base falls
+    # back to strict and reads as an ordinary green line forever. That is
+    # exactly how guard-self-tests.yml shipped this ratchet as a whole-tree
+    # check while every one of its three allowances believed otherwise
+    # (#6273); naming the mode is what makes the difference legible in a log
+    # rather than a thing to re-derive.
+    if base_commit:
+        mode_note = f" Judged against {base_commit[:12]}."
+    else:
+        mode_note = " No base resolved -- strict whole-tree check."
     print(
         f"check-prose: OK -- {total} grandfathered construction(s) "
         f"in {len(files)} file(s), none added; "
         f"{len(per_unit)} unit(s) within their header-length ceiling; "
         f"{len(per_grade)} file(s) within their reading-grade ceiling."
+        f"{mode_note}"
     )
     return 0
 

--- a/scripts/test-prose-guard.sh
+++ b/scripts/test-prose-guard.sh
@@ -198,6 +198,21 @@ expect_line() {
   fi
 }
 
+# $1 = case name, $2 = root, $3 = substring the guard's stdout must contain.
+# The guard must also exit 0 -- this is for the passing-mode-note cases, not
+# a general-purpose grep.
+expect_output_contains() {
+  out="$(python3 "$SCRIPT" "$2" 2>&1)"
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    no "$1" "the guard exited non-zero"
+  elif printf '%s' "$out" | grep -qF "$3"; then
+    ok "$1"
+  else
+    no "$1" "stdout has no \"$3\" -- got: $out"
+  fi
+}
+
 # ── P1: clean prose passes ───────────────────────────────────────────────────
 r="$(new_root p1)"
 doc "$r" docs/a.md <<'EOF'
@@ -1013,6 +1028,30 @@ expect_line "S7 the moved entry is carried, and capped at its own count" \
 expect_line "S7 the untouched file keeps the ceiling it had" \
   "$r" "docs/untouched.md filler-adverb 3"
 expect_absent "S7 the old path is gone" "$r" "docs/old.md"
+
+# ── S8: a run with no resolvable base says so, rather than passing silently
+# in strict mode (#6273). A repository at its very first commit has no
+# `HEAD^2`, no `origin/main`, and no `HEAD^1` -- every rung of
+# `resolve_base_commit` misses, exactly as it does on a depth-1
+# `guard-self-tests.yml` checkout. The green line must name that, or an inert
+# allowance and a working one print the same thing.
+r="$(new_root s8)"
+baseline "$r"
+commit_all "$r"
+expect_output_contains "S8 no base resolved is named on the way past" "$r" \
+  "No base resolved -- strict whole-tree check."
+
+# S9: a resolvable base is named too, so the two modes read differently in a
+# log rather than only one of them announcing itself.
+r="$(new_root s9)"
+baseline "$r"
+commit_all "$r"
+doc "$r" docs/second.md <<'EOF'
+The cache is keyed by path.
+EOF
+commit_all "$r"
+expect_output_contains "S9 a resolved base is named on the way past" "$r" \
+  "Judged against"
 
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

`guard-self-tests.yml`'s `gate-steps` job checks out with a bare
`actions/checkout` — `fetch-depth: 1`. `check-prose.py`'s
`resolve_base_commit` needs to read `HEAD^1`'s tree to know what this
change inherited; at depth 1 that commit is not in the clone, every branch
of `resolve_base_commit` misses, and it returns `""`. That collapses
`max(ceiling, base)` to the ceiling on all three ratchets (count, grade,
density), so every base-tree allowance the guard has has been inert on
every PR run — not just a corner case, the only mode CI ever exercised.
`#6266` hit this directly: two of its three failures were drift it
inherited from `main`, not anything its diff touched.

Fix: give the job the same `fetch-depth: 2` `file-size.yml` and `ci.yml`'s
`check` job already use for the identical `check-file-size.sh` pattern —
one extra commit in the clone, no extra cost otherwise. Alongside it,
`check-prose.py` now names which mode it ran on its way past, matching
`check-file-size.sh`'s existing `mode_note` — so an inert allowance and a
working one no longer print the same green line.

**Audit of every other base-aware ratchet** (issue DoD item 3): grepped
the whole `scripts/` tree for the `resolve_base_commit` / `HEAD^2` /
`merge-base HEAD` shape. Exactly two scripts implement it:
`check-prose.py` (fixed here) and `check-file-size.sh`. `check-file-size.sh`
runs from two workflow jobs — `file-size.yml`'s `file-size` job and
`ci.yml`'s `check` job — and both already check out at `fetch-depth: 2`.
Nothing else in the tree resolves a base commit this way (`check-rebase-replay.sh`
reads full branch history for an unrelated hazard and has its own dedicated
workflow already built for that; the other `_BASE_REF` hits are unrelated
release/arena scripting). Recorded here as audited and not applicable
beyond the one fix.

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

Two new cases in `scripts/test-prose-guard.sh` (S8/S9) pin the new
no-base-resolved reporting:

```
$ git stash push -- scripts/check-prose.py && ./scripts/test-prose-guard.sh 2>&1 | tail -4; git stash pop
FAIL S8 no base resolved is named on the way past -- stdout has no "No base resolved -- strict whole-tree check." -- got: check-prose: OK ...
FAIL S9 a resolved base is named on the way past -- stdout has no "Judged against" -- got: check-prose: OK ...
78 passed, 2 failed

$ ./scripts/test-prose-guard.sh 2>&1 | tail -3
ok   S8 no base resolved is named on the way past
ok   S9 a resolved base is named on the way past
80 passed, 0 failed
```

The workflow half (the actual bug — a depth-1 checkout) can't be unit-tested
inside this script; it's demonstrated directly against a real depth-1 vs.
depth-2 clone of the exact merge commit CI ran for #6266
(`cf47b1e28a092be5a8790c3942ef1188ac0b3dff`):

```
# depth 1 (today's checkout): AGENTS.md inherited drift wrongly FAILS
$ git fetch --depth=1 origin cf47b1e2...&& git checkout FETCH_HEAD
$ python3 scripts/check-prose.py .
check-prose: FAIL -- prose got harder to read.
  AGENTS.md: grade 11.71 allowed, 11.73 found
...

# depth 2 (this PR's checkout): same commit, same script -- AGENTS.md and
# crates/stella-cli are correctly forgiven as inherited drift; the real
# crates/stella-plugin failure still fails
$ git fetch --depth=2 origin cf47b1e2... && git checkout FETCH_HEAD
$ python3 scripts/check-prose.py .
check-prose: FAIL -- module headers got longer.
  crates/stella-plugin: 34.95 allowed, 35.00 mean header lines
check-prose: drift inherited from the base tree, which this change did not cause and does not fail on:
  crates/stella-cli: 23.25 mean header lines, 23.22 allowed, 23.25 in the base tree
  AGENTS.md: grade 11.73, 11.71 allowed, 11.73 in the base tree
```

That is exactly DoD item 2: #6266's two inherited failures stop failing;
its real `crates/stella-plugin` failure still does.

## The gate

- [x] `cargo fmt --check` — not applicable, no Rust changed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — not applicable, no Rust changed
- [x] `cargo test --workspace` — not applicable, no Rust changed
- [ ] Docs updated where behavior/flags changed (README, `--help`, doc comments) — n/a
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer — squash builds
      the commit body from commit messages, so the description alone won't carry it

Locally: `make guards-fast` (toolchain-free; this repo's own laptop policy
is CI builds and tests, not this machine) green, including
`check-prose: OK ... Judged against <sha>.` and `check-file-size: OK ...
Judged against <sha>.`; `python3 scripts/check-line-citations.py` green with
nothing added.

## Fix over file

A defect you saw while making this change is fixed in this PR, even when it
is off-topic. Name each extra fix below. File an issue only when a fix could
not ride this PR: it needs a maintainer call, a rig or spend, or more than
one session. File it only if fixing it moves a pillar: stability,
reliability, maintainability, innovation, efficiency, or performance
(AGENTS.md § "Fix over file"). The gate catches a `TODO` with no issue
number. It cannot catch what only you saw.

- [x] Extra fixes in this PR: ___ — **or** none: the audit in "What & why"
      found no second depth-1 hole to fix — `check-file-size.sh`'s two
      callers were already correct — so this PR is the one fix plus the
      reporting improvement the issue's own DoD asks for.
- [x] Filed, with the reason a fix could not ride this PR: #___ — **or** nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

`check-prose.py`'s new `mode_note` is deliberately appended only to the
`OK` line, mirroring `check-file-size.sh`'s existing behavior exactly —
every failure path already lists inherited-drift lines when a base
resolved, so the mode is legible on both the pass and the fail side.

Closes #6273

## Summary by Sourcery

Restore base-aware prose validation in CI and make the guard’s evaluation mode explicit in its output.

Bug Fixes:
- Ensure the prose guard can resolve its inherited base tree in CI by increasing the self-test checkout depth to two commits, restoring base-relative allowances for inherited drift.

Enhancements:
- Make prose-guard success output distinguish strict whole-tree checks from checks judged against a resolved base commit.

CI:
- Update the prose guard self-test workflow checkout configuration to provide the parent commit required for base-aware validation.

Tests:
- Add guard tests covering reporting for both unresolved and resolved base commits.