### PR TITLE
ci(main-red-clear): add a drill to rehearse the hold re-run call

### DIFF
--- a/.github/workflows/main-red-clear.yml
+++ b/.github/workflows/main-red-clear.yml
@@ -19,11 +19,30 @@ name: main-red-clear
 # canary closes with `GITHUB_TOKEN`, and GitHub starts no workflow from an
 # event raised by that token. Both callers run the same script, and running it
 # twice re-runs nothing the first pass already cleared.
+#
+# ── The drill (#6051) ─────────────────────────────────────────────────────
+#
+# The re-run call above only ever fires while a hold has actually failed,
+# which needs a real outage — so it is the one step here with no live
+# evidence, and a broken scope or a refused run id would surface only mid
+# outage. A `drill` input rehearses that exact call against one named pull
+# request's latest hold run, whatever its conclusion, and touches no other
+# pull request. Re-running a run that already passed still passes, so it is
+# safe to dispatch any day.
 
 on:
   issues:
     types: [closed, unlabeled]
   workflow_dispatch:
+    inputs:
+      drill:
+        description: >-
+          Pull request number to drill (e.g. 6051). Rehearses the re-run
+          call against that PR's latest main-red-hold run, whatever its
+          conclusion, and touches no other pull request. Leave empty for
+          the ordinary sweep.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -54,7 +73,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Re-run the hold on every open pull request
+      - name: Re-run the hold (drill on one PR, or sweep every open one)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./scripts/clear-main-red-holds.sh
+          DRILL_PR: ${{ inputs.drill }}
+        run: |
+          if [ -n "$DRILL_PR" ]; then
+            ./scripts/clear-main-red-holds.sh --drill "$DRILL_PR"
+          else
+            ./scripts/clear-main-red-holds.sh
+          fi

--- a/scripts/clear-main-red-holds.sh
+++ b/scripts/clear-main-red-holds.sh
@@ -59,9 +59,27 @@
 # required check, and the pull request stays unmergeable. The sweep counts those
 # and names them, so a reader knows which branches still need a push.
 #
+# ## The drill (`#6051`)
+#
+# The lookup half of a sweep runs constantly — every recovery exercises it.
+# The re-run call itself only fires while a hold has actually failed, which
+# needs a real outage. So the one step that clears the block was the one step
+# with no live evidence: if the token lacked a scope, or the endpoint refused
+# a run of that age, nothing would say so until the next outage, the worst
+# moment to find out.
+#
+# `--drill <pr>` rehearses that exact call on one named pull request's latest
+# hold run, whatever its conclusion. It never asks whether `main` is known
+# broken and never looks at any other pull request, so it is safe to run any
+# day: re-running a run that already passed still passes. A failure here —
+# a missing scope, a stale run id the API refuses — exits non-zero, on
+# purpose, unlike the rest of this script: the drill exists to surface that
+# failure now, not to fail open through it.
+#
 # Usage:
 #   scripts/clear-main-red-holds.sh
 #   scripts/clear-main-red-holds.sh --dry-run
+#   scripts/clear-main-red-holds.sh --drill <pr-number>
 #
 # Needs `gh` and a POSIX shell, so it runs on a bare CI runner.
 set -uo pipefail
@@ -72,9 +90,11 @@ workflow="main-red-hold.yml"
 # told when it cuts the list short.
 limit=0
 dry_run=0
+drill_pr=""
 fixture_open_issues=""
 fixture_open_prs=""
 fixture_stale_runs=""
+fixture_drill_run=""
 use_fixture=0
 
 while [ $# -gt 0 ]; do
@@ -91,6 +111,19 @@ while [ $# -gt 0 ]; do
     limit="$2"
     case "$limit" in '' | *[!0-9]*)
       echo "clear-main-red-holds: --limit takes a whole number" >&2
+      exit 2
+      ;;
+    esac
+    shift 2
+    ;;
+  --drill)
+    [ $# -ge 2 ] || {
+      echo "clear-main-red-holds: --drill needs a pull request number" >&2
+      exit 2
+    }
+    drill_pr="$2"
+    case "$drill_pr" in '' | *[!0-9]*)
+      echo "clear-main-red-holds: --drill takes a pull request number" >&2
       exit 2
       ;;
     esac
