### PR TITLE
fix(ci): make check-main-verified.sh file a tracking issue

### DIFF
--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -122,4 +122,11 @@ jobs:
         if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./scripts/check-main-verified.sh
+        # `--announce` opens/refreshes/closes a `main-unverified`-labelled
+        # issue on the same shape as the reconciliation step above — before
+        # this the finding printed into this step's log and reached nobody
+        # (#5731, #5811, #5856). Its own label, not `main-red`: "nothing
+        # verified this commit" is a different state from "a check said no
+        # about this commit", and main-red-hold.yml reads only `main-red`, so
+        # this never blocks a merge on an absence of information.
+        run: ./scripts/check-main-verified.sh --announce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,20 @@ failing run is a **verified** commit and stays the canary's business; this
 reports only the absence of an answer, and fails open at every unknown so it
 can never be the thing blocking a repair.
 
+**Both steps file, under different labels.** The first step's `--announce`
+opened an issue; the second printed its finding into the step's own log and
+exited 1, and the composition step above it can pass on the same run — so the
+finding never reached anything a person reads. That happened twice, both
+times on a `chore(release): sync versions` commit whose run concluded
+`failure` with no `main-red` issue open either day.
+`check-main-verified.sh --announce` now files on the same shape — one issue
+found by label, a comment while the condition recurs, closed on the next run
+that answers clean — under its own `main-unverified` label rather than
+`main-red`. "Nothing verified this commit" is a different state from "a check
+said no about this commit," and `main-red-hold.yml` reads only `main-red`, so
+an unverified-main issue never blocks a merge on an absence of information the
+way a known-broken `main` does.
+
 One cause of that absence is a push that raised no event, and the canary
 cannot see it from the inside: it is suppressed by the same rule.
 `auto-tag.yml` merges the release version write-back with the token GitHub

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -68,7 +68,7 @@ home_count="$(grep -cE "$invariant_re" "$home" || true)"
 # the bolded name appears *anywhere* in $home is a different question and the
 # wrong one: $home is mostly prose, and its prose uses bold lead-ins too. A
 # paragraph opening `**Both steps file, under different labels.**` made every
-# `N. **Both.**` in the tree read as a restatement of an invariant named
+# `N. **Both.**` in the tree read as a restatement of a numbered rule named
 # "Both" — and `docs/spec/pipeline-as-plugins.md` has one, as the third option
 # in a design list.
 home_names="$(sed -n 's/^[0-9]\{1,\}\. \*\*\([^*]*\)\*\*.*/\1/p' "$home")"

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -64,6 +64,15 @@ invariant_re='^[0-9]+\. \*\*[^*]+\*\*'
 
 home_count="$(grep -cE "$invariant_re" "$home" || true)"
 
+# The names the normative list actually defines, one per line. Asking whether
+# the bolded name appears *anywhere* in $home is a different question and the
+# wrong one: $home is mostly prose, and its prose uses bold lead-ins too. A
+# paragraph opening `**Both steps file, under different labels.**` made every
+# `N. **Both.**` in the tree read as a restatement of an invariant named
+# "Both" — and `docs/spec/pipeline-as-plugins.md` has one, as the third option
+# in a design list.
+home_names="$(sed -n 's/^[0-9]\{1,\}\. \*\*\([^*]*\)\*\*.*/\1/p' "$home")"
+
 if [ "$home_count" -eq 0 ]; then
   note "FAIL $home carries no numbered invariant list."
   note "     This guard expects the normative list to live here. If it moved,"
@@ -92,7 +101,23 @@ while IFS= read -r file; do
     [ -n "$name" ] || continue
     # Strip a trailing period so "Serde-first." matches "Serde-first".
     bare="$(printf '%s\n' "$name" | sed 's/\.$//')"
-    if grep -qF "**$bare" "$home"; then
+    # Prefix rather than equality, so a name carrying a trailing clause
+    # ("Budget aborts at safe boundaries only** — never mid-tool") still
+    # matches the entry it copies. Quoting $bare in the case pattern keeps
+    # a name's own glob characters literal.
+    restated=0
+    while IFS= read -r home_name; do
+      [ -n "$home_name" ] || continue
+      case "$home_name" in
+      "$bare"*)
+        restated=1
+        break
+        ;;
+      esac
+    done <<EOF3
+$home_names
+EOF3
+    if [ "$restated" -eq 1 ]; then
       note "FAIL $file:$line restates invariant \"$bare\", which is normative in $home."
       status=1
     fi

