### PR TITLE
fix(scripts): catch a Refs body that a commit still closes

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -227,7 +227,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-deleted-tests.sh
 
-      - name: closing-keywords guard catches a negated keyword (#6190)
+      - name: closing-keywords guard catches a negated keyword and a Refs/Closes mismatch (#6190, #6347)
         if: ${{ !cancelled() }}
         run: python3 ./scripts/test-closing-keywords.py
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1544,6 +1544,21 @@ its issue number, in one sentence. Its fix is the safe spelling: put the
 issue number in backticks, or write "advances #N" instead of a closing
 keyword.
 
+**A `Refs` demotion is not complete while a commit still says `Closes`.**
+Editing the description from `Closes #N` down to `Refs #N` — the remedy this
+section already names for a PR that advances an issue without finishing it —
+only edits half of what closes the issue. Squash reads the commits, not the
+description, so a commit anywhere in the branch's history still saying
+`Closes #N` reaches `main` and closes it regardless. `#6333` demoted its
+description to `Refs #6308` while a later commit still said `Closes #6308`;
+the issue closed on merge, and only a separate sweep that had already
+reopened its members kept that from mattering. `check-closing-keywords.py`
+checks this too: it fails when the description names an issue only with
+`Refs` while any commit message carries a genuine `Closes`/`Fixes`/`Resolves`
+for that same issue. The fix is not a history rewrite — squash-merge with a
+hand-edited commit message, or push a follow-up commit spelling that
+trailer `Refs #N` instead.
+
 ---
 
 ## Testing approach

--- a/Makefile
+++ b/Makefile
@@ -927,7 +927,7 @@ deleted-tests-test: ## Test the deleted-test guard's live-vs-stale PR body handl
 # reads a PR's description and commit messages, which a single local tree
 # does not carry (#6190).
 .PHONY: closing-keywords-test
-closing-keywords-test: ## Test the negated-closing-keyword guard (hermetic; not part of `gate`; #6190)
+closing-keywords-test: ## Test the closing-keywords guard (hermetic; not part of `gate`; #6190, #6347)
 	python3 ./scripts/test-closing-keywords.py
 
 # The canary's other half: it detects, this is what consumes the detection at

--- a/scripts/check-closing-keywords.py
+++ b/scripts/check-closing-keywords.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
-"""Guard: a pull request that says it does NOT close an issue must not close it.
+"""Guard: a pull request that says it does NOT close an issue must not close it,
+and a pull request that demotes an issue to `Refs #N` must not still close it
+through a commit the description cannot reach.
 
-See `#6190`. GitHub's own parser reads a closing keyword (`close`, `fix`,
-`resolve`, and their inflections) and the issue reference right after it. It
-does not read the words in front of the keyword, so a sentence written to
-*deny* the close reads to GitHub exactly like one that asks for it.
+Rule 1, a negated keyword still closes (`#6190`):
+
+GitHub's own parser reads a closing keyword (`close`, `fix`, `resolve`, and
+their inflections) and the issue reference right after it. It does not read
+the words in front of the keyword, so a sentence written to *deny* the close
+reads to GitHub exactly like one that asks for it.
 
 `#6180` hit this for real: its commit trailer carried `Refs #6155` (the
 correct spelling for "this advances the issue but does not finish it"), but
@@ -34,6 +38,25 @@ whitespace, or a newline — a trailer line like `Closes #6190` carries no
 terminal punctuation, so treating a newline as a boundary is what keeps that
 line's keyword from being read alongside negation words in the paragraph
 above it.
+
+Rule 2, a `Refs` demotion a commit never learned (`#6347`):
+
+AGENTS.md already says a `Closes #N` needs both the description and a
+commit trailer. Squash builds the merged commit message from the commits,
+never from the description. So when a description is edited down from
+`Closes #N` to `Refs #N`, that edit changes only half of what closes the
+issue. A commit that still says `Closes #N` reaches `main` and closes it,
+no matter what the description now says.
+
+This is a different bug than rule 1's. There, the description and the
+commit agree, on a sentence that says the wrong thing. Here, they disagree:
+the description says `Refs`, some commit says `Closes`. Neither line is
+wrong on its own, so this rule gets its own check and its own message.
+
+What this checks: the description names an issue with `Refs` and no
+closing keyword, while some commit message still closes that same issue for
+real — no negation word in front of the keyword, and no backticks around
+the number.
 
 Not a `make gate` step: like `check-deleted-tests.sh`, this reads the PR's
 description and commit messages, which are not information a single local
