### PR TITLE
ci(main-red-hold): re-run the hold when main breaks, not only when it heals

### DIFF
--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -68,9 +68,10 @@ permissions:
   # label on first use.
   issues: write
   # To find the open pull requests whose hold this run has just made stale,
-  # and to re-run it for them (#5913). Closing the issue is what ends the
-  # outage; the hold that failed during it is still the last word on each of
-  # those commits until something re-runs it.
+  # and to re-run it for them (#5913, #5949). Filing or closing the issue is
+  # what moves the answer; the hold on each of those commits is still the old
+  # one until something re-runs it. `actions: write` is the narrowest scope
+  # that re-runs a workflow run, and one scope covers both directions.
   pull-requests: read
   actions: write
 
@@ -99,14 +100,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/main-canary.sh --announce
 
-      # Recovery has to clear the holds the outage caused, or every pull
-      # request that was blocked stays blocked with no push to it (#5913).
-      # This does nothing while a `main-red` issue is open, so a run that
-      # found the tree still broken pays one tracker query for it.
-      - name: Clear the hold on every open pull request
+      # Both transitions leave every open pull request holding a stale answer,
+      # and this step re-asks for them. A break has to turn the passing holds
+      # red, or a pull request that finished before the issue was filed merges
+      # onto the breakage with a green required check (#5949). A recovery has
+      # to turn the failed ones green, or every pull request the outage
+      # blocked stays blocked with no push to it (#5913).
+      #
+      # It runs after the step above either way, because that step is what
+      # files or closes the issue this one reads.
+      - name: Refresh the hold on every open pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./scripts/clear-main-red-holds.sh
+        run: ./scripts/refresh-main-red-holds.sh
 
       # The other half of the same question, and the one nothing asked: is
       # there a commit on `main` that nothing VERIFIED — as distinct from one

--- a/.github/workflows/main-red-clear.yml
+++ b/.github/workflows/main-red-clear.yml
@@ -8,7 +8,7 @@ name: main-red-clear
 # after the outage ends. On 2026-09-05, ten pull requests stayed unmergeable
 # on a check whose own question had already changed its answer.
 #
-# `scripts/clear-main-red-holds.sh` re-runs those holds. This workflow is one
+# `scripts/refresh-main-red-holds.sh` re-runs those holds. This workflow is one
 # of its two callers, and covers the recovery a person performs by hand:
 # closing the `main-red` issue, or taking the label off it.
 #
@@ -79,7 +79,7 @@ jobs:
           DRILL_PR: ${{ inputs.drill }}
         run: |
           if [ -n "$DRILL_PR" ]; then
-            ./scripts/clear-main-red-holds.sh --drill "$DRILL_PR"
+            ./scripts/refresh-main-red-holds.sh --drill "$DRILL_PR"
           else
-            ./scripts/clear-main-red-holds.sh
+            ./scripts/refresh-main-red-holds.sh
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,8 +323,11 @@ it, the case where the tip already has a run included.
 
 A seventh, `main-red-hold.yml`, is the canary's other half: the canary *detects*,
 and this is what consumes the detection at the point a merge is still a
