### PR TITLE
fix(stella-learn,stella-cli): key the appraisal ledger and demotion lineage by (kind, id)

### DIFF
--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -769,7 +769,8 @@ impl SessionMemory {
             self.include_workspace_skills,
         )
         .skills;
-        let demoted = appraisals::demoted_skills(&self.store);
+        let demoted =
+            appraisals::demoted_skills(&self.store, stella_learn::ledger::ArtifactKind::Skill);
         if !demoted.is_empty() {
             skills.retain(|s| !demoted.contains(&s.name));
         }

--- a/crates/stella-cli/src/memory/appraisals.rs
+++ b/crates/stella-cli/src/memory/appraisals.rs
@@ -35,6 +35,16 @@
 //! workspace keeps the window it already paid for. Nothing rewrites that
 //! file. An append-only ledger is not edited; it simply stops growing.
 //!
+//! # The output ledgers use the same key
+//!
+//! [`APPRAISALS_FILE`] and the demotion lineage carry
+//! [`stella_learn::ledger::ArtifactKind`] beside the id, the same as
+//! [`TRIALS_FILE`]. [`latest_verdicts`], [`consecutive_negative_appraisals`],
+//! [`record_demotion`] and [`demoted_skills`] each take a `kind` and read
+//! only that kind's rows. A memory record and a skill can share an id and
+//! stay two rows, not one. An old row with no kind still reads as a skill
+//! row — the same default [`TRIALS_FILE`] uses.
+//!
 //! # How the loop closes
 //!
 //! Every piece here has a production caller:
@@ -104,10 +114,15 @@ pub const LEGACY_TRIALS_FILE: &str = "skill_trials.jsonl";
 /// the delta between them is the skill's own.
 pub const LIVE_WINDOW_TASK: &str = "live-window";
 
-/// The `proposal_lineage_id` prefix a skill's demotion events are filed
-/// under, so the fold in [`demoted_skills`] can tell them from directive
-/// events in the same ledger.
-const SKILL_LINEAGE_PREFIX: &str = "skill:";
+/// The `proposal_lineage_id` prefix `kind`'s demotion events are filed under.
+/// [`demoted_skills`] uses it to tell one kind's lineage from another's, and
+/// from a directive event, in the same ledger.
+///
+/// Built from [`ArtifactKind::as_str`], the same word the trial ledger
+/// writes. A skill row keeps the plain `skill:` prefix an old build wrote.
+fn lineage_prefix(kind: ArtifactKind) -> String {
+    format!("{}:", kind.as_str())
+}
 
 /// One queued candidate: enough to appraise and then render it, without
 /// re-mining.
@@ -129,15 +144,20 @@ pub struct QueuedCandidate {
     pub body: Option<String>,
 }
 
-/// The newest verdict per skill, as the creation gate reads it.
+/// The newest verdict per id of `kind`, as the creation gate reads it.
 ///