@@ -66,6 +89,19 @@ NEGATED_CLOSE = re.compile(
     + KEYWORD
     + r")\b(?:\s+\S+){0,3}?\s*(?P<ref>#\d+)",
     re.IGNORECASE,
+)
+
+# The keyword-plus-ref half of NEGATED_CLOSE. No negation word up front.
+# Rule 2 uses this to find a real close.
+CLOSING_REF = re.compile(
+    r"\b(?P<keyword>" + KEYWORD + r")\b(?:\s+\S+){0,3}?\s*(?P<ref>#\d+)",
+    re.IGNORECASE,
+)
+
+# "Refs #N" or "Ref #N". The demoting spelling AGENTS.md names. Same shape
+# as CLOSING_REF above. The ref may sit a few words after the word "Refs".
+REFS_MENTION = re.compile(
+    r"\bref(?:s|erences?)?\b(?:\s+\S+){0,3}?\s*(?P<ref>#\d+)", re.IGNORECASE
 )
 
 
@@ -112,6 +148,68 @@ def safe_spelling(match: re.Match[str]) -> str:
         f"write the issue number in backticks (`` {ref} `` ...) or say "
         f'"advances {ref}" instead of using a closing keyword there.'
     )
+
+
+def find_genuine_closes(
+    text: str,
+) -> dict[str, list[tuple[str, re.Match[str]]]]:
+    """Every `#N` named with a real closing keyword: unnegated (no
+    NEGATED_CLOSE match covers the same span) and unbackticked. Keyed by
+    issue reference, since rule 2 asks "did any commit close this ref",
+    not "which sentence".
+    """
+    closes: dict[str, list[tuple[str, re.Match[str]]]] = {}
+    for sentence in split_sentences(text):
+        negated_spans = [
+            (m.start(), m.end()) for m in NEGATED_CLOSE.finditer(sentence)
+        ]
+        for match in CLOSING_REF.finditer(sentence):
+            if is_backticked(sentence, match):
+                continue
+            if any(
+                start <= match.start() and match.end() <= end
+                for start, end in negated_spans
+            ):
+                continue
+            closes.setdefault(match.group("ref"), []).append(
+                (sentence.strip(), match)
+            )
+    return closes
+
+
+def find_refs_mentions(text: str) -> dict[str, tuple[str, re.Match[str]]]:
+    """The first `Refs #N` (unbackticked) sentence for each issue reference
+    the PR body demotes to `Refs` rather than a closing keyword."""
+    refs: dict[str, tuple[str, re.Match[str]]] = {}
+    for sentence in split_sentences(text):
+        for match in REFS_MENTION.finditer(sentence):
+            if is_backticked(sentence, match):
+                continue
+            refs.setdefault(match.group("ref"), (sentence.strip(), match))
+    return refs
+
+
+def find_demotion_violations(
+    body: str, commits: str
+) -> list[tuple[str, re.Match[str], str, re.Match[str]]]:
+    """(body_sentence, refs_match, commit_sentence, close_match) for every
+    issue the PR body names only with `Refs #N` while a commit message still
+    carries a genuine closing keyword for that same `#N` — see `#6347`.
+    """
+    body_refs = find_refs_mentions(body)
+    body_closes = find_genuine_closes(body)
+    commit_closes = find_genuine_closes(commits)
+
+    violations = []
+    for ref, (body_sentence, refs_match) in body_refs.items():
+        if ref in body_closes:
+            # The body already closes it too. Not a demotion.
+            continue
+        for commit_sentence, close_match in commit_closes.get(ref, []):
+            violations.append(
+                (body_sentence, refs_match, commit_sentence, close_match)
+            )
+    return violations
 
 
 def fetch_pr_body(pr_number: str | None) -> tuple[str, bool]:
@@ -207,35 +305,62 @@ def main(argv: list[str]) -> int:
     violations = find_violations(body, "the PR description") + find_violations(
         commits, "a commit message"
     )
+    demotions = find_demotion_violations(body, commits)
 
-    if not violations:
+    if not violations and not demotions:
         channels = []
         if body:
             channels.append("PR description" + ("" if body_live else " (stale snapshot)"))
         if commits:
             channels.append("commit messages" + ("" if commits_live else " (stale snapshot)"))
         print(
-            "check-closing-keywords: OK — no negated closing keyword found in "
-            + " or ".join(channels)
-            + "."
+            "check-closing-keywords: OK — no negated closing keyword and no "
+            "Refs/Closes mismatch found in " + " or ".join(channels) + "."
         )
         return 0
 
