### PR TITLE
fix(stella-cli): bound a self-driving turn so it cannot orphan a checkout

### DIFF
--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -80,6 +80,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use stella_protocol::issue::Issue;
 
@@ -419,6 +420,40 @@ pub(super) fn verify_locally(dir: &Path, command: &str, timeout_secs: u64) -> Re
     }
 }
 
+/// The wall-clock bound a self-driving turn gets when nobody named one.
+///
+/// The manifest at `plugins/stella-selfdriving/plugin.toml` bounds one whole
+/// driver session at 3600s. Before this constant, that was the only bound a
+/// stuck turn ever met: `run_turn` waited on its child with no bound of its
+/// own. A driver session's own timeout can fire while the turn is still
+/// running, and it kills only the driver's process
+/// (`SubprocessDriver`'s `GroupKillGuard` in
+/// `crates/stella-runtime/src/wrapper/driver_subprocess.rs`). It cannot
+/// reach the child `stella run`, or the worktree that child is writing to.
+/// So the worktree stayed behind, and the next attempt at the same issue hit
+/// it.
+///
+/// This constant closes that gap. It sits under 3600s, with 300s left for
+/// the rest of one driver session: cutting the worktree, seeding the code
+/// graph, reading the tree diff, and starting and stopping the process.
+/// `the_manifests_session_ceiling_leaves_this_bound_a_real_margin` checks
+/// both numbers against each other, so a change to either one that eats the
+/// margin fails the gate.
+pub(super) const DEFAULT_WORK_TURN_TIMEOUT_SECS: u64 = 3300;
+
+/// `flags`, with [`DEFAULT_WORK_TURN_TIMEOUT_SECS`] armed when the operator
+/// named no `--turn-timeout` of their own.
+///
+/// An operator's own bound is never widened or narrowed — only an absent one
+/// is filled in, the same "only what was not already set" rule
+/// [`TurnFlags::push_onto`] applies to every other flag.
+fn bounded(mut flags: TurnFlags) -> TurnFlags {
+    if flags.turn_timeout.is_none() {
+        flags.turn_timeout = Some(Duration::from_secs(DEFAULT_WORK_TURN_TIMEOUT_SECS));
+    }
+    flags
+}
+
 /// Spawn `stella run` in `dir` with `prompt` on stdin.
 ///
 /// Inherits stderr so a human watching a foreground cycle sees the turn, and
@@ -432,14 +467,17 @@ pub(super) fn verify_locally(dir: &Path, command: &str, timeout_secs: u64) -> Re
 /// child's ceiling to what is left and folding what it spent back in are two
 /// halves of one fact (#4353). Every child turn this loop runs — triage, work,
 /// retry — is spawned here, so this is the one place both halves can be paid,
-/// and a caller cannot pay one without the other.
+/// and a caller cannot pay one without the other. [`bounded`] is applied here
+/// rather than inside [`RunBudget`], so a `--turn-timeout` a human typed by
+/// hand for an ordinary `stella run` is never touched — only this loop's own
+/// spawned turns get a default they did not ask for.
 pub(super) fn run_turn(
     dir: &Path,
     state_root: &Path,
     prompt: &str,
     budget: &mut RunBudget,
 ) -> Result<String, String> {
-    let flags = budget.next_turn_flags().map_err(|out| out.to_string())?;
+    let flags = bounded(budget.next_turn_flags().map_err(|out| out.to_string())?);
     let exe = std::env::current_exe()
         .map_err(|error| format!("cannot resolve this binary to run the turn: {error}"))?;
 
@@ -1122,6 +1160,69 @@ mod tests {
             args,
             vec!["run", "--output-format", "json"],
             "an untouched invocation must spawn exactly the turn it always did"
+        );
+    }
+
+    /// **Witness.** Before this fix, a turn with no `--turn-timeout` had no
+    /// wall-clock bound at all — the same gap
+    /// [`an_unset_session_flag_is_not_forwarded`] just proved for every other
+    /// flag. `run_turn` waited on its child with no bound of its own, so a
+    /// stuck turn could outlive the driver session's own 3600s bound, and
+    /// its checkout stayed behind. [`bounded`] closes the gap: a turn this
+    /// loop starts always carries a bound, even when the operator set none.
+    #[test]
+    fn a_turn_with_no_operator_bound_still_gets_one_before_it_is_spawned() {
+        let args = turn_args(&bounded(TurnFlags::default()));
+
+        assert!(
+            args.windows(2).any(|pair| pair[0] == "--turn-timeout"
+                && pair[1] == DEFAULT_WORK_TURN_TIMEOUT_SECS.to_string()),
+            "an unbounded turn can wedge the whole driver session and orphan \
+             its checkout: {args:?}"
+        );
+    }
+
+    /// [`bounded`] fills a gap; it does not override a choice. An operator's
+    /// own `--turn-timeout` — however short or long — reaches the turn
+    /// exactly as typed.
+    #[test]
+    fn an_operators_own_turn_timeout_is_never_overridden() {
+        let chosen = Duration::from_secs(120);
+        let flags = bounded(TurnFlags {
+            turn_timeout: Some(chosen),
+            ..TurnFlags::default()
+        });
+        assert_eq!(flags.turn_timeout, Some(chosen));
+    }
+
+    /// **The margin, held to the manifest.** `bounded`'s doc comment claims
+    /// this constant leaves `plugins/stella-selfdriving/plugin.toml`'s
+    /// `[driver.process] timeout_secs` a real 300s margin for the rest of one
+    /// driver session — the worktree cut, the code-graph seed, the tree diff,
+    /// process start/stop. Read the shipped manifest rather than repeating its
+    /// number here, so the two cannot drift apart silently: a manifest edit
+    /// that erases the margin, in either direction, fails this rather than a
+    /// production session discovering it.
+    #[test]
+    fn the_manifests_session_ceiling_leaves_this_bound_a_real_margin() {
+        const MANIFEST: &str = include_str!("../../../../plugins/stella-selfdriving/plugin.toml");
+        const SESSION_OVERHEAD_MARGIN_SECS: u64 = 300;
+
+        let manifest = stella_plugin::PluginManifest::from_toml_str(MANIFEST)
+            .expect("the shipped self-driving manifest must parse");
+        let session_timeout_secs = manifest
+            .driver
+            .as_ref()
+            .and_then(|grant| grant.process.as_ref())
+            .expect("the shipped manifest declares a [driver.process] block")
+            .timeout_secs;
+
+        assert_eq!(
+            session_timeout_secs,
+            DEFAULT_WORK_TURN_TIMEOUT_SECS + SESSION_OVERHEAD_MARGIN_SECS,
+            "the manifest's session ceiling must be exactly this loop's own \
+             turn bound plus the stated overhead margin, so `timeout_secs` \
+             stays a derived number rather than an independent guess"
         );
     }
 