@@ -127,6 +160,15 @@ while [ $# -gt 0 ]; do
     use_fixture=1
     shift 2
     ;;
+  --fixture-drill-run)
+    [ $# -ge 2 ] || {
+      echo "clear-main-red-holds: --fixture-drill-run needs a value" >&2
+      exit 2
+    }
+    fixture_drill_run="$2"
+    use_fixture=1
+    shift 2
+    ;;
   -h | --help)
     # The whole block after the shebang, cut off at its first line of code.
     # A line number here goes stale the first time the header grows. Same
@@ -155,6 +197,61 @@ if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
   note "gh is not installed, so no hold could be cleared. A push to each"
   note "branch still clears its own hold."
   exit 0
+fi
+
+# ── The drill: rehearse the call on one named pull request (`#6051`) ────────
+#
+# Skips the "is main known-broken" question entirely — that question is what
+# makes the ordinary re-run untestable most days, and the drill exists to
+# rehearse the call without waiting for it to answer "yes". Never looks past
+# the one pull request it is given.
+
+if [ -n "$drill_pr" ]; then
+  drill_head=""
+  if [ "$use_fixture" -eq 1 ]; then
+    drill_head="$(printf '%s\n' "$fixture_open_prs" |
+      awk -v pr="$drill_pr" '$1 == pr { print $2; exit }')"
+  elif ! drill_head="$(gh pr view "$drill_pr" --json headRefOid \
+    --jq '.headRefOid' 2>/dev/null)" || [ -z "$drill_head" ]; then
+    drill_head=""
+  fi
+  if [ -z "$drill_head" ]; then
+    note "could not find pull request #$drill_pr, so there is nothing to drill."
+    exit 1
+  fi
+
+  drill_run=""
+  if [ "$use_fixture" -eq 1 ]; then
+    drill_run="$fixture_drill_run"
+  elif ! drill_run="$(gh api \
+    "repos/{owner}/{repo}/actions/workflows/$workflow/runs?head_sha=$drill_head&per_page=1" \
+    --jq '.workflow_runs[0].id // "none"' 2>/dev/null)"; then
+    drill_run=""
+  fi
+
+  if [ -z "$drill_run" ] || [ "$drill_run" = "none" ]; then
+    note "no $workflow run exists on the head of #$drill_pr — there is nothing"
+    note "to drill. Push a commit to that pull request first."
+    exit 1
+  fi
+
+  if [ "$dry_run" -eq 1 ]; then
+    say "would re-run the hold on PR #$drill_pr (head $drill_head, run $drill_run)"
+    exit 0
+  fi
+
+  if gh api -X POST --silent \
+    "repos/{owner}/{repo}/actions/runs/$drill_run/rerun" 2>/dev/null; then
+    say "re-ran the hold on PR #$drill_pr (head $drill_head, run $drill_run)"
+    repo_slug="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner \
+      --jq '.nameWithOwner' 2>/dev/null)}"
+    [ -n "$repo_slug" ] &&
+      say "https://github.com/$repo_slug/actions/runs/$drill_run"
+    exit 0
+  fi
+  note "could not re-run run $drill_run for PR #$drill_pr — does this job have"
+  note "\`actions: write\`? That is exactly the gap this drill exists to find."
+  exit 1
 fi
 
 # ── Is main still known-broken? ──────────────────────────────────────────────

--- a/scripts/test-main-red-hold.sh
+++ b/scripts/test-main-red-hold.sh
@@ -262,6 +262,67 @@ holds_text "...and holds the write scope that a re-run needs" \
 holds_text "a person closing the issue by hand starts a sweep too" \
   main-red-clear.yml "types: \[closed, unlabeled\]"
 
