### PR TITLE
ci(auto-tag): verify the commit an armed auto-merge lands

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -443,6 +443,7 @@ jobs:
       # the merge result, and merges the ordinary way. The admin merge stays
       # as a fallback for a repository whose protection still permits one.
       - name: Wait for the required checks, then merge the version-sync PR
+        id: merge
         if: steps.ver.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -667,8 +668,19 @@ jobs:
           # Last resort: arm auto-merge so a context that reports late still
           # lands the write-back with no human action, and say so, because a
           # step that reaches here has not merged anything.
-          gh pr merge "${BRANCH}" --squash --auto \
-            || echo "::warning::could not enable auto-merge — merge the ${BRANCH} PR manually once checks are green."
+          #
+          # `armed=true` tells the next step to wait for this merge to
+          # actually land before it asks whether the tip of main got checked
+          # (#5857): GitHub performs an armed auto-merge asynchronously,
+          # still under this run's token, so the resulting push raises no
+          # workflow-triggering event — same as the ordinary/admin merges
+          # above, except here nothing after this step would otherwise know
+          # a merge is still coming.
+          if gh pr merge "${BRANCH}" --squash --auto; then
+            echo "armed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "::warning::could not enable auto-merge — merge the ${BRANCH} PR manually once checks are green."
+          fi
           echo "::warning::${BRANCH} did not merge in this run; auto-merge is armed. If it is still open, check that its workflow runs are not parked in action_required (#5589)."
 
       # The merge above is made with `secrets.GITHUB_TOKEN`, and GitHub raises
@@ -692,8 +704,27 @@ jobs:
       #
       # `!cancelled()` rather than `success()`: a merge step that ended in a
       # warning still merged, and that tip is exactly the one to ask about.