-decision. It runs on `pull_request`, asks the tracker whether a `main-red`
-issue is open, and fails if one is — naming it. On 2026-08-19 the canary
+decision. It runs on `pull_request`. Each run asks the tracker whether a
+`main-red` issue is open at that moment, and fails if one is — naming it. That
+answer is a snapshot, and the paragraph below is how it gets re-taken when
+`main` moves under a pull request that is finished and waiting.
+On 2026-08-19 the canary
 worked exactly as designed and it did not help: it filed its issue at 16:57:01,
 and four more PRs merged onto the non-compiling tree over the next 35 minutes,
 the first of them **twelve seconds later** (#3917). Once `main` is red every
@@ -340,24 +343,35 @@ required status checks: a throwaway PR went red and unmergeable while a
 hand-filed, `main-red`-labelled issue stood, and green again once
 `unblocks-main` landed on it.
 
-**A hold outlives the outage unless something clears it.** Branch protection
-reads the last check run for that name on that commit, and the hold fires on
-`pull_request` — so a pull request that is finished and waiting has no event
-left to correct it. On 2026-09-05 `main` broke, a repair landed, the canary
-closed the issue, and ten open pull requests stayed unmergeable on a check
-whose own question now answered the other way. A push to each branch clears
-it; the two moves a session reaches for first, an empty commit and
-close-and-reopen, are the two this repository forbids.
-`scripts/clear-main-red-holds.sh` is what clears them: it asks whether any
-`main-red` issue is still open, and if none is, re-runs the failed hold on
-every open pull request, which reports under the same name on the same commit.
-It has two callers because neither sees every recovery — `main-canary.yml`, on
-the run that closes the issue, since GitHub starts no workflow from an event
+**A hold goes stale in both directions unless something re-asks it.** Branch
+protection reads the last check run for that name on that commit, and the hold
+fires on `pull_request` — so a pull request that is finished and waiting has no
+event left to correct it, while `main` breaks and gets fixed underneath.
+
+The stale failure blocks work that should land. On 2026-09-05 `main` broke, a
+repair landed, the canary closed the issue, and ten open pull requests stayed
+unmergeable on a check whose own question now answered the other way. The stale
+pass is the dangerous one: `#5928`'s hold ran at 09:41, the `main-red` issue
+for that outage was filed at 10:07, and it merged onto the broken tree during
+the red window with that 26-minute-old green as its required check. Both are
+one bug — the hold is a point-in-time answer that branch protection reads as a
+standing one. A push to the branch fixes either; the two moves a session
+reaches for first, an empty commit and close-and-reopen, are the two this
+repository forbids.
+
+`scripts/refresh-main-red-holds.sh` re-asks for them. One tracker query decides
+what every hold should be saying — failing while a `main-red` issue is open,
+passing while none is — and it re-runs the hold on each open pull request whose
+last run says the other thing, which reports under the same name on the same
+commit. One sweep rather than two, because it is one question: a second script
+for the break direction is a second copy to drift. It has two callers because
+neither sees every transition — `main-canary.yml`, on the push run that files
+or closes the issue, since GitHub starts no workflow from an event
 `GITHUB_TOKEN` raised; and `main-red-clear.yml`, when a person closes the issue
 or takes the label off it. Both fail open, and running it twice re-runs nothing
-the first pass cleared. `make clear-main-red-holds` prints what a sweep would
-re-run without re-running it; `make main-red-hold-test` covers the clearing
-half beside the blocking one.
+the first pass already moved. `make refresh-main-red-holds` prints what a sweep
+would re-run without re-running it; `make main-red-hold-test` covers both
+directions beside the blocking one.
 
 **The same staleness reaches `dod-check`, one gate over.** That check reads the
 linked issue's checklist and fires on pull request events, so the object it

--- a/Makefile
+++ b/Makefile
@@ -982,15 +982,16 @@ main-red-hold: ## Ask whether an open `main-red` issue should hold a PR (reads t
 	@./scripts/check-main-red-hold.sh
 
 .PHONY: main-red-hold-test
-main-red-hold-test: ## Test the red-main hold and its clean-up (hermetic; not part of `gate`)
+main-red-hold-test: ## Test the red-main hold and both refresh directions (hermetic; not part of `gate`)
 	./scripts/test-main-red-hold.sh
 
-# What the hold leaves behind once main recovers: a failed check run that is
-# still the last word on every blocked PR's head (#5913). CI re-runs those
-# holds; this prints what it would re-run, and changes nothing.
-.PHONY: clear-main-red-holds
-clear-main-red-holds: ## List the stale `main is not known-broken` failures a recovery left behind
-	@./scripts/clear-main-red-holds.sh --dry-run
+# What either transition leaves behind: a check run that is still the last
+# word on every open PR's head, answering the question main was asking then
+# (#5913 for a stale failure, #5949 for a stale pass). CI re-runs those holds;
+# this prints what it would re-run, and changes nothing.
+.PHONY: refresh-main-red-holds
+refresh-main-red-holds: ## List the `main is not known-broken` runs that no longer match the tracker
+	@./scripts/refresh-main-red-holds.sh --dry-run
 
 # The third signal in the red-main chain: the canary detects, the hold stops
 # a merge, and this stops a second session writing the same patch (#4680).

--- a/scripts/dod-recheck.sh
+++ b/scripts/dod-recheck.sh
@@ -72,7 +72,7 @@ while [ $# -gt 0 ]; do
   # Test-only seams. Either one stubs every lookup, and stops the re-run from
   # being sent. So a case cannot half-reach the network, and cannot pass or
   # fail for a reason it did not pick. Same rule as the fixtures in
-  # `clear-main-red-holds.sh`.
+  # `refresh-main-red-holds.sh`.
   --fixture-open-prs)
     [ $# -ge 2 ] || {
       echo "dod-recheck: --fixture-open-prs needs a value" >&2
@@ -94,7 +94,7 @@ while [ $# -gt 0 ]; do
   -h | --help)
     # The whole block after the shebang, cut off at its first line of code. A
     # line number here goes stale the first time the header grows. Same reader
-    # as the one in `clear-main-red-holds.sh`.
+    # as the one in `refresh-main-red-holds.sh`.
     awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
     exit 0
     ;;

--- a/scripts/refresh-main-red-holds.sh
+++ b/scripts/refresh-main-red-holds.sh
@@ -1,43 +1,65 @@
 #!/usr/bin/env bash
 #
-# Clear the merge hold a fixed `main` leaves behind. Filed as `#5913`.
+# Make every open pull request's `main is not known-broken` check answer
+# today's question. Filed as `#5913` and `#5949`.
 #
-# `main-red-hold.yml` reports the check `main is not known-broken` on every
-# pull request. It is right when it runs. But the branch rules read the last
-# check run on that commit, and nothing runs it again.
+# `main-red-hold.yml` reports that check on every pull request. It is right
+# when it runs. But the branch rules read the last check run on that commit,
+# and the workflow only fires on `pull_request`. A pull request that is
+# finished and waiting raises no such event, so its answer is frozen at the
+# moment it was produced.
 #
-# So the hold outlives the outage. On 2026-09-05 a fix landed and the canary
-# closed its issue. Ten open pull requests stayed stuck. Each was held by a
-# check that would now pass.
+# The state it is answering about is not frozen. `main` breaks and gets fixed
+# under it. So the check goes stale in both directions, and each direction
+# costs something different:
 #
-# A push to the branch clears it. A finished pull request has no reason to
-# push. The two moves a session tries first — an empty commit, and close and
-# reopen — are the two AGENTS.md bans.
+#   - Stale red. `main` is fixed, the hold still fails. On 2026-09-05 ten
+#     pull requests stayed unmergeable on a check whose own question had
+#     already changed its answer (`#5913`).
+#   - Stale green. `main` breaks, the hold still passes, and the pull request
+#     merges onto the breakage with a green required check. `#5928` did
+#     exactly that: its hold ran at 09:41, the `main-red` issue was filed at
+#     10:07, and it merged during the red window on a run 26 minutes older
+#     than the outage (`#5949`).
 #
-# So the fix has to clear the holds it caused. This script is that step. It
-# asks whether `main` is still known-broken. If it is not, it runs the failed
-# hold again on every open pull request. The new run lands under the same
-# name on the same commit. That is all the branch rules read.
+# A push to the branch fixes either one. A finished pull request has no reason
+# to push. The two moves a session tries first — an empty commit, and close
+# and reopen — are the two AGENTS.md bans.
+#
+# So this script re-asks for them. It reads the tracker once. An open
+# `main-red` issue means every hold should be failing; no open issue means
+# every hold should be passing. Then it runs the hold again on each open pull
+# request whose last run says the other thing. The new run lands under the
+# same name on the same commit. That is all the branch rules read.
+#
+# One sweep covers both directions because there is only one question. Asking
+# it twice, in two scripts, is how the two halves drift apart.
 #
 # ## Why run it again, and not post a new status
 #
 # The other way is to post a commit status with the same name. Then two
-# things wear one name: a failed check run, and a passing status. Which one
-# the branch rules trust is not a thing this repo can learn, short of
-# breaking `main` to see. Running the old run again leaves one verdict.
+# things wear one name: a check run, and a status. Which one the branch rules
+# trust is not a thing this repo can learn, short of breaking `main` to see.
+# Running the old run again leaves one verdict.
 #
 # ## Who calls it
 #
-# Two callers, since neither one sees every fix.
+# Two callers, since neither one sees every transition.
 #
-#   - `main-canary.yml`, on the run that closes the `main-red` issue. That is
-#     the normal path, and a workflow on the issue event cannot see it. The
-#     canary closes with `GITHUB_TOKEN`, and no event from that token starts
-#     a workflow.
+#   - `main-canary.yml`, on the push run that files or closes the `main-red`
+#     issue. That is the normal path for both directions, and a workflow on
+#     the issue event cannot see it. The canary writes with `GITHUB_TOKEN`,
+#     and no event from that token starts a workflow.
 #   - `main-red-clear.yml`, when a person closes the issue by hand, or takes
 #     the `main-red` label off it.
 #
-# Two runs cost nothing. The second finds the holds green and runs nothing.
+# Two runs cost nothing. The second finds each hold already answering today's
+# question and runs nothing.
+#
+# A pull request labelled `unblocks-main` is swept like any other. Its hold
+# passes while `main` is red, by design, so a sweep on the break path re-runs
+# it and it passes again. That is one wasted job on the repair pull request,
+# and the alternative is reading every pull request's labels to save it.
 #
 # ## Fails open, out loud
 #
@@ -61,25 +83,25 @@
 #
 # ## The drill (`#6051`)
 #
-# The lookup half of a sweep runs constantly — every recovery exercises it.
-# The re-run call itself only fires while a hold has actually failed, which
-# needs a real outage. So the one step that clears the block was the one step
-# with no live evidence: if the token lacked a scope, or the endpoint refused
-# a run of that age, nothing would say so until the next outage, the worst
-# moment to find out.
+# The lookup half of a sweep runs constantly. Every push to `main` exercises
+# it. The re-run call fires only while a hold disagrees with the tracker, and
+# that needs a real outage. So the one step that moves a check was the one
+# step with no live evidence. The token might lack a scope. The endpoint might
+# refuse a run of that age. Nothing would say so until the next outage, which
+# is the worst moment to find out.
 #
 # `--drill <pr>` rehearses that exact call on one named pull request's latest
-# hold run, whatever its conclusion. It never asks whether `main` is known
-# broken and never looks at any other pull request, so it is safe to run any
-# day: re-running a run that already passed still passes. A failure here —
-# a missing scope, a stale run id the API refuses — exits non-zero, on
-# purpose, unlike the rest of this script: the drill exists to surface that
-# failure now, not to fail open through it.
+# hold run, whatever its conclusion. It never asks the tracker anything and
+# never looks at any other pull request, so it is safe to run any day:
+# re-running a run that already passed still passes. A failure here — a
+# missing scope, a stale run id the API refuses — exits non-zero, on purpose,
+# unlike the rest of this script: the drill exists to surface that failure
+# now, not to fail open through it.
 #
 # Usage:
-#   scripts/clear-main-red-holds.sh
-#   scripts/clear-main-red-holds.sh --dry-run
-#   scripts/clear-main-red-holds.sh --drill <pr-number>
+#   scripts/refresh-main-red-holds.sh
+#   scripts/refresh-main-red-holds.sh --dry-run
+#   scripts/refresh-main-red-holds.sh --drill <pr-number>
 #
 # Needs `gh` and a POSIX shell, so it runs on a bare CI runner.
 set -uo pipefail
@@ -93,7 +115,7 @@ dry_run=0
 drill_pr=""
 fixture_open_issues=""
 fixture_open_prs=""
-fixture_stale_runs=""
+fixture_hold_runs=""
 fixture_drill_run=""
 use_fixture=0
 
@@ -105,12 +127,12 @@ while [ $# -gt 0 ]; do
     ;;
   --limit)
     [ $# -ge 2 ] || {
-      echo "clear-main-red-holds: --limit needs a number" >&2
+      echo "refresh-main-red-holds: --limit needs a number" >&2
       exit 2
     }
     limit="$2"
     case "$limit" in '' | *[!0-9]*)
-      echo "clear-main-red-holds: --limit takes a whole number" >&2
+      echo "refresh-main-red-holds: --limit takes a whole number" >&2
       exit 2
       ;;
     esac
@@ -118,12 +140,12 @@ while [ $# -gt 0 ]; do
     ;;
   --drill)
     [ $# -ge 2 ] || {
-      echo "clear-main-red-holds: --drill needs a pull request number" >&2
+      echo "refresh-main-red-holds: --drill needs a pull request number" >&2
       exit 2
     }
     drill_pr="$2"
     case "$drill_pr" in '' | *[!0-9]*)
