### PR TITLE
fix(ci): stop auto-tag checking out a ref its trigger picked

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -94,20 +94,66 @@ permissions:
 jobs:
   tag:
     runs-on: ubuntu-latest
-    # Only cut a release for a *successful* CI run triggered by a push to main.
-    # Guarding on the job (not just inside the step) keeps a red build from ever
-    # reaching the tag push.
+    # Only cut a release for a *successful* CI run that this repository's own
+    # main produced from a push. Guarding on the job (not just inside the step)
+    # keeps a red build from ever reaching the tag push, and the repository
+    # clause keeps a workflow_run delivered for some other repository's run
+    # from reaching a job that holds `contents: write` on this one.
     if: >-
+      github.event.workflow_run.repository.full_name == github.repository &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.event == 'push'
     steps:
+      # NO `ref:` HERE, AND IT MUST STAY THAT WAY (#6367, CodeQL alert 129,
+      # `actions/untrusted-checkout`). A workflow_run job runs with this
+      # repository's token and secrets no matter what produced the triggering
+      # run, so `ref: ${{ github.event.workflow_run.head_sha }}` would hand a
+      # ref the trigger does not vouch for to a job holding `contents: write`
+      # on main — the shape that lets a checked-out build script push a tag.
+      # The default ref for a workflow_run event is this repository's default
+      # branch, which is protected, so this clone is trusted before any of it
+      # runs. The step below is what moves the tree to the validated commit,
+      # after proving that commit is already on main.
+      #
+      # `scripts/check-untrusted-checkout.sh` holds this rule for every
+      # workflow_run workflow here, so a later edit reddens the gate rather
+      # than the security tab.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # Tag the exact commit CI validated, not whatever main is now.
-          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           fetch-tags: true
+
+      # The tag must point at the exact commit CI validated, not at whatever
+      # main is now — so the tree moves to that commit, but only once this
+      # step has shown the commit is reachable from main. Reachable from main
+      # means it passed branch protection and is the same trusted content the
+      # clone above already holds; a sha that is not on main fails the job
+      # instead of being checked out, which forgoes a release rather than
+      # running a ref nobody merged.
+      - name: Pin the tree to the CI-validated commit on main
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          case "${HEAD_SHA}" in
+            *[!0-9a-f]* | "")
+              echo "::error::workflow_run head_sha is not a hex commit id."
+              exit 1
+              ;;
+          esac
+          if [ "${#HEAD_SHA}" -ne 40 ]; then
+            echo "::error::workflow_run head_sha is not a full 40-character commit id."
+            exit 1
+          fi
+
+          git fetch --no-tags origin main
+          if ! git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null ||
+            ! git merge-base --is-ancestor "${HEAD_SHA}" FETCH_HEAD; then
+            echo "::error::${HEAD_SHA} is not reachable from main — refusing to check it out."
+            exit 1
+          fi
+          git checkout --detach "${HEAD_SHA}"
 
       - name: Compute next version
         id: ver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,15 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: ./scripts/check-action-pins.sh
 
