### PR TITLE
feat(scripts): claim a pull request, and stop a second copy of one finding

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -296,6 +296,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-issue-claim.sh
 
+      - name: the pull-request claim and the duplicate-finding gate
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-pr-claim.sh
+
       - name: the CodeQL canary opens, refreshes and closes a codeql-red issue
         if: ${{ !cancelled() }}
         run: ./scripts/test-codeql-canary.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,8 +454,12 @@ The claim half takes the rules above: a lapsing comment, a session word beside
 the login, and every unknown proceeding loudly. A merged or closed pull request
 stands a sweep down too, since neither one takes a comment.
 
-`post` is the half that would have stopped all three. It asks whether the same
-finding already stands, and writes only when it does not. The caller names the
+`post` is the half that would have stopped all three. It asks the claim
+question too, then asks whether the same finding already stands, and writes
+only when neither answer is yes — the finding question alone can only see what
+somebody already published, so it turns a second sweep away after it has spent
+its diagnosis rather than before. `--ignore-claim` posts over a live claim, for
+the operator who read it and said on the pull request why. The caller names the
 finding, because two sessions that find one thing write it up two ways, and a
 digest of the words would call them different. A key that has to go stale
 carries what it depends on: a finding about the head commit puts the head sha

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,13 +427,46 @@ It carries the same session word, and for the same reason: one login is one
 account, and the thing that has to be identified is the session. Comparing
 the login alone read a peer session's claim as this session's own and cleared
 both to work one issue (`#5875`). `scripts/lib/claim-session.sh` resolves the
-word for both scripts, so a fleet sets `STELLA_CLAIM_SESSION` once rather
-than twice, and both fail open the same way: a run with no word of its own,
-and a claim comment carrying none, fall back to the author-only rule.
+word for every claim script here, so a fleet sets `STELLA_CLAIM_SESSION` once
+rather than once per script, and they all fail open the same way: a run with
+no word of its own, and a claim comment carrying none, fall back to the
+author-only rule.
 
 Run it **before writing code and again before opening the PR**. The gap
 between those two is enough: a peer's PR can merge inside one issue's worth of
 work, and then the check that was clean at the start is stale at the end.
+
+**A pull request is the third thing two sessions take at once, and
+`scripts/pr-claim.sh` is that mechanic pointed at one.** Three sweep sessions
+read one pull request in eight minutes, each worked out the same merge
+conflict, and each posted it; a fourth stopped, because it read the comments
+first. Duplication here does not lose work, it publishes it, and the
+maintainer is left to diff three long comments to learn they say one thing
+(`#5861`).
+
+```bash
+./scripts/pr-claim.sh check 5835    # exit 0 proceed, 1 stand down
+./scripts/pr-claim.sh claim 5835    # check, then post the claim
+./scripts/pr-claim.sh post 5835 --finding conflict:5828 --body-file note.md
+```
+
+The claim half takes the rules above: a lapsing comment, a session word beside
+the login, and every unknown proceeding loudly. A merged or closed pull request
+stands a sweep down too, since neither one takes a comment.
+
+`post` is the half that would have stopped all three. It asks whether the same
+finding already stands, and writes only when it does not. The caller names the
+finding, because two sessions that find one thing write it up two ways, and a
+digest of the words would call them different. A key that has to go stale
+carries what it depends on: a finding about the head commit puts the head sha
+in the key. A read that failed says so and posts anyway, rather than reporting
+that nothing stands.
+
+Take the claim when you start to read the pull request, not when you are ready
+to write. Each of those three sessions spent twenty minutes on the conflict
+before it had anything to say, so a claim taken at the end would have saved
+none of it. `make pr-claim N=5835` asks by hand; `make pr-claim-test` covers
+both gates, the blocking branches included.
 
 An eighth, `windows-check.yml`, is the only compiler in this project that
 looks at a `#[cfg(windows)]` arm: `ci.yml` runs on `ubuntu-latest` and

--- a/Makefile
+++ b/Makefile
@@ -1000,6 +1000,14 @@ issue-claim: ## Ask whether somebody is already implementing an issue: make issu
 issue-claim-test: ## Test the issue-claim pre-flight, standing-down branch included (hermetic; not part of `gate`)
 	./scripts/test-issue-claim.sh
 
+.PHONY: pr-claim
+pr-claim: ## Ask whether somebody is already sweeping a pull request: make pr-claim N=5835
+	@./scripts/pr-claim.sh check $(N)
+
+.PHONY: pr-claim-test
+pr-claim-test: ## Test the pull-request claim and the duplicate-finding gate (hermetic; not part of `gate`)
+	./scripts/test-pr-claim.sh
+
 # Not a GATE_STEPS member -- one file, one narrow shape (#3459). The real
 # enforcement is its self-test's own live-tree case (F in
 # test-dependabot-pip-dirs.sh, "this repository's real dependabot.yml

--- a/scripts/lib/claim-session.sh
+++ b/scripts/lib/claim-session.sh
@@ -2,7 +2,8 @@
 #
 # The session word a claim carries beside its author.
 #
-# `scripts/main-red-claim.sh` and `scripts/issue-claim.sh` both read it.
+# Every claim script here reads it: `scripts/main-red-claim.sh`,
+# `scripts/issue-claim.sh` and `scripts/pr-claim.sh`.
 #
 # ## Why a login is not enough
 #

--- a/scripts/pr-claim.sh
+++ b/scripts/pr-claim.sh
@@ -448,16 +448,14 @@ report_held() {
   echo "         reason rather than a collision." >&2
 }
 
-# ── post: has this finding already been published? ───────────────────────────
+# ── post: may this finding be published here? ────────────────────────────────
 #
-# This gate runs on its own. A sweep that means to publish asks this and
-# nothing else, because a finding that already stands is a duplicate whoever
-# holds the pull request.
+# Two questions, in this order. Does a peer hold the pull request, and does
+# this finding already stand? The claim is asked first because it is the one
+# that can turn a sweep back before it spends its diagnosis. The finding is
+# asked second because a published copy costs a reader whoever holds the claim,
+# so it stops a post that this session's own claim covers.
 if [ "$mode" = "post" ]; then
-  # The claim gate runs here too. A finding gate on its own can only see what
-  # is already published, so two sweeps that both begin before either posts
-  # each spend a full diagnosis, and only the second is turned away. A claim
-  # taken at the start turns the second one back before it spends anything.
   if [ "$ignore_claim" -eq 0 ]; then
     scan_claims
     if [ -n "$held_by" ]; then

--- a/scripts/pr-claim.sh
+++ b/scripts/pr-claim.sh
@@ -303,6 +303,12 @@ if [ "$mode" = "post" ]; then
 fi
 
 if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
+  # `post` is the one mode that owes the caller a write. Reporting "proceed"
+  # there would tell a sweep its finding is up when nothing was sent.
+  if [ "$mode" = "post" ]; then
+    echo "pr-claim: gh is not installed, so nothing was posted on #$pr." >&2
+    exit 3
+  fi
   echo "note: gh is not installed, so this run could not ask whether #$pr is" >&2
   echo "      already being swept. Proceeding: a check that can block a sweep" >&2
   echo "      is worse than the duplication it stops." >&2

--- a/scripts/pr-claim.sh
+++ b/scripts/pr-claim.sh
@@ -6,6 +6,7 @@
 #   `scripts/pr-claim.sh check <n>     # exit 0 proceed, 1 stand down`
 #   `scripts/pr-claim.sh claim <n>     # check, then post the claim`
 #   `scripts/pr-claim.sh post <n> --finding <key> --body-file <path>`
+#   `scripts/pr-claim.sh post <n> --finding <key> --body <text> --ignore-claim`
 #   `scripts/pr-claim.sh select --now <unix-seconds>      # JSON in, rows out`
 #   `scripts/pr-claim.sh findings --finding <key> --now <unix-seconds>`
 #
@@ -30,13 +31,17 @@
 #
 # ── Two gates ────────────────────────────────────────────────────────────────
 #
-# `check` asks whether a peer holds the pull request. `post` asks whether this
-# finding is already up. They fire at different times, and only the second one
-# would have stopped all three comments above.
+# `check` asks whether a peer holds the pull request. `post` asks that too, and
+# then asks whether this finding is already up.
 #