--- a/plugins/stella-selfdriving/plugin.toml
+++ b/plugins/stella-selfdriving/plugin.toml
@@ -197,9 +197,19 @@ argv = ["python3", "${plugin_dir}/main.py"]
 # A session now includes the work, because `work_start` is served. The host
 # cuts a checkout and runs one turn in it while this program waits. A turn on a
 # real issue takes minutes. A one-minute backstop would have killed every
-# session that got as far as doing something. An hour is a backstop against a
-# child that wedges. It is not a work budget: `stella plugin drive
-# --spend-limit` is the number that decides what a session may cost.
+# session that got as far as doing something. It is not a work budget: `stella
+# plugin drive --spend-limit` is the number that decides what a session may
+# cost.
+#
+# 3600 is not an independent guess: it is
+# `crates/stella-cli/src/self_driving_cmd/work.rs`'s own
+# `DEFAULT_WORK_TURN_TIMEOUT_SECS` (3300s — the bound a work turn now carries
+# even when nobody asks for one, so a wedged `stella run` stops itself well
+# short of this ceiling) plus a fixed 300s margin for everything else one
+# session pays for: the worktree cut, the code-graph seed, the tree diff,
+# process start/stop. That file's own
+# `the_manifests_session_ceiling_leaves_this_bound_a_real_margin` reads this
+# exact number back and fails if the two drift apart.
 timeout_secs = 3600
 # Default-deny, and `PATH` is the whole list — it is here so the host can find
 # `python3`. This program reaches for no file, no forge token and no provider


### PR DESCRIPTION
## What & why

`stella plugin drive stella-selfdriving`'s `work_start` spawns one bounded
`stella run` (`self_driving_cmd::work::start` -> `run_turn`) inside a driver
session. `run_turn` waited on that child with `child.wait_with_output()` and
no bound of its own. The only ceiling anywhere near a wedged turn was the
driver session's own `[driver.process] timeout_secs = 3600`
(`plugins/stella-selfdriving/plugin.toml`), and firing that ceiling only
kills the *driver's own process* (`SubprocessDriver`'s `GroupKillGuard`,
`crates/stella-runtime/src/wrapper/driver_subprocess.rs`) — it cannot reach
the child `stella run` or the worktree that child is writing to. So a turn
that wedged could outlive the session, and the worktree it held stayed
behind, colliding with the next attempt at the same issue.

This PR gives every self-driving turn (triage, work, retry — all spawned
through `run_turn`) a bound of its own:

- `DEFAULT_WORK_TURN_TIMEOUT_SECS` (3300s) arms the engine's own enforced
  task deadline (`--turn-timeout`) on a turn that names no bound of its
  own, via a new `bounded()` step ahead of `run_turn`'s spawn. This reuses
  the engine's existing "stop at a safe boundary" mechanism
  (`one_shot_budget_guard`/`BudgetGuard::set_task_deadline`) rather than
  adding a second, process-level kill loop.