+      # Also toolchain-free. A workflow_run job runs with this repository's
+      # token whatever produced the triggering run, so a checkout of
+      # `github.event.workflow_run.head_sha` there is a pwn request — CodeQL
+      # alert 129 against auto-tag.yml, which holds `contents: write` on main
+      # (#6367).
+      - name: no workflow_run job checks out an untrusted ref
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        run: ./scripts/check-untrusted-checkout.sh
+
       # Also toolchain-free. `--locked` pins a tool's own dependency graph,
       # not the tool itself — this catches a `cargo install` that floats on
       # whatever version is newest at run time (#915).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,9 @@ machine runs before pushing:
 ```bash
 make gate                # = no-scratch + no-secrets + design-refs
                          #   + action-pins + cargo-install-pins
+                         #   + untrusted-checkout (no workflow_run job
+                         #     checks out a ref its trigger does not
+                         #     vouch for)
                          #   + license-allowlist-parity + repro-wiring
                          #   + shellcheck + invariants + doc-links
                          #   + adr-numbering

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,7 @@ A red gate is an automatic "not yet":
 ./scripts/check-no-secrets.sh
 ./scripts/check-design-refs.sh
 ./scripts/check-action-pins.sh
+./scripts/check-untrusted-checkout.sh
 ./scripts/check-cargo-install-pins.sh
 ./scripts/check-license-allowlist-parity.sh
 ./scripts/check-repro-wiring.sh

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ CARGO_SCOPE ?= --workspace
 # compiles the workspace for clippy anyway, so excluding wire-schema there
 # saved nothing and let a GATE=fast push land stale generated wire artifacts.
 GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-pins \
+                    untrusted-checkout \
                     license-allowlist-parity repro-wiring shellcheck invariants doc-links \
                     adr-numbering \
                     command-docs website-inputs brand-case file-size god-files gate-parity \
@@ -291,6 +292,10 @@ design-refs: ## Assert nothing outside docs/design cites it (docs/design is work
 .PHONY: action-pins
 action-pins: ## Assert every workflow `uses:` is pinned to a commit SHA (#648)
 	@./scripts/check-action-pins.sh
+
+.PHONY: untrusted-checkout
+untrusted-checkout: ## Assert no workflow_run job checks out a ref its trigger does not vouch for (#6367)
+	@./scripts/check-untrusted-checkout.sh
 
 .PHONY: cargo-install-pins
 cargo-install-pins: ## Assert every workflow `cargo install` names an exact version (#915)

--- a/scripts/check-untrusted-checkout.sh
+++ b/scripts/check-untrusted-checkout.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Guard: a workflow_run job must not check out a ref its trigger picked.
+#
+# A workflow_run job gets this repository's token. It gets that token no
+# matter which run set it off. `auto-tag.yml` is the one such job here. It can
+# write to the default branch, because it pushes the release tag.
+#
+# So a checkout of `github.event.workflow_run.head_sha` hands that token a
+# tree the trigger picked. Build scripts in the tree then run with it. CodeQL
+# calls this a pwn request. Alert 129 named this workflow.
+#
+# The fix is to clone the default branch. Branch protection already vouches
+# for it. The job then moves to the built commit, but only after
+# `git merge-base --is-ancestor` shows that commit is already on the branch.
+#
+# One deleted line is the whole fix, so it is easy to undo by accident. The
+# workflow says why the line is gone, and a comment is not a gate. CodeQL does
+# see it, but only after the merge, and only on the security tab.
+#
+# What this checks: in a workflow with a `workflow_run:` trigger, no step sets
+# `ref:` to a value naming `github.event.workflow_run`. A literal ref is fine.
+# So is one the base repository controls. The rule is about where a ref comes
+# from, not about having one.
+#
+# What it does not check: whether the job's `if:` gate is tight, or whether a
+# later `run:` step reaches the same sha. Both are review questions over prose
+# and shell. This one is a fact about a YAML key.
+#
+# POSIX tools only, so it runs on a bare CI runner.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+workflows="${1:-.github/workflows}"
+
+fail=0
+report=""
+note() { report="${report}check-untrusted-checkout: $1"$'\n'; }
+
+# The verdict is settled before anything is written. Emission is best-effort,
+# so a reader that closes the pipe changes neither the report nor the exit
+# status. scripts/check-gate-parity.sh is the shape copied here.
+emit() {
+  trap '' PIPE
+  printf '%s' "$report" >&2 || true
+}
+
+if [ ! -d "$workflows" ]; then
+  note "FAIL — $workflows is not a directory."
+  emit
+  exit 1
+fi
+
+scanned=0
+for wf in "$workflows"/*.yml "$workflows"/*.yaml; do
+  [ -f "$wf" ] || continue
+
+  # A `workflow_run:` key at the trigger's own indent. Anchored, so a mention
+  # in a comment or a `run:` block does not enrol an ordinary workflow.
+  grep -Eq '^[[:space:]]{1,4}workflow_run:' "$wf" || continue
+  scanned=$((scanned + 1))
+
+  hits="$(grep -nE '^[[:space:]]*ref:.*github\.event\.workflow_run' "$wf" || true)"
+  [ -n "$hits" ] || continue
+
+  fail=1
+  note "FAIL — $wf checks out a ref its workflow_run trigger picked:"
+  while IFS= read -r line; do
+    note "         $line"
+  done <<EOF
+$hits
+EOF
+  note "       Drop the \`ref:\`, so the clone is the default branch. Then move"
+  note "       the tree to the built commit, once \`git merge-base"
+  note "       --is-ancestor\` shows it is already on that branch."
+  note "       auto-tag.yml's checkout step is the worked example."
+done
+
+if [ "$scanned" -eq 0 ]; then
+  note "FAIL — no workflow declares a workflow_run trigger."
+  note "       This guard is then watching nothing. Either the trigger was"
+  note "       renamed away, or this script's pattern has rotted. Both want a"
+  note "       human, and a silent pass is how a guard becomes decoration."
+  emit
+  exit 1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  emit
+  exit 1
+fi
+
+echo "check-untrusted-checkout: OK — $scanned workflow_run workflow(s), none checks out a ref its trigger picked."


### PR DESCRIPTION
## What & why

`.github/workflows/auto-tag.yml` triggers on `workflow_run`, so its job gets
this repository's token and secrets whatever produced the triggering `ci`
run, and it holds `contents: write` on `main` so it can push the release
tag. Its first step checked out `github.event.workflow_run.head_sha` into
that job — the "pwn request" shape CodeQL alert 129
(`actions/untrusted-checkout/critical`) flags, open against
`refs/heads/main`.

Three changes:

1. **The checkout takes no `ref:`.** The default ref for a `workflow_run`
   event is this repository's default branch, which branch protection
   already vouches for, so the clone is trusted before any of it runs.
2. **A new step moves the tree to the CI-validated commit, after proving
   the commit is on `main`.** The tag must still point at the exact commit
   CI validated, so `Pin the tree to the CI-validated commit on main`
   validates the sha is 40 hex characters, fetches `main`, and detaches only
   when `git merge-base --is-ancestor` shows the commit is reachable from
   it. Reachable from `main` means it passed branch protection. A sha that
   is not on `main` fails the job rather than being checked out — forgoing a
   release rather than running a ref nobody merged.
3. **The job-level gate gained
   `github.event.workflow_run.repository.full_name == github.repository`**,
   beside the existing `conclusion == 'success'`, `head_branch == 'main'`
   and `event == 'push'` clauses.

`scripts/check-untrusted-checkout.sh` is a new `make gate` step
(`GATE_GUARDS_FAST`, and a step in `ci.yml`'s guards job) holding the rule
for every `workflow_run` workflow here: no step may set `ref:` to a value
naming `github.event.workflow_run`. It compiles nothing and runs in
milliseconds. Without it the repair above is one deleted line that only
CodeQL would notice — after the merge, and only on the security tab, which
is where alert 129 sat.

Closes #6367

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The guard itself is the witness, and it was checked the artisanal way:

```
$ git stash push -- .github/workflows/auto-tag.yml
$ ./scripts/check-untrusted-checkout.sh
check-untrusted-checkout: FAIL — .github/workflows/auto-tag.yml checks out a ref its workflow_run trigger picked:
check-untrusted-checkout:          108:          ref: ${{ github.event.workflow_run.head_sha }}
exit=1
$ git stash pop
$ ./scripts/check-untrusted-checkout.sh
check-untrusted-checkout: OK — 1 workflow_run workflow(s), none checks out a ref its trigger picked.
```

The workflow change itself cannot be exercised locally — nothing here can
deliver a `workflow_run` event — so its evidence is the guard plus review of
the ancestry check. The one behavioural claim that rests on a documented
platform fact rather than an observation is labelled as such below.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`, clean)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — CI's, per
      CLAUDE.md's "CI builds and tests; this laptop does not". No Rust changed.