-      echo "clear-main-red-holds: --drill takes a pull request number" >&2
+      echo "refresh-main-red-holds: --drill takes a pull request number" >&2
       exit 2
       ;;
     esac
@@ -133,12 +155,12 @@ while [ $# -gt 0 ]; do
   # are open, which run belongs to each head — so a case cannot half-reach
   # the network there. The write past that point still calls `gh`: a test
   # puts a stub `gh` ahead of the real one on `PATH`, so the mutation is
-  # exercised for real rather than assumed from "cleared N". That holds for
-  # the drill's own re-run too. Same read-side rule as the paired fixtures
-  # in `check-main-red-hold.sh`.
+  # exercised for real rather than assumed from a printed count. That holds
+  # for the drill's own re-run too. Same read-side rule as the paired
+  # fixtures in `check-main-red-hold.sh`.
   --fixture-open-issues)
     [ $# -ge 2 ] || {
-      echo "clear-main-red-holds: --fixture-open-issues needs a value" >&2
+      echo "refresh-main-red-holds: --fixture-open-issues needs a value" >&2
       exit 2
     }
     fixture_open_issues="$2"
@@ -147,25 +169,25 @@ while [ $# -gt 0 ]; do
     ;;
   --fixture-open-prs)
     [ $# -ge 2 ] || {
-      echo "clear-main-red-holds: --fixture-open-prs needs a value" >&2
+      echo "refresh-main-red-holds: --fixture-open-prs needs a value" >&2
       exit 2
     }
     fixture_open_prs="$2"
     use_fixture=1
     shift 2
     ;;
-  --fixture-stale-runs)
+  --fixture-hold-runs)
     [ $# -ge 2 ] || {
-      echo "clear-main-red-holds: --fixture-stale-runs needs a value" >&2
+      echo "refresh-main-red-holds: --fixture-hold-runs needs a value" >&2
       exit 2
     }
-    fixture_stale_runs="$2"
+    fixture_hold_runs="$2"
     use_fixture=1
     shift 2
     ;;
   --fixture-drill-run)
     [ $# -ge 2 ] || {
-      echo "clear-main-red-holds: --fixture-drill-run needs a value" >&2
+      echo "refresh-main-red-holds: --fixture-drill-run needs a value" >&2
       exit 2
     }
     fixture_drill_run="$2"
@@ -180,32 +202,32 @@ while [ $# -gt 0 ]; do
     exit 0
     ;;
   *)
-    echo "clear-main-red-holds: unknown argument '$1'" >&2
+    echo "refresh-main-red-holds: unknown argument '$1'" >&2
     exit 2
     ;;
   esac
 done
 
-note() { printf 'clear-main-red-holds: %s\n' "$*" >&2 || true; }
+note() { printf 'refresh-main-red-holds: %s\n' "$*" >&2 || true; }
 say() {
   # Ignore SIGPIPE and drop the write. A reader that closes the pipe must not
   # turn this into a failure — the `#1815` shape.
   trap '' PIPE
-  printf 'clear-main-red-holds: %s\n' "$*" || true
+  printf 'refresh-main-red-holds: %s\n' "$*" || true
 }
 
 if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
-  note "gh is not installed, so no hold could be cleared. A push to each"
-  note "branch still clears its own hold."
+  note "gh is not installed, so no hold could be refreshed. A push to each"
+  note "branch still refreshes its own hold."
   exit 0
 fi
 
 # ── The drill: rehearse the call on one named pull request (`#6051`) ────────
 #
-# Skips the "is main known-broken" question entirely — that question is what
-# makes the ordinary re-run untestable most days, and the drill exists to
-# rehearse the call without waiting for it to answer "yes". Never looks past
-# the one pull request it is given.
+# The drill asks the tracker nothing. That question is what makes the
+# ordinary re-run untestable most days. So the drill rehearses the call
+# without waiting for `main` to break. It never looks past the one pull
+# request it is given.
 
 if [ -n "$drill_pr" ]; then
   drill_head=""
@@ -255,17 +277,18 @@ if [ -n "$drill_pr" ]; then
   exit 1
 fi
 
-# ── Is main still known-broken? ──────────────────────────────────────────────
+# ── What should every hold be saying right now? ─────────────────────────────
 #
-# This one question decides whether there is anything to clear. While an issue
-# is open the holds are right, and they must stay red.
+# One question to the tracker, and it settles the whole sweep. While a
+# `main-red` issue is open the holds belong red; with none open they belong
+# green. Either way the sweep only touches a run that says the other thing.
 
 if [ "$use_fixture" -eq 1 ]; then
   open_issues="$fixture_open_issues"
 elif ! open_issues="$(gh issue list --label "$label" --state open \
   --limit 20 --json number --jq '.[].number' 2>/dev/null)"; then
-  note "could not reach the issue tracker, so this run could not ask whether"
-  note "main has recovered. Clearing nothing."
+  note "could not reach the issue tracker, so this run could not ask what the"
+  note "holds should be saying. Refreshing nothing."
   exit 0
 fi
 
@@ -273,11 +296,14 @@ open_issues="$(printf '%s' "$open_issues" | tr -d ' ' | tr '\n' ' ')"
 open_issues="${open_issues% }"
 
 if [ -n "$open_issues" ]; then
-  say "main is still known-broken ($open_issues) — the holds are correct."
-  exit 0
+  want="failure"
+  standing="main is known-broken ($open_issues)"
+else
+  want="success"
+  standing="main has recovered"
 fi
 