-# Take the claim when you start to read the pull request. Each of the three
-# sweeps spent twenty minutes on the conflict before it had a word to say. A
-# claim taken at the end saves none of that.
+# The second question alone can only see what is already published. Two sweeps
+# that both begin before either posts each spend a full diagnosis, and only the
+# second is turned away. The claim turns the second one back at the start,
+# which is where the twenty minutes are. So take the claim when you start to
+# read the pull request. A claim taken at the end saves none of them.
+#
+# `--ignore-claim` posts over a live claim. It is for the operator who read the
+# claim, judged it stale or aimed elsewhere, and said so on the pull request.
 #
 # ── The finding key ──────────────────────────────────────────────────────────
 #
@@ -86,6 +91,7 @@ pr=""
 finding=""
 body=""
 body_file=""
+ignore_claim=0
 fixture_login=""
 fixture_session=""
 fixture_claims=""
@@ -118,6 +124,13 @@ while [ $# -gt 0 ]; do
   --body-file)
     body_file="${2:-}"
     shift 2
+    ;;
+  # Post even though a peer's live claim stands. For the operator who read the
+  # claim, decided it was stale or covers other ground, and said so on the pull
+  # request.
+  --ignore-claim)
+    ignore_claim=1
+    shift
     ;;
   # The clock the pure modes read, so a test can pin it.
   --now)
@@ -327,12 +340,135 @@ if [ "$use_fixture" -eq 0 ]; then
   fi
 fi
 
+# ── Who holds the pull request ────────────────────────────────────────────
+#
+# `held_by` names the freshest live claim this session cannot account for.
+# Every unknown leaves it empty, which is the fail-open side. An unreadable
+# login, an unreadable comment list and a claim nobody can date each let the
+# run go on. `identity_ok` and `claims_ok` say which unknown was hit, so a
+# caller can report the reason rather than "nothing holds it".
+me=""
+my_session=""
+held_by=""
+held_session=""
+held_age=""
+identity_ok=1
+claims_ok=1
+
+scan_claims() {
+  if [ "$use_fixture" -eq 1 ]; then
+    me="$fixture_login"
+  elif ! me="$(gh api user --jq .login 2>/dev/null)"; then
+    me=""
+  fi
+  if [ -z "$me" ]; then
+    echo "note: could not read this session's login, so a claim on #$pr cannot" >&2
+    echo "      be told from one of its own. Proceeding (fail-open)." >&2
+    identity_ok=0
+    return
+  fi
+
+  if [ "$use_fixture" -eq 1 ]; then
+    my_session="$fixture_session"
+  elif ! my_session="$(resolve_session)"; then
+    my_session=""
+  fi
+  if [ -z "$my_session" ]; then
+    echo "note: this run has no session word, so a claim of its own login cannot" >&2
+    echo "      be told from a peer session's. Proceeding on those (fail-open)." >&2
+  fi
+
+  local claims=""
+  if [ "$use_fixture" -eq 1 ]; then
+    if [ "$fixture_claims_failed" -eq 1 ]; then
+      claims_ok=0
+    else
+      claims="$fixture_claims"
+    fi
+  elif [ "$comments_ok" -eq 0 ]; then
+    claims_ok=0
+  elif ! claims="$(printf '%s' "$comments_json" | select_claims "$(date -u +%s)")"; then
+    claims_ok=0
+  fi
+  if [ "$claims_ok" -eq 0 ]; then
+    echo "note: could not read #$pr's comments. Proceeding (fail-open)." >&2
+    return
+  fi
+
+  # Its own claim is no reason to stand a session down. Re-running the
+  # pre-flight is what a session does when it comes back to work it started.
+  # Same login and same word is its own. Same login with either word missing is
+  # unprovable, and an unknown proceeds.
+  local who claim_session age
+  while read -r who claim_session age; do
+    [ -n "$who" ] || continue
+    if [ "$who" = "$me" ]; then
+      [ -z "$my_session" ] && continue
+      [ "$claim_session" = "-" ] && continue
+      [ "$claim_session" = "$my_session" ] && continue
+    fi
+    case "$age" in
+    '' | *[!0-9]*) continue ;;
+    esac
+    [ "$age" -lt "$window_seconds" ] || continue
+    if [ -z "$held_age" ] || [ "$age" -lt "$held_age" ]; then
+      held_by="$who"
+      held_session="$claim_session"
+      held_age="$age"
+    fi
+  done <<EOF
+$claims
+EOF
+}
+
+# The stand-down a live peer claim earns, shared by both gates so they cannot
+# drift into saying different things about one claim.
+report_held() {
+  local minutes=$((held_age / 60)) held_where
+  if [ "$held_session" = "-" ]; then
+    held_where="session unknown"
+  else
+    held_where="session $held_session"
+  fi
+  echo "STAND DOWN  #$pr is already being swept." >&2
+  echo "" >&2
+  echo "     claimed by @$held_by ($held_where), ${minutes}m ago" \
+    "(window: ${window_minutes}m)" >&2
+  echo "" >&2
+  if [ "$held_by" = "$me" ]; then
+    echo "     That login is yours, so this is another of your own sessions —" >&2
+    echo "     a second agent in a second worktree, which is the case the" >&2
+    echo "     session word exists to catch." >&2
+    echo "" >&2
+  fi
+  echo "     What to do:" >&2
+  echo "       - Pick another pull request. The claim lapses by itself after" >&2
+  echo "         ${window_minutes}m, so a session that died cannot hold this shut." >&2
+  echo "       - Working it anyway? Say so on #$pr, so the next session reads a" >&2
+  echo "         reason rather than a collision." >&2
+}
+
 # ── post: has this finding already been published? ───────────────────────────
 #
 # This gate runs on its own. A sweep that means to publish asks this and
 # nothing else, because a finding that already stands is a duplicate whoever
 # holds the pull request.
 if [ "$mode" = "post" ]; then
+  # The claim gate runs here too. A finding gate on its own can only see what
+  # is already published, so two sweeps that both begin before either posts
+  # each spend a full diagnosis, and only the second is turned away. A claim
+  # taken at the start turns the second one back before it spends anything.
+  if [ "$ignore_claim" -eq 0 ]; then
+    scan_claims
+    if [ -n "$held_by" ]; then
+      report_held
+      echo "" >&2
+      echo "     Nothing was posted. Pass --ignore-claim once you have read the" >&2
+      echo "     claim and said on #$pr why you are posting anyway." >&2
+      exit 1
+    fi
+  fi
+
   hits=""
   hits_ok=1
   if [ "$use_fixture" -eq 1 ]; then
@@ -432,95 +568,16 @@ elif [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
   exit 1
 fi
 
-if [ "$use_fixture" -eq 1 ]; then
-  me="$fixture_login"
-elif ! me="$(gh api user --jq .login 2>/dev/null)"; then
-  me=""
-fi
-if [ -z "$me" ]; then
-  echo "note: could not read this session's login, so a claim on #$pr cannot" >&2
-  echo "      be told from one of its own. Proceeding (fail-open)." >&2
+scan_claims
+if [ "$identity_ok" -eq 0 ]; then
   proceed "ok  proceed (identity unknown)"
 fi
-
-if [ "$use_fixture" -eq 1 ]; then
-  my_session="$fixture_session"
-elif ! my_session="$(resolve_session)"; then
-  my_session=""
-fi
-if [ -z "$my_session" ]; then
-  echo "note: this run has no session word, so a claim of its own login cannot" >&2
-  echo "      be told from a peer session's. Proceeding on those (fail-open)." >&2
-fi
-
-claims=""
-claims_ok=1
-if [ "$use_fixture" -eq 1 ]; then
-  if [ "$fixture_claims_failed" -eq 1 ]; then
-    claims_ok=0
-  else
-    claims="$fixture_claims"
-  fi
-elif [ "$comments_ok" -eq 0 ]; then
-  claims_ok=0
-elif ! claims="$(printf '%s' "$comments_json" | select_claims "$(date -u +%s)")"; then
-  claims_ok=0
-fi
 if [ "$claims_ok" -eq 0 ]; then
-  echo "note: could not read #$pr's comments. Proceeding (fail-open)." >&2
   proceed "ok  proceed (comments unreadable)"
 fi
 
-# The freshest claim this session cannot account for. Its own is no reason to
-# stand it down: re-running the pre-flight is what a session does when it comes
-# back to work it started. Same login and same word is its own. Same login with
-# either word missing is unprovable, and an unknown proceeds.
-held_by=""
-held_session=""
-held_age=""
-while read -r who claim_session age; do
-  [ -n "$who" ] || continue
-  if [ "$who" = "$me" ]; then
-    [ -z "$my_session" ] && continue
-    [ "$claim_session" = "-" ] && continue
-    [ "$claim_session" = "$my_session" ] && continue
-  fi
-  case "$age" in
-  '' | *[!0-9]*) continue ;;
-  esac
-  [ "$age" -lt "$window_seconds" ] || continue
-  if [ -z "$held_age" ] || [ "$age" -lt "$held_age" ]; then
-    held_by="$who"
-    held_session="$claim_session"
-    held_age="$age"
-  fi
-done <<EOF
-$claims
-EOF
-
 if [ -n "$held_by" ]; then
