### PR TITLE
fix(stella-cli): the deck's approve and dismiss keys reach the gate a running turn is held on

### DIFF
--- a/crates/stella-cli/src/command_deck.rs
+++ b/crates/stella-cli/src/command_deck.rs
@@ -118,9 +118,10 @@ mod voice_cmd;
 mod whistle;
 mod worker_control;
 use driver_support::{
-    graph_ready_callback, handle_supervisor_msg, service_approve_revision, service_edit_memory,
-    service_registry_action, service_reject_memory, service_rerun_gate, service_undo_delete,
-    spawn_mcp_connect, spawn_notification_poller, spawn_pr_monitor,
+    graph_ready_callback, handle_supervisor_msg, service_approve_revision,
+    service_dismiss_revision, service_edit_memory, service_registry_action, service_reject_memory,
+    service_rerun_gate, service_undo_delete, spawn_mcp_connect, spawn_notification_poller,
+    spawn_pr_monitor,
 };
 use lead_turn::run_lead_turn;
 use panel_snapshots::{engine_config_inbound, tool_policy_inbound};
@@ -1913,8 +1914,8 @@ pub async fn run_deck_session(
         // The lead lane's pause seam — `p` on the lead row (#1219).
         let lead_pause = lead_control::LeadPause::new();
         let mut friction = TurnFriction::default(); // #3962
-        // Outlives the turn future, so a cancel can still drain it (#4853).
-        let drain = forwarder::forwarder_slot();
+        // Outlive the turn future: a cancel drains it (#4853), keys reach it.
+        let slots = forwarder::turn_slots();
         let end = {
             // Both arms return `Result<(), CliFailure>`, so one pinned future
             // drives either path through the same select loop.
@@ -1936,7 +1937,7 @@ pub async fn run_deck_session(
                 recall,
                 memory.as_ref(),
                 &mut friction,
-                &drain,
+                &slots,
             );
             tokio::pin!(turn);
             loop {
@@ -2349,14 +2350,19 @@ pub async fn run_deck_session(
                         ) => {
                             voice::service(&input, &mut voice_lane, &deck_tx, cfg);
                         }
-                        // `a approve r{n}` on a revision proposal: one row on
-                        // the task board, serviced mid-turn on the same
-                        // reasoning as the three above. The reader is looking
-                        // at a gate that just failed, and the whole point of
-                        // the proposal is that the plan changes before more
-                        // work runs against the old one.
-                        Some(input @ WorkspaceInput::ApproveRevision { .. }) => {
-                            service_approve_revision(&input, &registry, &in_tx);
+                        // `a approve r{n}` and `x dismiss` on a revision
+                        // proposal, serviced mid-turn on the same reasoning as
+                        // the three above and for a sharper reason: the
+                        // running turn is refusing its own tool calls until
+                        // one of them is pressed, so a verb held to the turn
+                        // boundary could never arrive.
+                        Some(
+                            input @ (WorkspaceInput::ApproveRevision { .. }
+                            | WorkspaceInput::DismissRevision { .. }),
+                        ) => {
+                            let slot = &slots.revisions;
+                            let _ = service_approve_revision(&input, slot, &registry, &in_tx)
+                                || service_dismiss_revision(&input, slot, &in_tx);
                         }
                         // INSPECT is answered mid-turn too: the receipts of
                         // earlier steps are already durable, and watching the
@@ -2616,7 +2622,7 @@ pub async fn run_deck_session(
                     dispatch.cancelled(&submitted);
                 }
                 dropped_turn::close_dropped_turn(
-                    &drain,
+                    &slots.drain,
                     execution.as_ref(),
                     registry.as_ref(),
                     "cancelled",
@@ -2656,7 +2662,7 @@ pub async fn run_deck_session(
                 dispatch.reset();
                 queue.clear();
                 dropped_turn::close_dropped_turn(
-                    &drain,
+                    &slots.drain,
                     execution.as_ref(),
                     registry.as_ref(),
                     "cleared",

--- a/crates/stella-cli/src/command_deck/driver_support.rs
+++ b/crates/stella-cli/src/command_deck/driver_support.rs
@@ -327,7 +327,7 @@ pub(super) fn service_approve_revision(
     let WorkspaceInput::ApproveRevision { proposal, .. } = input else {
         return false;
     };
-    let pending = agree_on_the_running_turns_gate(revisions);
+    let answered = agree_to(revisions, proposal);
     let board = registry.task_board();
     let mut guard = board.lock().unwrap_or_else(|p| p.into_inner());
     let message = if let Some(existing) = guard
@@ -336,8 +336,11 @@ pub(super) fn service_approve_revision(
         .find(|item| item.subject == proposal.subject)
     {
         format!(
-            "{} was already approved — task {} \"{}\" is on the board",
-            proposal.revision, existing.id, existing.subject
+            "{} was already approved — task {} \"{}\" is on the board{}",
+            proposal.revision,
+            existing.id,
+            existing.subject,
+            answered.note()
         )
     } else {
         // The cause rides the row's description, which is where the drift
@@ -363,7 +366,7 @@ pub(super) fn service_approve_revision(
             proposal.revision,
             task.id,
             task.subject,
-            pending_note(pending),
+            answered.note(),
             proposal.gate,
             proposal.cause.as_str()
         )
@@ -409,26 +412,55 @@ pub(super) fn service_dismiss_revision(
     true
 }
 
-/// Say yes on the gate the running turn is reading, and report what stood.
-///
-/// `None` when no turn is running or none is holding a change: the board row
-/// below is then the whole of the approval, and the notice says so.
-fn agree_on_the_running_turns_gate(
-    revisions: &RevisionSlot,
-) -> Option<stella_protocol::RevisionProposal> {
-    parked_revisions(revisions)?
-        .lock()
-        .unwrap_or_else(|p| p.into_inner())
-        .agree()
-        .ok()
+/// What became of a yes offered to the running turn's gate.
+enum Answered {
+    /// The gate took it, and its next guarded tool call writes the revision.
+    Recorded,
+    /// No turn is running, or none is holding a change. The board row is then
+    /// the whole of the approval.
+    NoHold,
+    /// A turn is holding a *different* change. The reader answered the card in
+    /// front of them, and it is not the question being asked, so their yes is
+    /// not applied to the other one.
+    OtherChange,
 }
 
-/// What the approval notice says about the revision it has not written yet.
-fn pending_note(pending: Option<stella_protocol::RevisionProposal>) -> &'static str {
-    if pending.is_some() {
-        " — the plan change is written on the turn's next tool call"
-    } else {
-        ""
+impl Answered {
+    /// What the notice says about the revision this has not written yet.
+    fn note(&self) -> &'static str {
+        match self {
+            Self::Recorded => " — the plan change is written on the turn's next tool call",
+            Self::NoHold => "",
+            Self::OtherChange => {
+                " — the running turn is holding a different change, which this answer leaves standing"
+            }
+        }
+    }
+}
+
+/// Say yes on the gate the running turn is reading, for `proposal` and nothing
+/// else.
+///
+/// The match is what keeps this from repeating the defect it fixes one level
+/// down: a yes applied to whatever happens to be standing is consent the
+/// reader did not give to the change they were shown. The deck already refuses
+/// to send `a` on a card that is not the standing one, so this is the second
+/// answer to the same question rather than the only one.
+fn agree_to(revisions: &RevisionSlot, proposal: &stella_protocol::RevisionProposal) -> Answered {
+    let Some(gate) = parked_revisions(revisions) else {
+        return Answered::NoHold;
+    };
+    let mut gate = gate.lock().unwrap_or_else(|p| p.into_inner());
+    match gate.pending() {
+        None => Answered::NoHold,
+        Some(standing) if standing == proposal => match gate.agree() {
+            Ok(_) => Answered::Recorded,
+            // Unreachable: a proposal is standing, and its absence is the
+            // only thing `agree` refuses. Reported rather than asserted away,
+            // so a future refusal reaches the reader instead of a panic.
+            Err(_) => Answered::NoHold,
+        },
+        Some(_) => Answered::OtherChange,
     }
 }
 
@@ -950,10 +982,22 @@ mod revision_verb_tests {
 
     /// A slot holding a gate with `subject` standing, as a running turn's
     /// forwarder would have left it.
-    fn turn_holding(subject: &str) -> (RevisionSlot, super::super::SharedRevisions) {
+    /// Returns the slot the verbs read, the gate to assert on, and the card
+    /// the reader is looking at.
+    fn turn_holding(
+        case: &str,
+    ) -> (
+        RevisionSlot,
+        super::super::SharedRevisions,
+        stella_protocol::RevisionProposal,
+    ) {
+        // `RevisionGate::observe` mints the proposal, so the card the test
+        // presses `a` on is the one the gate is holding rather than a
+        // hand-built copy that could differ from it in some field.
         let gate =
             super::super::SharedRevisions::new(std::sync::Mutex::new(RevisionGate::default()));
-        gate.lock()
+        let standing = gate
+            .lock()
             .expect("the gate")
             .observe(
                 stella_protocol::PlanRevision::new(2).expect("r2"),
@@ -963,16 +1007,17 @@ mod revision_verb_tests {
                     gates: vec![stella_protocol::GateRow {
                         name: "tests".into(),
                         state: stella_protocol::GateState::Failed {
-                            case: subject.into(),
+                            case: case.into(),
                             log: "assertion `left == right` failed".into(),
                         },
                         deterministic: true,
                     }],
                 },
             )
-            .expect("a plain gate failure puts a change up");
+            .expect("a plain gate failure puts a change up")
+            .clone();
         let slot = RevisionSlot::new(Some(std::sync::Arc::clone(&gate)));
-        (slot, gate)
+        (slot, gate, standing)
     }
 
     fn proposal(subject: &str) -> stella_protocol::RevisionProposal {
@@ -986,12 +1031,16 @@ mod revision_verb_tests {
         }
     }
 
-    fn approve_with(revisions: &RevisionSlot, registry: &ToolRegistry, subject: &str) -> String {
+    fn approve_card(
+        revisions: &RevisionSlot,
+        registry: &ToolRegistry,
+        card: &stella_protocol::RevisionProposal,
+    ) -> String {
         let (tx, mut rx) = mpsc::unbounded_channel();
         assert!(service_approve_revision(
             &WorkspaceInput::ApproveRevision {
                 agent: LEAD.into(),
-                proposal: Box::new(proposal(subject)),
+                proposal: Box::new(card.clone()),
             },
             revisions,
             registry,
@@ -1004,15 +1053,15 @@ mod revision_verb_tests {
     }
 
     fn approve(registry: &ToolRegistry, subject: &str) -> String {
-        approve_with(&no_turn(), registry, subject)
+        approve_card(&no_turn(), registry, &proposal(subject))
     }
 
-    fn dismiss(revisions: &RevisionSlot, subject: &str) -> String {
+    fn dismiss(revisions: &RevisionSlot, card: &stella_protocol::RevisionProposal) -> String {
         let (tx, mut rx) = mpsc::unbounded_channel();
         assert!(service_dismiss_revision(
             &WorkspaceInput::DismissRevision {
                 agent: LEAD.into(),
-                proposal: Box::new(proposal(subject)),
+                proposal: Box::new(card.clone()),
             },
             revisions,
             &tx,
@@ -1094,13 +1143,13 @@ mod revision_verb_tests {
     fn approving_says_yes_on_the_running_turns_gate() {
         let dir = tempfile::tempdir().expect("tempdir");
         let registry = ToolRegistry::new(dir.path().to_path_buf());
-        let (slot, gate) = turn_holding("a_short_cycle_is_detected");
+        let (slot, gate, card) = turn_holding("a_short_cycle_is_detected");
         assert!(
             !gate.lock().expect("the gate").agreed(),
             "nobody has answered yet"
         );
 
-        let notice = approve_with(&slot, &registry, "repair a_short_cycle_is_detected");
+        let notice = approve_card(&slot, &registry, &card);
         assert!(
             gate.lock().expect("the gate").agreed(),
             "the yes is on the gate the turn reads"
@@ -1111,6 +1160,27 @@ mod revision_verb_tests {
         );
     }
 
+    /// A yes goes to the change it answers and to no other. The gate is
+    /// holding one thing; the card the reader pressed names another; the hold
+    /// stays where it is, and the notice says so.
+    ///
+    /// The defect this whole change fixes is consent inferred rather than
+    /// given. Applying a yes to whatever happens to be standing is the same
+    /// error one level down.
+    #[test]
+    fn a_yes_to_one_change_is_not_a_yes_to_the_one_the_gate_is_holding() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = ToolRegistry::new(dir.path().to_path_buf());
+        let (slot, gate, _) = turn_holding("a_short_cycle_is_detected");
+
+        let notice = approve_card(&slot, &registry, &proposal("repair something else"));
+        assert!(
+            !gate.lock().expect("the gate").agreed(),
+            "the standing change was not answered"
+        );
+        assert!(notice.contains("holding a different change"), "{notice}");
+    }
+
     /// **Witness.** `x` drops the standing change on that same gate, which is
     /// what lifts the hold — `RevisionGate::admits` answers `true` again and
     /// the turn's next tool call runs.
@@ -1119,13 +1189,13 @@ mod revision_verb_tests {
     /// and the turn stayed refused until it ended.
     #[test]
     fn dismissing_drops_the_change_the_running_turn_is_held_on() {
-        let (slot, gate) = turn_holding("a_short_cycle_is_detected");
+        let (slot, gate, card) = turn_holding("a_short_cycle_is_detected");
         assert!(
             !gate.lock().expect("the gate").admits(),
             "a standing change withholds"
         );
 
-        let notice = dismiss(&slot, "repair a_short_cycle_is_detected");
+        let notice = dismiss(&slot, &card);
         assert!(
             gate.lock().expect("the gate").admits(),
             "the hold is lifted"
@@ -1141,7 +1211,7 @@ mod revision_verb_tests {
     /// rather than reporting a hold it did not release.
     #[test]
     fn dismissing_with_no_turn_running_says_nothing_was_waiting() {
-        let notice = dismiss(&no_turn(), "repair a_short_cycle_is_detected");
+        let notice = dismiss(&no_turn(), &proposal("repair a_short_cycle_is_detected"));
         assert!(notice.contains("no turn was holding it"), "{notice}");
     }
 

--- a/crates/stella-cli/src/command_deck/driver_support.rs
+++ b/crates/stella-cli/src/command_deck/driver_support.rs
@@ -17,6 +17,7 @@ use stella_tools::ToolRegistry;
 use stella_tui::{AgentMeta, AgentStatus, Inbound, WorkspaceInput};
 use tokio::sync::mpsc::{self, UnboundedSender};
 
+use super::task_tap::{RevisionSlot, parked_revisions};
 use super::{
     LEAD, agent, ci_status_token, now_ms, observe_pr, pr_status_token, session_clear,
     sessions_view, system_notice, worker_control,
@@ -304,19 +305,29 @@ pub(super) fn service_rerun_gate(input: &WorkspaceInput, in_tx: &UnboundedSender
 /// the same repair step under two ids that never resolve to one task.
 ///
 /// It does **not** build a `PlanGraph` here. The live one belongs to the
-/// turn's `PlanGate`, this is between turns, and a throwaway graph
-/// reconstructed from the board would restart at `r1` — so every number it
-/// produced would contradict the `r{n}` the reader just approved. The
-/// engine-side gate, where `RevisionGate::admits` withholds the *tool calls*
-/// of a turn already in flight, is #5296.
+/// turn's `PlanGate`, and a throwaway graph reconstructed from the board would
+/// restart at `r1`, so every number it produced would contradict the `r{n}`
+/// the reader just approved. What this does instead is say yes on that gate —
+/// `RevisionGate::agree` through the slot the running turn parked its gate in
+/// — and the turn's next guarded tool call writes the revision through
+/// `RevisionGate::approve`. Reading the yes off the board row instead, which
+/// is what the engine-side gate did until now, made a row the model created
+/// with the same subject indistinguishable from consent.
+///
+/// The notice says the write is still to come, because it is: the plan can
+/// move while the answer is in flight, and `RevisionGate::approve` refuses a
+/// proposal it moved past. A sentence claiming the revision was written would
+/// be one the plan can contradict.
 pub(super) fn service_approve_revision(
     input: &WorkspaceInput,
+    revisions: &RevisionSlot,
     registry: &ToolRegistry,
     in_tx: &UnboundedSender<Inbound>,
 ) -> bool {
     let WorkspaceInput::ApproveRevision { proposal, .. } = input else {
         return false;
     };
+    let pending = agree_on_the_running_turns_gate(revisions);
     let board = registry.task_board();
     let mut guard = board.lock().unwrap_or_else(|p| p.into_inner());
     let message = if let Some(existing) = guard
@@ -348,10 +359,11 @@ pub(super) fn service_approve_revision(
             None,
         );
         format!(
-            "{} approved — task {} \"{}\", because the {} gate reported: {}",
+            "{} approved — task {} \"{}\"{}, because the {} gate reported: {}",
             proposal.revision,
             task.id,
             task.subject,
+            pending_note(pending),
             proposal.gate,
             proposal.cause.as_str()
         )
@@ -359,6 +371,65 @@ pub(super) fn service_approve_revision(
     drop(guard);
     let _ = in_tx.send(Inbound::Notice(message));
     true
+}
+
+/// Service `x dismiss` on a standing plan revision (SPEC 8.1). Returns `true`
+/// if `input` was that verb.
+///
+/// A dismissal writes nothing — no revision, no board row — and it still has
+/// to happen here. The gate withholding a running turn's tool calls is the
+/// turn's, the deck cannot reach it, and a card cleared on screen while that
+/// gate still stands leaves the turn refused until it ends. That was the state
+/// of this key before: drawn, labelled, and wired to nothing.
+pub(super) fn service_dismiss_revision(
+    input: &WorkspaceInput,
+    revisions: &RevisionSlot,
+    in_tx: &UnboundedSender<Inbound>,
+) -> bool {
+    let WorkspaceInput::DismissRevision { proposal, .. } = input else {
+        return false;
+    };
+    let dropped = parked_revisions(revisions)
+        .and_then(|gate| gate.lock().unwrap_or_else(|p| p.into_inner()).dismiss());
+    let message = match dropped {
+        Some(dropped) => format!(
+            "{} dismissed — the plan is unchanged and the turn goes on without \"{}\"",
+            dropped.revision, dropped.subject
+        ),
+        // Nothing was holding it: the turn that put the change up has already
+        // ended, so the card was the last of it. Said plainly rather than
+        // silently, because a key that answers nothing leaves the reader
+        // waiting to see what it did.
+        None => format!(
+            "{} dismissed — no turn was holding it, so nothing was waiting on the answer",
+            proposal.revision
+        ),
+    };
+    let _ = in_tx.send(Inbound::Notice(message));
+    true
+}
+
+/// Say yes on the gate the running turn is reading, and report what stood.
+///
+/// `None` when no turn is running or none is holding a change: the board row
+/// below is then the whole of the approval, and the notice says so.
+fn agree_on_the_running_turns_gate(
+    revisions: &RevisionSlot,
+) -> Option<stella_protocol::RevisionProposal> {
+    parked_revisions(revisions)?
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .agree()
+        .ok()
+}
+
+/// What the approval notice says about the revision it has not written yet.
+fn pending_note(pending: Option<stella_protocol::RevisionProposal>) -> &'static str {
+    if pending.is_some() {
+        " — the plan change is written on the turn's next tool call"
+    } else {
+        ""
+    }
 }
 
 /// Service a session-registry / inbox verb from the deck. Returns `true` if
@@ -867,8 +938,42 @@ mod undo_delete_tests {
 }
 
 #[cfg(test)]
-mod approve_revision_tests {
+mod revision_verb_tests {
     use super::*;
+    use stella_store::plan_graph::RevisionGate;
+
+    /// An empty slot: no turn is running, which is where these two verbs still
+    /// have to do something sensible.
+    fn no_turn() -> RevisionSlot {
+        RevisionSlot::default()
+    }
+
+    /// A slot holding a gate with `subject` standing, as a running turn's
+    /// forwarder would have left it.
+    fn turn_holding(subject: &str) -> (RevisionSlot, super::super::SharedRevisions) {
+        let gate =
+            super::super::SharedRevisions::new(std::sync::Mutex::new(RevisionGate::default()));
+        gate.lock()
+            .expect("the gate")
+            .observe(
+                stella_protocol::PlanRevision::new(2).expect("r2"),
+                &[],
+                &stella_protocol::GateBoard {
+                    patch: None,
+                    gates: vec![stella_protocol::GateRow {
+                        name: "tests".into(),
+                        state: stella_protocol::GateState::Failed {
+                            case: subject.into(),
+                            log: "assertion `left == right` failed".into(),
+                        },
+                        deterministic: true,
+                    }],
+                },
+            )
+            .expect("a plain gate failure puts a change up");
+        let slot = RevisionSlot::new(Some(std::sync::Arc::clone(&gate)));
+        (slot, gate)
+    }
 
     fn proposal(subject: &str) -> stella_protocol::RevisionProposal {
         stella_protocol::RevisionProposal {
@@ -881,19 +986,40 @@ mod approve_revision_tests {
         }
     }
 
-    fn approve(registry: &ToolRegistry, subject: &str) -> String {
+    fn approve_with(revisions: &RevisionSlot, registry: &ToolRegistry, subject: &str) -> String {
         let (tx, mut rx) = mpsc::unbounded_channel();
         assert!(service_approve_revision(
             &WorkspaceInput::ApproveRevision {
                 agent: LEAD.into(),
                 proposal: Box::new(proposal(subject)),
             },
+            revisions,
             registry,
             &tx,
         ));
         match rx.try_recv() {
             Ok(Inbound::Notice(text)) => text,
             other => panic!("an approval always answers in words: {other:?}"),
+        }
+    }
+
+    fn approve(registry: &ToolRegistry, subject: &str) -> String {
+        approve_with(&no_turn(), registry, subject)
+    }
+
+    fn dismiss(revisions: &RevisionSlot, subject: &str) -> String {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        assert!(service_dismiss_revision(
+            &WorkspaceInput::DismissRevision {
+                agent: LEAD.into(),
+                proposal: Box::new(proposal(subject)),
+            },
+            revisions,
+            &tx,
+        ));
+        match rx.try_recv() {
+            Ok(Inbound::Notice(text)) => text,
+            other => panic!("a dismissal always answers in words: {other:?}"),
         }
     }
 
@@ -955,5 +1081,92 @@ mod approve_revision_tests {
         let board = registry.task_board();
         let guard = board.lock().unwrap_or_else(|p| p.into_inner());
         assert_eq!(guard.items().len(), 1);
+    }
+
+    /// **Witness.** `a` says yes on the gate the running turn is reading, so
+    /// the hold that turn is under can be lifted by the answer rather than by
+    /// whatever the board happens to contain.
+    ///
+    /// Before the driver could reach that gate, this verb wrote a board row
+    /// and nothing else, and the notice claimed a revision that had not been
+    /// written yet.
+    #[test]
+    fn approving_says_yes_on_the_running_turns_gate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = ToolRegistry::new(dir.path().to_path_buf());
+        let (slot, gate) = turn_holding("a_short_cycle_is_detected");
+        assert!(
+            !gate.lock().expect("the gate").agreed(),
+            "nobody has answered yet"
+        );
+
+        let notice = approve_with(&slot, &registry, "repair a_short_cycle_is_detected");
+        assert!(
+            gate.lock().expect("the gate").agreed(),
+            "the yes is on the gate the turn reads"
+        );
+        assert!(
+            notice.contains("written on the turn's next tool call"),
+            "the notice says the write is still to come: {notice}"
+        );
+    }
+
+    /// **Witness.** `x` drops the standing change on that same gate, which is
+    /// what lifts the hold — `RevisionGate::admits` answers `true` again and
+    /// the turn's next tool call runs.
+    ///
+    /// This verb reached no driver at all before: the deck cleared its card
+    /// and the turn stayed refused until it ended.
+    #[test]
+    fn dismissing_drops_the_change_the_running_turn_is_held_on() {
+        let (slot, gate) = turn_holding("a_short_cycle_is_detected");
+        assert!(
+            !gate.lock().expect("the gate").admits(),
+            "a standing change withholds"
+        );
+
+        let notice = dismiss(&slot, "repair a_short_cycle_is_detected");
+        assert!(
+            gate.lock().expect("the gate").admits(),
+            "the hold is lifted"
+        );
+        assert!(notice.contains("r2 dismissed"), "{notice}");
+        assert!(
+            notice.contains("the plan is unchanged"),
+            "a dismissal writes no revision, and says so: {notice}"
+        );
+    }
+
+    /// With no turn running there is nothing to lift, and the verb says that
+    /// rather than reporting a hold it did not release.
+    #[test]
+    fn dismissing_with_no_turn_running_says_nothing_was_waiting() {
+        let notice = dismiss(&no_turn(), "repair a_short_cycle_is_detected");
+        assert!(notice.contains("no turn was holding it"), "{notice}");
+    }
+
+    /// Neither verb answers the other's input.
+    #[test]
+    fn each_verb_claims_only_its_own_input() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let registry = ToolRegistry::new(dir.path().to_path_buf());
+        let (tx, _rx) = mpsc::unbounded_channel();
+        assert!(!service_approve_revision(
+            &WorkspaceInput::DismissRevision {
+                agent: LEAD.into(),
+                proposal: Box::new(proposal("repair it")),
+            },
+            &no_turn(),
+            &registry,
+            &tx,
+        ));
+        assert!(!service_dismiss_revision(
+            &WorkspaceInput::ApproveRevision {
+                agent: LEAD.into(),
+                proposal: Box::new(proposal("repair it")),
+            },
+            &no_turn(),
+            &tx,
+        ));
     }
 }

--- a/crates/stella-cli/src/command_deck/dropped_turn.rs
+++ b/crates/stella-cli/src/command_deck/dropped_turn.rs
@@ -340,7 +340,7 @@ mod tests {
         // The turn future is dropped: its own sender goes with it, the
         // registry's clone does not, and the event is still in the channel.
         drop(tx);
-        let slot = forwarder::forwarder_slot();
+        let slot = forwarder::turn_slots().drain;
         *slot.lock().expect("slot") = Some(forwarder);
         (slot, in_rx)
     }

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -13,6 +13,7 @@ use crate::agent;
 use crate::cache_insight::{InsightScope, cache_insight_for};
 use crate::memory::TurnFriction;
 
+use super::task_tap::RevisionSlot;
 /// Re-exported beside [`spawn_forwarder`], the function that takes one, so a
 /// caller of the seam picks up the type from the same place.
 pub(crate) use super::task_tap::SharedRevisions;
@@ -446,9 +447,28 @@ pub(crate) async fn close_turn_stream(
 /// to await.
 pub(crate) type ForwarderSlot = std::sync::Mutex<Option<tokio::task::JoinHandle<LaneStreamEnd>>>;
 
-/// An empty slot for one lane's forwarders, reused across that lane's turns.
-pub(crate) fn forwarder_slot() -> ForwarderSlot {
-    std::sync::Mutex::new(None)
+/// What the driver loop owns for the turn it is about to run, and the turn
+/// only borrows.
+///
+/// Both cells answer the same shape of question — something outside the turn
+/// future needs to reach something built inside it — so they are handed over
+/// together rather than as two more parameters on a call whose signature is
+/// already long enough to carry an `#[expect(clippy::too_many_arguments)]`.
+pub(crate) struct TurnSlots {
+    /// The live forwarder, so the cancel that drops the turn can still drain
+    /// the stream that turn opened.
+    pub(crate) drain: ForwarderSlot,
+    /// The turn's plan-change gate, so the deck's `a` and `x` keys reach the
+    /// gate withholding that turn's tool calls (`task_tap::plan_gate`).
+    pub(crate) revisions: RevisionSlot,
+}
+
+/// Empty slots for one lane, reused across that lane's turns.
+pub(crate) fn turn_slots() -> TurnSlots {
+    TurnSlots {
+        drain: std::sync::Mutex::new(None),
+        revisions: std::sync::Mutex::new(None),
+    }
 }
 
 /// Wait out the forwarder of a turn whose future was dropped mid-flight.

--- a/crates/stella-cli/src/command_deck/lead_turn.rs
+++ b/crates/stella-cli/src/command_deck/lead_turn.rs
@@ -21,7 +21,7 @@ use stella_tools::hook_runner::HostHookRunner;
 use stella_tui::{AgentStatus, Inbound};
 use tokio::sync::mpsc::{self, UnboundedSender};
 
-use super::task_tap::{PlanSetup, SharedRevisions, TaskTap};
+use super::task_tap::{PlanSetup, SharedRevisions, TaskTap, park_revisions};
 use super::{LEAD, agent, close_turn_stream, forwarder, lead_control, spawn_forwarder};
 use crate::claims::{ClaimTap, ShellWatch};
 use crate::config::Config;
@@ -62,8 +62,9 @@ pub(super) async fn run_lead_turn(
     session_memory: Option<&SessionMemory>, // #3243 Phase 3: behind the re-query
     friction: &mut TurnFriction,            // #3962: filled from the lane's own stream
     // Owned by the driver loop so a cancel — which drops this whole future —
-    // can still wait the forwarder out (#4853).
-    drain: &forwarder::ForwarderSlot,
+    // can still wait the forwarder out (#4853), and so the deck's keys can
+    // reach this turn's plan-change gate while it runs.
+    slots: &forwarder::TurnSlots,
 ) -> Result<(), crate::failure::CliFailure> {
     budget.begin_turn();
     let (tx, rx) = mpsc::unbounded_channel::<AgentEvent>();
@@ -88,6 +89,10 @@ pub(super) async fn run_lead_turn(
     // gate below reads it, because the turn's plan graph lives there and
     // nowhere else (`task_tap::plan_gate::revision`).
     let revisions = SharedRevisions::default();
+    // ...and parked where the driver loop's `a` and `x` arms can reach it, for
+    // exactly as long as this turn runs. The guard empties the slot on both
+    // ways out, the dropped future a cancel leaves behind included.
+    let _parked = park_revisions(&slots.revisions, &revisions);
     let forwarder = spawn_forwarder(
         rx,
         execution.clone(),
@@ -100,7 +105,7 @@ pub(super) async fn run_lead_turn(
     // Park it where the driver's cancel arm can reach it, and take it back on
     // the path that ends normally — whichever of the two runs, exactly one
     // holds the handle, because the future either completes or is dropped.
-    *drain.lock().unwrap_or_else(|p| p.into_inner()) = Some(forwarder);
+    *slots.drain.lock().unwrap_or_else(|p| p.into_inner()) = Some(forwarder);
     // First events of the turn: what recall put in front of the model, and
     // the skills that rode the same block (SPEC 6.3).
     for event in recall.events {
@@ -209,7 +214,7 @@ pub(super) async fn run_lead_turn(
     // Taken out of the slot before the await, never held across it: the lock is
     // a plain `std::sync::Mutex` and a guard alive over a yield point would be
     // one held by a task the runtime may park.
-    let parked = drain.lock().unwrap_or_else(|p| p.into_inner()).take();
+    let parked = slots.drain.lock().unwrap_or_else(|p| p.into_inner()).take();
     let ended = match parked {
         Some(forwarder) => close_turn_stream(registry, tx, forwarder).await,
         // Unreachable while this function is the only writer of the slot; a

--- a/crates/stella-cli/src/command_deck/task_tap.rs
+++ b/crates/stella-cli/src/command_deck/task_tap.rs
@@ -12,7 +12,9 @@ use crate::subsession::SupervisorMsg;
 
 pub(crate) mod plan_gate;
 
-pub(crate) use plan_gate::{PlanSetup, SharedRevisions};
+pub(crate) use plan_gate::{
+    PlanSetup, RevisionSlot, SharedRevisions, park_revisions, parked_revisions,
+};
 
 /// Hands `task_assign`'s spawn requests to the driver's supervisor channel,
 /// and turns the board into a **scope**: the same board traffic is what the

--- a/crates/stella-cli/src/command_deck/task_tap/plan_gate.rs
+++ b/crates/stella-cli/src/command_deck/task_tap/plan_gate.rs
@@ -78,7 +78,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 mod revision;
 
-pub(crate) use revision::SharedRevisions;
+pub(crate) use revision::{RevisionSlot, SharedRevisions, park_revisions, parked_revisions};
 
 /// The label whose selection means "run this plan". Matched by exact string
 /// against [`stella_protocol::Answer::chosen`], so it is named once here
@@ -269,7 +269,7 @@ impl PlanGate {
         // A waiting plan change is settled first. The plan changed under a
         // turn that is already running, and SPEC 8.1 item 3 says nothing runs
         // until somebody answers that (see the `revision` submodule).
-        if let Some(held) = self.settle_revision(board) {
+        if let Some(held) = self.settle_revision() {
             return Some(held);
         }
         let steps = plan_steps(board);

--- a/crates/stella-cli/src/command_deck/task_tap/plan_gate/revision.rs
+++ b/crates/stella-cli/src/command_deck/task_tap/plan_gate/revision.rs
@@ -20,19 +20,25 @@
 //! here and nowhere else. Two gates would each hold half the answer and
 //! disagree about the rest.
 //!
-//! # A yes goes through the plan graph
+//! # A yes is said on the gate, and written into the plan graph
 //!
-//! The person driving says yes on the deck, and that verb puts the repair on
-//! the task board (`driver_support::service_approve_revision`). So a board
-//! that carries the waiting subject **is** their yes, and the next
-//! [`PlanGate::review`] writes it: [`PlanGate::approve_revision`] hands the
-//! graph to `RevisionGate::approve`. The `[:NEXT]` edge and the cause come
-//! from `PlanGraph::revise`. One writer makes them, so no second path can
-//! disagree.
+//! The person driving answers on the deck, and that key reaches the gate
+//! through a [`RevisionSlot`]: `a` records the yes with `RevisionGate::agree`
+//! and `x` drops the proposal with `RevisionGate::dismiss`
+//! (`driver_support::service_approve_revision` and its dismiss sibling). The
+//! next [`PlanGate::review`] writes a recorded yes:
+//! [`PlanGate::approve_revision`] hands the graph to `RevisionGate::approve`,
+//! and the `[:NEXT]` edge and the cause come from `PlanGraph::revise`. One
+//! writer makes them, so no second path can disagree.
+//!
+//! Reading the yes off the task board instead — which is what this did until
+//! the deck could reach the gate — made a row the model itself created with
+//! the waiting subject indistinguishable from consent, and gave `x` nowhere to
+//! act, so a dismissed proposal held the turn until it ended.
 
 use std::sync::{Arc, Mutex};
 
-use stella_protocol::{ErrorClass, PlanRevision, RevisionProposal, TaskItem, ToolOutput};
+use stella_protocol::{ErrorClass, PlanRevision, RevisionProposal, ToolOutput};
 use stella_store::plan_graph::{RevisionError, RevisionGate};
 
 use super::PlanGate;
@@ -43,6 +49,46 @@ use super::PlanGate;
 /// ledgers. A lane with no plan gate still gets one, so its proposals reach
 /// the deck the way they always did.
 pub(crate) type SharedRevisions = Arc<Mutex<RevisionGate>>;
+
+/// Where a running turn parks its plan-change gate so the deck's keys can
+/// reach the gate that turn is reading.
+///
+/// The driver loop owns it and the turn borrows it, the way the forwarder slot
+/// beside it is owned and borrowed — for the same reason. The gate is built
+/// inside `run_lead_turn` and dies with it, and the keyboard lives in the
+/// driver loop, so neither one can hand the other a handle directly.
+///
+/// Empty between turns, and that is an answer rather than a gap: with no turn
+/// running there is no held tool call to release, and the verbs say so.
+pub(crate) type RevisionSlot = Mutex<Option<SharedRevisions>>;
+
+/// Park `revisions` in `slot` for as long as the returned guard lives.
+///
+/// A guard rather than a pair of assignments, because a turn can end by being
+/// dropped: the deck's cancel drops the whole turn future, and a slot cleared
+/// only on the path that returns normally would leave the deck's keys acting
+/// on the gate of a turn that is over.
+pub(crate) fn park_revisions<'a>(
+    slot: &'a RevisionSlot,
+    revisions: &SharedRevisions,
+) -> ParkedRevisions<'a> {
+    *slot.lock().unwrap_or_else(|p| p.into_inner()) = Some(Arc::clone(revisions));
+    ParkedRevisions(slot)
+}
+
+/// What [`park_revisions`] hands back: the slot is emptied when this drops.
+pub(crate) struct ParkedRevisions<'a>(&'a RevisionSlot);
+
+impl Drop for ParkedRevisions<'_> {
+    fn drop(&mut self) {
+        *self.0.lock().unwrap_or_else(|p| p.into_inner()) = None;
+    }
+}
+
+/// The running turn's plan-change gate, or `None` when no turn is running.
+pub(crate) fn parked_revisions(slot: &RevisionSlot) -> Option<SharedRevisions> {
+    slot.lock().unwrap_or_else(|p| p.into_inner()).clone()
+}
 
 /// What the model is told while a plan change waits on the person driving.
 ///
@@ -59,13 +105,18 @@ const REVISION_STALE: &str = "the plan change could not be written, so nothing r
      person driving is asked again.";
 
 impl PlanGate {
-    /// Settle the waiting plan change against `board`, and return the refusal
-    /// a guarded tool call gets while it is still waiting.
+    /// Settle the waiting plan change, and return the refusal a guarded tool
+    /// call gets while it is still waiting.
     ///
     /// `None` in three cases: nothing is waiting; there is no plan to write a
-    /// yes into; or the board carries the change, so it is written and work
-    /// goes on.
-    pub(super) fn settle_revision(&self, board: &[TaskItem]) -> Option<ToolOutput> {
+    /// yes into; or the person driving has said yes, so the change is written
+    /// and work goes on.
+    ///
+    /// The yes is read off the gate rather than off the task board. A board
+    /// row is not consent: the model creates rows itself, and one whose
+    /// subject happens to be the waiting change's would otherwise release a
+    /// hold nobody answered.
+    pub(super) fn settle_revision(&self) -> Option<ToolOutput> {
         let waiting = self.pending_revision()?;
         let planned = self
             .state
@@ -78,7 +129,7 @@ impl PlanGate {
             // so a hold raised before one exists could never be lifted.
             return None;
         }
-        if !board.iter().any(|item| item.subject == waiting.subject) {
+        if !self.revision_agreed() {
             return Some(ToolOutput::classified_error(
                 ErrorClass::RefusedByPolicy,
                 hold_message(REVISION_HELD, &waiting),
@@ -95,6 +146,14 @@ impl PlanGate {
                 hold_message(REVISION_STALE, &waiting),
             )),
         }
+    }
+
+    /// Whether the person driving has said yes to the waiting change.
+    fn revision_agreed(&self) -> bool {
+        self.revisions
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .agreed()
     }
 
     /// The plan change on the table, if there is one.
@@ -154,7 +213,8 @@ mod tests {
 
     use async_trait::async_trait;
     use stella_protocol::{
-        Answer, GateBoard, GateRow, GateState, QuestionOutcome, QuestionRequest, TaskStatus,
+        Answer, GateBoard, GateRow, GateState, QuestionOutcome, QuestionRequest, TaskItem,
+        TaskStatus,
     };
     use stella_tools::ToolRegistry;
     use stella_tools::registry::question::QuestionResponder;
@@ -305,9 +365,22 @@ mod tests {
             "the hold names the gate that failed: {message}"
         );
 
-        // The deck's approve verb puts the repair on the board. That row is
-        // the person's yes, and the next call reads it.
+        // A board row is not an answer. The model creates rows itself, so one
+        // whose subject matches the waiting change is a coincidence, and the
+        // hold stands.
         plan.push(row("4", &waiting.subject));
+        assert!(
+            gate.review(&plan).await.is_some(),
+            "a row nobody was asked about is not consent"
+        );
+
+        // The deck's approve verb says yes on this gate. The next call reads
+        // that, writes the change, and goes on.
+        revisions
+            .lock()
+            .expect("the gate")
+            .agree()
+            .expect("standing");
         assert!(
             gate.review(&plan).await.is_none(),
             "work goes on once the change is answered"
@@ -334,6 +407,53 @@ mod tests {
         );
     }
 
+    /// **The witness for `x dismiss`.** A change dropped on the gate lifts the
+    /// hold, and the turn's next tool call runs — with no plan revision
+    /// written, because declining a change is not reverting one.
+    ///
+    /// Nothing could reach this gate before, so a reader who did not want the
+    /// repair task had no way to release the turn: it stayed refused until it
+    /// ended.
+    #[tokio::test]
+    async fn dropping_the_waiting_change_lifts_the_hold_and_writes_no_revision() {
+        let registry = ToolRegistry::new(std::path::PathBuf::from("."));
+        let (gate, revisions, _events) = gate(&registry);
+        let plan = board(3);
+        assert!(gate.review(&plan).await.is_none(), "r1 runs");
+        let waiting = observe(&revisions, &gate);
+
+        assert!(
+            gate.review(&plan).await.is_some(),
+            "nothing runs while a change waits"
+        );
+
+        // What `x` does, from the driver's side.
+        let dropped = revisions
+            .lock()
+            .expect("the gate")
+            .dismiss()
+            .expect("a change was standing");
+        assert_eq!(dropped.subject, waiting.subject);
+
+        assert!(
+            gate.review(&plan).await.is_none(),
+            "the hold is lifted and the next tool call runs"
+        );
+        let graph = gate.plan_graph().expect("a plan was put up this turn");
+        assert_eq!(
+            graph.revision(),
+            PlanRevision::FIRST,
+            "a dismissal writes no revision"
+        );
+        assert!(
+            graph
+                .planned(graph.revision())
+                .iter()
+                .all(|task| task.subject != waiting.subject),
+            "and inserts no task"
+        );
+    }
+
     /// A change put up before any plan cannot be written, since a plan graph
     /// is what it would be written into. It must not wedge the turn either.
     #[tokio::test]
@@ -352,7 +472,7 @@ mod tests {
             "there is no plan, so there is nothing to write into"
         );
         assert!(
-            gate.settle_revision(&board(2)).is_none(),
+            gate.settle_revision().is_none(),
             "a change nobody can write must not wedge the turn"
         );
     }

--- a/crates/stella-store/src/plan_graph/graph/revision.rs
+++ b/crates/stella-store/src/plan_graph/graph/revision.rs
@@ -90,6 +90,7 @@ pub enum RevisionError {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RevisionGate {
     pending: Option<RevisionProposal>,
+    agreed: bool,
 }
 
 impl RevisionGate {
@@ -141,6 +142,32 @@ impl RevisionGate {
         self.pending.as_ref()
     }
 
+    /// Whether the person driving has said yes to the standing proposal.
+    ///
+    /// `false` while nothing stands, because a yes is cleared by the two
+    /// verbs that end a proposal — [`Self::approve`] writes it and
+    /// [`Self::dismiss`] drops it.
+    #[must_use]
+    pub fn agreed(&self) -> bool {
+        self.agreed
+    }
+
+    /// SPEC 8.1's `a approve r4`, the half a person presses: record the yes.
+    ///
+    /// The write is [`Self::approve`] and it happens elsewhere, because the
+    /// yes and the write are given in two places — the keyboard has no plan
+    /// graph, and the gate the running turn reads has no reader. Recording
+    /// the yes here is what lets the write ask whether one was given, instead
+    /// of inferring it from some other trace the person's answer left behind.
+    ///
+    /// Returns what was agreed to, so a caller can name it rather than
+    /// repeating the proposal it was holding.
+    pub fn agree(&mut self) -> Result<RevisionProposal, RevisionError> {
+        let agreed = self.pending.clone().ok_or(RevisionError::NothingPending)?;
+        self.agreed = true;
+        Ok(agreed)
+    }
+
     /// Whether work may proceed — `false` for as long as a proposal stands.
     ///
     /// SPEC 8.1's "nothing runs until approval", as one question with one
@@ -163,6 +190,9 @@ impl RevisionGate {
         }
         let pending = self.pending.as_mut().ok_or(RevisionError::NothingPending)?;
         pending.subject = subject;
+        // A yes given before the edit was a yes to the old subject, so it
+        // does not carry over: the reader is answering a different insert now.
+        self.agreed = false;
         Ok(())
     }
 
@@ -173,6 +203,7 @@ impl RevisionGate {
     /// the difference between declining a change and reverting one — and the
     /// gate admits again.
     pub fn dismiss(&mut self) -> Option<RevisionProposal> {
+        self.agreed = false;
         self.pending.take()
     }
 
@@ -205,6 +236,7 @@ impl RevisionGate {
         ));
         let revision = graph.revise(tasks, proposal.cause.clone())?;
         self.pending = None;
+        self.agreed = false;
         Ok(revision)
     }
 }

--- a/crates/stella-store/src/plan_graph/graph/revision/tests.rs
+++ b/crates/stella-store/src/plan_graph/graph/revision/tests.rs
@@ -436,6 +436,71 @@ fn approving_a_stale_proposal_is_refused_rather_than_renumbered() {
     );
 }
 
+// ── the yes ───────────────────────────────────────────────────────
+
+/// A yes is a state on the gate. The code that writes the revision asks the
+/// gate for it. It reads no other trace.
+///
+/// Both verbs that end a proposal clear it. So does an edit: a yes to one
+/// subject is not a yes to the next one.
+#[test]
+fn a_yes_is_recorded_on_the_gate_and_cleared_by_everything_that_ends_it() {
+    let mut graph = plan();
+    let mut gate = RevisionGate::default();
+    gate.observe(
+        graph.revision().next(),
+        &graph.planned(graph.revision()),
+        &one_failure(),
+    )
+    .expect("a plain gate failure puts a proposal up");
+    assert!(
+        !gate.agreed(),
+        "a fresh proposal has been agreed to by nobody"
+    );
+
+    let agreed = gate.agree().expect("a proposal stands");
+    assert!(gate.agreed(), "the yes is on the gate");
+    assert_eq!(
+        agreed.revision,
+        gate.pending().expect("still standing").revision,
+        "agreeing names what it agreed to and changes nothing about it"
+    );
+
+    gate.edit("repair the router instead")
+        .expect("a standing proposal can be edited");
+    assert!(
+        !gate.agreed(),
+        "the reader changed the insert, so the earlier yes was to something else"
+    );
+
+    gate.agree().expect("and can be agreed to again");
+    gate.approve(&mut graph).expect("the plan has not moved");
+    assert!(!gate.agreed(), "a written revision leaves no yes standing");
+
+    gate.observe(
+        graph.revision().next(),
+        &graph.planned(graph.revision()),
+        &one_failure(),
+    )
+    .expect("the repair is planned, so the next board proposes afresh");
+    gate.agree().expect("a proposal stands");
+    gate.dismiss().expect("and can be dropped instead");
+    assert!(
+        !gate.agreed(),
+        "a dismissed proposal leaves no yes standing"
+    );
+}
+
+/// Nothing to agree to is a named error, not a silent no-op. A caller that
+/// could not tell the two apart would report a yes no gate holds.
+#[test]
+fn agreeing_with_nothing_standing_is_refused_by_name() {
+    assert_eq!(
+        RevisionGate::default().agree(),
+        Err(RevisionError::NothingPending)
+    );
+}
+
 // ── the helpers ────────────────────────────────────────────────────────────
 
 /// The insertion takes the id the board would give it, so an approved revision

--- a/crates/stella-tui/examples/deck_demo.rs
+++ b/crates/stella-tui/examples/deck_demo.rs
@@ -475,6 +475,15 @@ async fn main() -> std::io::Result<()> {
                         proposal.revision, proposal.subject
                     )));
                 }
+                // `x` on the same row. The demo runs no turn, so there is no
+                // hold to lift and the answer is the sentence the real driver
+                // sends when it has lifted one.
+                WorkspaceInput::DismissRevision { proposal, .. } => {
+                    let _ = react_tx.send(Inbound::Notice(format!(
+                        "{} dismissed — the plan is unchanged",
+                        proposal.revision
+                    )));
+                }
                 // The demo has no microphone: a dictation gesture answers
                 // with the failure the real driver would send if it had no
                 // recorder, so the deck's voice state settles.

--- a/crates/stella-tui/src/deck_ui/row_keys.rs
+++ b/crates/stella-tui/src/deck_ui/row_keys.rs
@@ -126,16 +126,17 @@ pub(super) fn act(c: char, model: &WorkspaceModel, ui: &mut DeckUi) -> Option<De
         // `x` on a standing proposal is `x dismiss` instead (SPEC 8.1). One
         // letter, two rows, and no ambiguity: the two verbs are selected by
         // what the highlight is on, and a row is one or the other.
+        //
+        // It travels, like `a`. Clearing the card here releases the deck's own
+        // withholding and nothing else; the gate that is refusing the running
+        // turn's tool calls is the driver's, and the driver answers in words
+        // once it has lifted the hold.
         'x' => {
             if let Some((agent, proposal)) = take_selected_proposal(model, ui) {
-                let message = format!(
-                    "{} dismissed on {agent}: {}",
-                    proposal.revision, proposal.subject
-                );
-                ui.notice.push(message.clone());
-                ui.scrollback
-                    .announce(format!("{}{message}", crate::accessible::NOTICE_MARKER));
-                return Some(DeckAction::Handled);
+                return Some(DeckAction::Send(WorkspaceInput::DismissRevision {
+                    agent,
+                    proposal: Box::new(proposal),
+                }));
             }
             let (memory_id, text) = super::memory::selected_memory(model, ui)?;
             Some(DeckAction::Send(WorkspaceInput::RejectMemory {

--- a/crates/stella-tui/src/deck_ui/tests/revision.rs
+++ b/crates/stella-tui/src/deck_ui/tests/revision.rs
@@ -106,21 +106,30 @@ fn nothing_dispatches_until_the_proposal_is_answered() {
     );
 }
 
-/// `x dismiss`: the proposal goes, the withholding goes with it, and nothing
-/// is sent — a dismissal writes no revision, so there is nothing for a driver
-/// to do about it.
+/// **The witness for `x dismiss`.** The proposal goes, the deck's own
+/// withholding goes with it, and the dismissal is *sent*.
+///
+/// It is sent because the gate that holds a running turn's tool calls is the
+/// driver's. A dismissal the deck answers alone clears the card and leaves
+/// that turn held until it ends.
 #[test]
-fn x_dismisses_the_proposal_and_sends_nothing() {
+fn x_sends_the_dismissal_so_the_driver_can_lift_the_hold() {
     let mut model = model_with(&["lead"]);
     let mut ui = ready_ui();
     proposed(&mut model, &mut ui);
 
     let action = handle_deck_key(key(KeyCode::Char('x')), &model, &mut ui);
-    assert_eq!(action, DeckAction::Handled, "x claimed the keystroke");
-    assert!(ui.pending_revisions.is_empty());
+    assert_eq!(
+        action,
+        DeckAction::Send(WorkspaceInput::DismissRevision {
+            agent: "lead".into(),
+            proposal: Box::new(proposal()),
+        }),
+        "x sends the dismissal, carrying the proposal the driver drops"
+    );
     assert!(
-        ui.notice.entries().iter().any(|n| n.contains("r2")),
-        "the dismissal says what it dropped"
+        ui.pending_revisions.is_empty(),
+        "and releases the deck's own withholding"
     );
 }
 

--- a/crates/stella-tui/src/envelope.rs
+++ b/crates/stella-tui/src/envelope.rs
@@ -1325,12 +1325,21 @@ pub enum WorkspaceInput {
     /// proposal whose revision number the plan has moved past, and a subject
     /// on its own carries no number to check.
     ///
-    /// `e edit` and `x dismiss` are absent from this enum on purpose. Both are
-    /// answered entirely inside the deck — `e` hands the subject to the
-    /// composer and stands the proposal down, `x` drops it — and neither
-    /// writes anything, so a round trip to the driver would be a message whose
-    /// only effect is latency.
+    /// `e edit` is absent from this enum on purpose: it is answered inside the
+    /// deck, which hands the subject to the composer and stands the proposal
+    /// down, so a round trip would be a message whose only effect is latency.
     ApproveRevision {
+        agent: AgentId,
+        proposal: Box<stella_protocol::RevisionProposal>,
+    },
+    /// `x` on a highlighted revision proposal: drop it — SPEC 8.1's
+    /// `x dismiss`.
+    ///
+    /// It writes no revision, and it still has to travel. A running turn
+    /// withholds its tool calls while the change stands, and only the driver
+    /// can reach the gate that withholds them. A dismissal the deck answered
+    /// alone would clear the card and leave the turn refused.
+    DismissRevision {
         agent: AgentId,
         proposal: Box<stella_protocol::RevisionProposal>,
     },


### PR DESCRIPTION
## What & why

A plan change raised by a failing gate withholds a running turn's tool calls
(#5296). The person driving could answer it one indirect way, and could not
answer it the other way at all.

**`x dismiss` reached nothing.** `RevisionGate::dismiss` exists, the deck draws
the `x` key, and nothing in `stella-cli` called it. A reader who did not want
the repair task cleared the card on screen and left the turn refused until it
ended — a live wedge.

**`a approve` worked by side effect.** It put a repair row on the task board,
and the next `PlanGate::review` read a board row whose subject matched the
waiting change as the person's yes. The model creates rows itself, so a row it
created with that subject released a hold nobody had answered. The deck's
notice also claimed the revision was written before it was, so an `approve`
that then failed with `PlanMoved` left the reader told one thing and the plan
saying another.

### The fix

The driver loop now holds a clone of the running turn's gate.
`forwarder::TurnSlots` bundles the forwarder slot the driver already owned with
a new `RevisionSlot`; `run_lead_turn` parks its `SharedRevisions` there for the
life of the turn. A slot rather than another parameter for the reason the
forwarder slot exists: the gate is built inside the turn future and the
keyboard lives outside it. `park_revisions` hands back an RAII guard, so the
slot empties on both ways out — including the dropped future a cancel leaves
behind.

`stella_store::plan_graph::RevisionGate` gains the state a recorded yes needs.
`agree` records it, `agreed` reports it, and `approve`, `dismiss` and `edit`
each clear it — an edit clears it because a yes given to one subject is not a
yes to the one that replaces it. The state belongs there because the gate is
pure and property-tested, per the issue.

`PlanGate::settle_revision` asks the gate for the yes instead of scanning the
board, so a model-created row is no longer consent. The write still goes
through `RevisionGate::approve` on the turn's next guarded call, so the
`[:NEXT]` edge and the `DivergenceCause` come from `PlanGraph::revise` as
before — one writer, no second path.

`WorkspaceInput::DismissRevision` is the new envelope variant, and the deck's
`x` sends it rather than answering locally. The approval notice now says the
plan change is written on the turn's next tool call, because that is when it
happens.

`command_deck.rs` is a god file: this change rewrites lines there and adds six,
against a ceiling it sits roughly nine hundred lines under. The import list and
the one dispatch arm are the whole of it — every new function lives in
`driver_support.rs` and `plan_gate/revision.rs`.

Closes #5867

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

Every one of them runs with no terminal and no plugin:

- `a_waiting_plan_change_stops_the_next_tool_call_until_it_is_answered`
  (`plan_gate/revision.rs`) now asserts a matching board row does **not** lift
  the hold. **Proven by reverting**: putting `settle_revision` back on the board
  scan fails it with `a row nobody was asked about is not consent`.
- `dropping_the_waiting_change_lifts_the_hold_and_writes_no_revision` — `x` at
  the plan gate: the hold lifts, the next call runs, and the plan stays at r1.
- `dismissing_drops_the_change_the_running_turn_is_held_on` and
  `approving_says_yes_on_the_running_turns_gate` (`driver_support.rs`) — the two
  driver verbs against a parked gate. Neither compiles on `main`: the verb, the
  input variant and the slot do not exist there.
- `x_sends_the_dismissal_so_the_driver_can_lift_the_hold` (`stella-tui`) — the
  deck's `x` returns `Send(DismissRevision)` rather than `Handled`.
- `a_yes_is_recorded_on_the_gate_and_cleared_by_everything_that_ends_it` and
  `agreeing_with_nothing_standing_is_refused_by_name` (`stella-store`) — the new
  gate state and its clearing rules.
- `a_yes_to_one_change_is_not_a_yes_to_the_one_the_gate_is_holding` — a yes
  offered for one card does not land on a different standing change.

**One test was renamed, not deleted**: `x_dismisses_the_proposal_and_sends_nothing`
became `x_sends_the_dismissal_so_the_driver_can_lift_the_hold`. The behaviour it
pinned — `x` sending nothing — is the defect this PR fixes.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`)
- [x] `cargo clippy -p stella-store -p stella-tui -p stella-cli --all-targets -- -D warnings` — green. The workspace run is CI's (CLAUDE.md: "CI builds and tests; this laptop does not").
- [x] `cargo test -p stella-store --lib plan_graph`, `cargo test -p stella-tui --lib`, `cargo test -p stella-tui --test deck_render_snapshots`, `cargo test -p stella-cli --bin stella command_deck::` — all green. Workspace tests are CI's.
- [x] `make guards-fast` and `python3 scripts/check-prose.py` — green.
- [x] Docs updated where behavior changed: the module doc of `plan_gate/revision.rs`, the doc comments on both driver verbs, and the `ApproveRevision`/`DismissRevision` variants in `envelope.rs`.
- [x] CLA signed
- [x] `Closes #5867` appears both above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: the approval notice no longer claims a revision that has not been written; `RevisionGate::edit` clears an earlier yes, which it could not have done before because there was no yes to clear; and `agree_to` matches the card the reader answered against what the gate is standing on, so a yes cannot land on a change they were never shown — the deck already refuses to send `a` on a stale card, so this is the second answer to that question rather than the only one.
- [x] Filed, with the reason a fix could not ride this PR: **nothing was deferred**

`e edit` in place remains #5289's, untouched here.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary types — `WorkspaceInput` is `stella-tui`'s own deck envelope and crosses no serde boundary

## Anything reviewers should know?

The issue names `stella_core::plan_graph::RevisionGate`. `RevisionGate` lives in
`stella-store` (`crates/stella-store/src/plan_graph/graph/revision.rs`); the
crate name in the issue is wrong, the reasoning is not — the gate is pure and
property-tested, which is why the new state went there rather than into
`stella-cli`.
