### PR TITLE
fix(stella-tools): give witness 3's grandchild time to exist on Windows

### DIFF
--- a/crates/stella-tools/tests/group_kill_witnesses.rs
+++ b/crates/stella-tools/tests/group_kill_witnesses.rs
@@ -58,6 +58,22 @@ use stella_tools::registry::Tool;
 /// bytes here and a killed one by none.
 const OBSERVATION: Duration = Duration::from_millis(200);
 
+/// Witness 3's hook budget. It is also the time its grandchild has to appear.
+///
+/// Witnesses 1 and 2 wait on [`started_beating`], then kill. Spawn time costs
+/// them nothing. Witness 3 cannot wait, because the hook's own timeout is what
+/// kills. Its grandchild has to write a first byte before the budget runs out.
+/// If it does not, the test fails its own premise, not the thing it checks.
+///
+/// At 300ms that is what happened, on `windows-latest`. Windows has to find a
+/// shell and then start two processes. That does not fit in 300ms. A `fork`
+/// and an `exec` do, which is why Linux never saw it.
+///
+/// A longer budget costs the test nothing. The command in
+/// [`backgrounding_command`] ends in `sleep 30`, so the hook still times out.
+/// Only the grandchild's head start grows.
+const HOOK_BUDGET_MS: u64 = 3_000;
+
 /// Bytes written to a heartbeat file so far; `0` for one that does not exist
 /// yet.
 fn beats(path: &Path) -> u64 {
@@ -223,7 +239,7 @@ async fn a_timed_out_hook_leaves_no_surviving_grandchild() {
     let dir = tempfile::tempdir().expect("tempdir");
     let pulse = dir.path().join("hook.pulse");
     let mut hung = HookAction::new(backgrounding_command(&pulse));
-    hung.timeout_ms = Some(300);
+    hung.timeout_ms = Some(HOOK_BUDGET_MS);
 
     let err = HostHookRunner
         .run(&hung, "{}", &dir.path().display().to_string())


### PR DESCRIPTION
## What & why

`a_timed_out_hook_leaves_no_surviving_grandchild` fails on `windows-latest` at its own precondition, not at the property it exists to prove:

```
panicked at crates/stella-tools/tests/group_kill_witnesses.rs:
no grandchild ever ran, so this test would prove nothing about killing one
```

The three witnesses in this file are not symmetrical, and that is the whole bug. Witnesses 1 and 2 call `started_beating` and *only then* kill, so process-spawn time cannot race them. Witness 3 has no such ordering available — the hook's own `timeout_ms` is what kills — so the grandchild has to reach the disk inside that budget or the assertion above trips.

The budget was 300ms. On Windows the hook must resolve a shell and then create two processes; that does not reliably fit in 300ms, where the `fork`/`exec` the number was chosen against does. So the witness reports a premise failure on a platform where the property it tests is fine.

`HOOK_BUDGET_MS` raises it to 3s. The witness is unchanged in meaning: `backgrounding_command` ends in `sleep 30`, so the hook still times out at any budget here — only the grandchild's head start grows.

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: this *is* the repair of a witness. The fail→pass flip lives on `windows-check.yml`, which is the only Windows compiler in the project and cannot be run from this session. Adding a Linux test that pins a Windows timing constant would assert nothing.

## The gate

- [x] `cargo fmt --check` — clean (`-p stella-tools`)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not run; a comment and one constant, no new code paths. CI is the gate.
- [x] `cargo test --workspace` — scoped per SCR-001 to the file changed: `cargo test -p stella-tools --test group_kill_witnesses` → **3 passed**, 3.21s (up from ~0.5s, which is the raised budget).
- [x] Docs updated where behavior/flags changed — `HOOK_BUDGET_MS` carries the reason
- [x] CLA signed
- [ ] `Closes #N` — none; see below

Also run, all clean: `check-prose.py`, `check-line-citations.py`, `check-left-behind.sh`, `check-measured-constants.sh`.

**What the evidence does *not* establish.** The Linux run proves this does not regress Linux. It does **not** prove the Windows failure is fixed — no Windows runner is reachable from this session, and `windows-check.yml` on this branch is what settles it. The diagnosis above is read off the failing job's log plus the two sibling witnesses' ordering; treat the Windows half as argued, not measured, until that run reports.

**On `MEASURED:`** — 3s is deliberately *not* marked. It is a bound chosen to clear a platform's spawn latency with room to spare, not a number read off a measurement, and marking it would make the marker mean less everywhere it appears (AGENTS.md § "Code style", `measured-constants`).

## Fix over file

- [x] Extra fixes in this PR: none
- [x] Filed: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] N/A — no new cross-boundary types

## Anything reviewers should know?

**No issue is linked, so this needs the `no-issue` label to clear `dod`.** I could not apply it from this session. Per AGENTS.md § "Fix over file" the defect was fixed in the PR rather than filed, and a one-constant CI repair is what the escape hatch is for — but say the word and I will file one instead.

**Where it came from.** PR #6369's `windows-check` run went red on this test. That PR touches only `crates/stella-cli` and `crates/stella-runtime`; the failing test is in `crates/stella-tools`, which sits *below* both in the dependency graph, so #6369's diff cannot reach it. The cheap control AGENTS.md asks for says the same thing from the other side: `windows-check` is green on `main`'s recent pushes and on every other branch today. The one other red run in its history (`fix/6292-runtime-batch`, 22:50) was an unrelated clippy `too many arguments` error, so there is no flake precedent for this test — it went red for the first time here.

I could not re-run the job to confirm (`rerun-failed-jobs` returns 403 for this token), which is the path AGENTS.md names for exactly this case: judge it a flake, lack the means to re-run, and the flaky test is fixable within scope — so fix it rather than re-run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RM28VChGtJgEaWk6cCEeAZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RM28VChGtJgEaWk6cCEeAZ)_

## Summary by Sourcery

Bug Fixes:
- Increase the timed hook witness budget so Windows has enough time to spawn and run its grandchild before the timeout assertion.