-  minutes=$((held_age / 60))
-  if [ "$held_session" = "-" ]; then
-    held_where="session unknown"
-  else
-    held_where="session $held_session"
-  fi
-  echo "STAND DOWN  #$pr is already being swept." >&2
-  echo "" >&2
-  echo "     claimed by @$held_by ($held_where), ${minutes}m ago" \
-    "(window: ${window_minutes}m)" >&2
-  echo "" >&2
-  if [ "$held_by" = "$me" ]; then
-    echo "     That login is yours, so this is another of your own sessions —" >&2
-    echo "     a second agent in a second worktree, which is the case the" >&2
-    echo "     session word exists to catch." >&2
-    echo "" >&2
-  fi
-  echo "     What to do:" >&2
-  echo "       - Pick another pull request. The claim lapses by itself after" >&2
-  echo "         ${window_minutes}m, so a session that died cannot hold this shut." >&2
-  echo "       - Working it anyway? Say so on #$pr, so the next session reads a" >&2
-  echo "         reason rather than a collision." >&2
+  report_held
   exit 1
 fi
 

--- a/scripts/pr-claim.sh
+++ b/scripts/pr-claim.sh
@@ -1,0 +1,557 @@
+#!/usr/bin/env bash
+#
+# Is somebody already sweeping a pull request, and is this finding already
+# posted there? (`#5861`)
+#
+#   `scripts/pr-claim.sh check <n>     # exit 0 proceed, 1 stand down`
+#   `scripts/pr-claim.sh claim <n>     # check, then post the claim`
+#   `scripts/pr-claim.sh post <n> --finding <key> --body-file <path>`
+#   `scripts/pr-claim.sh select --now <unix-seconds>      # JSON in, rows out`
+#   `scripts/pr-claim.sh findings --finding <key> --now <unix-seconds>`
+#
+# ── Why this exists ──────────────────────────────────────────────────────────
+#
+# Three sweeps read one pull request in eight minutes. Each worked out the same
+# merge conflict, wrote the same table, and posted it. A fourth reached the
+# same answer and stopped, because it read the comments first. The maintainer
+# was left to diff three long comments to learn they say one thing.
+#
+# The cost is not lost work. It is published work. That is what makes it worse
+# than the same race over an issue. A spare comment lands on the maintainer's
+# pull request and stays there.
+#
+# `scripts/issue-claim.sh` claims an issue. Nothing claimed a pull request.
+# This is that mechanic pointed at one. Its rules are that script's rules.
+# The tracker is the table, since a local note is hidden from the peer that
+# needs it. A comment is the claim, so it carries an author and a time with no
+# new storage. It lapses, so a session that dies cannot hold a pull request
+# shut. And every unknown proceeds, out loud: a check that can block a sweep
+# is worse than the waste it stops.
+#
+# ── Two gates ────────────────────────────────────────────────────────────────
+#
+# `check` asks whether a peer holds the pull request. `post` asks whether this
+# finding is already up. They fire at different times, and only the second one
+# would have stopped all three comments above.
+#
+# Take the claim when you start to read the pull request. Each of the three
+# sweeps spent twenty minutes on the conflict before it had a word to say. A
+# claim taken at the end saves none of that.
+#
+# ── The finding key ──────────────────────────────────────────────────────────
+#
+# The caller names the finding. This script does not read the words. Two
+# sweeps that find one thing write it up two ways, so a digest of the text
+# would call them different. The key is what they agree on:
+#
+#   `scripts/pr-claim.sh post 5835 --finding conflict:5828 --body-file note.md`
+#
+# A key that has to go stale carries what it rests on. A finding about the head
+# commit puts the head sha in the key. A later push can then be reported again.
+#
+# ── The author alone is not the identity ─────────────────────────────────────
+#
+# One login is one account, and one person runs several sessions at once. So a
+# claim carries a session word beside the login:
+#
+#   `<!-- pr-claim --> <login> <session>`
+#
+# A claim is this session's own only when both match. The word comes from
+# `scripts/lib/claim-session.sh`, shared with the other two claim scripts.
+#
+# A finding takes no session word. A finding that stands is published. Who
+# published it does not change what a second copy costs.
+#
+# ── What it cannot see ───────────────────────────────────────────────────────
+#
+# A claim is a signal somebody chose to leave. It is not a lock. Two sessions
+# that check in the same second both proceed. It turns the common case, a peer
+# who began ten minutes ago, from hidden into plain. That is all it offers.
+
+set -uo pipefail
+
+# `plain_word` and `resolve_session` — the same word the other two claim
+# scripts use, so they cannot disagree about which session this is.
+# shellcheck source=scripts/lib/claim-session.sh
+. "$(dirname "$0")/lib/claim-session.sh"
+
+# A decided verdict must survive a reader that closes the pipe early.
+trap '' PIPE
+
+marker="<!-- pr-claim -->"
+window_minutes=90
+
+mode=""
+pr=""
+finding=""
+body=""
+body_file=""
+fixture_login=""
+fixture_session=""
+fixture_claims=""
+fixture_claims_failed=0
+fixture_findings=""
+fixture_findings_failed=0
+fixture_pr_state="OPEN"
+fixture_pr_state_failed=0
+select_now=""
+use_fixture=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  check | claim | post | select | findings)
+    mode="$1"
+    shift
+    ;;
+  --window-minutes)
+    window_minutes="${2:-}"
+    shift 2
+    ;;
+  --finding)
+    finding="${2:-}"
+    shift 2
+    ;;
+  --body)
+    body="${2:-}"
+    shift 2
+    ;;
+  --body-file)
+    body_file="${2:-}"
+    shift 2
+    ;;
+  # The clock the pure modes read, so a test can pin it.
+  --now)
+    select_now="${2:-}"
+    shift 2
+    ;;
+  # Test-only, and paired: a fixture that supplied claims but read the real
+  # tracker would compare two different worlds.
+  --fixture-login)
+    fixture_login="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  # This session's own word. An empty value is the run that has none, which is
+  # the open side of the comparison.
+  --fixture-session)
+    fixture_session="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-claims)
+    fixture_claims="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  # Test-only: the comment read itself failing, as against answering with
+  # nothing. The two must never report the same way.
+  --fixture-claims-failed)
+    fixture_claims_failed=1
+    use_fixture=1
+    shift
+    ;;
+  # Rows of `<login> <age-in-seconds>`, one per comment already carrying this
+  # finding's marker.
+  --fixture-findings)
+    fixture_findings="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-findings-failed)
+    fixture_findings_failed=1
+    use_fixture=1
+    shift
+    ;;
+  # Test-only: the pull request's own state, as `gh pr view --json state`
+  # reports it. Defaults to OPEN.
+  --fixture-pr-state)
+    fixture_pr_state="${2:-}"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-pr-state-failed)
+    fixture_pr_state_failed=1
+    use_fixture=1
+    shift
+    ;;
+  -h | --help)
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+    exit 0
+    ;;
+  *)
+    if [ -z "$pr" ]; then
+      pr="$1"
+      shift
+    else
+      echo "pr-claim: unknown argument '$1'" >&2
+      exit 2
+    fi
+    ;;
+  esac
+done
+
+# Every claim comment in a `gh pr view --json comments` payload, as
+# `<login> <session> <age-in-seconds>`. A `-` marks a claim with no session
+# word. Pure: the payload comes in on stdin and `now` is an argument, so the
+# tests below run the filter production runs.
+#
+# Only the first line is read, with CRLF stripped and runs of spaces collapsed.
+# The marker takes three fields, so the session word is the fifth. Padding with
+# `-` is what lets a two-word claim parse instead of erroring on a field that
+# is not there.
+#
+# The login comes from `.author.login`, which GitHub stamps. A body can say
+# anything.
+select_claims() {
+  jq -r --arg marker "$marker" --argjson now "$1" '
+    .comments[]
+    | select(.body | startswith($marker))
+    | ((.body | split("\n")[0] | gsub("\r"; "") | split(" ")
+        | map(select(length > 0)))
+       + ["-", "-", "-", "-", "-"]) as $word
+    | "\(.author.login) \($word[4]) \(($now - (.createdAt | fromdateiso8601)) | floor)"
+  '
+}
+
+# Every comment already carrying one finding's marker, as `<login> <age>`.
+# The marker must open the comment, so a comment quoting one — this script's
+# own report does — is not read as the finding itself.
+select_findings() {
+  jq -r --arg marker "$1" --argjson now "$2" '
+    .comments[]
+    | select(.body | startswith($marker))
+    | "\(.author.login) \(($now - (.createdAt | fromdateiso8601)) | floor)"
+  '
+}
+
+# A finding key rides into a marker and into a jq argument, so it takes a
+# small alphabet. It also has to stay readable in a comment a person reads.
+check_finding_key() {
+  case "$finding" in
+  "")
+    echo "pr-claim: $mode needs --finding <key>" >&2
+    exit 2
+    ;;
+  *[!A-Za-z0-9._:@/-]*)
+    echo "pr-claim: --finding takes letters, digits and . _ : @ / - only" >&2
+    exit 2
+    ;;
+  esac
+  if [ "${#finding}" -gt 120 ]; then
+    echo "pr-claim: --finding is capped at 120 characters" >&2
+    exit 2
+  fi
+}
+
+# The pure modes are the seam a test drives head on: real comments JSON goes
+# in, the parsed rows come out. Production wires them to `gh pr view` below
+# rather than writing these filters into that call. Break a filter and a test
+# fails here, not a live sweep, silently, later.
+if [ "$mode" = "select" ] || [ "$mode" = "findings" ]; then
+  [ -n "$select_now" ] || {
+    echo "pr-claim: $mode needs --now <unix-seconds>" >&2
+    exit 2
+  }
+  if [ "$mode" = "select" ]; then
+    select_claims "$select_now"
+    exit $?
+  fi
+  check_finding_key
+  select_findings "<!-- pr-finding: $finding -->" "$select_now"
+  exit $?
+fi
+
+if [ -z "$mode" ] || [ -z "$pr" ]; then
+  echo "pr-claim: usage: pr-claim.sh check|claim|post <pr-number>" >&2
+  exit 2
+fi
+case "$pr" in '' | *[!0-9]*)
+  echo "pr-claim: '<pr>' takes a whole number" >&2
+  exit 2
+  ;;
+esac
+case "$window_minutes" in '' | *[!0-9]*)
+  echo "pr-claim: --window-minutes takes a whole number of minutes" >&2
+  exit 2
+  ;;
+esac
+window_seconds=$((window_minutes * 60))
+
+# `proceed` is the only exit this script takes when it is unsure, so it is one
+# function rather than a pair of lines that could drift apart.
+proceed() {
+  echo "$1" || true
+  exit 0
+}
+
+if [ "$mode" = "post" ]; then
+  check_finding_key
+  if [ -n "$body_file" ]; then
+    if [ -n "$body" ]; then
+      echo "pr-claim: pass --body or --body-file, not both" >&2
+      exit 2
+    fi
+    if ! body="$(cat "$body_file")"; then
+      echo "pr-claim: could not read --body-file '$body_file'" >&2
+      exit 2
+    fi
+  fi
+  if [ -z "$body" ]; then
+    echo "pr-claim: post needs --body <text> or --body-file <path>" >&2
+    exit 2
+  fi
+fi
+
+if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
+  echo "note: gh is not installed, so this run could not ask whether #$pr is" >&2
+  echo "      already being swept. Proceeding: a check that can block a sweep" >&2
+  echo "      is worse than the duplication it stops." >&2
+  proceed "ok  proceed (could not ask)"
+fi
+
+# One read of the comments, shared by both gates. `comments_ok` is whether the
+# read answered at all. "nothing stands" is a claim about a list that was read;
+# a read that failed to ask must never report in that shape.
+comments_json=""
+comments_ok=1
+if [ "$use_fixture" -eq 0 ]; then
+  if ! comments_json="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh pr view "$pr" \
+    --json comments 2>/dev/null)"; then
+    comments_ok=0
+  fi
+fi
+
+# ── post: has this finding already been published? ───────────────────────────
+#
+# This gate runs on its own. A sweep that means to publish asks this and
+# nothing else, because a finding that already stands is a duplicate whoever
+# holds the pull request.
+if [ "$mode" = "post" ]; then
+  hits=""
+  hits_ok=1
+  if [ "$use_fixture" -eq 1 ]; then
+    if [ "$fixture_findings_failed" -eq 1 ]; then
+      hits_ok=0
+    else
+      hits="$fixture_findings"
+    fi
+  elif [ "$comments_ok" -eq 0 ]; then
+    hits_ok=0
+  elif ! hits="$(printf '%s' "$comments_json" \
+    | select_findings "<!-- pr-finding: $finding -->" "$(date -u +%s)")"; then
+    hits_ok=0
+  fi
+
+  first_by=""
+  first_age=""
+  while read -r who age; do
+    [ -n "$who" ] || continue
+    case "$age" in
+    '' | *[!0-9]*) continue ;;
+    esac
+    if [ -z "$first_age" ] || [ "$age" -gt "$first_age" ]; then
+      first_by="$who"
+      first_age="$age"
+    fi
+  done <<EOF
+$hits
+EOF
+
+  if [ -n "$first_by" ]; then
+    minutes=$((first_age / 60))
+    echo "STAND DOWN  '$finding' is already posted on #$pr." >&2
+    echo "" >&2
+    echo "     posted by @$first_by, ${minutes}m ago" >&2
+    echo "" >&2
+    echo "     Three sweeps once posted one conflict analysis to one pull" >&2
+    echo "     request in eight minutes. Each was right. The maintainer still" >&2
+    echo "     had to read all three to learn they said one thing." >&2
+    echo "" >&2
+    echo "     Read the comment that stands. If yours adds something it does" >&2
+    echo "     not have, post that part under a key of its own." >&2
+    exit 1
+  fi
+
+  if [ "$hits_ok" -eq 0 ]; then
+    echo "note: could not read #$pr's comments, so this run cannot tell whether" >&2
+    echo "      '$finding' is already posted. Proceeding (fail-open) — read the" >&2
+    echo "      pull request before you trust this." >&2
+  fi
+
+  if [ "$use_fixture" -eq 1 ]; then
+    if [ "$hits_ok" -eq 0 ]; then
+      proceed "ok  post '$finding' (duplicate check unreadable) (fixture: nothing was posted)"
+    fi
+    proceed "ok  post '$finding' on #$pr — nothing carries that key (fixture: nothing was posted)"
+  fi
+
+  if ! gh pr comment "$pr" --body "<!-- pr-finding: $finding -->
+$body" >/dev/null 2>&1; then
+    echo "pr-claim: could not post on #$pr" >&2
+    exit 3
+  fi
+  if [ "$hits_ok" -eq 0 ]; then
+    proceed "ok  posted '$finding' on #$pr (duplicate check unreadable)"
+  fi
+  proceed "ok  posted '$finding' on #$pr — nothing carried that key"
+fi
+
+# ── A merged or closed pull request is not work to sweep ─────────────────────
+#
+# The stronger signal, and the one a claim can never carry: the pull request is
+# done. `state_ok` is whether the read answered.
+pr_state=""
+state_ok=1
+if [ "$use_fixture" -eq 1 ]; then
+  if [ "$fixture_pr_state_failed" -eq 1 ]; then
+    state_ok=0
+  else
+    pr_state="$fixture_pr_state"
+  fi
+elif ! pr_state="$(CLICOLOR_FORCE=0 NO_COLOR=1 gh pr view "$pr" \
+  --json state --jq .state 2>/dev/null)"; then
+  state_ok=0
+fi
+
+if [ "$state_ok" -eq 0 ]; then
+  echo "note: could not read #$pr's state, so this run cannot tell an open" >&2
+  echo "      pull request from a merged one. Proceeding (fail-open); the" >&2
+  echo "      claim check below still runs." >&2
+elif [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
+  echo "STAND DOWN  #$pr is $pr_state." >&2
+  echo "" >&2
+  echo "     A merged pull request is finished, and a closed one was dropped." >&2
+  echo "     Neither takes a comment. If the work still matters, it belongs on" >&2
+  echo "     the issue or on a new pull request." >&2
+  exit 1
+fi
+
+if [ "$use_fixture" -eq 1 ]; then
+  me="$fixture_login"
+elif ! me="$(gh api user --jq .login 2>/dev/null)"; then
+  me=""
+fi
+if [ -z "$me" ]; then
+  echo "note: could not read this session's login, so a claim on #$pr cannot" >&2
+  echo "      be told from one of its own. Proceeding (fail-open)." >&2
+  proceed "ok  proceed (identity unknown)"
+fi
+
+if [ "$use_fixture" -eq 1 ]; then
+  my_session="$fixture_session"
+elif ! my_session="$(resolve_session)"; then
+  my_session=""
+fi
+if [ -z "$my_session" ]; then
+  echo "note: this run has no session word, so a claim of its own login cannot" >&2
+  echo "      be told from a peer session's. Proceeding on those (fail-open)." >&2
+fi
+
+claims=""
+claims_ok=1
+if [ "$use_fixture" -eq 1 ]; then
+  if [ "$fixture_claims_failed" -eq 1 ]; then
+    claims_ok=0
+  else
+    claims="$fixture_claims"
+  fi
+elif [ "$comments_ok" -eq 0 ]; then
+  claims_ok=0
+elif ! claims="$(printf '%s' "$comments_json" | select_claims "$(date -u +%s)")"; then
+  claims_ok=0
+fi
+if [ "$claims_ok" -eq 0 ]; then
+  echo "note: could not read #$pr's comments. Proceeding (fail-open)." >&2
+  proceed "ok  proceed (comments unreadable)"
+fi
+
+# The freshest claim this session cannot account for. Its own is no reason to
+# stand it down: re-running the pre-flight is what a session does when it comes
+# back to work it started. Same login and same word is its own. Same login with
+# either word missing is unprovable, and an unknown proceeds.
+held_by=""
+held_session=""
+held_age=""
+while read -r who claim_session age; do
+  [ -n "$who" ] || continue
+  if [ "$who" = "$me" ]; then
+    [ -z "$my_session" ] && continue
+    [ "$claim_session" = "-" ] && continue
+    [ "$claim_session" = "$my_session" ] && continue
+  fi
+  case "$age" in
+  '' | *[!0-9]*) continue ;;
+  esac
+  [ "$age" -lt "$window_seconds" ] || continue
+  if [ -z "$held_age" ] || [ "$age" -lt "$held_age" ]; then
+    held_by="$who"
+    held_session="$claim_session"
+    held_age="$age"
+  fi
+done <<EOF
+$claims
+EOF
+
+if [ -n "$held_by" ]; then
+  minutes=$((held_age / 60))
+  if [ "$held_session" = "-" ]; then
+    held_where="session unknown"
+  else
+    held_where="session $held_session"
+  fi
+  echo "STAND DOWN  #$pr is already being swept." >&2
+  echo "" >&2
+  echo "     claimed by @$held_by ($held_where), ${minutes}m ago" \
+    "(window: ${window_minutes}m)" >&2
+  echo "" >&2
+  if [ "$held_by" = "$me" ]; then
+    echo "     That login is yours, so this is another of your own sessions —" >&2
+    echo "     a second agent in a second worktree, which is the case the" >&2
+    echo "     session word exists to catch." >&2
+    echo "" >&2
+  fi
+  echo "     What to do:" >&2
+  echo "       - Pick another pull request. The claim lapses by itself after" >&2
+  echo "         ${window_minutes}m, so a session that died cannot hold this shut." >&2
+  echo "       - Working it anyway? Say so on #$pr, so the next session reads a" >&2
+  echo "         reason rather than a collision." >&2
+  exit 1
+fi
+
+if [ "$mode" = "check" ]; then
+  if [ "$state_ok" -eq 0 ]; then
+    proceed "ok  proceed (state unreadable) — no live claim holds #$pr."
+  fi
+  proceed "ok  #$pr is unswept — it is open, and no live claim holds it."
+fi
+
+# The session word rides on the marker line, where the check parses it. A run
+# without one posts the two-word body, which every reader still accepts.
+if [ -n "$my_session" ]; then
+  claimant="$me $my_session"
+  session_note="
+The second word is this session's own, so another session of the same author
+reads this as somebody else's claim."
+else
+  claimant="$me"
+  session_note="
+This run had no session word to add, so another session of the same author
+reads this as its own and proceeds."
+fi
+
+body="$marker $claimant
+Sweeping this. The claim lapses after ${window_minutes} minutes, so it cannot
+hold the pull request shut if this session dies
+(\`scripts/pr-claim.sh\`, \`#5861\`).${session_note}"
+
+if [ "$use_fixture" -eq 1 ]; then
+  proceed "ok  claimed #$pr as @$me (fixture: nothing was posted)"
+fi
+
+if ! gh pr comment "$pr" --body "$body" >/dev/null 2>&1; then
+  echo "note: could not post the claim on #$pr. Proceeding anyway: the claim is" >&2
+  echo "      an aid, and the work is not." >&2
+  proceed "ok  proceed (claim not posted)"
+fi
+
+echo "ok  claimed #$pr as @$me" || true

--- a/scripts/test-pr-claim.sh
+++ b/scripts/test-pr-claim.sh
@@ -105,6 +105,62 @@ want "an old finding still stops a copy — a published comment does not lapse" 
   post 5835 --finding conflict:5828 --body "the same analysis" \
   --fixture-login ada --fixture-findings "grace 999999"
 
+# ── A peer's claim also stops a post ────────────────────────────────────────
+#
+# The finding gate alone can only see what is already published. Two sweeps
+# that both begin before either posts each spend a full diagnosis, and only the
+# second is turned away. The claim turns the second one back at the start,
+# which is where the twenty minutes are.
+
+want "a peer's live claim stops a post before the finding gate" \
+  expect-block "already being swept" \
+  post 5835 --finding conflict:5828 --body "the analysis" \
+  --fixture-login ada --fixture-claims "grace - 300" --fixture-findings ""
+
+want "...and says nothing was posted, with the way through" \
+  expect-block "Nothing was posted. Pass --ignore-claim" \
+  post 5835 --finding conflict:5828 --body "the analysis" \
+  --fixture-login ada --fixture-claims "grace - 300" --fixture-findings ""
+
+want "--ignore-claim posts over a peer's claim" \
+  expect-proceed "nothing carries that key" \
+  post 5835 --finding conflict:5828 --body "the analysis" --ignore-claim \
+  --fixture-login ada --fixture-claims "grace - 300" --fixture-findings ""
+
+# The holder of the claim is the session that must still be able to publish.
+# Blocking it would leave the finding on nobody.
+want "a session's own claim does not stop its own post" \
+  expect-proceed "nothing carries that key" \
+  post 5835 --finding conflict:5828 --body "the analysis" \
+  --fixture-login ada --fixture-session s1 --fixture-claims "ada s1 300" \
+  --fixture-findings ""
+
+# A lapsed claim is not a claim here either.
+want "a lapsed claim does not stop a post" \
+  expect-proceed "nothing carries that key" \
+  post 5835 --finding conflict:5828 --body "the analysis" \
+  --fixture-login ada --fixture-claims "grace - 999999" --fixture-findings ""
+
+# Fail-open reaches the composed gate: an unreadable claim list must not hold
+# a finding back.
+want "an unreadable claim list still lets a post through" \
+  expect-proceed "nothing carries that key" \
+  post 5835 --finding conflict:5828 --body "the analysis" \
+  --fixture-login ada --fixture-claims-failed --fixture-findings ""
+
+want "an unknown identity still lets a post through" \
+  expect-proceed "nothing carries that key" \
+  post 5835 --finding conflict:5828 --body "the analysis" \
+  --fixture-login "" --fixture-claims "grace - 300" --fixture-findings ""
+
+# A finding that already stands still wins over a claim of this session's own:
+# the published copy is the thing that costs a reader.
+want "a standing finding stops a post even when this session holds the claim" \
+  expect-block "is already posted on" \
+  post 5835 --finding conflict:5828 --body "the analysis" \
+  --fixture-login ada --fixture-session s1 --fixture-claims "ada s1 300" \
+  --fixture-findings "grace 300"
+
 # ── The unknown proceeds ────────────────────────────────────────────────────
 #
 # A read that failed is not an empty list. The wrong report here is the one

--- a/scripts/test-pr-claim.sh
+++ b/scripts/test-pr-claim.sh
@@ -272,6 +272,43 @@ want "--body-file is read" \
   post 5835 --finding conflict:5828 --body-file "$tmp_body" \
   --fixture-login ada --fixture-findings ""
 
+# ── No `gh` at all ──────────────────────────────────────────────────────────
+#
+# A `check` with no `gh` proceeds, like every other unknown. A `post` cannot:
+# it owes the caller a write, and reporting "proceed" would tell a sweep its
+# finding is up when nothing was sent. The runs below use a PATH holding one
+# pair of symlinks, so `gh` is absent for real rather than stubbed.
+
+bare_bin="$(mktemp -d)"
+trap 'rm -f "$tmp_body"; rm -rf "$bare_bin"' EXIT
+ln -s "$(command -v bash)" "$bare_bin/bash"
+ln -s "$(command -v dirname)" "$bare_bin/dirname"
+
+out="$(PATH="$bare_bin" "$SCRIPT" check 5835 2>&1)"
+rc=$?
+case "$rc,$out" in
+0,*"could not ask"*)
+  ok "a check with no gh proceeds and says it could not ask"
+  ;;
+*)
+  bad "expected exit 0 and 'could not ask', got exit $rc: $out"
+  ;;
+esac
+
+out="$(PATH="$bare_bin" "$SCRIPT" post 5835 --finding conflict:5828 --body x 2>&1)"
+rc=$?
+case "$rc,$out" in
+0,*)
+  bad "a post with no gh reported success while posting nothing: $out"
+  ;;
+*,*"nothing was posted"*)
+  ok "a post with no gh fails and says nothing was posted"
+  ;;
+*)
+  bad "expected a non-zero exit naming 'nothing was posted', got exit $rc: $out"
+  ;;
+esac
+
 # ── The parse itself ────────────────────────────────────────────────────────
 #
 # Every case above drives a fixture. Those rows are already parsed, so the jq

--- a/scripts/test-pr-claim.sh
+++ b/scripts/test-pr-claim.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+#
+# Hermetic tests for `scripts/pr-claim.sh` (`#5861`).
+#
+#   `./scripts/test-pr-claim.sh`    (or: `make pr-claim-test`)
+#
+# No network and no `gh`. Every case drives a fixture seam. The suite reads the
+# same on a bare runner as on a box with a live tracker.
+#
+# The two cases the issue asks for come first, one on each side. The spare
+# comment is stopped: two sweeps that find one thing post one comment. A gate
+# that cannot be shown to block is a comment, not a gate, and this one spends
+# its life letting sweeps through. The unknown proceeds, and says so: a run
+# that could not read the comments must post, and must not report that nothing
+# stands. Those are two sentences and only one of them is true.
+#
+# Not a `make gate` step, matching the other two claim suites. The subject asks
+# a tracker a question. The gate is offline by contract.
+#
+# bash 3.2 compatible.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+SCRIPT="$repo_root/scripts/pr-claim.sh"
+
+# Named first, so a missing subject reads as a missing subject. Without this
+# every case below fails on exit 127, and a case that only asks for a non-zero
+# exit would pass on nothing at all.
+if [ ! -x "$SCRIPT" ]; then
+  printf '  \033[31m✗\033[0m %s\n' "$SCRIPT is missing or not executable"
+  exit 1
+fi
+
+pass=0
+fail=0
+
+ok() {
+  printf '  \033[32m✓\033[0m %s\n' "$*"
+  pass=$((pass + 1))
+}
+bad() {
+  printf '  \033[31m✗\033[0m %s\n' "$*"
+  fail=$((fail + 1))
+}
+
+# One shape for the whole suite. Pin every seam, then compare the exit code
+# and the reason. An expected block names its reason too. A typo can satisfy
+# "exit 1" just as well as the case can.
+want() { # want <name> <expect-proceed|expect-block> <want-text> <args...>
+  local name="$1" expect="$2" want_text="$3"
+  shift 3
+  local out rc
+  out="$("$SCRIPT" "$@" 2>&1)"
+  rc=$?
+  if [ "$expect" = "expect-proceed" ] && [ "$rc" -ne 0 ]; then
+    bad "$name — expected proceed, got exit $rc: $out"
+    return
+  fi
+  if [ "$expect" = "expect-block" ] && [ "$rc" -eq 0 ]; then
+    bad "$name — expected a stand-down, got exit 0: $out"
+    return
+  fi
+  case "$out" in
+  *"$want_text"*) ok "$name" ;;
+  *) bad "$name — right exit, wrong reason (wanted '$want_text'): $out" ;;
+  esac
+}
+
+echo "pr-claim"
+
+# ── The finding gate ────────────────────────────────────────────────────────
+#
+# At most one comment per finding. Three sweeps posted one conflict analysis to
+# one pull request in eight minutes. The second and third must stop here.
+
+want "a finding already posted stops a second copy" \
+  expect-block "is already posted on" \
+  post 5835 --finding conflict:5828 --body "the same analysis" \
+  --fixture-login ada --fixture-findings "grace 300"
+
+want "...and the report names who posted it and when" \
+  expect-block "posted by @grace, 5m ago" \
+  post 5835 --finding conflict:5828 --body "the same analysis" \
+  --fixture-login ada --fixture-findings "grace 300"
+
+# The other way round, and the one that must not break. A sweep with something
+# new to say still posts.
+want "a finding nobody has posted goes through" \
+  expect-proceed "nothing carries that key" \
+  post 5835 --finding conflict:5828 --body "the analysis" \
+  --fixture-login ada --fixture-findings ""
+
+# A different key is a different finding. The gate keys on what the caller
+# named. One sweep's second finding is not held back by its first.
+want "a comment carrying another key does not block this one" \
+  expect-proceed "nothing carries that key" \
+  post 5835 --finding stale-golden --body "a second finding" \
+  --fixture-login ada --fixture-findings ""
+
+# Age is not a window here. A finding that stands is published. A copy of it a
+# week later costs a reader the same diff. A sweep that means to report again
+# after a push puts the head sha in the key.
+want "an old finding still stops a copy — a published comment does not lapse" \
+  expect-block "is already posted on" \
+  post 5835 --finding conflict:5828 --body "the same analysis" \
+  --fixture-login ada --fixture-findings "grace 999999"
+
+# ── The unknown proceeds ────────────────────────────────────────────────────
+#
+# A read that failed is not an empty list. The wrong report here is the one
+# that says nothing stands. A sweep would believe it.
+out="$("$SCRIPT" post 5835 --finding conflict:5828 --body "the analysis" \
+  --fixture-login ada --fixture-findings-failed 2>&1)"
+rc=$?
+case "$rc,$out" in
+0,*"nothing carries that key"*)
+  bad "a failed comment read claimed to have read the comments: $out"
+  ;;
+0,*"duplicate check unreadable"*)
+  ok "a failed comment read posts anyway, and says it could not check"
+  ;;
+0,*)
+  bad "a failed comment read proceeded with unexpected wording: $out"
+  ;;
+*)
+  bad "a failed comment read blocked — expected exit 0, got $rc: $out"
+  ;;
+esac
+
+# ── The claim gate ──────────────────────────────────────────────────────────
+
+want "a fresh claim by somebody else stands this sweep down" \
+  expect-block "claimed by @grace" \
+  check 5835 --fixture-login ada --fixture-claims "grace - 300"
+
+want "an unclaimed open pull request proceeds" \
+  expect-proceed "is unswept" \
+  check 5835 --fixture-login ada --fixture-claims ""
+
+want "a claim of this session's own does not stand it down" \
+  expect-proceed "is unswept" \
+  check 5835 --fixture-login ada --fixture-claims "ada - 300"
+
+want "a claim past the window has lapsed" \
+  expect-proceed "is unswept" \
+  check 5835 --fixture-login ada --fixture-claims "grace - 999999"
+
+want "--window-minutes reaches the comparison" \
+  expect-proceed "is unswept" \
+  check 5835 --window-minutes 1 --fixture-login ada --fixture-claims "grace - 300"
+
+want "a claim with an unreadable age is ignored" \
+  expect-proceed "is unswept" \
+  check 5835 --fixture-login ada --fixture-claims "grace - notanumber"
+
+want "an unknown identity proceeds" \
+  expect-proceed "identity unknown" \
+  check 5835 --fixture-login "" --fixture-claims "grace - 300"
+
+want "an unreadable comment list proceeds" \
+  expect-proceed "comments unreadable" \
+  check 5835 --fixture-login ada --fixture-claims-failed
+
+want "claim posts when the pull request is free" \
+  expect-proceed "ok  claimed" \
+  claim 5835 --fixture-login ada --fixture-claims ""
+
+want "claim stands down rather than posting over a peer" \
+  expect-block "claimed by @grace" \
+  claim 5835 --fixture-login ada --fixture-claims "grace - 300"
+
+# ── A merged or closed pull request is done ─────────────────────────────────
+
+want "a merged pull request stands this sweep down" \
+  expect-block "is MERGED" \
+  check 5835 --fixture-login ada --fixture-claims "" --fixture-pr-state MERGED
+
+want "so does a closed one" \
+  expect-block "is CLOSED" \
+  check 5835 --fixture-login ada --fixture-claims "" --fixture-pr-state CLOSED
+
+# An unreadable state proceeds, and the claim check still runs after it. A
+# peer's live claim must block even when the state would not read.
+out="$("$SCRIPT" check 5835 --fixture-login ada --fixture-claims "grace - 300" \
+  --fixture-pr-state-failed 2>&1)"
+rc=$?
+case "$rc,$out" in
+1,*"state, so this run cannot tell an open"*"claimed by @grace"*)
+  ok "an unreadable state proceeds to the claim check, which still blocks"
+  ;;
+*)
+  bad "expected the state note and then a stand-down on @grace, got exit $rc: $out"
+  ;;
+esac
+
+want "an unreadable state proceeds when nothing else blocks" \
+  expect-proceed "state unreadable" \
+  check 5835 --fixture-login ada --fixture-claims "" --fixture-pr-state-failed
+
+# ── Two sessions of one author ──────────────────────────────────────────────
+#
+# The case a login alone cannot answer. A fleet, or several agent worktrees on
+# one machine, all run as one login.
+
+want "a second session of the same author is stood down" \
+  expect-block "claimed by @ada (session s1)" \
+  check 5835 --fixture-login ada --fixture-session s2 --fixture-claims "ada s1 300"
+
+want "this session's own claim still does not stand it down" \
+  expect-proceed "is unswept" \
+  check 5835 --fixture-login ada --fixture-session s1 --fixture-claims "ada s1 300"
+
+want "a claim with no session word falls back to the author-only rule" \
+  expect-proceed "is unswept" \
+  check 5835 --fixture-login ada --fixture-session s1 --fixture-claims "ada - 300"
+
+want "a run with no session word of its own proceeds on its own login" \
+  expect-proceed "no session word" \
+  check 5835 --fixture-login ada --fixture-session "" --fixture-claims "ada s1 300"
+
+want "another author's claim still blocks a run with no word" \
+  expect-block "claimed by @grace" \
+  check 5835 --fixture-login ada --fixture-session "" --fixture-claims "grace s1 300"
+
+# ── Argument handling ───────────────────────────────────────────────────────
+
+out="$("$SCRIPT" check 2>&1)"
+if [ $? -eq 2 ] && [ -z "${out##*usage*}" ]; then
+  ok "a missing pull request number is a usage error, not a silent proceed"
+else
+  bad "a missing pull request number did not error: $out"
+fi
+
+out="$("$SCRIPT" check abc 2>&1)"
+if [ $? -eq 2 ]; then
+  ok "a non-numeric pull request number is refused"
+else
+  bad "a non-numeric pull request number was accepted: $out"
+fi
+
+# A post with no key would key on nothing. Every finding would then look like
+# every other one. That has to be an error, not a default.
+out="$("$SCRIPT" post 5835 --body x --fixture-login ada --fixture-findings "" 2>&1)"
+if [ $? -eq 2 ] && [ -z "${out##*needs --finding*}" ]; then
+  ok "a post with no finding key is refused"
+else
+  bad "a post with no finding key was accepted: $out"
+fi
+
+out="$("$SCRIPT" post 5835 --finding 'a key with spaces' --body x \
+  --fixture-login ada --fixture-findings "" 2>&1)"
+if [ $? -eq 2 ]; then
+  ok "a finding key outside the alphabet is refused"
+else
+  bad "a finding key outside the alphabet was accepted: $out"
+fi
+
+out="$("$SCRIPT" post 5835 --finding k --fixture-login ada --fixture-findings "" 2>&1)"
+if [ $? -eq 2 ] && [ -z "${out##*needs --body*}" ]; then
+  ok "a post with no body is refused"
+else
+  bad "a post with no body was accepted: $out"
+fi
+
+# `--body-file` is the shape a sweep uses. The write-up is long, and a long
+# write-up does not belong on a command line.
+tmp_body="$(mktemp)"
+trap 'rm -f "$tmp_body"' EXIT
+printf 'the analysis\n' >"$tmp_body"
+want "--body-file is read" \
+  expect-proceed "nothing carries that key" \
+  post 5835 --finding conflict:5828 --body-file "$tmp_body" \
+  --fixture-login ada --fixture-findings ""
+
+# ── The parse itself ────────────────────────────────────────────────────────
+#
+# Every case above drives a fixture. Those rows are already parsed, so the jq
+# filters that make them run in none of it. These cases drive the pure modes:
+# real `gh pr view --json comments` JSON, on stdin, through the real filters.
+# A typo in one now fails a case here, not a live sweep, later.
+NOW_SELECT=2000000000
+
+iso() { jq -n --argjson t "$1" '$t | todateiso8601'; }
+
+# comment <login> <body> <created-unix> — one comment object.
+comment() {
+  local login="$1" body="$2" created
+  created="$(iso "$3")"
+  printf '{"author":{"login":"%s"},"body":%s,"createdAt":%s}' \
+    "$login" "$(printf '%s' "$body" | jq -Rs .)" "$created"
+}
+
+# want_select <name> <expect-line> <json> [mode-args...]
+want_select() {
+  local name="$1" expect="$2" json="$3"
+  shift 3
+  local out rc
+  out="$(printf '%s' "$json" | "$SCRIPT" "$@" --now "$NOW_SELECT" 2>/dev/null)"
+  rc=$?
+  if [ "$out" = "$expect" ] && [ "$rc" -eq 0 ]; then
+    ok "$name"
+  else
+    bad "$name — wanted '$expect' (exit 0), got '$out' (exit $rc)"
+  fi
+}
+
+want_select "a live claim parses as <login> <session> <age>" \
+  "grace s7 300" \
+  "{\"comments\":[$(comment grace "<!-- pr-claim --> grace s7" $((NOW_SELECT - 300)))]}" \
+  select
+
+want_select "a claim with no session word parses with a '-' in that column" \
+  "grace - 300" \
+  "{\"comments\":[$(comment grace "<!-- pr-claim --> grace" $((NOW_SELECT - 300)))]}" \
+  select
+
+want_select "a marker line with extra spaces still parses" \
+  "grace s7 300" \
+  "{\"comments\":[$(comment grace "<!-- pr-claim -->   grace   s7" $((NOW_SELECT - 300)))]}" \
+  select
+
+want_select "a CRLF first line still parses cleanly" \
+  "grace s7 300" \
+  "{\"comments\":[$(comment grace "$(printf '<!-- pr-claim --> grace s7\r\nmore')" $((NOW_SELECT - 300)))]}" \
+  select
+
+want_select "a finding comment parses as <login> <age>" \
+  "grace 300" \
+  "{\"comments\":[$(comment grace "$(printf '<!-- pr-finding: conflict:5828 -->\nthe analysis')" $((NOW_SELECT - 300)))]}" \
+  findings --finding conflict:5828
+
+# The marker has to open the comment. A reply that quotes one is talking about
+# the finding, not publishing it. It must not stand the next sweep down.
+out="$(printf '{"comments":[%s]}' \
+  "$(comment grace "$(printf 'I read the\n<!-- pr-finding: conflict:5828 -->\ncomment')" $((NOW_SELECT - 10)))" \
+  | "$SCRIPT" findings --finding conflict:5828 --now "$NOW_SELECT" 2>/dev/null)"
+rc=$?
+if [ -z "$out" ] && [ "$rc" -eq 0 ]; then
+  ok "a comment that only quotes a marker is not the finding"
+else
+  bad "a quoted marker should produce no row, got '$out' (exit $rc)"
+fi
+
+out="$(printf '{"comments":[%s]}' \
+  "$(comment grace "<!-- pr-finding: other-key -->" $((NOW_SELECT - 10)))" \
+  | "$SCRIPT" findings --finding conflict:5828 --now "$NOW_SELECT" 2>/dev/null)"
+rc=$?
+if [ -z "$out" ] && [ "$rc" -eq 0 ]; then
+  ok "another key's finding produces no row"
+else
+  bad "another key should produce no row, got '$out' (exit $rc)"
+fi
+
+out="$(printf '{"comments":[%s]}' \
+  "$(comment grace "just an unrelated comment" $((NOW_SELECT - 10)))" \
+  | "$SCRIPT" select --now "$NOW_SELECT" 2>/dev/null)"
+rc=$?
+if [ -z "$out" ] && [ "$rc" -eq 0 ]; then
+  ok "a comment that is not a claim produces no row"
+else
+  bad "a non-claim comment should produce no row, got '$out' (exit $rc)"
+fi
+
+# A bad timestamp must fail the parse, not emit a wrong age. Production reads
+# a failed parse as "comments unreadable" and proceeds. So failing closed here
+# is what stops that path reporting a made-up number.
+malformed='{"comments":[{"author":{"login":"grace"},"body":"<!-- pr-claim --> grace","createdAt":"not-a-date"}]}'
+out="$(printf '%s' "$malformed" | "$SCRIPT" select --now "$NOW_SELECT" 2>/dev/null)"
+rc=$?
+if [ "$rc" -ne 0 ] && [ -z "$out" ]; then
+  ok "a bad timestamp fails the parse rather than emitting a wrong age"
+else
+  bad "a bad timestamp should fail closed, got exit $rc: '$out'"
+fi
+
+echo ""
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