+holds_text "the workflow carries a drill input to rehearse the re-run call" \
+  main-red-clear.yml "drill:"
+
+holds_text "...and passes it to the script rather than running blind" \
+  main-red-clear.yml "clear-main-red-holds.sh --drill"
+
+printf '\n\033[1mdrilling — the re-run call is rehearsed without an outage\033[0m\n'
+
+# The drill never asks whether main is broken and never sweeps a second pull
+# request, so its own fixtures are a one-line PR/head table and a bare run id
+# — the ordinary sweep's issue and multi-PR fixtures play no part here.
+drill_says() { # drill_says <name> <want-substring> <expect-rc> <pr> <prs> <run>
+  local name="$1" want_text="$2" expect_rc="$3" pr="$4" prs="$5" run="$6"
+  local out rc
+  out="$("$CLEAR" --drill "$pr" --fixture-open-prs "$prs" \
+    --fixture-drill-run "$run" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne "$expect_rc" ]; then
+    bad "$name — expected exit $expect_rc, got $rc: $out"
+    return
+  fi
+  case "$out" in
+  *"$want_text"*) ok "$name" ;;
+  *) bad "$name — wanted '$want_text': $out" ;;
+  esac
+}
+
+# `#6051`'s own fixture: one pull request, and a run id the drill must name
+# back exactly, regardless of what that run's real conclusion was.
+drill_prs="5903 aaaaaaa"
+
+drill_says "a drill re-runs the named pull request's latest hold run" \
+  "5903 (head aaaaaaa, run 99999999)" 0 \
+  "5903" "$drill_prs" "99999999"
+
+# The point of the drill: a sweep would never touch a run that already
+# passed — nothing failed. The drill must rehearse it anyway, which is what
+# lets it run on an ordinary day with nothing broken.
+drill_says "...even when that run already passed" \
+  "5903 (head aaaaaaa, run 12345678)" 0 \
+  "5903" "$drill_prs" "12345678"
+
+# The one negative case the definition of done names by name: a pull request
+# that carries no hold run at all. Nothing to rehearse, and the drill says so
+# loudly rather than reporting a quiet, meaningless success.
+drill_says "a pull request with no hold run at all fails loudly" \
+  "no main-red-hold.yml run exists on the head of" 1 \
+  "5903" "$drill_prs" "none"
+
+# A pull request number the fixture does not know is a caller mistake, not a
+# silent no-op.
+drill_says "an unknown pull request number fails loudly, not silently" \
+  "could not find pull request" 1 \
+  "9999" "$drill_prs" ""
+
+out="$("$CLEAR" --drill 2>&1)"
+if [ $? -eq 2 ]; then ok "drilling: a flag missing its value exits 2, not 0"; else bad "drilling: a flag missing its value did not exit 2"; fi
+
+out="$("$CLEAR" --drill banana 2>&1)"
+if [ $? -eq 2 ]; then ok "drilling: --drill given a word exits 2, not 0"; else bad "drilling: --drill given a word did not exit 2"; fi
+
 printf '\n'
 if [ "$fail" -eq 0 ]; then
   printf '\033[32mmain-red-hold-test: OK\033[0m — %d checks passed\n' "$pass"


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

`scripts/clear-main-red-holds.sh` re-runs a failed `main-red-hold.yml` run
once `main` recovers, but the re-run call itself (`POST
/repos/{owner}/{repo}/actions/runs/<id>/rerun-failed-jobs`) only ever fires
while a hold has actually failed, so a broken token scope or a refused run id
would surface for the first time mid-outage — the worst moment to find it.

This PR adds `--drill <pr-number>` to `clear-main-red-holds.sh` and a
matching `drill` `workflow_dispatch` input on `main-red-clear.yml`. The drill
looks up the named pull request's latest `main-red-hold.yml` run and re-runs
it with the plain `rerun` endpoint, whatever that run's conclusion — it never
checks whether `main` is known-broken, and it never touches any other pull
request. Re-running a run that already passed still passes, so the drill is
safe to dispatch on an ordinary day and proves the permission, the endpoint,
and the run-id lookup without needing a real outage.