-# ── Run the hold again on every open pull request ────────────────────────────
+# ── Run the hold again wherever it disagrees ────────────────────────────────
 
 # `gh pr list --limit N` capped the sweep at one page and said nothing about
 # what it never looked at. `--paginate` follows the Link headers instead, so
@@ -287,7 +313,7 @@ if [ "$use_fixture" -eq 1 ]; then
 elif ! open_prs="$(gh api --paginate \
   "repos/{owner}/{repo}/pulls?state=open&per_page=100" \
   --jq '.[] | "\(.number) \(.head.sha)"' 2>/dev/null)"; then
-  note "could not list the open pull requests, so no hold was cleared."
+  note "could not list the open pull requests, so no hold was refreshed."
   exit 0
 fi
 
@@ -302,33 +328,37 @@ if [ "$limit" -gt 0 ]; then
   fi
 fi
 
-# `<state> <run id>` for the last hold run on one head. A re-run updates the
-# run in place, so `[0]` is that run and its conclusion is the verdict the
+# `<conclusion> <run id>` for the last hold run on one head. A re-run updates
+# the run in place, so `[0]` is that run and its conclusion is the verdict the
 # branch rules read.
 #
-#   failure <id>  the last run failed — a re-run is what clears it
-#   ok      -     the last run is not a failure; nothing to do
-#   none    -     no hold run on this head at all, so there is nothing to
-#                 re-run and the required check stays unreported
-#   unknown -     the API could not be read
+#   success <id>  The hold passed.
+#   failure <id>  The hold failed.
+#   running -     A run is under way. It reports today's answer by itself.
+#   none    -     No hold run on this head at all. Nothing to re-run, and the
+#                 required check stays unreported.
+#   unknown -     The API could not be read.
+#
+# Any other conclusion is neither verdict. `cancelled` and `timed_out` never
+# match what the sweep wants, so they get re-run. That is right. The branch
+# rules read those as not-passing too.
 hold_state() { # hold_state <head sha>
   local head="$1" answer rest total conclusion id
   if [ "$use_fixture" -eq 1 ]; then
-    # A fixture line is `<head> <run id>`, or `<head> ok` / `<head> none` for
-    # the two states that carry no run to name. A head the fixture does not
-    # mention is `none`, which is what "nothing is known about it" means.
-    answer="$(printf '%s\n' "$fixture_stale_runs" |
-      awk -v head="$head" '$1 == head { print $2; exit }')"
+    # A fixture line is `<head> <conclusion> <run id>`; the run id may be left
+    # off for a state that carries none. A head the fixture does not mention is
+    # `none`, which is what "nothing is known about it" means.
+    answer="$(printf '%s\n' "$fixture_hold_runs" |
+      awk -v head="$head" '$1 == head { print $2, ($3 == "" ? "-" : $3); exit }')"
     case "$answer" in
-    '' | none) printf 'none -' ;;
-    ok) printf 'ok -' ;;
-    *) printf 'failure %s' "$answer" ;;
+    '') printf 'none -' ;;
+    *) printf '%s' "$answer" ;;
     esac
     return 0
   fi
   if ! answer="$(gh api \
     "repos/{owner}/{repo}/actions/workflows/$workflow/runs?head_sha=$head&per_page=20" \
-    --jq '"\(.total_count) \(.workflow_runs[0].conclusion // "-") \(.workflow_runs[0].id // "-")"' \
+    --jq '"\(.total_count) \(.workflow_runs[0].conclusion // "running") \(.workflow_runs[0].id // "-")"' \
     2>/dev/null)" || [ -z "$answer" ]; then
     printf 'unknown -'
     return 0
@@ -339,14 +369,12 @@ hold_state() { # hold_state <head sha>
   id="${rest##* }"
   if [ "$total" = "0" ]; then
     printf 'none -'
-  elif [ "$conclusion" = "failure" ]; then
-    printf 'failure %s' "$id"
   else
-    printf 'ok -'
+    printf '%s %s' "$conclusion" "$id"
   fi
 }
 
-cleared=0
+refreshed=0
 seen=0
 unrun=""
 
@@ -365,28 +393,35 @@ while read -r pr head; do
     note "swept nor counted as needing a push."
     continue
     ;;
-  ok) continue ;;
+  running) continue ;;
+  "$want") continue ;;
   esac
   if [ "$dry_run" -eq 1 ]; then
     say "would re-run the hold on PR #$pr (head $head, run $run)"
-    cleared=$((cleared + 1))
+    refreshed=$((refreshed + 1))
     continue
   fi
+  # `rerun`, not `rerun-failed-jobs`, and one endpoint for both directions.
+  # On the break path the run being refreshed passed, so it has no failed job
+  # and `rerun-failed-jobs` would re-run nothing at all. On the recovery path
+  # the two are the same call, because `main-red-hold.yml` has one job. The
+  # drill has always used this endpoint for the same reason.
   if gh api -X POST --silent \
-    "repos/{owner}/{repo}/actions/runs/$run/rerun-failed-jobs" 2>/dev/null; then
+    "repos/{owner}/{repo}/actions/runs/$run/rerun" 2>/dev/null; then
     say "re-ran the hold on PR #$pr (head $head, run $run)"
-    cleared=$((cleared + 1))
+    refreshed=$((refreshed + 1))
   else
     # This needs `actions: write`. A job without it must say so, rather than
     # report a clean sweep it did not do.
     note "could not re-run run $run for PR #$pr — does this job have"
-    note "\`actions: write\`? That hold stays red until the branch is pushed."
+    note "\`actions: write\`? That hold keeps its old answer until the branch"
+    note "is pushed."
   fi
 done <<EOF
 $open_prs
 EOF
 
-say "main has recovered — cleared the hold on $cleared of $seen open pull request(s)."
+say "$standing — re-ran the stale hold on $refreshed of $seen open pull request(s)."
 
 if [ -n "$unrun" ]; then
   say "no $workflow run exists on the head of${unrun} — there is nothing to"

--- a/scripts/test-main-red-hold.sh
+++ b/scripts/test-main-red-hold.sh
@@ -2,7 +2,8 @@
 #
 # Hermetic tests for the two halves of the red-main hold.
 # `check-main-red-hold.sh` blocks a merge while `main` is broken.
-# `clear-main-red-holds.sh` clears those blocks once it is not.
+# `refresh-main-red-holds.sh` keeps that block matching the tracker after the
+# pull request has stopped raising events of its own.
 #
 #   ./scripts/test-main-red-hold.sh     (or: make main-red-hold-test)
 #
@@ -10,13 +11,14 @@
 # the same on a bare runner as on a dev box with a live tracker.
 #
 # The case that matters most is the negative control. A hold that cannot be
-# shown to *block* is a claim rather than a guard — and this one spends its
+# shown to *block* is a claim rather than a guard. And this one spends its
 # life passing, because main is usually green, so nothing else would ever
 # exercise the branch it exists for.
 #
-# The clearing half has the same gap. It is built for the moment `main` gets
-# fixed. Nothing else reaches that moment, since a green `main` leaves no
-# stale hold to clear.
+# The refreshing half has the same gap, twice over. It is built for the two
+# moments `main` changes state. Neither is reached on an ordinary day. So each
+# direction gets its own case, driven from fixtures: the stale failure a
+# recovery leaves behind, and the stale pass a break leaves behind.
 #
 # Not a `make gate` step, matching `main-canary-test`: the thing
 # under test is a CI-only guard that asks the issue tracker a question, and
@@ -27,7 +29,7 @@ set -uo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
 SCRIPT="$repo_root/scripts/check-main-red-hold.sh"