Several autonomous PR-sweep sessions run against this repository at once, and
nothing told one that another was already reading a given pull request. Three
of them worked out the same merge conflict on one pull request in eight
minutes and each posted it; a fourth reached the same answer and stopped,
because it read the comments first. Duplication here does not lose work, it
publishes it: the maintainer is left to diff three long comments to learn they
say one thing.

`scripts/issue-claim.sh` claims an `issue:<n>`. Nothing claimed a `pr:<n>`.
This adds `scripts/pr-claim.sh` — that mechanic pointed at a pull request,
plus the read-before-write gate the issue names as shape (1):

```bash
./scripts/pr-claim.sh check 5835    # exit 0 proceed, 1 stand down
./scripts/pr-claim.sh claim 5835    # check, then post the claim
./scripts/pr-claim.sh post 5835 --finding conflict:5828 --body-file note.md
```

- **`check` / `claim`** are the issue-claim rules unchanged: the tracker is the
  table, a comment is the claim, it lapses after 90 minutes, a session word
  rides beside the login so two sessions of one author can tell each other
  apart, and every unknown proceeds out loud. A merged or closed pull request
  stands a sweep down as well, since neither takes a comment.
- **`post`** is the half that would have stopped all three comments. It runs
  the claim check first, then asks whether a comment already carries this
  finding's key, and writes only when neither answer is yes.
  `--ignore-claim` posts over a live claim, for the operator who read it and
  said on the pull request why.