-      - name: Make sure the merged tip of main gets checked
+      #
+      # `steps.merge.outputs.armed == 'true'` means the merge step reached
+      # the last-resort branch: nothing merged in THIS run, but auto-merge is
+      # now armed and will land later, asynchronously, once the required
+      # checks report — still under this run's token, so that later push
+      # raises no workflow-triggering event either (#5857, the async half of
+      # the gap #5817 closed for the synchronous merge paths above).
+      # `scripts/wait-for-armed-merge.sh` waits here, bounded, for it to land
+      # before this asks: if it does, the dispatcher below reads the new tip
+      # and starts the missing runs; if it does not land within the wait,
+      # the dispatcher reads the tip this run started from — already checked
+      # — and the daily main-canary schedule stays the backstop, exactly as
+      # before this step existed.
+      - name: Wait for an armed auto-merge to land, then check the merged tip
         if: ${{ !cancelled() && steps.ver.outputs.skip != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: ./scripts/dispatch-main-verification.sh
+          ARMED: ${{ steps.merge.outputs.armed }}
+        run: |
+          set -uo pipefail
+          if [ "${ARMED:-}" = "true" ]; then
+            ./scripts/wait-for-armed-merge.sh bot/version-sync
+          fi
+          ./scripts/dispatch-main-verification.sh

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -315,6 +315,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-dispatch-main-verification.sh
 
+      - name: the armed-auto-merge wait, and its bounded timeout
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-wait-for-armed-merge.sh
+
       - name: the session-scratch boundary
         if: ${{ !cancelled() }}
         run: ./scripts/test-no-scratch.sh

--- a/Makefile
+++ b/Makefile
@@ -953,6 +953,17 @@ dispatch-main-verification: ## Start the ci and canary runs main's tip never got
 dispatch-main-verification-test: ## Test the main-tip dispatcher (hermetic; not part of `gate`)
 	./scripts/test-dispatch-main-verification.sh
 
+# auto-tag.yml's last resort — the ordinary and admin merges both fail, so it
+# arms GitHub's native auto-merge and ends the job. That merge lands later,
+# asynchronously, still under the run's own token, so the resulting push
+# raises no workflow-triggering event either (#5857). This is the wait in
+# between: it holds the "check main's tip" step below until the armed PR
+# actually merges (or is closed), so the dispatcher above asks about the
+# right commit instead of the one from before the sync PR.
+.PHONY: wait-for-armed-merge-test
+wait-for-armed-merge-test: ## Test the armed-auto-merge wait (hermetic; not part of `gate`)
+	./scripts/test-wait-for-armed-merge.sh
+
 .PHONY: main-red-hold
 main-red-hold: ## Ask whether an open `main-red` issue should hold a PR (reads the tracker)
 	@./scripts/check-main-red-hold.sh

--- a/scripts/test-wait-for-armed-merge.sh
+++ b/scripts/test-wait-for-armed-merge.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+#
+# Tests for `scripts/wait-for-armed-merge.sh`.
+#
+#   `./scripts/test-wait-for-armed-merge.sh`
+#   `make wait-for-armed-merge-test`
+#
+# No network and no real `gh`. Each case puts a fake one first on `PATH`.
+# It answers `gh pr view <branch> --json state`. It reads one state per
+# poll from a small script. A case that names several states, and still
+# gets the last one, proves the loop polls. It does not just read once and
+# stop.
+#
+# `--poll-seconds 0` means "ask once, then give up." `dispatch-main-verification.sh`
+# uses the same flag the same way. It is not a fast way to run several polls.
+# A case that proves the loop keeps going uses a small real
+# `--poll-seconds 1` and pays a few seconds of wall clock for it. A case
+# that only needs one answer keeps `--poll-seconds 0`. That costs nothing.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/wait-for-armed-merge.sh"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+pass=0
+fail=0
+
+ok() {
+  printf '  \033[32m✓\033[0m %s\n' "$*"
+  pass=$((pass + 1))
+}
+bad() {
+  printf '  \033[31m✗\033[0m %s\n' "$*"
+  fail=$((fail + 1))
+}
+
+# One fake `gh` per case, in its own folder. `states` holds one PR state per
+# line, read in order — one line per `gh pr view` call — and the last line
+# repeats once the script runs past the end, the same "hold the last answer"
+# shape `test-dispatch-main-verification.sh`'s fake uses.
+new_case() { # new_case <name> <states...>
+  local dir="$work/$1"
+  mkdir -p "$dir"
+  shift
+  printf '%s\n' "$@" >"$dir/states"
+  cat >"$dir/gh" <<'SHIM'
+#!/usr/bin/env bash
+set -u
+dir="$GH_SHIM_DIR"
+printf '%s\n' "$*" >>"$dir/calls.log"
+case "${1:-}" in
+pr)
+  if [ "${2:-}" = "view" ]; then
+    [ -f "$dir/view-fails" ] && exit 1
+    n=0
+    [ -f "$dir/cursor" ] && n="$(cat "$dir/cursor")"
+    n=$((n + 1))
+    printf '%s' "$n" >"$dir/cursor"
+    line="$(sed -n "${n}p" "$dir/states")"
+    [ -z "$line" ] && line="$(tail -n 1 "$dir/states")"
+    printf '%s\n' "$line"
+    exit 0
+  fi
+  ;;
+esac
+echo "fake gh: unhandled call: $*" >&2
+exit 3
+SHIM
+  chmod +x "$dir/gh"
+  echo "$dir"
+}
+
+# The script under test, with that case's fake `gh` and nothing else changed.
+run_case() { # run_case <dir> [args...]
+  local dir="$1"
+  shift
+  PATH="$dir:$PATH" GH_SHIM_DIR="$dir" \
+    "$SCRIPT" "$@" 2>&1
+}
+
+said() { # said <name> <text> <output>
+  case "$3" in
+  *"$2"*) ok "$1" ;;
+  *) bad "$1 — wanted '$2', got: $3" ;;
+  esac
+}
+
+view_calls() { # view_calls <dir>
+  grep -c "^pr view" "$1/calls.log" 2>/dev/null || true
+}
+
+printf '\033[1mwait-for-armed-merge — the armed PR actually landing gets noticed\033[0m\n'
+
+# ── It merges on the first poll. ─────────────────────────────────────────────
+dir="$(new_case merged_first MERGED)"
+out="$(run_case "$dir" bot/version-sync --poll-seconds 0)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "a PR already merged exits 0"
+else
+  bad "a merged PR exited $rc: $out"
+fi
+said "and reports MERGED" "MERGED" "$out"
+
+# ── It merges after sitting open a few polls — the loop actually polls. ─────
+dir="$(new_case merged_later OPEN OPEN OPEN MERGED)"
+out="$(run_case "$dir" bot/version-sync --timeout-seconds 30 --poll-seconds 1)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "a PR that merges on a later poll exits 0"
+else
+  bad "a later merge exited $rc: $out"
+fi
+said "and still reports MERGED" "MERGED" "$out"
+if [ "$(view_calls "$dir")" -ge 4 ]; then
+  ok "and it actually polled — $(view_calls "$dir") calls, not one"
+else
+  bad "it did not poll: $(cat "$dir/calls.log")"
+fi
+
+# ── It is closed without merging. ────────────────────────────────────────────
+dir="$(new_case closed OPEN CLOSED)"
+out="$(run_case "$dir" bot/version-sync --timeout-seconds 10 --poll-seconds 1)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "a closed PR exits 0"
+else
+  bad "a closed PR exited $rc: $out"
+fi
+said "and reports CLOSED, not a merge" "CLOSED" "$out"
+
+# ── The actual gap this script closes: still open when asked. ───────────────
+# `--poll-seconds 0` asks once and gives up, which is exactly a PR still
+# sitting OPEN after this script's caller has already waited as long as it
+# is willing to — the shape the workflow's own bounded wait degrades to
+# once its budget runs out.
+dir="$(new_case timeout OPEN)"
+out="$(run_case "$dir" bot/version-sync --poll-seconds 0)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "a PR that never resolves before the deadline still exits 0"
+else
+  bad "a timed-out wait exited $rc: $out"
+fi
+said "and reports TIMEOUT, not a false MERGED" "TIMEOUT" "$out"
+
+# ── `gh` cannot even be asked once. ──────────────────────────────────────────
+dir="$(new_case unreadable OPEN)"
+touch "$dir/view-fails"
+out="$(run_case "$dir" bot/version-sync --poll-seconds 0)"
+rc=$?
+if [ "$rc" -eq 0 ] && [ -z "${out##*UNKNOWN*}" ]; then
+  ok "a state that can never be read is UNKNOWN, not a failure"
+else
+  bad "an unreadable state exited $rc: $out"
+fi
+
+nogh="$work/nogh"
+mkdir -p "$nogh"
+bash_bin="$(command -v bash)"
+out="$(PATH="$nogh" "$bash_bin" "$SCRIPT" bot/version-sync --poll-seconds 0 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ] && [ -z "${out##*UNKNOWN*}" ]; then
+  ok "no gh at all is UNKNOWN, not a failure"
+else
+  bad "a missing gh exited $rc: $out"
+fi
+
+# ── A caller mistake is loud. ────────────────────────────────────────────────
+out="$("$SCRIPT" 2>&1)"
+if [ $? -eq 2 ]; then
+  ok "a missing branch argument exits 2"
+else
+  bad "a missing branch did not exit 2: $out"
+fi
+
+out="$("$SCRIPT" bot/version-sync --timeout-seconds banana 2>&1)"
+if [ $? -eq 2 ]; then
+  ok "a flag given a word instead of a number exits 2"
+else
+  bad "a bad number did not exit 2: $out"
+fi
+
+out="$("$SCRIPT" bot/version-sync --nonsense 2>&1)"
+if [ $? -eq 2 ]; then
+  ok "an unknown flag exits 2"
+else
+  bad "an unknown flag did not exit 2: $out"
+fi
+
+printf '\n'
+if [ "$fail" -eq 0 ]; then
+  printf '\033[32mwait-for-armed-merge-test: OK\033[0m — %d checks passed\n' "$pass"
+  exit 0
+fi
+printf '\033[31mwait-for-armed-merge-test: FAILED\033[0m — %d passed, %d failed\n' "$pass" "$fail"
+exit 1

--- a/scripts/wait-for-armed-merge.sh
+++ b/scripts/wait-for-armed-merge.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Wait, bounded, for a PR that has armed GitHub's native auto-merge to
+# actually land.
+#
+#   scripts/wait-for-armed-merge.sh <branch> [--timeout-seconds N] [--poll-seconds N]
+#
+# ── Why this exists. ─────────────────────────────────────────────────────
+#
+# `auto-tag.yml` has a last resort. When the plain merge and the admin
+# merge of the `bot/version-sync` PR both fail, it arms auto-merge and ends
+# the job. GitHub merges the PR later, on its own. It still uses the run's
+# own token. A push made with that token starts no new workflow run. The
+# merge paths above hit the same wall, and already ask for the missing run
+# by hand. So the commit that lands this way gets no `ci` run and no
+# `main-canary` run. Only the daily canary schedule ever checks it.
+#
+# `scripts/dispatch-main-verification.sh` fixes "nothing asks." But it
+# reads the CURRENT tip of main. Right after auto-merge is armed, that tip
+# is still the old one, from before the sync PR — already checked. Calling
+# the dispatcher right then asks about the wrong commit.
+#
+# This script is the wait in between. It polls the armed PR until GitHub
+# merges it, or someone closes it. Then the caller can run the dispatcher
+# on the new tip. It knows nothing about `ci` runs or dispatching — one
+# job, the wait — so tests can cover it alone.
+#
+# ── What it prints. ──────────────────────────────────────────────────────
+#
+# Always exit 0. This runs at the end of a release and must never fail it.
+# One line of:
+#
+#   MERGED   — the PR merged while this script waited.
+#   CLOSED   — the PR was closed without merging.
+#   TIMEOUT  — neither happened before the deadline. Only the daily canary
+#              schedule checks the merged commit now, unless someone reruns
+#              dispatch-main-verification.sh by hand.
+#   UNKNOWN — <reason> — `gh` is missing, or the PR's state could not be
+#              read even once. A caller treats this like TIMEOUT: it is
+#              not yet safe to ask about main's tip.
+#
+# Only a missing or bad `<branch>` argument, or a bad flag value, exits
+# non-zero. That is a mistake by the caller, not a fact about the PR.
+#
+# bash 3.2 compatible.
+
+set -uo pipefail
+
+branch="${1:-}"
+if [ -z "$branch" ] || [ "${branch#-}" != "$branch" ]; then
+  echo "wait-for-armed-merge: usage: wait-for-armed-merge.sh <branch> [--timeout-seconds N] [--poll-seconds N]" >&2
+  exit 2
+fi
+shift
+
+timeout_seconds=2400
+poll_seconds=30
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --timeout-seconds)
+    timeout_seconds="${2:-}"
+    shift 2
+    ;;
+  # Zero polls once and gives up, which is what the tests want.
+  --poll-seconds)
+    poll_seconds="${2:-}"
+    shift 2
+    ;;
+  -h | --help)
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+    exit 0
+    ;;
+  *)
+    echo "wait-for-armed-merge: unknown argument '$1'" >&2
+    exit 2
+    ;;
+  esac
+done
+case "$timeout_seconds" in '' | *[!0-9]*)
+  echo "wait-for-armed-merge: --timeout-seconds takes a whole number" >&2
+  exit 2
+  ;;
+esac
+case "$poll_seconds" in '' | *[!0-9]*)
+  echo "wait-for-armed-merge: --poll-seconds takes a whole number" >&2
+  exit 2
+  ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "wait-for-armed-merge: UNKNOWN — gh is not installed, so ${branch}'s state could not be read"
+  exit 0
+fi
+
+echo "wait-for-armed-merge: waiting up to ${timeout_seconds}s for ${branch} to merge or close."
+
+deadline=$(( $(date +%s) + timeout_seconds ))
+saw_any=false
+state=""
+while :; do
+  answer="$(gh pr view "$branch" --json state --jq '.state' 2>/dev/null || true)"
+  if [ -n "$answer" ]; then
+    saw_any=true
+    state="$answer"
+  fi
+  case "$state" in
+  MERGED)
+    echo "wait-for-armed-merge: MERGED — ${branch} merged while this waited."
+    exit 0
+    ;;
+  CLOSED)
+    echo "wait-for-armed-merge: CLOSED — ${branch} was closed without merging."
+    exit 0
+    ;;
+  esac
+  now="$(date +%s)"
+  if [ "$poll_seconds" -le 0 ] || [ "$now" -ge "$deadline" ]; then
+    break
+  fi
+  sleep "$poll_seconds"
+done
+
+if [ "$saw_any" = false ]; then
+  echo "wait-for-armed-merge: UNKNOWN — could not read ${branch}'s state even once"
+  exit 0
+fi
+
+echo "wait-for-armed-merge: TIMEOUT — ${branch} has not merged or closed yet; it stays armed."
+exit 0