The ordinary path (`workflow_dispatch` with no `drill` input, and the
`issues` trigger) is unchanged — it still runs the existing sweep.

Closes #6051

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`scripts/test-main-red-hold.sh` gained a "drilling" section: a drill that
finds a stale run, one that finds an already-passing run (the case that
proves the whole point — the ordinary sweep would never touch it), a pull
request with no hold run at all (the DoD's named negative case), an unknown
pull request number, and the `--drill` argument-handling cases. Checked the
artisanal way: with only the test file's new assertions applied against the
unmodified script, 6 of them fail with `unknown argument '--drill'`; with the
script and workflow changes applied too, all 38 checks in the suite pass.

## The gate

- [x] `cargo fmt --check` — no Rust touched
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no Rust touched
- [x] `cargo test --workspace` — no Rust touched; `make main-red-hold-test`
      (`bash scripts/test-main-red-hold.sh`) is the suite this change extends,
      run locally: 38/38 passing
- [ ] Docs updated where behavior/flags changed (README, `--help`, doc comments) — the script's own header comment documents `--drill`, and it has no `--help`-listed public surface beyond that header (`-h`/`--help` prints the header)
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #6051` appears **both** above and as a commit trailer — squash builds
      the commit body from commit messages, so the description alone won't carry it

## Fix over file

A defect you saw while making this change is fixed in this PR, even when it
is off-topic. Name each extra fix below. File an issue only when a fix could
not ride this PR: it needs a maintainer call, a rig or spend, or more than
one session. File it only if fixing it moves a pillar: stability,
reliability, maintainability, innovation, efficiency, or performance
(AGENTS.md § "Fix over file"). The gate catches a `TODO` with no issue
number. It cannot catch what only you saw.

- [x] Extra fixes in this PR: none — **or** none
- [x] Filed, with the reason a fix could not ride this PR: #___ — **or** nothing was deferred

## Ground-rule check

<!-- Delete lines that don't apply. -->

- [x] No I/O added to `stella-core`; no new deps without justification below — no Rust crate touched at all
- [x] No new outbound network calls (Stella never phones home) — the drill calls the same GitHub Actions API the sweep already calls, under the same `actions: write` scope, and only when a human explicitly dispatches it with a PR number
- [ ] New cross-boundary types round-trip through serde (test included) — no types added

## Anything reviewers should know?

The drill uses the plain `rerun` endpoint
(`POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun`) rather than the
sweep's `rerun-failed-jobs`, because the whole point is to exercise it
"whatever its conclusion" (the issue's own wording) — `rerun-failed-jobs` has
nothing to do on a run with no failed jobs, which is exactly the everyday
case the drill needs to cover. It still exercises the same `actions: write`
permission and the same run-id lookup the real recovery call depends on.

The drill also departs from the rest of the script's fail-open philosophy on
purpose: every other path in `clear-main-red-holds.sh` prints a note and
exits 0 on any unknown, because a canary must never say `main` is broken from
a `gh` blip. The drill is not part of that canary path — its only job is to
surface a broken scope or a refused call *before* an outage, so a failed
re-run, a missing hold run, or an unresolvable pull request number all exit
non-zero and fail the dispatched workflow run loudly.

## Summary by Sourcery

Add a safe, single-pull-request drill to verify the main-red hold re-run path without requiring an outage.

New Features:
- Add a targeted drill mode that re-runs the latest main-red-hold workflow for a specified pull request regardless of the run conclusion.
- Expose the drill through the main-red-clear workflow dispatch input.

Enhancements:
- Make drill failures explicit for missing pull requests, missing hold runs, or unsuccessful re-run requests while preserving the ordinary fail-open sweep behavior.

Documentation:
- Document the drill mode and its usage in the workflow and script headers.

Tests:
- Extend the main-red hold test suite with successful, negative, and argument-validation drill cases.