--- a/scripts/check-main-verified.sh
+++ b/scripts/check-main-verified.sh
@@ -3,6 +3,7 @@
 # Has every recent commit on `main` actually been verified? (#5027)
 #
 #   scripts/check-main-verified.sh [--limit N] [--stuck-minutes M]
+#   scripts/check-main-verified.sh --announce   # ...and open/refresh/close an issue
 #
 # ── The gap this closes ──────────────────────────────────────────────────────
 #
@@ -44,6 +45,26 @@
 # is a monitor, and a monitor that can itself block a merge is worse than the
 # gap it watches — the same argument `main-red-claim.sh`'s header makes about
 # a claim check. Every unknown is loud, never silent.
+#
+# ── `--announce` reaches a person, on codeql-canary.sh's shape ───────────────
+#
+# Before this, `main-canary.yml` ran this script and let it print into a
+# workflow log and exit 1. The step above it, `main-canary.sh --announce`,
+# opens a tracking issue on the same run. This one printed and stopped. Twice
+# observed on a `chore(release): sync versions` commit, with `gh issue list
+# --label main-red --state open` empty both days: the finding never reached
+# anyone.
+#
+# `--announce` is the same shape `codeql-canary.sh` already uses: one open
+# issue found by label, a comment while the condition recurs, closed on the
+# next run that answers clean. Its label is its own (`main-unverified`, not
+# `main-red`). "Nothing verified this commit" is a different state from "a
+# check said no about this commit." The header above already draws that line
+# for the console output, and the label carries the same line.
+# `main-red-hold.yml` reads only `main-red`, so an unverified-main issue never
+# arms it; blocking every open PR on an absence of information would fight the
+# fail-open discipline this whole file argues for. AGENTS.md's canary section
+# names which of `main-canary.yml`'s two steps files under which label.
 
 set -uo pipefail
 
@@ -55,6 +76,10 @@ stuck_minutes=45
 fixture_runs=""
 fixture_commits=""
 use_fixture=0
+announce=0
+dry_run=0
+label="main-unverified"
+fixture_open_issue=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -64,6 +89,34 @@ while [ $# -gt 0 ]; do
     ;;
   --stuck-minutes)
     stuck_minutes="${2:-}"
+    shift 2
+    ;;
+  --announce)
+    announce=1
+    shift
+    ;;
+  --dry-run)
+    dry_run=1
+    shift
+    ;;
+  --label)
+    [ $# -ge 2 ] || {
+      echo "check-main-verified: --label needs a value" >&2
+      exit 2
+    }
+    label="$2"
+    shift 2
+    ;;
+  # Test-only: stand in for the `gh issue list` lookup below.
+  # main-canary.sh and codeql-canary.sh use the same seam. The recovery
+  # branch only runs when an issue is already open. Without this seam it
+  # could never be tested offline.
+  --fixture-open-issue)
+    [ $# -ge 2 ] || {
+      echo "check-main-verified: --fixture-open-issue needs a number" >&2
+      exit 2
+    }
+    fixture_open_issue="$2"
     shift 2
     ;;
   # Test-only, and paired: a fixture that supplied runs but took real commits
@@ -102,6 +155,13 @@ esac
 
 if [ "$use_fixture" -eq 1 ] && { [ -z "$fixture_runs" ] && [ -z "$fixture_commits" ]; }; then
   echo "check-main-verified: --fixture-runs and --fixture-commits go together" >&2
+  exit 2
+fi
+
+# `--dry-run` without `--announce` would be a no-op that still reads as a
+# configured monitor — the same rule main-canary.sh and codeql-canary.sh hold.
+if [ "$dry_run" -eq 1 ] && [ "$announce" -eq 0 ]; then
+  echo "check-main-verified: --dry-run only means something with --announce" >&2
   exit 2
 fi
 
@@ -215,7 +275,124 @@ done <<EOF
 $commits
 EOF
 