**The caller names the finding, not a digest of the prose.** The three
duplicates on the pull request that prompted this were worded differently and
said the same thing, so a hash of the text would have called them distinct.
A key that has to go stale carries what it rests on — a finding about the head
commit puts the head sha in the key, so a later push can be reported again.

**A read that failed is not an empty list.** A run that could not read the
comments posts anyway and says `duplicate check unreadable`, rather than
reporting that nothing stands. That is the wording rule #5834 landed for
`issue-claim.sh`, applied on both gates here.

Both jq filters are reachable as pure modes (`select`, `findings`): comments
JSON on stdin, parsed rows out, so a typo in a filter fails a test rather than
a live sweep.

Closes #5861

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`scripts/test-pr-claim.sh` (`make pr-claim-test`), hermetic — no network, no
`gh`. It runs in `guard-self-tests.yml` beside the other two claim suites, so
`check-gate-parity` is satisfied.

The fail→pass demonstration, run by hand:

```
$ mv scripts/pr-claim.sh /tmp/x.bak && ./scripts/test-pr-claim.sh
  x  /Users/.../scripts/pr-claim.sh is missing or not executable
  exit=1
$ mv /tmp/x.bak scripts/pr-claim.sh && ./scripts/test-pr-claim.sh
  50 passed, 0 failed
```