### PR DESCRIPTION
## What & why

`auto-tag.yml`'s last resort arms GitHub's native auto-merge on the
`bot/version-sync` PR and ends the job. GitHub merges it later, still under
the run's own token, so the resulting push starts no `ci.yml` or
`main-canary.yml` run — the same async gap #5817 closed for the synchronous
merge paths, left open here because nothing after that step knew a merge
was still coming. The maintainer's own follow-up comment on the issue shows
this is not rare: it is the path a sync PR takes whenever it cannot merge
in the run that opened it.

`scripts/wait-for-armed-merge.sh` is the fix: it polls the armed PR,
bounded, until it merges or is closed. The workflow calls it right before
the existing `scripts/dispatch-main-verification.sh` step, so that step
reads the *new* tip of `main` instead of the one from before the sync PR
(already checked).

**Option chosen, and its cost** (the issue names three): option 2, a
bounded wait inside the job, not option 1 (a `workflow_run` trigger on
`auto-tag.yml`'s own completion). That event fires right after arming
auto-merge — before the async merge lands — so it would ask about the
wrong commit; the issue itself flags this timing problem. The wait costs
up to 40 extra minutes of runner time, but only on the already-rare
last-resort path, and every branch of it still exits 0: a stuck check, a
closed PR, or a `gh` failure all fall through to the unchanged behavior
(the daily canary schedule stays the backstop), so nothing new can red the
release job.

Refs #5857 — see "Anything reviewers should know?" for why this refs
rather than closes.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed

`scripts/test-wait-for-armed-merge.sh` is new — it does not exist on
`main`, so it cannot even run there, which is the strongest form of
"fails on the old code." It covers the script hermetically (no network, a
fake `gh`): merges on the first poll, merges after several polls (proving
the loop actually polls), closed without merging, timeout while still
open, and `gh` missing or unreadable. All 14 checks pass on this branch
(`make wait-for-armed-merge-test`).

The workflow-YAML wiring itself (the new `id: merge` output and the
renamed step that calls the script) is not independently unit-testable —
`auto-tag.yml` has no in-tree harness, same as its existing
`dispatch-main-verification.sh` call. It is exercised by the next release
that reaches the last-resort branch, which per the issue's own evidence is
routine; I'll link that run once one lands.

## The gate

- [x] `cargo fmt --check` — no Rust touched
- [x] clippy across the workspace at `-D warnings` — no Rust touched
- [x] the workspace test suite — no Rust touched
- [ ] Docs updated where behavior/flags changed — none of `--help`/README describe this internal release-workflow detail
- [x] CLA signed
- [x] `Refs #5857` appears both above and as a commit trailer (not
      `Closes` — the issue's DoD is not fully verified yet; see below)

Ran locally instead of the Rust gate (no crate touched): `shellcheck -x` on
both new scripts, `python3 scripts/check-prose.py` (clean — the reading
grade was 9.94/3.73 before a rewrite, both now under the 6.00 ceiling),
`./scripts/check-gate-parity.sh` (the new self-test needed hosting —
added a step in `guard-self-tests.yml` beside its
`dispatch-main-verification.sh` sibling), and YAML validation on both
touched workflow files.

## Fix over file

- [ ] Extra fixes in this PR: none — **or** none
- [x] Filed, with the reason a fix could not ride this PR: #6367 — **or** nothing was deferred

CodeQL flagged an untrusted-checkout alert (#129, critical) on
`auto-tag.yml`'s existing checkout step, elsewhere in the same file from
what this PR touches. It is already open on `main` (unrelated to this
diff), and deciding whether the job's existing `if:` gate already
mitigates it — or whether it needs hardening — is a security-posture
call on the release-tagging pipeline, not something to drive by inside
this PR. Filed as #6367.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home) — the new
      script calls `gh`, the same tool `dispatch-main-verification.sh`
      already calls from this same job
- [ ] New cross-boundary types round-trip through serde — n/a, no protocol types touched

## Anything reviewers should know?

The 40-minute wait is a judgment call on the cost/benefit tradeoff the
issue itself asked for ("the option chosen is named in the PR with its
cost"). It stacks on top of the already-existing up-to-~50-minute wait in
the merge step before this branch is even reached, and `auto-tag`'s
`concurrency` group is documented as already tolerating a queued run
stretching to the length of the slowest one — so this is more of the same
shape, not a new one. Happy to shorten it if a smaller bound is preferred.

**Why this refs #5857 instead of closing it.** The issue's first DoD item
("a sync commit landed by armed auto-merge carries a terminal `ci` run …")
needs a *live* release that reaches the last-resort branch — I have no
safe way to manufacture that condition against this repository's real
release pipeline from a PR. The maintainer's own comment on the issue
says the branch is routine, so the very next release after this merges
should exercise it. I'll watch for that run, link the SHA and its `ci`/
`main-canary` run on the issue, tick the last box, and close it then —
consistent with SCR-003 and AGENTS.md's "`Refs #N` when a PR advances an
issue without finishing it."