-/// Later lines win: an appraisal is a measurement at a point in time, and a
-/// skill that stopped helping must not be held up by the run that said it did.
-/// A missing or unreadable ledger yields an empty map, which the gate reads as
-/// [`EvalEvidence::Unevaluated`] — the honest answer when nobody has looked.
-pub fn latest_verdicts(workspace_root: &Path) -> HashMap<String, EvalEvidence> {
+/// Later lines win: an appraisal is a measurement at a point in time, and an
+/// artifact that stopped helping must not be held up by the run that said it
+/// did. `kind` keeps a memory and a skill sharing an id as two verdicts, not
+/// one folded together. A missing or unreadable ledger yields an empty map,
+/// which the gate reads as [`EvalEvidence::Unevaluated`] — the honest answer
+/// when nobody has looked.
+pub fn latest_verdicts(workspace_root: &Path, kind: ArtifactKind) -> HashMap<String, EvalEvidence> {
     let mut verdicts = HashMap::new();
     for appraisal in read_jsonl::<SkillAppraisal>(&path(workspace_root, APPRAISALS_FILE)) {
+        if appraisal.kind != kind {
+            continue;
+        }
         verdicts.insert(
             appraisal.skill.clone(),
             EvalEvidence::from_verdict(&appraisal.verdict),
@@ -287,7 +307,7 @@ pub fn sweep(
     let mut out = Vec::new();
     for id in ids {
         let trials = by_id.remove(&id).unwrap_or_default();
-        let appraisal = appraise(&id, &trials, config);
+        let appraisal = appraise(kind, &id, &trials, config);
         let origin = origins
             .get(&id)
             .copied()
@@ -298,44 +318,52 @@ pub fn sweep(
     out
 }
 
-/// How many of the newest appraisals of `skill` are demotable verdicts
-/// (`Harms` or `Inert`), counted back from the ledger's end until the first
-/// verdict that is not.
+/// How many of the newest appraisals of `skill` under `kind` are demotable
+/// verdicts (`Harms` or `Inert`), counted back from the ledger's end until the
+/// first verdict that is not.
 ///
 /// The hysteresis input: one confident negative is recorded and visible, but
-/// only a run of them retires a skill — the length is
+/// only a run of them retires an artifact — the length is
 /// `context.promotion.skill.demote_after_consecutive_negatives` (default 3),
 /// because a single unlucky window must not undo a promotion that took a
-/// task set to earn.
-pub fn consecutive_negative_appraisals(workspace_root: &Path, skill: &str) -> usize {
+/// task set to earn. `kind` gives a memory and a skill sharing an id their
+/// own runs.
+pub fn consecutive_negative_appraisals(
+    workspace_root: &Path,
+    kind: ArtifactKind,
+    skill: &str,
+) -> usize {
     read_jsonl::<SkillAppraisal>(&path(workspace_root, APPRAISALS_FILE))
         .iter()
         .rev()
-        .filter(|a| a.skill == skill)
+        .filter(|a| a.kind == kind && a.skill == skill)
         .take_while(|a| a.verdict.demotes())
         .count()
 }
 
-/// Append the demotion state row for `skill` to the `context_records` ledger.
+/// Append the demotion state row for `skill` under `kind` to the
+/// `context_records` ledger.
 ///
 /// An INSERT and only an INSERT: the ledger's own triggers abort `UPDATE` and
 /// `DELETE` (`stella-context::store::schema`, `migrate_v8`), so a demotion is
-/// a new `promotion_event` row with [`PromotionAction::Retired`] against the
-/// `skill:<name>` lineage, and un-demoting is a later row against the same
-/// lineage — never an edit. The skill's file is untouched: demotion is
-/// removal from *selection*, and restore must survive it.
+/// a new `promotion_event` row against the `<kind>:<skill>` lineage
+/// ([`lineage_prefix`]), and un-demoting is a later row against the same
+/// lineage — never an edit. The artifact's own file or record is untouched:
+/// demotion is removal from *selection*, and restore must survive it. A
+/// memory and a skill sharing an id demote as two rows, one lineage each.
 ///
 /// [`PromotionActor::System`] because no person was asked, which also caps
 /// what this call can ever grant: `PromotionEventRecord::new` refuses a
 /// system actor carrying blocking enforcement outright.
 pub fn record_demotion(
     store: &ContextStore,
+    kind: ArtifactKind,
     skill: &str,
     reason: &str,
     occurred_at: &str,
 ) -> Result<String, String> {
     let event = PromotionEventRecord::new(
-        format!("{SKILL_LINEAGE_PREFIX}{skill}"),
+        format!("{}{skill}", lineage_prefix(kind)),
         PromotionAction::Retired,
         PromotionActor::System,
         None,
@@ -348,18 +376,20 @@ pub fn record_demotion(
     Ok(event.record_id)
 }
 
-/// The skills currently demoted out of selection — the last-write-wins fold
-/// over the `skill:` lineages in the promotion-event ledger.
+/// The ids of `kind` currently demoted out of selection — the last-write-wins
+/// fold over that kind's lineages in the promotion-event ledger.
 ///
 /// Last write wins for the same reason `proposals_cmd::decisions` folds that
-/// way: a skill demoted and later reinstated is reinstated, and both acts
+/// way: an artifact demoted and later reinstated is reinstated, and both acts
 /// remain readable. An unreadable ledger folds to the empty set, which fails
-/// toward offering a skill that should be excluded — recoverable on the next
-/// sweep — rather than silently withholding every skill a user has.
-pub fn demoted_skills(store: &ContextStore) -> HashSet<String> {
+/// toward offering an artifact that should be excluded — recoverable on the
+/// next sweep — rather than silently withholding every one a user has. A
+/// memory and a skill sharing an id fold as two standings, not one.
+pub fn demoted_skills(store: &ContextStore, kind: ArtifactKind) -> HashSet<String> {
+    let prefix = lineage_prefix(kind);
     let mut standing: HashMap<String, PromotionAction> = HashMap::new();
     for event in crate::proposals_cmd::promotion_events(store) {
-        if let Some(skill) = event.proposal_lineage_id.strip_prefix(SKILL_LINEAGE_PREFIX) {
+        if let Some(skill) = event.proposal_lineage_id.strip_prefix(&prefix) {
             standing.insert(skill.to_string(), event.action);
         }
     }

--- a/crates/stella-cli/src/memory/appraisals/tests.rs
+++ b/crates/stella-cli/src/memory/appraisals/tests.rs
@@ -50,7 +50,7 @@ fn candidate(name: &str) -> SkillCandidate {
 #[test]
 fn an_absent_ledger_yields_no_verdicts() {
     let root = workspace("absent");
-    assert!(latest_verdicts(&root).is_empty());
+    assert!(latest_verdicts(&root, ArtifactKind::Skill).is_empty());
     assert!(queued_candidates(&root).is_empty());
     assert!(
         sweep(
@@ -69,6 +69,7 @@ fn an_absent_ledger_yields_no_verdicts() {
 fn the_newest_verdict_per_skill_wins() {
     let root = workspace("newest");
     let helping = SkillAppraisal {
+        kind: ArtifactKind::Skill,
         skill: "s".into(),
         verdict: SkillVerdict::Helps { lift: 1.0 },
         report: stella_learn::comparison::compare(
@@ -86,11 +87,14 @@ fn the_newest_verdict_per_skill_wins() {
     };
     record_appraisal(&root, &helping);
     assert_eq!(
-        latest_verdicts(&root).get("s"),
+        latest_verdicts(&root, ArtifactKind::Skill).get("s"),
         Some(&EvalEvidence::MeasuredLift)
     );
     record_appraisal(&root, &stale);
-    assert_eq!(latest_verdicts(&root).get("s"), Some(&EvalEvidence::NoLift));
+    assert_eq!(
+        latest_verdicts(&root, ArtifactKind::Skill).get("s"),
+        Some(&EvalEvidence::NoLift)
+    );
     let _ = std::fs::remove_dir_all(&root);
 }
 
@@ -339,4 +343,99 @@ fn the_sweep_still_reads_the_rows_an_older_build_wrote() {
     assert!(matches!(swept[0].0.verdict, SkillVerdict::Harms { .. }));
     assert!(swept[0].1.is_demotion());
     let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A fresh `context.db`, for the demotion-lineage tests below.
+fn context_store() -> (tempfile::TempDir, stella_context::ContextStore) {
+    let dir = tempfile::tempdir().expect("workspace");
+    let store =
+        stella_context::ContextStore::open(dir.path().join("context.db")).expect("context.db");
+    (dir, store)
+}
+
+/// **The witness for the output-side key.** Two kinds can share one id. Each
+/// must appraise and demote as its own row, never as one collapsed row.
+#[test]
+fn two_appraisals_under_one_id_do_not_collide() {
+    let root = workspace("output-kinds");
+    let skill_appraisal = SkillAppraisal {
+        kind: ArtifactKind::Skill,
+        skill: "shared".into(),
+        verdict: SkillVerdict::Helps { lift: 1.0 },
+        report: stella_learn::comparison::compare(
+            &[],
+            &stella_learn::comparison::ComparisonConfig::new(
+                "without_skill",
+                stella_learn::comparison::Metric::PassRate,
+            ),
+        ),
+        harm: None,
+    };
+    let memory_appraisal = SkillAppraisal {
+        kind: ArtifactKind::Memory,
+        verdict: SkillVerdict::Harms { lift: -1.0 },
+        ..skill_appraisal.clone()
+    };
+    record_appraisal(&root, &skill_appraisal);
+    record_appraisal(&root, &memory_appraisal);
+
+    // Two verdicts, not one folded together.
+    assert_eq!(
+        latest_verdicts(&root, ArtifactKind::Skill).get("shared"),
+        Some(&EvalEvidence::MeasuredLift),
+        "the memory row must not shadow the skill row"
+    );
+    assert_eq!(
+        latest_verdicts(&root, ArtifactKind::Memory).get("shared"),
+        Some(&EvalEvidence::NoLift)
+    );
+
+    // Only the memory row is demotable. Only its hysteresis sees a negative.
+    assert_eq!(
+        consecutive_negative_appraisals(&root, ArtifactKind::Skill, "shared"),
+        0
+    );
+    assert_eq!(
+        consecutive_negative_appraisals(&root, ArtifactKind::Memory, "shared"),
+        1
+    );
+
+    // A demotion under one kind leaves the other selectable.
+    let (_dir, store) = context_store();
+    record_demotion(
+        &store,
+        ArtifactKind::Memory,
+        "shared",
+        "it stopped helping",
+        "2026-09-06T00:00:00Z",
+    )
+    .expect("the demotion writes");
+    assert!(
+        demoted_skills(&store, ArtifactKind::Memory).contains("shared"),
+        "the demoted kind excludes it"
+    );
+    assert!(
+        !demoted_skills(&store, ArtifactKind::Skill).contains("shared"),
+        "the skill of the same id is unaffected"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A build before this change wrote a demotion under the bare `skill:`
+/// prefix. [`demoted_skills`] must still find it.
+#[test]
+fn a_skill_demotion_written_before_kinds_existed_still_folds() {
+    let (_dir, store) = context_store();
+    let event = stella_records::context_record::PromotionEventRecord::new(
+        "skill:old-timer".to_string(),
+        stella_records::context_record::PromotionAction::Retired,
+        stella_records::context_record::PromotionActor::System,
+        None,
+        None,
+        "a demotion event a build before this change wrote",
+        "2026-01-01T00:00:00Z",
+    )
+    .expect("a valid event");
+    crate::proposals_cmd::record_event(&store, &event).expect("the event writes");
+    assert!(demoted_skills(&store, ArtifactKind::Skill).contains("old-timer"));
 }

--- a/crates/stella-cli/src/memory/learning.rs
+++ b/crates/stella-cli/src/memory/learning.rs
@@ -688,7 +688,10 @@ impl SessionMemory {
         let loaded = self.load_skills();
         let origins: std::collections::HashMap<String, skills::SkillOrigin> =
             loaded.iter().map(|s| (s.name.clone(), s.origin)).collect();
-        let already_demoted = super::appraisals::demoted_skills(&self.store);
+        let already_demoted = super::appraisals::demoted_skills(
+            &self.store,
+            stella_learn::ledger::ArtifactKind::Skill,
+        );
         let threshold = super::tuning::skill_promotion(&self.workspace_root)
             .demote_after_consecutive_negatives as usize;
 
@@ -714,6 +717,7 @@ impl SessionMemory {
             }
             let negatives = super::appraisals::consecutive_negative_appraisals(
                 &self.workspace_root,
+                appraisal.kind,
                 &appraisal.skill,
             );
             if negatives < threshold {
@@ -732,6 +736,7 @@ impl SessionMemory {
             );
             match super::appraisals::record_demotion(
                 &self.store,
+                appraisal.kind,
                 &appraisal.skill,
                 &reason,
                 &self.clock.now_rfc3339(),
@@ -768,7 +773,10 @@ impl SessionMemory {
     /// be rendered from the queue alone; they wait for the miner's re-raise,
     /// which flows through the same gate with the same verdict.
     fn promote_measured_queued(&mut self, quiet: bool) {
-        let verdicts = super::appraisals::latest_verdicts(&self.workspace_root);
+        let verdicts = super::appraisals::latest_verdicts(
+            &self.workspace_root,
+            stella_learn::ledger::ArtifactKind::Skill,
+        );
         let promotable: Vec<skills::SkillCandidate> =
             super::appraisals::queued_candidates(&self.workspace_root)
                 .into_iter()
@@ -965,7 +973,10 @@ impl SessionMemory {
         // observation frequency alone, and the verdict comes from the appraisal
         // ledger rather than from this turn — one turn cannot measure a skill
         // that has never been injected.
-        let verdicts = super::appraisals::latest_verdicts(&self.workspace_root);
+        let verdicts = super::appraisals::latest_verdicts(
+            &self.workspace_root,
+            stella_learn::ledger::ArtifactKind::Skill,
+        );
         for candidate in candidates {
             let evidence = verdicts
                 .get(&candidate.name)

--- a/crates/stella-cli/src/memory/learning/skill_lifecycle.rs
+++ b/crates/stella-cli/src/memory/learning/skill_lifecycle.rs
@@ -17,6 +17,7 @@
 use std::path::Path;
 
 use stella_context::EpisodeOutcome;
+use stella_learn::ledger::ArtifactKind;
 use stella_learn::self_tuning::TaskOutcome;
 use stella_learn::skills::appraisal::{AppraisalConfig, SkillTrial, SkillVerdict, appraise};
 
@@ -187,7 +188,12 @@ fn the_measured_gate_holds_a_candidate_until_a_recorded_lift_promotes_it() {
             });
         }
     }
-    let appraisal = appraise(&candidate.name, &trials, &AppraisalConfig::default());
+    let appraisal = appraise(
+        ArtifactKind::Skill,
+        &candidate.name,
+        &trials,
+        &AppraisalConfig::default(),
+    );
     assert!(
         matches!(appraisal.verdict, SkillVerdict::Helps { .. }),
         "the fixture must measure a lift: {:?}",
@@ -363,14 +369,15 @@ async fn a_promoted_skill_that_stops_helping_is_demoted_and_no_longer_selected()
     let mut memory = session(dir.path());
     for pass in 1..=3 {
         memory.auto_create_skills(&log_path(dir.path()), true);
-        let negatives = appraisals::consecutive_negative_appraisals(dir.path(), &name);
+        let negatives =
+            appraisals::consecutive_negative_appraisals(dir.path(), ArtifactKind::Skill, &name);
         assert_eq!(
             negatives, pass,
             "each sweep records exactly one negative appraisal"
         );
     }
     assert!(
-        appraisals::demoted_skills(&memory.store).contains(&name),
+        appraisals::demoted_skills(&memory.store, ArtifactKind::Skill).contains(&name),
         "three consecutive negatives demote the skill"
     );
 

--- a/crates/stella-cli/src/memory/retirement/tests.rs
+++ b/crates/stella-cli/src/memory/retirement/tests.rs
@@ -2,6 +2,7 @@
 //! provably never touches a protected record.
 
 use stella_context::ContextStore;
+use stella_learn::ledger::ArtifactKind;
 use stella_learn::skills::appraisal::{AppraisalConfig, SkillTrial, appraise, decide_demotion};
 use stella_records::context_record::{
     DirectiveEnforcement, PromotionAction, PromotionActor, PromotionEventRecord,
@@ -50,7 +51,12 @@ fn decided(
     origin: SkillOrigin,
     trials: Vec<SkillTrial>,
 ) -> (SkillAppraisal, DemotionDecision) {
-    let appraisal = appraise(record_id, &trials, &AppraisalConfig::default());
+    let appraisal = appraise(
+        ArtifactKind::Memory,
+        record_id,
+        &trials,
+        &AppraisalConfig::default(),
+    );
     let decision = decide_demotion(origin, &appraisal);
     (appraisal, decision)
 }

--- a/crates/stella-cli/src/memory/rule_efficacy.rs
+++ b/crates/stella-cli/src/memory/rule_efficacy.rs
@@ -28,12 +28,12 @@
 //!
 //! # Nothing here writes to a skill ledger
 //!
-//! `SkillAppraisal::skill` is a bare string. `appraisals::record_demotion`
-//! files under a `skill:<name>` lineage. A rule id in either would clash with
-//! a skill of the same name (`#6103`). So this writes to neither. A verdict is
-//! acted on and never stored, the way the memory sweep acts on one. A
-//! retraction is filed under the record's own `lineage_id`, which is unique in
-//! the workspace.
+//! `appraisals::record_demotion` and `appraisals::latest_verdicts` key by
+//! `(kind, id)`, so a rule id and a skill of the same name appraise and demote
+//! as separate rows. This module still writes to neither: a verdict is acted
+//! on and never stored, the way the memory sweep acts on one. A retraction is
+//! filed under the record's own `lineage_id`, which is unique in the
+//! workspace.
 //!
 //! # A candidate with no window
 //!

--- a/crates/stella-learn/src/ledger.rs
+++ b/crates/stella-learn/src/ledger.rs
@@ -73,7 +73,11 @@ pub struct ArtifactTrial {
 }
 
 /// What a row with no kind meant. See [`ArtifactTrial::kind`].
-fn skill_kind() -> ArtifactKind {
+///
+/// `pub(crate)` rather than private: [`crate::skills::appraisal::SkillAppraisal`]
+/// needs the identical default for the same reason, on the ledger a sweep
+/// writes rather than the one it reads.
+pub(crate) fn skill_kind() -> ArtifactKind {
     ArtifactKind::Skill
 }
 

--- a/crates/stella-learn/src/skills/appraisal.rs
+++ b/crates/stella-learn/src/skills/appraisal.rs
@@ -51,6 +51,15 @@
 //! recommends is removal from *selection*, with the file and a tombstone left
 //! behind, so restore works. The caller owns both halves; nothing here does
 //! I/O.
+//!
+//! # The kind rides along, the names do not — yet
+//!
+//! [`SkillAppraisal`] now carries [`ArtifactKind`] beside the id, the same
+//! key [`crate::ledger::ArtifactTrial`] uses. A memory and a skill sharing an
+//! id appraise as two rows, not one. The types keep their old names for now.
+//! Renaming `SkillAppraisal` and its siblings is a second, mechanical pass
+//! across `stella-learn` and `stella-cli`. Doing the re-key first lets a
+//! reviewer read that change on its own.
 
 use serde::{Deserialize, Serialize};
 
@@ -59,6 +68,7 @@ use crate::comparison::{
     ArmTrials, ComparisonConfig, ComparisonReport, ComparisonVerdict, FeatureCounts, Guard,
     LiftEvidence, Metric, TrialRecord, compare,
 };
+use crate::ledger::{ArtifactKind, skill_kind};
 use crate::self_tuning::{KeepReason, RewardWeights, SelectionConfig, TaskOutcome};
 
 /// The arm holding turns where the skill was injected.
@@ -172,7 +182,16 @@ impl SkillVerdict {
 /// One skill's appraisal: the verdict, and the evidence behind it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SkillAppraisal {
-    /// The skill's name, as it appears in the frontmatter and the filename.
+    /// Which surface [`Self::skill`] names.
+    ///
+    /// An appraisal with no kind reads as [`ArtifactKind::Skill`]. A build
+    /// that recorded no kind recorded only skills, the same default
+    /// [`crate::ledger::ArtifactTrial::kind`] reads an old row under. So a
+    /// workspace's old appraisal history still reads correctly.
+    #[serde(default = "skill_kind")]
+    pub kind: ArtifactKind,
+    /// The artifact's stable id: a skill's name, a memory id, a record
+    /// handle. See the module docs on why the field keeps the name it has.
     pub skill: String,
     /// What the evidence says.
     pub verdict: SkillVerdict,
@@ -187,17 +206,26 @@ pub struct SkillAppraisal {
     pub harm: Option<LiftEvidence>,
 }
 
-/// Appraise one skill from its trials.
+/// Appraise one artifact from its trials.
 ///
 /// Runs the comparison twice with the baseline swapped. That is not
 /// redundancy: [`crate::self_tuning::select_winner`] answers "did the leading
 /// arm confidently beat the named baseline", which is a one-directional
 /// question, and both directions are findings here. The forward run asks
-/// whether the skill helps; the reverse asks whether removing it does.
+/// whether the artifact helps; the reverse asks whether removing it does.
+///
+/// `kind` names which surface `skill` is an id on — it rides straight onto
+/// the returned [`SkillAppraisal`], so a memory and a skill sharing an id
+/// appraise as two rows.
 ///
 /// Total: no trials, one-sided trials, and non-finite outcomes all resolve to
 /// a stated [`SkillVerdict::Insufficient`] rather than a panic.
-pub fn appraise(skill: &str, trials: &[SkillTrial], config: &AppraisalConfig) -> SkillAppraisal {
+pub fn appraise(
+    kind: ArtifactKind,
+    skill: &str,
+    trials: &[SkillTrial],
+    config: &AppraisalConfig,
+) -> SkillAppraisal {
     let arms = arms_from(trials);
     let report = compare(&arms, &forward_config(config));
 
@@ -209,17 +237,18 @@ pub fn appraise(skill: &str, trials: &[SkillTrial], config: &AppraisalConfig) ->
             lift: evidence.promotion.lift,
         },
         ComparisonVerdict::NoWinner { reason } => {
-            // The skill did not confidently help. Ask the other question
+            // The artifact did not confidently help. Ask the other question
             // before concluding anything: not-helping and actively-harming are
             // different findings with different consequences.
             let reverse = compare(&arms, &reverse_config(config));
             return match reverse.verdict {
                 // Guards are not applied in reverse. A guard exists to refuse a
-                // *promotion* whose price is too high; a skill that is making
-                // turns worse does not get to keep its place because removing
-                // it would also cost tokens.
+                // *promotion* whose price is too high; an artifact that is
+                // making turns worse does not get to keep its place because
+                // removing it would also cost tokens.
                 ComparisonVerdict::Winner(evidence) | ComparisonVerdict::GuardBlocked(evidence) => {
                     SkillAppraisal {
+                        kind,
                         skill: skill.to_string(),
                         verdict: SkillVerdict::Harms {
                             lift: evidence.promotion.lift,
@@ -229,6 +258,7 @@ pub fn appraise(skill: &str, trials: &[SkillTrial], config: &AppraisalConfig) ->
                     }
                 }
                 ComparisonVerdict::NoWinner { .. } => SkillAppraisal {
+                    kind,
                     skill: skill.to_string(),
                     verdict: inert_or_insufficient(&report, reason.clone(), config),
                     report,
@@ -239,6 +269,7 @@ pub fn appraise(skill: &str, trials: &[SkillTrial], config: &AppraisalConfig) ->
     };
 
     SkillAppraisal {
+        kind,
         skill: skill.to_string(),
         verdict,
         report,

--- a/crates/stella-learn/src/skills/appraisal/tests.rs
+++ b/crates/stella-learn/src/skills/appraisal/tests.rs
@@ -42,7 +42,12 @@ fn a_skill_that_helps_is_promoted_with_its_lift_recorded() {
     let mut trials = arm("fix-git", false, false, 6);
     trials.extend(arm("fix-git", true, true, 6));
 
-    let appraisal = appraise("witness-assertions", &trials, &AppraisalConfig::default());
+    let appraisal = appraise(
+        ArtifactKind::Skill,
+        "witness-assertions",
+        &trials,
+        &AppraisalConfig::default(),
+    );
     let SkillVerdict::Helps { lift } = appraisal.verdict else {
         panic!("expected Helps, got {:?}", appraisal.verdict);
     };
@@ -63,7 +68,12 @@ fn a_skill_that_helps_is_promoted_with_its_lift_recorded() {
 #[test]
 fn frequency_without_lift_never_promotes() {
     let trials = window(30, 20, 20);
-    let appraisal = appraise("noise", &trials, &AppraisalConfig::default());
+    let appraisal = appraise(
+        ArtifactKind::Skill,
+        "noise",
+        &trials,
+        &AppraisalConfig::default(),
+    );
     assert!(!appraisal.verdict.promotes(), "{:?}", appraisal.verdict);
     assert!(
         matches!(appraisal.verdict, SkillVerdict::Inert { .. }),
@@ -167,7 +177,12 @@ fn a_regressing_skill_is_demoted_with_its_evidence() {
     // The with-skill arm solves nothing; the without-skill arm solves
     // everything. Removing the skill confidently wins.
     let trials = window(8, 0, 8);
-    let appraisal = appraise("stale-convention", &trials, &AppraisalConfig::default());
+    let appraisal = appraise(
+        ArtifactKind::Skill,
+        "stale-convention",
+        &trials,
+        &AppraisalConfig::default(),
+    );
 
     let SkillVerdict::Harms { lift } = appraisal.verdict else {
         panic!("expected Harms, got {:?}", appraisal.verdict);
@@ -197,7 +212,12 @@ fn a_regressing_skill_is_demoted_with_its_evidence() {
 #[test]
 fn a_hand_authored_skill_is_never_auto_demoted() {
     let trials = window(8, 0, 8);
-    let appraisal = appraise("house-style", &trials, &AppraisalConfig::default());
+    let appraisal = appraise(
+        ArtifactKind::Skill,
+        "house-style",
+        &trials,
+        &AppraisalConfig::default(),
+    );
     assert!(
         appraisal.verdict.demotes(),
         "the fixture's window really does regress"
@@ -266,7 +286,12 @@ fn every_origin_is_listed() {
 fn a_short_window_is_insufficient_not_inert() {
     // Six a side clears `min_samples_per_arm` but not the 20-trial window.
     let trials = window(6, 4, 4);
-    let appraisal = appraise("quiet", &trials, &AppraisalConfig::default());
+    let appraisal = appraise(
+        ArtifactKind::Skill,
+        "quiet",
+        &trials,
+        &AppraisalConfig::default(),
+    );
     assert!(
         matches!(appraisal.verdict, SkillVerdict::Insufficient { .. }),
         "got {:?}",
@@ -293,7 +318,12 @@ fn a_short_window_is_insufficient_not_inert() {
 fn a_one_sided_window_measures_nothing() {
     for selected in [true, false] {
         let trials = arm("live", selected, true, 10);
-        let appraisal = appraise("always-on", &trials, &AppraisalConfig::default());
+        let appraisal = appraise(
+            ArtifactKind::Skill,
+            "always-on",
+            &trials,
+            &AppraisalConfig::default(),
+        );
         let SkillVerdict::Insufficient {
             reason: KeepReason::InsufficientSamples { n, .. },
         } = &appraisal.verdict
@@ -342,7 +372,7 @@ fn a_guard_regression_holds_a_helpful_skill() {
         guards: vec![Guard::strict(Metric::CostUsd)],
         ..AppraisalConfig::default()
     };
-    let appraisal = appraise("expensive", &trials, &config);
+    let appraisal = appraise(ArtifactKind::Skill, "expensive", &trials, &config);
     assert!(
         matches!(appraisal.verdict, SkillVerdict::GuardBlocked { .. }),
         "got {:?}",
@@ -375,7 +405,7 @@ fn a_harmful_skill_is_demoted_even_under_a_guard_set() {
         ],
         ..AppraisalConfig::default()
     };
-    let appraisal = appraise("stale", &trials, &config);
+    let appraisal = appraise(ArtifactKind::Skill, "stale", &trials, &config);
     assert!(matches!(appraisal.verdict, SkillVerdict::Harms { .. }));
 }
 
@@ -384,7 +414,12 @@ fn a_harmful_skill_is_demoted_even_under_a_guard_set() {
 #[test]
 fn an_appraisal_round_trips() {
     let trials = window(8, 8, 0);
-    let appraisal = appraise("helper", &trials, &AppraisalConfig::default());
+    let appraisal = appraise(
+        ArtifactKind::Skill,
+        "helper",
+        &trials,
+        &AppraisalConfig::default(),
+    );
     let json = serde_json::to_string(&appraisal).unwrap();
     let back: SkillAppraisal = serde_json::from_str(&json).unwrap();
     assert_eq!(appraisal, back);
@@ -434,7 +469,7 @@ proptest! {
     /// Appraisal is total for any window, including empty and one-sided ones.
     #[test]
     fn appraisal_never_panics(trials in proptest::collection::vec(arb_trial(), 0..40)) {
-        let _ = appraise("s", &trials, &AppraisalConfig::default());
+        let _ = appraise(ArtifactKind::Skill, "s", &trials, &AppraisalConfig::default());
     }
 
     /// A skill is never both promotable and demotable — the two directions of
@@ -443,7 +478,7 @@ proptest! {
     fn a_verdict_never_points_both_ways(
         trials in proptest::collection::vec(arb_trial(), 0..60),
     ) {
-        let appraisal = appraise("s", &trials, &AppraisalConfig::default());
+        let appraisal = appraise(ArtifactKind::Skill, "s", &trials, &AppraisalConfig::default());
         prop_assert!(!(appraisal.verdict.promotes() && appraisal.verdict.demotes()));
     }
 
@@ -452,7 +487,7 @@ proptest! {
     fn no_window_can_demote_a_hand_authored_skill(
         trials in proptest::collection::vec(arb_trial(), 0..60),
     ) {
-        let appraisal = appraise("s", &trials, &AppraisalConfig::default());
+        let appraisal = appraise(ArtifactKind::Skill, "s", &trials, &AppraisalConfig::default());
         for origin in SkillOrigin::ALL.iter().copied().filter(|o| o.is_hand_authored()) {
             prop_assert_eq!(
                 decide_demotion(origin, &appraisal),
@@ -468,8 +503,8 @@ proptest! {
     ) {
         let config = AppraisalConfig::default();
         prop_assert_eq!(
-            serde_json::to_string(&appraise("s", &trials, &config)).unwrap(),
-            serde_json::to_string(&appraise("s", &trials, &config)).unwrap()
+            serde_json::to_string(&appraise(ArtifactKind::Skill, "s", &trials, &config)).unwrap(),
+            serde_json::to_string(&appraise(ArtifactKind::Skill, "s", &trials, &config)).unwrap()
         );
     }
 }


### PR DESCRIPTION
## What & why

`crates/stella-learn/src/skills/appraisal.rs`'s `SkillAppraisal` was keyed by
a bare `skill: String`, and everything downstream in
`crates/stella-cli/src/memory/appraisals.rs` — `APPRAISALS_FILE`,
`latest_verdicts`, `consecutive_negative_appraisals`, `record_demotion`,
`demoted_skills` — read and wrote that same bare id. #6093 already keyed the
*input* side (the trial ledger, `ArtifactTrial`) by `(ArtifactKind, id)`
because a memory record, a mined rule, and a skill can all be appraised now.
The output side was still shaped for skills alone: two artifacts of
different kinds sharing an id would collapse into one appraisal row and one
demotion lineage.

This is step 1 from the issue (the re-key). Step 2 (renaming
`SkillAppraisal`/`SkillTrial`/etc. to say "artifact" rather than "skill") is
a separate, wide, mechanical pass across `stella-learn` and `stella-cli`,
deliberately not done here so the re-key is reviewable on its own — the
issue itself calls this split out.

- `SkillAppraisal` now carries `ArtifactKind` beside its id, with the same
  `#[serde(default = "skill_kind")]` alias trick `ArtifactTrial` already
  uses, so a row a build before this change wrote still reads as the skill
  row it was.
- `appraise()` takes a `kind: ArtifactKind` and stamps it onto the returned
  `SkillAppraisal`.
- `latest_verdicts`, `consecutive_negative_appraisals`, `record_demotion`
  and `demoted_skills` each take a `kind` and scope to it.
- The demotion lineage prefix is now built from the kind
  (`format!("{}:", kind.as_str())`) instead of a hardcoded `"skill:"`
  constant — `ArtifactKind::Skill.as_str()` is `"skill"`, so an existing
  workspace's skill demotion history reads under the identical prefix.

Closes #6134

## The witness

Stella's definition of done is a test that **fails on the old code and
passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`crates/stella-cli/src/memory/appraisals/tests.rs::two_appraisals_under_one_id_do_not_collide`
records a `Helps` skill appraisal and a `Harms` memory appraisal under the
same id `"shared"`, then asserts `latest_verdicts`,
`consecutive_negative_appraisals`, `record_demotion` and `demoted_skills`
each read/write only their own kind's row. On `main` (pre-`kind` field) this
does not compile — `SkillAppraisal` has no `kind` field and none of the five
reader/writer functions take one — so the test is a genuine fail→pass
witness for the API shape the issue asks for. A second test,
`a_skill_demotion_written_before_kinds_existed_still_folds`, is the
backward-compatibility half: a `skill:<name>` demotion event written by hand
(simulating a pre-change ledger) still folds correctly through
`demoted_skills(&store, ArtifactKind::Skill)`.

Verified locally (stash the two changed crates, re-run, restore):
- `cargo test -p stella-learn` — 246/246 pass, including 17
  `skills::appraisal::tests::*` covering the new `appraise(kind, …)` shape.
- `cargo check -p stella-cli` — production code compiles clean.
- `cargo fmt --check -p stella-learn -p stella-cli` — clean.
- `python3 scripts/check-prose.py` — OK, no new content-free prose or
  reading-grade regression.

`cargo test -p stella-cli --bin stella memory::appraisals` was still
compiling stella-cli's full dependency graph under the `test` cfg when this
PR was opened — the machine this session runs on was under load average
44-57 on 10 cores from many concurrent sibling sessions, and an earlier
identical run compiled every dependency stella-cli has with zero errors
before being interrupted, reaching `Compiling stella-cli` itself. Watching
CI for the actual test-suite confirmation.

## The gate

- [x] `cargo fmt --check`
- [ ] the clippy gate — scoped locally to `-p stella-learn -p stella-cli`;
      CI runs the full gate
- [ ] the test gate — scoped locally to `-p stella-learn` (full pass) and
      `-p stella-cli` (still compiling under heavy shared load when this PR
      opened); CI runs the full gate
- [ ] Docs updated where behavior/flags changed (README, `--help`, doc
      comments) — no user-facing flag or doc changed; module and function
      doc comments updated in place for the new `kind` parameter
- [ ] CLA signed (the bot prompts on your first PR — nothing to do per
      commit)
- [x] `Closes #6134` appears **both** above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: `crates/stella-cli/src/memory/rule_efficacy.rs`'s
      module doc claimed a rule id "would clash with a skill of the same
      name" in `record_demotion`/`latest_verdicts` — true before this PR,
      false after. Corrected the doc in the same PR since it is the exact
      claim this PR falsifies. — **or** none
- [ ] Filed, with the reason a fix could not ride this PR: #___ — **or**
      nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)
- [x] New cross-boundary types round-trip through serde (test included) —
      `SkillAppraisal`'s new `kind` field is exercised by the existing
      round-trip test plus the two new witness tests

## Anything reviewers should know?

The rename from "skill" to "artifact" vocabulary (`SkillTrial`,
`SkillAppraisal`, `SkillVerdict`, `WITH_SKILL_ARM`/`WITHOUT_SKILL_ARM`) is
deliberately **not** in this PR — the issue calls it out as a second,
mechanical pass that should be regenerated on a fresh `main` rather than
carried on a stale branch. This PR only re-keys.

## Summary by Sourcery

Scope appraisal and demotion state by artifact kind and id while retaining compatibility with legacy skill records.

Bug Fixes:
- Key appraisals and demotion lineages by artifact kind and id so artifacts of different kinds sharing an id no longer collide.
- Preserve compatibility with existing appraisal rows and skill demotion events written before artifact kinds were added.

Enhancements:
- Propagate artifact kind through appraisal, verdict, hysteresis, and demotion APIs and callers.
- Correct rule-efficacy documentation to reflect kind-scoped appraisal and demotion behavior.

Tests:
- Add coverage proving same-id appraisals and demotions remain isolated by artifact kind.
- Add backward-compatibility coverage for legacy skill demotion lineages.