-CLEAR="$repo_root/scripts/clear-main-red-holds.sh"
+REFRESH="$repo_root/scripts/refresh-main-red-holds.sh"
 
 pass=0
 fail=0
@@ -101,15 +103,15 @@ if [ $? -eq 2 ]; then ok "a flag missing its value exits 2, not 0"; else bad "a 
 out="$("$SCRIPT" --nonsense 2>&1)"
 if [ $? -eq 2 ]; then ok "an unknown flag exits 2, not 0"; else bad "an unknown flag did not exit 2"; fi
 
-printf '\n\033[1mclearing — a recovered main un-blocks the pull requests it stopped\033[0m\n'
+printf '\n\033[1mrefreshing — the hold keeps up with a main that moved under it\033[0m\n'
 
 # A stub `gh`, ahead of the real one on `PATH` for the rest of this file.
-# `--fixture-*` stubs the reads (open issues, open PRs, which run belongs to
-# a head); the write past that point — the `-X POST .../rerun-failed-jobs`
-# call that is the point of the script — reaches this stub instead, so a
-# case exercises the mutation for real. It records the exact call in
-# `$gh_calls_log` and, when `GH_STUB_FAIL_MATCH` names a substring the call
-# contains, fails it the way a missing `actions: write` scope would.
+# `--fixture-*` stubs the reads: open issues, open PRs, and which run belongs
+# to a head. The write past that point is the `-X POST .../rerun` call this
+# script exists to make, and it reaches the stub instead. So a case exercises
+# the mutation for real. The stub records each call in `$gh_calls_log`. When
+# `GH_STUB_FAIL_MATCH` names a substring the call contains, it fails the call
+# the way a missing `actions: write` scope would.
 gh_stub_dir="$(mktemp -d)"
 trap 'rm -rf "$gh_stub_dir"' EXIT
 gh_calls_log="$gh_stub_dir/calls.log"
@@ -128,29 +130,30 @@ chmod +x "$gh_stub_dir/gh"
 export GH_STUB_CALLS_LOG="$gh_calls_log"
 export PATH="$gh_stub_dir:$PATH"
 
-# The stale-hold state, as fixtures. `main` is fixed, so no issue is open.
-# Three pull requests are open. Two still carry a failed hold on the head
-# they have now. That is the shape of 2026-09-05, when ten pull requests
-# were stuck on a check that would have passed.
+# The stale-hold state, as fixtures. Three pull requests are open, and each
+# one's hold last ran at some earlier moment. Two failed, one passed. Which of
+# those three answers is stale depends on what the tracker says now, so one
+# fixture table drives both directions.
 #
-# A fixture run line is `<head> <run id>` for a failed hold, `<head> ok` for a
-# hold that already passes, and `<head> none` for a head that carries no hold
-# run at all. Without the split those two are one state — an absent line — and
-# the sweep reads both as "nothing to do" (`#6052`).
-recovered_prs="5903 aaaaaaa
+# A fixture run line is `<head> <conclusion> <run id>`. The run id may be left
+# off for a state that carries none: `<head> none` is a head with no hold run
+# at all, and `<head> running` is one whose run has not finished. Without
+# those two spellings a missing line is one state, and the sweep reads it as
+# "nothing to do" (`#6052`).
+held_prs="5903 aaaaaaa
 5899 bbbbbbb
 5894 ccccccc"
-stale_runs="aaaaaaa 33951700124
-bbbbbbb ok
-ccccccc 33950666389"
+hold_runs="aaaaaaa failure 33951700124
+bbbbbbb success 33951700200
+ccccccc failure 33950666389"
 
 # Every case checks the exit code too. This script runs inside the canary. A
 # non-zero exit there would say `main` is broken when it builds.