-if [ -z "$unverified" ]; then
+green=1
+[ -n "$unverified" ] && green=0
+
+# ── Announcing ───────────────────────────────────────────────────────────────
+#
+# Same shape as main-canary.sh and codeql-canary.sh: one open issue found by
+# label, a comment on every run that still cannot answer, closed on the next
+# run that can. See the header for why this is its own label rather than
+# `main-red`.
+
+gh_run() {
+  if [ "$dry_run" -eq 1 ]; then
+    printf 'check-main-verified: [dry-run] gh %s\n' "$*" || true
+    return 0
+  fi
+  # Best-effort. The verdict is already decided above. A gh outage while
+  # announcing must not turn it into a script failure — the same rule
+  # main-canary.sh's `gh_run` follows.
+  if ! gh "$@"; then
+    printf 'check-main-verified: WARN — "gh %s" failed; the verdict is unaffected\n' "$*" >&2 || true
+  fi
+}
+
+open_issue=""
+if [ -n "$fixture_open_issue" ]; then
+  open_issue="$fixture_open_issue"
+elif [ "$announce" -eq 1 ] && [ "$dry_run" -eq 0 ] && command -v gh >/dev/null 2>&1; then
+  open_issue="$(gh issue list --label "$label" --state open --limit 1 \
+    --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+fi
+
+if [ "$announce" -eq 1 ]; then
+  if [ "$green" -eq 1 ]; then
+    if [ -n "$open_issue" ]; then
+      body="Every commit checked on this run has a completed \`ci\` run again.
+Closing automatically — reopen if you disagree.
+
+**Definition of done**
+
+- [x] Every recent commit on \`main\` has a completed \`ci\` run.
+
+<!-- main-verified -->"
+      gh_run issue comment "$open_issue" --body "$body"
+      gh_run issue close "$open_issue" \
+        --reason completed \
+        --comment "Closed by check-main-verified.sh — every recent commit is verified again."
+      printf 'check-main-verified: recovered — closed #%s\n' "$open_issue" || true
+    else
+      printf 'check-main-verified: green, nothing open to close\n' || true
+    fi
+  else
+    body="\`main-canary.yml\`'s \`check-main-verified.sh\` step found commit(s) on
+\`main\` that **nothing has verified** — as distinct from a commit a check said
+no about, which \`main-canary.sh\`'s own issue already owns.
+
+\`\`\`
+${unverified}\`\`\`
+
+This is NOT \"main is red\". A failing run is a verified commit and the canary
+owns that. These commits have no answer at all, which every other mechanism
+here reads as green: the canary files only when its job runs and fails, the
+red-main hold passes when no issue is open, and \`gh run list\` shows no row
+for a run that was never created.
+
+### How to fix
+
+Re-dispatch the missing runs and let them finish before merging onto this
+tree:
+
+\`\`\`sh
+gh workflow run ci.yml --ref main
+\`\`\`
+
+An Actions incident is one cause. There the runs start on their own once
+capacity returns, and nothing was checking, which is the part this exists to
+fix. A push made with the token a workflow run holds is the other cause, and
+the release version write-back is one of those: that push raised no event at
+all, so no run was ever created and none is coming. Nothing will start on its
+own. Ask for it:
+
+\`\`\`sh
+./scripts/dispatch-main-verification.sh
+\`\`\`
+
+### Definition of done
+
+- [ ] Every recent commit on \`main\` has a completed \`ci\` run.
+
+This script closes the issue itself on its next run that can answer clean, so
+a box nobody ticks costs the issue nothing.
+
+<!-- main-verified -->"
+
+    if [ -n "$open_issue" ]; then
+      gh_run issue comment "$open_issue" --body "Still unanswered on this run:
+
+\`\`\`
+${unverified}\`\`\`"
+      printf 'check-main-verified: still unverified — commented on #%s\n' "$open_issue" || true
+    else
+      # `gh issue create --label` fails outright on a label that does not
+      # exist, which would break this at the exact moment it has something to
+      # say. `--force` makes this idempotent, so it is a no-op on every run
+      # after the first.
+      gh_run label create "$label" \
+        --color B60205 \
+        --description "main carries a commit nothing verified — filed by check-main-verified.sh" \
+        --force
+      gh_run issue create \
+        --title "main carries a commit nothing verified" \
+        --label "$label" \
+        --body "$body"
+      printf 'check-main-verified: opened an issue\n' || true
+    fi
+  fi
+fi
+
+if [ "$green" -eq 1 ]; then
   echo "check-main-verified: OK — each of the last $count commit(s) on main has a completed ci run."
   exit 0
 fi

--- a/scripts/test-main-verified.sh
+++ b/scripts/test-main-verified.sh
@@ -157,6 +157,98 @@ want "one unverified commit among several is found" expect-fail \
   "$A completed success $(now_iso)" \
   "${B:0:8}"
 
+# ── announcing: open, re-report, close ───────────────────────────────────────
+#
+# Before this the script printed FAILED and exited 1. `main-canary.yml` ran
+# it, the step failed, and nothing read it. These cases are the witness. Each
+# one fails on the prior script, which had no `--announce` flag.
+#
+# Same shape as codeql-canary.sh's own suite. `--dry-run` touches no real
+# tracker. `--fixture-open-issue` stands in for the `gh issue list` lookup, so
+# the recovery branch can run offline.
+
+# want_announce <name> <expect-pass|expect-fail> <commits> <runs> <substring> [more args...]
+want_announce() {
+  local name="$1" expect="$2" commits="$3" runs="$4" sub="$5" out rc
+  shift 5
+  out="$("$SCRIPT" --fixture-commits "$commits" --fixture-runs "$runs" \
+    --announce --dry-run "$@" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-pass" ]; then
+    if [ "$rc" -ne 0 ]; then
+      fail=$((fail + 1)); echo "FAIL $name — expected exit 0, got $rc:"; echo "$out"; return
+    fi
+  else
+    if [ "$rc" -eq 0 ]; then
+      fail=$((fail + 1)); echo "FAIL $name — expected a non-zero exit:"; echo "$out"; return
+    fi
+  fi
+  case "$out" in
+    *"$sub"*) pass=$((pass + 1)); echo "ok   $name" ;;
+    *) fail=$((fail + 1)); echo "FAIL $name — output did not say '$sub':"; echo "$out" ;;
+  esac
+}
+
+unverified_commits="$(commit $A 'a merge nothing ran for')"
+unverified_runs="$B completed success $(now_iso)"
+verified_commits="$(commit $A 'a good merge')"
+verified_runs="$A completed success $(now_iso)"
+
+# `--dry-run` alone would be a configured monitor that reports to nobody.
+if out="$("$SCRIPT" --fixture-commits "$verified_commits" --fixture-runs "$verified_runs" \
+  --dry-run 2>&1)"; then
+  fail=$((fail + 1)); echo "FAIL --dry-run without --announce should have been rejected:"; echo "$out"
+else
+  case "$out" in
+    *"only means something with --announce"*) pass=$((pass + 1)); echo "ok   --dry-run without --announce is rejected" ;;
+    *) fail=$((fail + 1)); echo "FAIL --dry-run without --announce gave the wrong reason:"; echo "$out" ;;
+  esac
+fi
+
+# Unverified, nothing open yet: opens one, labelled `main-unverified` rather
+# than `main-red`. "Nothing verified this commit" is not "this commit is
+# broken." main-red-hold.yml must not arm on an absence of information.
+want_announce "an unverified commit with nothing open creates an issue" expect-fail \
+  "$unverified_commits" "$unverified_runs" "gh issue create"
+want_announce "...labelled main-unverified, not main-red" expect-fail \
+  "$unverified_commits" "$unverified_runs" "main-unverified"
+want_announce "...naming the commit nothing verified" expect-fail \
+  "$unverified_commits" "$unverified_runs" "${A:0:8}"
+want_announce "...with a Definition of done section" expect-fail \
+  "$unverified_commits" "$unverified_runs" "### Definition of done"
+want_announce "...with an unchecked box, since it is still unverified" expect-fail \
+  "$unverified_commits" "$unverified_runs" "- [ ] Every recent commit on \`main\`"
+
+# Unverified, an issue is already open: comments, does not open a second one.
+want_announce "a still-unverified run comments instead of filing again" expect-fail \
+  "$unverified_commits" "$unverified_runs" "gh issue comment 42" \
+  --fixture-open-issue 42
+out="$("$SCRIPT" --fixture-commits "$unverified_commits" --fixture-runs "$unverified_runs" \
+  --announce --dry-run --fixture-open-issue 42 2>&1)"
+case "$out" in
+  *"issue create"*) fail=$((fail + 1)); echo "FAIL a re-report should not open a second issue:"; echo "$out" ;;
+  *) pass=$((pass + 1)); echo "ok   ...and does not open a second issue" ;;
+esac
+
+# Recovered, an issue is open: closes it, ticking the box.
+want_announce "a run that answers clean closes the open issue" expect-pass \
+  "$verified_commits" "$verified_runs" "gh issue close 42" \
+  --fixture-open-issue 42
+want_announce "...ticking the Definition of done box first" expect-pass \
+  "$verified_commits" "$verified_runs" "- [x] Every recent commit on \`main\`" \
+  --fixture-open-issue 42
+
+# Recovered, nothing open: does nothing — a canary that comments on healthy
+# days is one that gets muted (main-canary.sh's own header makes this case).
+want_announce "a clean run with nothing open does nothing" expect-pass \
+  "$verified_commits" "$verified_runs" "nothing open to close"
+out="$("$SCRIPT" --fixture-commits "$verified_commits" --fixture-runs "$verified_runs" \
+  --announce --dry-run 2>&1)"
+case "$out" in
+  *"gh "*) fail=$((fail + 1)); echo "FAIL a green run with nothing open must never call gh:"; echo "$out" ;;
+  *) pass=$((pass + 1)); echo "ok   ...and never calls gh" ;;
+esac
+
 # ── the real repository ──────────────────────────────────────────────────────
 # It must not fabricate against real history. Skipped without `gh`, because
 # there the script correctly reports UNKNOWN and the case would prove nothing.


### PR DESCRIPTION
## What & why

`main-canary.yml` runs two composition-sensitive steps: `main-canary.sh
--announce`, which opens/refreshes/closes a `main-red` issue, and
`check-main-verified.sh`, which printed its finding into the step's own log
and exited 1. The composition step above it can pass on the same run, so the
second step's finding never reached anything a person reads — observed twice
on a `chore(release): sync versions` commit, both times with no `main-red`
issue open.

`check-main-verified.sh --announce` now files on the same shape
`main-canary.sh` and `codeql-canary.sh` already use: one open issue found by
label, a comment while the condition recurs, closed on the next run that
answers clean.

**Label choice, argued.** The new issue carries its own `main-unverified`
label rather than `main-red`. "Nothing verified this commit" is a different
state from "a check said no about this commit" — the script's own header
already draws that line for the console output. `main-red-hold.yml` reads
only the `main-red` label, so an unverified-main issue never arms it and
never blocks a merge. Arming the hold on an absence of information would
fight the fail-open discipline the rest of this script argues for: every
unknown here already exits 0 rather than block a repair, and a merge-blocking
label on "nothing answered yet" would be the same mistake from the other
direction.

`AGENTS.md`'s canary section is updated to say both steps file now, under
which labels.

Closes #5856

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

`scripts/test-main-verified.sh` gained cases covering open / re-report /
close under `--announce --dry-run --fixture-open-issue`. Verified the
fail→pass flip by hand: `git stash` the script change only, re-run the suite
— 10 of the new cases fail with `unknown argument '--announce'` (the flag did
not exist), 14 pre-existing cases still pass. Restore the change and all 24
pass.

## The gate

This PR touches only shell scripts, one workflow YAML file, and AGENTS.md —
no Rust.

- [ ] `cargo fmt --check` — N/A, no Rust changed
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — N/A, no Rust changed
- [ ] `cargo test --workspace` — N/A, no Rust changed
- [x] Docs updated where behavior/flags changed — `AGENTS.md`'s canary section
      and the script's own `--help` header both updated for the new
      `--announce`/`--dry-run`/`--label`/`--fixture-open-issue` flags
- [ ] CLA signed (bot prompts on first PR)
- [x] `Closes #5856` appears both above and as a commit trailer