-    print("check-closing-keywords: FAILED", file=sys.stderr)
-    print("", file=sys.stderr)
-    print(
-        "GitHub's closing-keyword parser reads the keyword and the issue "
-        "reference right after it. It does not read the negation in front "
-        "of the keyword, so a sentence written to DENY a close reads to "
-        "GitHub exactly like one that asks for it.",
-        file=sys.stderr,
-    )
-    print("", file=sys.stderr)
-    for source, sentence, match in violations:
-        print(f"  in {source}: \"{sentence}\"", file=sys.stderr)
-        print(f"    offending phrase: \"{match.group(0)}\"", file=sys.stderr)
-        print(f"    fix: {safe_spelling(match)}", file=sys.stderr)
+    if violations:
+        print("check-closing-keywords: FAILED (negated closing keyword)", file=sys.stderr)
         print("", file=sys.stderr)
+        print(
+            "GitHub's closing-keyword parser reads the keyword and the issue "
+            "reference right after it. It does not read the negation in front "
+            "of the keyword, so a sentence written to DENY a close reads to "
+            "GitHub exactly like one that asks for it.",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
+        for source, sentence, match in violations:
+            print(f"  in {source}: \"{sentence}\"", file=sys.stderr)
+            print(f"    offending phrase: \"{match.group(0)}\"", file=sys.stderr)
+            print(f"    fix: {safe_spelling(match)}", file=sys.stderr)
+            print("", file=sys.stderr)
+
+    if demotions:
+        print("check-closing-keywords: FAILED (Refs/Closes mismatch)", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(
+            "The PR description names an issue only with `Refs`, but a commit "
+            "message still carries a closing keyword for that same issue. "
+            "Squash — this repository's default merge strategy — composes the "
+            "merged commit message from the commits, never from the "
+            "description, so the issue closes on merge regardless of the "
+            "demotion.",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
+        for body_sentence, refs_match, commit_sentence, close_match in demotions:
+            ref = refs_match.group("ref")
+            print(f"  in the PR description: \"{body_sentence}\"", file=sys.stderr)
+            print(f"  in a commit message: \"{commit_sentence}\"", file=sys.stderr)
+            print(
+                f"    fix: squash-merge with a hand-edited commit message, or "
+                f"push a follow-up commit spelling the {ref} trailer `Refs "
+                f"{ref}` — do not force-push a shared branch.",
+                file=sys.stderr,
+            )
+            print("", file=sys.stderr)
+
     print(
         "AGENTS.md \u00a7 \"Closing the issue on merge\" has the full rule.",
         file=sys.stderr,

--- a/scripts/test-closing-keywords.py
+++ b/scripts/test-closing-keywords.py
@@ -159,6 +159,73 @@ check(
     result.stderr,
 )
 
+# ── Rule 2: a `Refs` demotion a commit never learned (`#6347`) ──────────────
+
+result = run(
+    body=f"Refs {REF}",
+    commits=f"chore: prep work\n\nCloses {REF}",
+)
+check(
+    "a Refs body with a commit that closes the same issue fails",
+    result.returncode == 1,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+check(
+    "the demotion failure is labelled distinctly from the negation one",
+    "Refs/Closes mismatch" in result.stderr,
+    result.stderr,
+)
+check(
+    "the demotion failure names the PR description site",
+    "in the PR description" in result.stderr and f"Refs {REF}" in result.stderr,
+    result.stderr,
+)
+check(
+    "the demotion failure names the commit site",
+    "in a commit message" in result.stderr and f"Closes {REF}" in result.stderr,
+    result.stderr,
+)
+
+result = run(
+    body=f"Refs {REF}",
+    commits=f"chore: prep work\n\nRefs {REF}",
+)
+check(
+    "a Refs body beside a Refs-only commit passes",
+    result.returncode == 0,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+
+result = run(
+    body=f"Closes {REF}",
+    commits=f"chore: prep work\n\nCloses {REF}",
+)
+check(
+    "a Closes body beside a Closes commit still passes",
+    result.returncode == 0,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+
+result = run(
+    body=f"Refs {REF} for background. Closes {REF}.",
+    commits=f"chore: prep work\n\nCloses {REF}",
+)
+check(
+    "a body that also genuinely closes the issue is not flagged as a demotion",
+    result.returncode == 0,
+    f"exit={result.returncode} stderr={result.stderr!r}",
+)
+
+result = run(
+    body=f"Refs {REF}",
+    commits=f"chore: prep work\n\nThis does not close {REF}.",
+)
+check(
+    "a negated commit close is rule 1's failure, not also a demotion mismatch",
+    "Refs/Closes mismatch" not in result.stderr,
+    result.stderr,
+)
+
 # ── Nothing to check ──────────────────────────────────────────────────────────
 
 result = run()


### PR DESCRIPTION
<!--
  Thanks for contributing to Stella! Keep it to one logical change per PR.
  Full expectations: CONTRIBUTING.md — the short version is the checklist below.
-->

## What & why

Demoting a PR description from `Closes #N` down to `Refs #N` only edits half
of what closes the issue: squash builds the merged commit message from the
commits, never from the description, so a commit anywhere in the branch's
history still saying `Closes #N` reaches `main` and closes the issue
regardless. `#6333` hit this for real against `#6308` and was saved only by
an unrelated sweep that had already reopened the issue's members first.

`scripts/check-closing-keywords.py` gets a second, independently-labelled
rule: it now fails when the PR body names an issue only with `Refs #N` while
any commit message still carries a genuine (unnegated, unbackticked)
`Closes`/`Fixes`/`Resolves` for that same issue. The existing negation rule
(#6190) is untouched — this is a different bug (description and commit
disagree, rather than agreeing on a wrong sentence) and gets its own failure
message and its own remedy.

AGENTS.md § "Closing the issue on merge" states the inverse rule beside the
existing one.

Closes #6347

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

On the pre-change script, this exact fixture — body `Refs #6308`, commit
message `Closes #6308` — passes silently:

```
$ python3 scripts/check-closing-keywords.py --fixture-pr-body "Refs #6308" \
    --fixture-commit-messages "chore: prep work\n\nCloses #6308"
exit: 0
check-closing-keywords: OK — no negated closing keyword found in PR description or commit messages.
```

On the post-change script, the same fixture fails with a distinctly-labelled
`Refs/Closes mismatch`, naming both sites and the remedy:

```
exit: 1
check-closing-keywords: FAILED (Refs/Closes mismatch)
  in the PR description: "Refs #6308"
  in a commit message: "Closes #6308"
    fix: squash-merge with a hand-edited commit message, or push a follow-up
    commit spelling the #6308 trailer `Refs #6308` — do not force-push a
    shared branch.
```

`scripts/test-closing-keywords.py` adds the positive control plus three
negative controls (a `Refs` body beside a `Refs`-only commit; a `Closes` body
beside a `Closes` commit — the promoting direction, unchanged; a body that
also genuinely closes the issue is not flagged as a demotion). All 30 cases
pass: `python3 scripts/test-closing-keywords.py` → `30 passed, 0 failed`.

## The gate

- [x] `cargo fmt --check` — n/a, no Rust changed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — n/a, no Rust changed
- [x] `cargo test --workspace` — n/a, no Rust changed; the guard's own hermetic
      suite (`python3 scripts/test-closing-keywords.py`) is the test surface here
- [x] Docs updated where behavior/flags changed (AGENTS.md § "Closing the
      issue on merge" carries the new rule)
- [x] CLA signed
- [x] `Closes #N` appears **both** above and as a commit trailer

Also verified locally (scoped, no workspace build):

- `python3 scripts/check-prose.py` → OK, none added
- `python3 scripts/check-line-citations.py` → OK, none added
- `./scripts/check-gate-parity.sh` → OK
- `python3 scripts/check-guard-trigger-coverage.py` → OK, `check-closing-keywords.py` still one of the four unfiltered guards

## Fix over file

- [x] Extra fixes in this PR: none — this is exactly issue #6347's scope
- [x] Filed: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps — Python script and CI/docs only
- [x] No new outbound network calls
- N/A — no new cross-boundary Rust types

## Anything reviewers should know?

This is a CI/guard-only change (Python + `AGENTS.md` + a workflow step name +
a Makefile help-text tweak). No UI or design-system surface is touched, so
the "Not applicable" DoD item on #6347 stands as written. The guard stays out
of `make gate` for the same reason its sibling rule does: it reads the PR
body and commit messages from `gh`, which a single local tree does not carry.

## Summary by Sourcery

Prevent issue-closing keywords in commit messages from overriding a PR description that demotes the issue to `Refs #N`.

Bug Fixes:
- Detect PRs whose description demotes an issue to `Refs #N` while a commit still genuinely closes the same issue, preventing unintended closure on squash merge.

Enhancements:
- Keep the existing negated-keyword validation distinct while providing targeted diagnostics and remediation for Refs/Closes mismatches.

CI:
- Expand the hermetic closing-keywords guard test coverage and workflow labeling for the new mismatch rule.

Documentation:
- Document that demoting a PR description to `Refs #N` also requires correcting closing keywords in commit messages.

Tests:
- Add positive and negative coverage for Refs/Closes mismatches, matching Refs trailers, valid closing promotions, genuine body closures, and negated commit references.

Chores:
- Update Makefile help text to reflect the expanded closing-keywords guard.