-clear_says() { # clear_says <name> <want-substring> <issues> <prs> <runs>
+sweep_says() { # sweep_says <name> <want-substring> <issues> <prs> <runs>
   local name="$1" want_text="$2" issues="$3" prs="$4" runs="$5"
   local out rc
-  out="$("$CLEAR" --fixture-open-issues "$issues" --fixture-open-prs "$prs" \
-    --fixture-stale-runs "$runs" 2>&1)"
+  out="$("$REFRESH" --fixture-open-issues "$issues" --fixture-open-prs "$prs" \
+    --fixture-hold-runs "$runs" 2>&1)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
     bad "$name — expected exit 0 (fail-open), got $rc: $out"
@@ -162,81 +165,108 @@ clear_says() { # clear_says <name> <want-substring> <issues> <prs> <runs>
   esac
 }
 
-clear_lacks() { # clear_lacks <name> <unwanted-substring> <issues> <prs> <runs>
+sweep_lacks() { # sweep_lacks <name> <unwanted-substring> <issues> <prs> <runs>
   local name="$1" unwanted="$2" issues="$3" prs="$4" runs="$5"
   local out
-  out="$("$CLEAR" --fixture-open-issues "$issues" --fixture-open-prs "$prs" \
-    --fixture-stale-runs "$runs" 2>&1)"
+  out="$("$REFRESH" --fixture-open-issues "$issues" --fixture-open-prs "$prs" \
+    --fixture-hold-runs "$runs" 2>&1)"
   case "$out" in
   *"$unwanted"*) bad "$name — said '$unwanted' when it should not: $out" ;;
   *) ok "$name" ;;
   esac
 }
 
-# The witness. Before this fix, nothing ran the hold again. The failure from
-# the outage stayed the last word on that commit. The pull request could not
-# merge until someone pushed to it.
+# ── A recovered main un-blocks the pull requests it stopped (`#5913`) ────────
+#
+# Before that fix, nothing ran the hold again. The failure from the outage
+# stayed the last word on that commit. The pull request could not merge until
+# someone pushed to it.
 #
 # Each case names the run as well as the pull request. Running the wrong run
-# would still look like a sweep, and would clear nothing.
-clear_says "a recovered main re-runs the hold on the first stale PR" \
-  "5903 (head aaaaaaa, run 33951700124)" "" "$recovered_prs" "$stale_runs"
+# would still look like a sweep, and would move nothing.
+sweep_says "a recovered main re-runs the hold on the first stale PR" \
+  "5903 (head aaaaaaa, run 33951700124)" "" "$held_prs" "$hold_runs"
 
-clear_says "...and on every other PR still carrying a stale failure" \
-  "5894 (head ccccccc, run 33950666389)" "" "$recovered_prs" "$stale_runs"
+sweep_says "...and on every other PR still carrying a stale failure" \
+  "5894 (head ccccccc, run 33950666389)" "" "$held_prs" "$hold_runs"
 
 # A green hold is already the right answer. Running it again would spend a
 # job to change nothing.
-clear_lacks "a PR whose hold already passes is left alone" \
-  "5899" "" "$recovered_prs" "$stale_runs"
+sweep_lacks "a PR whose hold already passes is left alone" \
+  "5899" "" "$held_prs" "$hold_runs"
 
-clear_says "the summary counts what it swept" \
-  "cleared the hold on 2 of 3 open pull request" "" "$recovered_prs" "$stale_runs"
+sweep_says "the summary counts what it swept" \
+  "re-ran the stale hold on 2 of 3 open pull request" "" "$held_prs" "$hold_runs"
 
-# The negative control, and the worse direction. Clearing a hold while `main`
-# is still broken would drop the signal, not the leftovers.
-clear_says "an open main-red issue keeps every hold in place" \
-  "main is still known-broken (5901)" "5901" "$recovered_prs" "$stale_runs"
+# ── A broken main turns the passing holds red (`#5949`) ──────────────────────
+#
+# The other direction, and the one that lets a bad merge through rather than
+# blocking a good one. `#5928`'s hold ran at 09:41 and passed. The `main-red`
+# issue for that outage was filed at 10:07. Nothing re-ran the hold, so
+# `#5928` merged onto the broken tree with a 26-minute-old green as its
+# required check. PR 5899 below is that pull request: its hold passed, and
+# `main` is red now.
+sweep_says "a filed main-red issue re-runs the hold that still passes" \
+  "5899 (head bbbbbbb, run 33951700200)" "5901" "$held_prs" "$hold_runs"
 
-clear_lacks "...and re-runs nothing at all while it stands" \
-  "re-run the hold" "5901" "$recovered_prs" "$stale_runs"
+# The negative control for this direction. A sweep that read the tracker
+# backwards would clear the two failing holds — and those are the signal, not
+# a leftover.
+sweep_lacks "a hold that already fails is left alone while main is red" \
+  "5903 (head aaaaaaa" "5901" "$held_prs" "$hold_runs"
+
+sweep_lacks "...and the sweep never claims a recovery that has not happened" \
+  "main has recovered" "5901" "$held_prs" "$hold_runs"
+
+sweep_says "the summary names the issue that decided the sweep" \
+  "main is known-broken (5901) — re-ran the stale hold on 1 of 3" \
+  "5901" "$held_prs" "$hold_runs"
+
+# A run still in flight will report today's answer by itself. Re-running it
+# would cancel the run that is already asking the right question.
+running_runs="aaaaaaa running
+bbbbbbb success 33951700200
+ccccccc failure 33950666389"
+
+sweep_lacks "a hold still running is left to finish" \
+  "5903" "" "$held_prs" "$running_runs"
 
 # No open pull request is a state, not an error.
-clear_says "a repository with no open pull request says so and stops" \
-  "cleared the hold on 0 of 0 open pull request" "" "" ""
+sweep_says "a repository with no open pull request says so and stops" \
+  "re-ran the stale hold on 0 of 0 open pull request" "" "" ""
 
 # A head with no hold run at all. Nothing can be re-run, and `main is not
 # known-broken` is a required check, so that pull request stays unmergeable.
 # An unsplit sweep passes over it in silence and counts it as swept.
 unrun_prs="5903 aaaaaaa
 9 ddddddd"
-unrun_runs="aaaaaaa 33951700124
+unrun_runs="aaaaaaa failure 33951700124
 ddddddd none"
 
-clear_says "a head with no hold run at all is named" \
+sweep_says "a head with no hold run at all is named" \
   "no main-red-hold.yml run exists on the head of #9" "" "$unrun_prs" "$unrun_runs"
 
-clear_says "...and the reader is told a push is what starts one" \
+sweep_says "...and the reader is told a push is what starts one" \
   "until its branch is pushed" "" "$unrun_prs" "$unrun_runs"
 
-clear_says "...while the pull request that can be swept still is" \
+sweep_says "...while the pull request that can be swept still is" \
   "5903 (head aaaaaaa, run 33951700124)" "" "$unrun_prs" "$unrun_runs"
 
 # A hold that already passes is a different state, and must not be reported as
 # a branch needing a push.
-clear_lacks "a passing hold is not reported as a missing run" \
-  "no main-red-hold.yml run exists" "" "$recovered_prs" "$stale_runs"
+sweep_lacks "a passing hold is not reported as a missing run" \
+  "no main-red-hold.yml run exists" "" "$held_prs" "$hold_runs"
 
 # A silent cap makes a repository with more open pull requests than one page
 # read as a clean sweep of a list nothing ever saw the end of.
 capped_prs="1 aaaaaaa
 2 bbbbbbb
 3 ccccccc"
-capped_runs="aaaaaaa ok
-bbbbbbb ok
-ccccccc ok"
-out="$("$CLEAR" --limit 2 --fixture-open-issues "" --fixture-open-prs "$capped_prs" \
-  --fixture-stale-runs "$capped_runs" 2>&1)"
+capped_runs="aaaaaaa success 1
+bbbbbbb success 2
+ccccccc success 3"
+out="$("$REFRESH" --limit 2 --fixture-open-issues "" --fixture-open-prs "$capped_prs" \
+  --fixture-hold-runs "$capped_runs" 2>&1)"
 rc=$?
 if [ "$rc" -ne 0 ]; then
   bad "a cut-short list exited $rc: $out"
@@ -252,17 +282,17 @@ case "$out" in
 esac
 
 # The default is no cap at all, so nothing is silently left out.
-clear_says "with no --limit every open pull request is swept" \
+sweep_says "with no --limit every open pull request is swept" \
   "0 of 3 open pull request" "" "$capped_prs" "$capped_runs"
 
-out="$("$CLEAR" --limit 2>&1)"
-if [ $? -eq 2 ]; then ok "clearing: a flag missing its value exits 2, not 0"; else bad "clearing: a flag missing its value did not exit 2"; fi
+out="$("$REFRESH" --limit 2>&1)"
+if [ $? -eq 2 ]; then ok "sweeping: a flag missing its value exits 2, not 0"; else bad "sweeping: a flag missing its value did not exit 2"; fi
 
-out="$("$CLEAR" --limit banana 2>&1)"
-if [ $? -eq 2 ]; then ok "clearing: --limit given a word exits 2, not 0"; else bad "clearing: --limit given a word did not exit 2"; fi
+out="$("$REFRESH" --limit banana 2>&1)"
+if [ $? -eq 2 ]; then ok "sweeping: --limit given a word exits 2, not 0"; else bad "sweeping: --limit given a word did not exit 2"; fi
 
-out="$("$CLEAR" --nonsense 2>&1)"
-if [ $? -eq 2 ]; then ok "clearing: an unknown flag exits 2, not 0"; else bad "clearing: an unknown flag did not exit 2"; fi
+out="$("$REFRESH" --nonsense 2>&1)"
+if [ $? -eq 2 ]; then ok "sweeping: an unknown flag exits 2, not 0"; else bad "sweeping: an unknown flag did not exit 2"; fi
 
 printf '\n\033[1mthe write itself — the mutation, not the sweep'"'"'s account of it\033[0m\n'
 
@@ -272,34 +302,55 @@ printf '\n\033[1mthe write itself — the mutation, not the sweep'"'"'s account 
 # that never fires all turn this section red without changing a word the
 # sweep prints.
 : >"$gh_calls_log"
-"$CLEAR" --fixture-open-issues "" --fixture-open-prs "$recovered_prs" \
-  --fixture-stale-runs "$stale_runs" >/dev/null 2>&1
+"$REFRESH" --fixture-open-issues "" --fixture-open-prs "$held_prs" \
+  --fixture-hold-runs "$hold_runs" >/dev/null 2>&1
 calls="$(cat "$gh_calls_log")"
-want_calls="api -X POST --silent repos/{owner}/{repo}/actions/runs/33951700124/rerun-failed-jobs
-api -X POST --silent repos/{owner}/{repo}/actions/runs/33950666389/rerun-failed-jobs"
+want_calls="api -X POST --silent repos/{owner}/{repo}/actions/runs/33951700124/rerun
+api -X POST --silent repos/{owner}/{repo}/actions/runs/33950666389/rerun"
 if [ "$(printf '%s\n' "$calls" | sort)" = "$(printf '%s\n' "$want_calls" | sort)" ]; then
-  ok "the sweep POSTs the exact rerun-failed-jobs endpoint for each stale run, and only those"
+  ok "the sweep POSTs the exact rerun endpoint for each stale run, and only those"
 else
   bad "gh calls did not match — got [$calls] want [$want_calls]"
 fi
 
-# The PR whose hold already passes (5899, head bbbbbbb, "ok") has no run to
-# name, so the call log above already proves nothing was sent for it — the
-# comparison is exact, not a substring, so a spurious third call would have
-# failed it already. This case says so in a name the DoD checklist can point
-# at directly.
+# `rerun`, not `rerun-failed-jobs`, and the break direction is why. The run
+# being refreshed there passed, so it has no failed job and that endpoint
+# would re-run nothing. On this path the two are the same call, because
+# `main-red-hold.yml` has one job.
+case "$calls" in
+*rerun-failed-jobs*) bad "the sweep still calls rerun-failed-jobs: $calls" ;;
+*) ok "the endpoint is one that works in both directions" ;;
+esac
+
+# The PR whose hold already passes (5899, head bbbbbbb) is not stale on this
+# path. The call log above already proves nothing was sent for it: the
+# comparison is exact rather than a substring, so a spurious third call would
+# have failed it. This case says so in a name the checklist can point at.
 case "$calls" in
 *"5899"* | *"bbbbbbb"*) bad "the sweep called gh for a PR whose hold already passes: $calls" ;;
 *) ok "no POST is sent for a PR whose hold already passes" ;;
 esac
 