- [ ] `cargo test --workspace` — same. No Rust changed.
- [x] Docs updated: AGENTS.md's gate block and CONTRIBUTING.md's gate fence
      both name the new step (`check-gate-parity.sh` passes).
- [x] CLA signed
- [x] `Closes #6367` appears both here and as a commit trailer

`make guards-fast` is green on this branch, `shellcheck` clean on the new
script, `python3 scripts/check-prose.py` green, and both edited workflows
parse under `yaml.safe_load`.

## Fix over file

- [x] Extra fixes in this PR: none
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Anything reviewers should know?

**The claim I verified vs. the one I assumed.** Verified: the new guard
fails on the old file and passes on the new; the `if:` gate's new clause and
the ancestry check are in the diff. Assumed, from GitHub's own "Events that
trigger workflows" table rather than from an observation: for a
`workflow_run` event, `GITHUB_REF` is the default branch, which is what
makes a `ref:`-less `actions/checkout` clone `main`. If that were wrong the
job would fail loudly at the ancestry check rather than tag the wrong
commit, because the check compares against a freshly fetched `origin/main`
either way.

**Blast radius.** This is the release-tagging pipeline, so a mistake here
stops releases shipping rather than shipping a wrong one. The failure
direction is deliberate: every new refusal path exits non-zero before the
tag push. The first merge to `main` after this lands is the real test — if
`auto-tag` errors at the new step, the sha it names should be compared
against `git log origin/main` before anything is reverted.

**The alert.** It stands against `refs/heads/main`, so it clears when CodeQL
next scans `main` after this merges, not on this PR. The `actions` leg of
`codeql.yml` runs on this PR and should report the instance as fixed.

## Summary by Sourcery

Harden the release-tagging workflow against untrusted workflow_run checkouts while preserving tags for the exact CI-validated commit.

Bug Fixes:
- Prevent release tagging from checking out an untrusted commit selected by a workflow_run trigger.
- Reject workflow_run events originating from repositories other than the current repository.

Enhancements:
- Pin release tagging to the CI-validated commit only after verifying it is a valid commit reachable from protected main.
- Add a repository guard to the release job before granting access to its write-capable token.

CI:
- Add a fast CI and make gate that detects workflow_run workflows checking out refs derived from workflow_run event data.

Documentation:
- Document the new untrusted-checkout gate in contributor and agent gate instructions.

Tests:
- Add the shell guard script that fails when a workflow_run checkout uses a trigger-selected ref.