Before the suite grew its missing-subject preflight, that first run reported
one accidental pass beside the rest: a case asking only for a non-zero exit is
satisfied by `exit 127`. The preflight is why an absent subject now reads as
an absent subject rather than as a wall of unrelated failures.

The two cases the issue's DoD asks for, by name:

- `a finding already posted stops a second copy` and `an old finding still
  stops a copy — a published comment does not lapse` — the duplicate is
  suppressed.
- `a failed comment read posts anyway, and says it could not check` — it
  asserts the report does **not** say `nothing carries that key`, so the
  wording half is checked from both sides.

`4b7437c` adds the claim gate to `post`, with eight further cases covering
both fail-open directions and the case where a session's own claim must not
block its own post.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`)
- [ ] workspace clippy — no Rust in this diff; CI runs it
- [ ] workspace tests — no Rust in this diff; CI runs it
- [x] Docs updated where behavior changed — AGENTS.md's claim section, and the
      script's own `--help`
- [x] CLA signed
- [x] `Closes #5861` appears above **and** as a commit trailer

Local evidence: `make guards-fast` exits 0 (shellcheck, `check-gate-parity`,
`check-file-size`, `check-prose`, `check-line-citations` and the rest),
`python3 scripts/check-prose.py` reports OK with nothing added, and
`./scripts/test-pr-claim.sh` passes. No workspace build was run on the
maintainer's laptop; CI is this PR's build evidence.