+# The same question the other way round: while `main` is red, the one POST
+# must be for the hold that still passes, and for nothing else.
+: >"$gh_calls_log"
+"$REFRESH" --fixture-open-issues "5901" --fixture-open-prs "$held_prs" \
+  --fixture-hold-runs "$hold_runs" >/dev/null 2>&1
+red_calls="$(cat "$gh_calls_log")"
+want_red="api -X POST --silent repos/{owner}/{repo}/actions/runs/33951700200/rerun"
+if [ "$red_calls" = "$want_red" ]; then
+  ok "a broken main POSTs exactly one rerun, for the hold that still passes"
+else
+  bad "gh calls did not match — got [$red_calls] want [$want_red]"
+fi
+
 # The write can fail — a job without `actions: write`, say. The sweep must
 # stay fail-open (exit 0), name the run it could not re-run rather than
 # claim it, and still credit the run that did succeed.
 : >"$gh_calls_log"
-out="$(GH_STUB_FAIL_MATCH="33951700124" "$CLEAR" \
-  --fixture-open-issues "" --fixture-open-prs "$recovered_prs" \
-  --fixture-stale-runs "$stale_runs" 2>&1)"
+out="$(GH_STUB_FAIL_MATCH="33951700124" "$REFRESH" \
+  --fixture-open-issues "" --fixture-open-prs "$held_prs" \
+  --fixture-hold-runs "$hold_runs" 2>&1)"
 rc=$?
 if [ "$rc" -ne 0 ]; then
   bad "a failed POST changed the exit code — expected 0 (fail-open), got $rc: $out"
@@ -307,7 +358,7 @@ else
   ok "a failed POST still exits 0"
 fi
 case "$out" in
-*"run 33951700124 for"*"5903 — does this job have"*) ok "a failed POST reports which run it could not clear" ;;
+*"run 33951700124 for"*"5903 — does this job have"*) ok "a failed POST reports which run it could not re-run" ;;
 *) bad "a failed POST gave no reason: $out" ;;
 esac
 case "$out" in
@@ -319,15 +370,15 @@ case "$out" in
 *) bad "a failed POST for one PR swallowed the successful one: $out" ;;
 esac
 case "$out" in
-*"cleared the hold on 1 of 3 open pull request"*) ok "the summary counts only what actually succeeded" ;;
+*"re-ran the stale hold on 1 of 3 open pull request"*) ok "the summary counts only what actually succeeded" ;;
 *) bad "the summary did not reflect the failed POST: $out" ;;
 esac
 
 # `--dry-run` is the one caller-facing way to suppress the write. With
 # fixtures active it must still block every call: none reaches `gh` at all.
 : >"$gh_calls_log"
-"$CLEAR" --dry-run --fixture-open-issues "" --fixture-open-prs "$recovered_prs" \
-  --fixture-stale-runs "$stale_runs" >/dev/null 2>&1
+"$REFRESH" --dry-run --fixture-open-issues "" --fixture-open-prs "$held_prs" \
+  --fixture-hold-runs "$hold_runs" >/dev/null 2>&1
 if [ -s "$gh_calls_log" ]; then
   bad "--dry-run still called gh: $(cat "$gh_calls_log")"
 else
@@ -346,8 +397,10 @@ holds_text() { # holds_text <name> <file> <pattern>
   fi
 }
 
-holds_text "the canary sweeps on the run that closes the issue" \
-  main-canary.yml "clear-main-red-holds.sh"
+# The canary is the caller for both transitions: the push run that files the
+# `main-red` issue is the same shape as the one that closes it.
+holds_text "the canary sweeps on the run that files or closes the issue" \
+  main-canary.yml "refresh-main-red-holds.sh"
 
 holds_text "...and holds the write scope that a re-run needs" \
   main-canary.yml "actions: write"
@@ -361,17 +414,31 @@ holds_text "the workflow carries a drill input to rehearse the re-run call" \
   main-red-clear.yml "drill:"
 
 holds_text "...and passes it to the script rather than running blind" \
-  main-red-clear.yml "clear-main-red-holds.sh --drill"
+  main-red-clear.yml "refresh-main-red-holds.sh --drill"
+
+# The sweep reads the tracker, so it has to run after the step that writes to
+# it. Reversed, a break path would sweep against the answer from before the
+# issue was filed and re-run nothing — which is the `#5949` bug with extra
+# machinery in front of it.
+canary="$repo_root/.github/workflows/main-canary.yml"
+announce_line="$(grep -n 'main-canary.sh --announce' "$canary" | head -1 | cut -d: -f1)"
+sweep_line="$(grep -n 'refresh-main-red-holds.sh' "$canary" | head -1 | cut -d: -f1)"
+if [ -n "$announce_line" ] && [ -n "$sweep_line" ] &&
+  [ "$announce_line" -lt "$sweep_line" ]; then
+  ok "the sweep runs after the step that files or closes the issue"
+else
+  bad "the canary sweeps before it writes the issue the sweep reads"
+fi
 
 printf '\n\033[1mdrilling — the re-run call is rehearsed without an outage\033[0m\n'
 
