### PR TITLE
fix(stella-tools): give the hook witness time to have a grandchild

### DIFF
--- a/crates/stella-tools/tests/group_kill_witnesses.rs
+++ b/crates/stella-tools/tests/group_kill_witnesses.rs
@@ -58,6 +58,19 @@ use stella_tools::registry::Tool;
 /// bytes here and a killed one by none.
 const OBSERVATION: Duration = Duration::from_millis(200);
 
+/// How long Witness 3's hook runs before its own budget ends it.
+///
+/// Witnesses 1 and 2 watch a live process and abort it once it is beating, so
+/// the writer has as long as it needs to start. Witness 3 cannot: the hook's
+/// timeout is what kills the group, so the first `printf` has to land inside
+/// this budget or it never lands at all, and the premise assert reads a file
+/// that will now stay empty forever. At 300ms that window was narrower than a
+/// cold Windows runner takes to spawn a shell, a subshell and a `printf`, and
+/// the witness failed there on the premise rather than on the property. Three
+/// seconds is wide enough for that spawn and far short of the `sleep 30` the
+/// hook then waits on, so the budget is still what ends it.
+const HOOK_BUDGET_MS: u64 = 3_000;
+
 /// Bytes written to a heartbeat file so far; `0` for one that does not exist
 /// yet.
 fn beats(path: &Path) -> u64 {
@@ -223,7 +236,7 @@ async fn a_timed_out_hook_leaves_no_surviving_grandchild() {
     let dir = tempfile::tempdir().expect("tempdir");
     let pulse = dir.path().join("hook.pulse");
     let mut hung = HookAction::new(backgrounding_command(&pulse));
-    hung.timeout_ms = Some(300);
+    hung.timeout_ms = Some(HOOK_BUDGET_MS);
 
     let err = HostHookRunner
         .run(&hung, "{}", &dir.path().display().to_string())


### PR DESCRIPTION
## What & why

`windows-check.yml` is red on `a_timed_out_hook_leaves_no_surviving_grandchild`
(`crates/stella-tools/tests/group_kill_witnesses.rs`), and it fails on its own
**premise** rather than on the property it exists to prove:

```
thread 'a_timed_out_hook_leaves_no_surviving_grandchild' panicked at
crates\stella-tools\tests\group_kill_witnesses.rs:236:5:
no grandchild ever ran, so this test would prove nothing about killing one
```

Observed on [#6369's run](https://github.com/macanderson/stella/actions/runs/34081458574/job/101617388283)
(job `101617388283`), where the `TimedOut` assert above it passed — so the shell
resolved, the hook ran, and the budget did end it. Only the grandchild's first
write never landed.

Witnesses 1 and 2 in the same file run the identical `backgrounding_command`
against the same runner and pass. The difference is **when each one looks**.
Both of those watch a live process and abort it only once `started_beating`
answers, so the writer has as long as it needs to reach its first `printf`.
Witness 3 cannot do that: the hook's own timeout is what kills the group, and
the premise assert runs after it. The whole window the grandchild ever has is
therefore the hook's budget — and once the group is dead, the 5s
`started_beating` poll is watching a file that will stay empty forever.

At 300ms that window was narrower than a cold Windows runner takes to spawn a
shell, a subshell and a `printf`.

The budget is now a named `HOOK_BUDGET_MS` at three seconds, with the
constraint on it in the doc comment: wide enough for that spawn, and far short
of the `sleep 30` the hook then waits on, so the budget is still what ends the
hook. Nothing about the property under test moves — only how long the
grandchild is given to exist before the kill it must survive is measured.

Refs #6369 (that PR's diff touches only `stella-cli/wrapper_plugin` and
`stella-runtime/wrapper` — no `stella-tools`, no hook code — so this failure
was never its own; it is ported out here rather than widening that PR).

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: this **is** a
      repair to a test's own premise. A witness would have to be a second test
      asserting the first one's timing, which proves less than the job itself.
      The evidence is `the platform split still compiles on Windows` going
      green on this branch, on the same job that failed on #6369.

## The gate

- [x] `cargo fmt --check` — clean on the changed file
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — CI's job
      (CLAUDE.md: "CI builds and tests; this laptop does not")
- [ ] `cargo test --workspace` — CI's job; the Linux run of this file is
      unaffected (all three witnesses already pass there)
- [x] Toolchain-free guards run locally: `make prose`, `make line-citations`,
      `make left-behind` — all OK
- [x] Docs updated where behavior changed — the constant carries its own
      constraint in a doc comment; no user-facing behavior moves

## Fix over file

- [x] Extra fixes in this PR: none — the change is one constant and its
      doc comment
- [x] Nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

Three seconds is chosen for headroom, not from a measurement of Windows spawn
cost — I have no such measurement, which is why it carries no `MEASURED:`
marker. If the witness ever flakes again at this budget, the honest next step
is to measure that spawn rather than to raise the number again.

The residual shape is inherent to what Witness 3 proves: a timeout-driven kill
cannot be observed without the killed thing having started first, so the budget
is the only lever. Witnesses 1 and 2 have no such coupling and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjAtn43cWo16yGjZYXg3uQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjAtn43cWo16yGjZYXg3uQ)_

## Summary by Sourcery

Bug Fixes:
- Increase the timed-out hook witness budget so Windows runners have enough time to start and observe the grandchild before the process group is terminated.