## Fix over file

- [x] Extra fixes in this PR, two of them:
      1. AGENTS.md said `scripts/lib/claim-session.sh` resolves the session
         word "for both scripts" and that "both fail open the same way", and
         that file's own header named the two scripts that read it. Three read
         it now, so both sentences name the set rather than counting it — a
         count in prose is a promise nobody keeps.
      2. `pr-claim.sh post` took the shared no-`gh` branch, which proceeds out
         loud and exits 0. Right for `check`; for `post` it told a sweep its
         finding was up while nothing had been sent. It exits 3 and names what
         did not happen, covered by `a post with no gh fails and says nothing
         was posted` — run against a PATH holding two symlinks, so `gh` is
         absent for real.
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls — the script talks to `gh`, which the two
      sibling claim scripts already do, and it is never on a `stella` run path

## Anything reviewers should know?

**What this does not do.** Nothing in this repository drives the sweeps, so
nothing here can force a sweep to call this. The issue says as much. What
lands is the mechanism, its self-test, and the AGENTS.md paragraph that tells
a session to use it — the same standing this repository gives
`scripts/issue-claim.sh`.

**Why the claim is taken early.** The maintainer's follow-up comment on the
issue reports the same collision reaching commits, not just comments, and
argues the expensive part is the twenty minutes of diagnosis before a session
has anything to claim about. Both the script header and the AGENTS.md
paragraph say to claim when you start reading the pull request, not when you
are ready to write.

**Not a lock.** Two sessions that check inside the same second both proceed,
exactly as with `issue-claim.sh`. The finding gate is the stronger half: it
compares against what is already published, so it holds even when the claims
raced.


---
_Generated by [Claude Code](https://claude.ai/code)_