- The manifest's `timeout_secs = 3600` is no longer an independent guess:
  it is `DEFAULT_WORK_TURN_TIMEOUT_SECS` plus a documented 300s margin for
  the rest of one driver session (the worktree cut, the code-graph seed,
  the tree diff, process start/stop), and a new test
  (`the_manifests_session_ceiling_leaves_this_bound_a_real_margin`) parses
  the shipped manifest and fails if the two numbers drift apart.

With the turn now bounded well inside the session's own ceiling, the
session-level timeout no longer needs to fire while a turn is in flight in
the ordinary case — closing the window that could otherwise orphan a
checkout. The existing lazy self-heal (`discard_undelivered_attempt` in
`self_driving_cmd/work.rs`, reached by *both* the driver path and the shell
loop, since both call the same `start()`) still recovers a checkout left by
an ordinary turn failure on the next attempt at the same issue, unchanged.

Closes #6285

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`a_turn_with_no_operator_bound_still_gets_one_before_it_is_spawned` proves the
defect directly: it builds the exact argv `run_turn` hands its child through
`turn_args(&bounded(TurnFlags::default()))` and asserts `--turn-timeout`
appears. `bounded()` does not exist on `main`, so the test cannot even
compile there — and the sibling, unmodified test
`an_unset_session_flag_is_not_forwarded` (same file) already proves, on
`main` today, that an unset `TurnFlags` produces exactly
`["run", "--output-format", "json"]` with **no** `--turn-timeout` — the
old-code half of the same fact. `an_operators_own_turn_timeout_is_never_overridden`
proves the fix never clobbers a bound an operator did set.
`the_manifests_session_ceiling_leaves_this_bound_a_real_margin` is a
consistency guard rather than a behavior witness: it parses the real
shipped manifest and fails if `timeout_secs` and the new constant drift
apart.

Verified locally: the crate's self-driving `work` unit tests (scoped run) —
21 passed, 0 failed.

## The gate

- [x] `cargo fmt --check` — scoped to `stella-cli`, clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — scoped to
      `stella-cli` with `--all-targets -D warnings`, clean
- [x] full test suite — scoped run of
      `self_driving_cmd::work::tests::` in `stella-cli`, 21/21 passing (a
      whole-workspace build/test is intentionally not run on this machine
      per AGENTS.md — CI runs the full gate)
- [x] Docs updated where behavior/flags changed (README, `--help`, doc
      comments) — the manifest's own comment above `timeout_secs` now states
      the derivation
- [x] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer

Also ran locally: `make guards-fast` (clean) and `python3
scripts/check-prose.py` (clean — the reading-grade ratchet on
`self_driving_cmd/work.rs` tripped once on my first draft of these doc
comments and was fixed by shortening them).

## Fix over file

- [x] Extra fixes in this PR: ___ — **or** none — this PR is scoped to
      #6285's three DoD items and touches nothing else.
- [x] Filed, with the reason a fix could not ride this PR: #___ — **or**
      nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)
- [ ] New cross-boundary types round-trip through serde (test included) —
      n/a, no new cross-boundary type

## Anything reviewers should know?

**What this PR does *not* claim to fix, and why.** #6285's first DoD item
("a session killed on its timeout leaves no checkout the next attempt
collides with") is closed here by removing the *cause* — the turn can no
longer wedge indefinitely — rather than by adding a Drop-triggered cleanup
at the `WorkSlot`/`HostDriverCapabilities` layer. I looked hard at that
alternative and rejected it: `SpawnedWorkRunner::run`'s work happens inside
`tokio::task::spawn_blocking`, and a `spawn_blocking` closure that has
already started running cannot be cancelled by dropping the future awaiting
it — Tokio detaches it instead, and it keeps running to completion
regardless. A `Drop`-based release racing that still-running closure would
risk deleting files out from under a turn that is still writing them, which
is worse than the defect. Bounding the turn itself removes the scenario
rather than trying to clean up after it.

Also worth a reviewer's eye: `run_turn` is the one spawn point for every
self-driving turn (triage, work, retry — see its own doc comment), so this
default bound now applies to all three, not just `work_start`'s turn. I did
not tune a smaller bound for triage specifically; 3300s is a ceiling, not a
target, and a triage turn finishing in seconds is unaffected by a 55-minute
backstop it will never reach.

## Summary by Sourcery

Ensure self-driving turns stop before their driver session can expire and orphan a checkout.

New Features:
- Bound every self-driving turn with a default 3300-second timeout when no operator-defined timeout is provided.

Bug Fixes:
- Prevent wedged self-driving turns from outliving their driver session and leaving checkouts orphaned for subsequent attempts.

Enhancements:
- Keep operator-specified turn timeouts unchanged while deriving the driver session ceiling from the turn bound plus a documented margin.

Documentation:
- Document the relationship between the self-driving turn timeout and the driver session timeout in the plugin manifest.

Tests:
- Add coverage for default timeout injection, preservation of operator-defined timeouts, and consistency between the turn bound and shipped session ceiling.