-# The drill never asks whether main is broken and never sweeps a second pull
-# request, so its own fixtures are a one-line PR/head table and a bare run id
-# — the ordinary sweep's issue and multi-PR fixtures play no part here.
+# The drill asks the tracker nothing, and it sweeps no second pull request.
+# So its fixtures are one PR/head line and a bare run id. The sweep's issue
+# and multi-PR fixtures play no part here.
 drill_says() { # drill_says <name> <want-substring> <expect-rc> <pr> <prs> <run>
   local name="$1" want_text="$2" expect_rc="$3" pr="$4" prs="$5" run="$6"
   local out rc
-  out="$("$CLEAR" --drill "$pr" --fixture-open-prs "$prs" \
+  out="$("$REFRESH" --drill "$pr" --fixture-open-prs "$prs" \
     --fixture-drill-run "$run" 2>&1)"
   rc=$?
   if [ "$rc" -ne "$expect_rc" ]; then
@@ -412,10 +479,10 @@ drill_says "an unknown pull request number fails loudly, not silently" \
   "could not find pull request" 1 \
   "9999" "$drill_prs" ""
 
-out="$("$CLEAR" --drill 2>&1)"
+out="$("$REFRESH" --drill 2>&1)"
 if [ $? -eq 2 ]; then ok "drilling: a flag missing its value exits 2, not 0"; else bad "drilling: a flag missing its value did not exit 2"; fi
 
-out="$("$CLEAR" --drill banana 2>&1)"
+out="$("$REFRESH" --drill banana 2>&1)"
 if [ $? -eq 2 ]; then ok "drilling: --drill given a word exits 2, not 0"; else bad "drilling: --drill given a word did not exit 2"; fi
 
 printf '\n'


### PR DESCRIPTION
## What & why

`main is not known-broken` is evaluated once, when the `pull_request` event fires. Branch protection then reads that answer for as long as the head stays put, and a pull request that is finished and waiting raises no further event. So the hold keeps answering a question about an earlier moment while `main` breaks and gets fixed underneath it.

`#5913` fixed the direction that costs a merge — the stale failure a recovery leaves behind. This is the direction that lets one through:

| fact | value |
|---|---|
| `#5928`'s `main is not known-broken` run | job `101285911129`, completed **09:41:22Z**, conclusion `success` |
| `#5939` (`main-red`) filed | **10:07:09Z** — 26 minutes later |
| `#5928` merged | `e4a137c`, during the red window, on that green |

Both directions are one bug, so this is one sweep rather than two. `scripts/clear-main-red-holds.sh` becomes `scripts/refresh-main-red-holds.sh` and asks the tracker what every hold *should* be saying — failing while a `main-red` issue is open, passing while none is — then re-runs the hold on each open pull request whose last run says the other thing. The new run lands under the same name on the same commit, which is all branch protection reads.

A second script for the break direction would be a second copy of that one question, free to drift from the first. The canary already calls the sweep and already carries `actions: write` (added for `#5913`), so the break path needs no wider permission and no second call site: the push run that files the issue is the same run that closes it.

The POST becomes `.../rerun` rather than `.../rerun-failed-jobs`, one endpoint for both directions. On the break path the run being refreshed *passed*, so it has no failed job and the old endpoint would re-run nothing at all. On the recovery path the two are the same call, because `main-red-hold.yml` has one job — and the drill added in `#6051` has always used this endpoint for that reason. A test case pins it in both directions.

Closes #5949

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The new cases live in `scripts/test-main-red-hold.sh` under "A broken main turns the passing holds red". Run before and after on the same scenario — one `main-red` issue open, three open pull requests, one of whose holds passed:

**Base** (`git show origin/main:scripts/clear-main-red-holds.sh`, its own fixture spelling):

```
$ /tmp/base-sweep.sh --dry-run --fixture-open-issues 5901 --fixture-open-prs '…' --fixture-stale-runs '…'
clear-main-red-holds: main is still known-broken (5901) — the holds are correct.
exit=0
```

Nothing re-run. That is `#5928`'s merge window, reproduced.

**This branch**, same scenario:

```
$ ./scripts/refresh-main-red-holds.sh --dry-run --fixture-open-issues 5901 …
refresh-main-red-holds: would re-run the hold on PR #5899 (head bbbbbbb, run 33951700200)
refresh-main-red-holds: main is known-broken (5901) — re-ran the stale hold on 1 of 3 open pull request(s).
```

The assertion that matters most is not the printed line but the call log. `#6364` put a stub `gh` ahead of the real one on `PATH` so the suite reaches the mutation; this PR adds the break-direction case to that section:

```
a broken main POSTs exactly one rerun, for the hold that still passes
  want: api -X POST --silent repos/{owner}/{repo}/actions/runs/33951700200/rerun
```

Negative controls for this direction: a hold that already fails is left alone while `main` is red, and the sweep never prints "main has recovered" while an issue stands. One further case is about wiring rather than the script — the sweep step in `main-canary.yml` must come *after* the step that files or closes the issue. Reversed, the break path would read the tracker's answer from before the issue existed and re-run nothing, which is this bug with more machinery in front of it.

`./scripts/test-main-red-hold.sh` reports **52 checks passed**.

## The gate

- [x] `cargo fmt --check` — via `make guards-fast`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — no Rust in this diff; CI runs it
- [ ] `cargo test --workspace` — no Rust in this diff; CI runs it
- [x] Docs updated where behavior changed — AGENTS.md § the seventh workflow, and the `Makefile` target
- [x] CLA signed
- [x] `Closes #5949` appears both above and as a commit trailer

`python3 scripts/check-prose.py` reports `OK — none added` and every touched file inside its reading-grade ceiling; `shellcheck` is clean on all three shell files.

## Fix over file

- [x] Extra fixes in this PR:
  - **A `cancelled` or `timed_out` hold was never swept.** The old predicate was "did the last run fail". Branch protection reads those two conclusions as not-passing as well, so they blocked a pull request exactly like a failure and no sweep touched them. The new predicate compares the conclusion against what the tracker says it should be, which covers them by construction.
  - **A run still in flight is now left alone.** The old sweep would have re-run one, cancelling a run that was already asking today's question.
  - **`scripts/dod-recheck.sh`'s two citations of the renamed script** are repointed, so its header does not name a file that no longer exists.
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

Not applicable — one workflow file, two shell scripts, a `Makefile` target and AGENTS.md. No crate, no interface, no dependency, no colour token.

## Anything reviewers should know?

The rename is what makes the design honest rather than cosmetic: a script that also turns holds red cannot keep a name that says "clear". `main-red-clear.yml` keeps its own name — it is still only the recovery caller, since it fires on the issue being closed or unlabelled.

A pull request labelled `unblocks-main` is swept like any other on the break path. Its hold passes by design, so it gets re-run and passes again — one wasted job on the repair pull request, against the cost of reading every pull request's labels to save it. The script's header says so.

This supersedes #6376, which was opened against an older `main`, went `CONFLICTING`, and therefore started no `pull_request` workflow at all. Rather than rebase a branch whose conflict was in the same two files `#6364` had just rewritten, the change was rebuilt on the current tip so nothing of `#6364`'s could be silently reverted — the hazard `rebase-replay` exists for.

## Summary by Sourcery

Refresh pull request hold checks whenever `main` changes state so branch protection always reflects the current red-main status.

Bug Fixes:
- Refresh stale `main is not known-broken` checks in both directions so pull requests cannot retain a passing hold after `main` breaks or a failing hold after it recovers.
- Handle cancelled, timed-out, and in-progress hold runs correctly by refreshing only completed runs whose conclusion disagrees with the current tracker state.

Enhancements:
- Replace the recovery-only hold sweep with a unified refresh operation that determines the expected hold result from the current `main-red` issue state.
- Use the workflow rerun endpoint for refreshing both passing and failing hold runs.
- Run the refresh after the canary files or closes the `main-red` issue and update manual recovery callers to use the renamed script.

Build:
- Rename the Makefile dry-run target to `refresh-main-red-holds` and update its description.

CI:
- Extend the hermetic hold tests to cover stale passes, stale failures, in-progress runs, exact rerun calls, and workflow step ordering.

Documentation:
- Update AGENTS.md to document hold staleness and refresh behavior in both directions.

Tests:
- Add witness coverage proving a broken main re-runs passing holds while leaving already-failing and in-progress holds untouched.

Chores:
- Rename `clear-main-red-holds.sh` to `refresh-main-red-holds.sh` and update related references.