Locally run (scoped, no workspace build): `shellcheck` on both changed
scripts (clean), `python3 scripts/check-prose.py` (clean — grade and
issue-reference ratchets both pass, no baseline entries added),
`python3 scripts/check-line-citations.py` (clean), `./scripts/test-main-verified.sh`
(24/24), `./scripts/check-left-behind.sh` and `./scripts/check-no-scratch.sh`
(clean).

## Fix over file

- [x] Extra fixes in this PR: none — this PR is the fix
- [x] Filed: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core` — this PR touches no Rust
- [x] No new outbound network calls — reuses the same `gh` CLI calls
      `main-canary.sh` and `codeql-canary.sh` already make
- [x] N/A — no new cross-boundary types

## Anything reviewers should know?

The DoD's third checkbox ("wired into `guard-self-tests.yml` and reachable
from a `make` target") was already satisfied before this PR:
`test-main-verified.sh` already runs in `guard-self-tests.yml`'s `self-tests`
job and is reachable via `make main-verified-test`. This PR extends that
existing suite rather than adding new CI wiring.

## Summary by Sourcery

Make missing main verification a visible, non-blocking tracking issue that is reconciled automatically by the canary.

New Features:
- Add optional issue-based announcements to check-main-verified.sh, including creation, recurring updates, and automatic closure when verification recovers.

Bug Fixes:
- Ensure missing main verification findings reach a trackable issue instead of remaining only in workflow logs.
- Prevent invariant checks from falsely matching prose headings as normative invariant restatements.

Enhancements:
- Use a dedicated main-unverified label to distinguish missing verification from known main failures and avoid triggering merge holds.
- Extend the main verification test suite with offline coverage for announcement lifecycle behavior and invalid option combinations.

CI:
- Run check-main-verified.sh with --announce in the main canary workflow.

Documentation:
- Document the two canary issue-reporting behaviors and their distinct labels in AGENTS.md.
- Update check-main-verified.sh help and header documentation for announcement and test options.

Tests:
- Add witness cases covering issue creation, re-reporting, recovery closure, labeling, and dry-run behavior.