### PR TITLE
feat(stella-cli): re-open a driver session after it asks to sleep

### DIFF
--- a/crates/stella-autonomy/README.md
+++ b/crates/stella-autonomy/README.md
@@ -80,6 +80,7 @@ the CLI does — so the dashboard and the terminal cannot disagree.
 |---|---|
 | [`src/lib.rs`](src/lib.rs) | The dedup digest, the `AimdLimits`/`Calibration`/`calibrate` controller, the `Lens`/`Tooling`/`LENSES` aperture ladder and `advance`, `CycleRecord`/`dry_streak`, the `Supply`/`Demand`/`Floors`/`CyclePlan`/`plan_cycle` governor, `Metrics`/`metrics`/`starved`, `QueueIssue` (ranked by `priority::triage` — see that module), and `Liveness`/`liveness`/`RunRow`/`fold_runs`. |
 | [`src/step.rs`](src/step.rs) | The top-level loop machine: `LoopState`/`LoopObservation`/`step`, the `Unblock` remedies for a broken base, and the `Blocked` reasons. |
+| [`src/drive.rs`](src/drive.rs) | The session sequencer: `next_session` says whether a driver plugin gets another session and after how long, given how the last one ended and what the whole run has spent. `stella plugin drive` is its host. |
 | [`src/deliver.rs`](src/deliver.rs) | The per-PR delivery machine: `PrState`/`Observation`/`deliver_next`, the fix/rebase ceilings, and the escalation reasons. |
 | [`src/doctrine.rs`](src/doctrine.rs) | The policy knobs a human sets: `Doctrine`, `ForeignBreakage`, contention policy and `contention_verdict`. |
 | [`src/priority.rs`](src/priority.rs) | `triage`: rank by the ladder the repo actually uses, with unassessed issues distinct from unrankable ones. |

--- a/crates/stella-autonomy/src/drive.rs
+++ b/crates/stella-autonomy/src/drive.rs
@@ -1,0 +1,435 @@
+//! Whether to open another driver session, and when.
+//!
+//! A driver plugin ends each session with one word. `sleep` asks to be woken
+//! again. `halt` says it is done. Something has to hear that and act on it, or
+//! a driver that asks for fifteen minutes waits for ever. This module is the
+//! part that decides; the host it runs in does the waiting.
+//!
+//! # A halt has to stop the run
+//!
+//! [`SessionEnding::Halt`] ends the sequence. It is read before any other
+//! rule. Money left and sessions left cannot outvote it.
+//!
+//! # The ceilings span the run
+//!
+//! A spend cap that reset each session would cap nothing. Ten sessions under
+//! a ten dollar cap would buy a hundred dollars. So [`RunSoFar`] carries what
+//! the whole run has spent, and [`DriveLimits::spend_cap`] is read against
+//! that total. [`DriveLimits::session_ceiling`] does the same for how many
+//! sessions a run may open.
+//!
+//! # No clock, no sleeping
+//!
+//! [`next_session`] returns the wait in seconds and never takes one. That is
+//! what lets a test drive a sequence of sessions in no time at all, and it is
+//! this crate's own rule: the decisions are pure and the host does the I/O.
+//! The wait it returns is already clamped to
+//! [`DriveLimits::max_sleep_secs`], so a driver cannot buy an unbounded
+//! absence by asking for one.
+
+use serde::{Deserialize, Serialize};
+
+/// How the session that just ended ended.
+///
+/// A local type rather than `stella_plugin::DriveNext`, for the reason the
+/// loop machine keeps its own [`IssueRef`](crate::IssueRef): this crate
+/// depends on no workspace crate, so the host maps. It also holds one case
+/// the wire type cannot — a session that failed before it said anything.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "ending")]
+pub enum SessionEnding {
+    /// The driver asked to be woken again after this many seconds.
+    Sleep {
+        /// What it asked for, before this module's ceiling is applied.
+        secs: u32,
+    },
+    /// The driver stopped, and said why.
+    Halt {
+        /// The sentence a human reads in the ledger.
+        reason: String,
+    },
+    /// The session never reached an answer: the process would not start, timed
+    /// out, died, or ended without saying what to do next.
+    Failed {
+        /// The host's own message, which already names the program.
+        message: String,
+    },
+}
+
+/// What bounds a run of sessions.
+///
+/// Every field is a ceiling. None of them is a floor: a driver that asks for
+/// less gets what it asked for.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct DriveLimits {
+    /// The whole run's spend ceiling in USD, or `None` to spend unbounded.
+    ///
+    /// `None` is the observed mode `--spend-limit` already describes: spend is
+    /// still summed so a run can report what it cost, and nothing is refused.
+    pub spend_cap: Option<f64>,
+    /// The longest wait this host will honour between sessions.
+    ///
+    /// The host clamps a driver's request at the socket already
+    /// (`stella_runtime::wrapper::MAX_SLEEP_SECS`). Naming it here as well is
+    /// what makes the ceiling a fact this function can be tested against
+    /// rather than one it has to trust its caller for.
+    pub max_sleep_secs: u32,
+    /// How many sessions one invocation may open, or `None` for as many as the
+    /// driver asks for.
+    pub session_ceiling: Option<u32>,
+}
+
+/// What the run has done so far.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+pub struct RunSoFar {
+    /// How many sessions this invocation has already opened, the one that just
+    /// ended included.
+    pub sessions: u32,
+    /// What those sessions have spent between them, in USD.
+    pub spent_usd: f64,
+}
+
+/// Why a run of sessions ended.
+///
+/// Typed because the reader of a finished run has three different next moves.
+/// The driver decided, the host failed, or a ceiling was met.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "stop")]
+pub enum StopReason {
+    /// The driver halted, and this is what it said.
+    Halted {
+        /// The driver's own reason, carried through to the ledger.
+        reason: String,
+    },
+    /// A session failed before it could say what to do next.
+    Failed {
+        /// The host's message.
+        message: String,
+    },
+    /// The run met its spend ceiling.
+    BudgetSpent {
+        /// The ceiling.
+        cap: f64,
+        /// What the run had spent when it was met.
+        spent: f64,
+    },
+    /// The run opened every session it was allowed.
+    SessionCeiling {
+        /// How many that was.
+        ceiling: u32,
+    },
+}
+
+/// The run's next move.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "drive")]
+pub enum DriveStep {
+    /// Open another session, after waiting this long.
+    Open {
+        /// Seconds to wait first, already clamped to the host's ceiling. Zero
+        /// means open the next one now.
+        after_secs: u32,
+    },
+    /// Stop the run, and say why.
+    Stop {
+        /// What ended it.
+        reason: StopReason,
+    },
+}
+
+/// Decide what to do after a session ends.
+///
+/// Total over its inputs, with no clock, no randomness and no I/O, so the same
+/// ending under the same run always yields the same move.
+///
+/// # Precedence
+///
+/// The order is the policy, so it is written down rather than read out of the
+/// body:
+///
+/// 1. **A halt ends the run.** Checked first, so nothing outvotes it.
+/// 2. **A failed session ends the run.** A driver that could not answer cannot
+///    be asked to answer again by the same host in the same way.
+/// 3. **The spend ceiling ends the run**, measured against everything the run
+///    has spent rather than against one session.
+/// 4. **The session ceiling ends the run.**
+/// 5. **A sleep re-opens**, after the wait it asked for or the host's ceiling,
+///    whichever is shorter.
+#[must_use]
+pub fn next_session(ending: &SessionEnding, run: &RunSoFar, limits: &DriveLimits) -> DriveStep {
+    // 1 and 2. What the session itself decided outranks every ceiling. A
+    // ceiling says the run may not continue; these say it is already over.
+    match ending {
+        SessionEnding::Halt { reason } => {
+            return DriveStep::Stop {
+                reason: StopReason::Halted {
+                    reason: reason.clone(),
+                },
+            };
+        }
+        SessionEnding::Failed { message } => {
+            return DriveStep::Stop {
+                reason: StopReason::Failed {
+                    message: message.clone(),
+                },
+            };
+        }
+        SessionEnding::Sleep { .. } => {}
+    }
+
+    // 3. The cap is against the run's total. Anything else caps nothing.
+    if let Some(cap) = limits.spend_cap
+        && run.spent_usd >= cap
+    {
+        return DriveStep::Stop {
+            reason: StopReason::BudgetSpent {
+                cap,
+                spent: run.spent_usd,
+            },
+        };
+    }
+
+    // 4. How many sessions one invocation is allowed to open.
+    if let Some(ceiling) = limits.session_ceiling
+        && run.sessions >= ceiling
+    {
+        return DriveStep::Stop {
+            reason: StopReason::SessionCeiling { ceiling },
+        };
+    }
+
+    // 5. The wait the driver asked for, under the host's ceiling.
+    let SessionEnding::Sleep { secs } = ending else {
+        unreachable!("the two other endings returned above");
+    };
+    DriveStep::Open {
+        after_secs: (*secs).min(limits.max_sleep_secs),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A day, the ceiling the driver socket already applies.
+    const DAY: u32 = 24 * 60 * 60;
+
+    fn limits() -> DriveLimits {
+        DriveLimits {
+            spend_cap: None,
+            max_sleep_secs: DAY,
+            session_ceiling: None,
+        }
+    }
+
+    fn after(sessions: u32, spent_usd: f64) -> RunSoFar {
+        RunSoFar {
+            sessions,
+            spent_usd,
+        }
+    }
+
+    /// **The witness.** Before this module nothing answered "open another
+    /// one?", so a driver that asked to sleep was never woken.
+    #[test]
+    fn a_sleep_asks_for_another_session_after_the_wait_it_named() {
+        assert_eq!(
+            next_session(
+                &SessionEnding::Sleep { secs: 900 },
+                &after(1, 0.0),
+                &limits()
+            ),
+            DriveStep::Open { after_secs: 900 }
+        );
+    }
+
+    /// A halt ends the sequence, and the driver's own words are what the run
+    /// reports — that is what reaches the ledger.
+    #[test]
+    fn a_halt_ends_the_run_and_keeps_its_reason() {
+        assert_eq!(
+            next_session(
+                &SessionEnding::Halt {
+                    reason: "backlog empty".into()
+                },
+                &after(1, 0.0),
+                &limits()
+            ),
+            DriveStep::Stop {
+                reason: StopReason::Halted {
+                    reason: "backlog empty".into()
+                }
+            }
+        );
+    }
+
+    /// Nothing outvotes a halt: money left and sessions left are both no
+    /// reason to open another one.
+    #[test]
+    fn a_halt_outranks_every_ceiling_that_would_allow_another_session() {
+        let generous = DriveLimits {
+            spend_cap: Some(100.0),
+            max_sleep_secs: DAY,
+            session_ceiling: Some(50),
+        };
+        assert!(matches!(
+            next_session(
+                &SessionEnding::Halt {
+                    reason: "done".into()
+                },
+                &after(1, 0.0),
+                &generous
+            ),
+            DriveStep::Stop {
+                reason: StopReason::Halted { .. }
+            }
+        ));
+    }
+
+    /// A session that never answered ends the run rather than being retried.
+    #[test]
+    fn a_failed_session_ends_the_run() {
+        assert_eq!(
+            next_session(
+                &SessionEnding::Failed {
+                    message: "driver \"watcher\" timed out".into()
+                },
+                &after(1, 0.0),
+                &limits()
+            ),
+            DriveStep::Stop {
+                reason: StopReason::Failed {
+                    message: "driver \"watcher\" timed out".into()
+                }
+            }
+        );
+    }
+
+    /// The cap is read against the run's total, so a sequence cannot spend
+    /// past it by spending a little at a time.
+    #[test]
+    fn the_spend_cap_is_measured_against_the_whole_run() {
+        let capped = DriveLimits {
+            spend_cap: Some(10.0),
+            ..limits()
+        };
+        let asleep = SessionEnding::Sleep { secs: 5 };
+
+        assert_eq!(
+            next_session(&asleep, &after(3, 9.5), &capped),
+            DriveStep::Open { after_secs: 5 },
+            "under the cap, the run continues"
+        );
+        assert_eq!(
+            next_session(&asleep, &after(4, 10.0), &capped),
+            DriveStep::Stop {
+                reason: StopReason::BudgetSpent {
+                    cap: 10.0,
+                    spent: 10.0
+                }
+            },
+            "at the cap, the run stops"
+        );
+    }
+
+    /// No cap is the observed mode: spend is summed and nothing is refused.
+    #[test]
+    fn an_uncapped_run_is_never_stopped_for_spending() {
+        assert_eq!(
+            next_session(
+                &SessionEnding::Sleep { secs: 1 },
+                &after(99, 1_000.0),
+                &limits()
+            ),
+            DriveStep::Open { after_secs: 1 }
+        );
+    }
+
+    /// An invocation opens as many sessions as it was allowed and no more.
+    #[test]
+    fn the_session_ceiling_ends_the_run() {
+        let two = DriveLimits {
+            session_ceiling: Some(2),
+            ..limits()
+        };
+        let asleep = SessionEnding::Sleep { secs: 30 };
+
+        assert_eq!(
+            next_session(&asleep, &after(1, 0.0), &two),
+            DriveStep::Open { after_secs: 30 }
+        );
+        assert_eq!(
+            next_session(&asleep, &after(2, 0.0), &two),
+            DriveStep::Stop {
+                reason: StopReason::SessionCeiling { ceiling: 2 }
+            }
+        );
+    }
+
+    /// The wait is a ceiling, never a floor. A decade is cut to the host's
+    /// bound; a minute is honoured as asked.
+    #[test]
+    fn a_long_wait_is_cut_to_the_hosts_ceiling_and_a_short_one_is_not() {
+        let decade = 10 * 365 * DAY;
+        assert_eq!(
+            next_session(
+                &SessionEnding::Sleep { secs: decade },
+                &after(1, 0.0),
+                &limits()
+            ),
+            DriveStep::Open { after_secs: DAY }
+        );
+        assert_eq!(
+            next_session(
+                &SessionEnding::Sleep { secs: 60 },
+                &after(1, 0.0),
+                &limits()
+            ),
+            DriveStep::Open { after_secs: 60 }
+        );
+    }
+
+    /// Serde-first: every type here crosses into `stella-cli`, so each one
+    /// round-trips byte for byte (AGENTS.md's rule 4).
+    #[test]
+    fn the_types_round_trip_through_json() {
+        let ending = SessionEnding::Halt {
+            reason: "budget spent".into(),
+        };
+        let json = serde_json::to_string(&ending).expect("serialize");
+        assert_eq!(
+            serde_json::from_str::<SessionEnding>(&json).expect("deserialize"),
+            ending
+        );
+
+        let step = DriveStep::Stop {
+            reason: StopReason::BudgetSpent {
+                cap: 30.0,
+                spent: 31.5,
+            },
+        };
+        let json = serde_json::to_string(&step).expect("serialize");
+        assert_eq!(
+            serde_json::from_str::<DriveStep>(&json).expect("deserialize"),
+            step
+        );
+
+        let run = after(4, 2.5);
+        let json = serde_json::to_string(&run).expect("serialize");
+        assert_eq!(
+            serde_json::from_str::<RunSoFar>(&json).expect("deserialize"),
+            run
+        );
+
+        let bounds = DriveLimits {
+            spend_cap: Some(30.0),
+            max_sleep_secs: DAY,
+            session_ceiling: Some(4),
+        };
+        let json = serde_json::to_string(&bounds).expect("serialize");
+        assert_eq!(
+            serde_json::from_str::<DriveLimits>(&json).expect("deserialize"),
+            bounds
+        );
+    }
+}

--- a/crates/stella-autonomy/src/lib.rs
+++ b/crates/stella-autonomy/src/lib.rs
@@ -58,6 +58,7 @@ mod convention;
 pub mod curate;
 mod deliver;
 mod doctrine;
+pub mod drive;
 pub mod escalation;
 pub mod gate;
 pub mod meta;

--- a/crates/stella-cli/src/driver_plugin.rs
+++ b/crates/stella-cli/src/driver_plugin.rs
@@ -33,11 +33,13 @@
 //! driver's own vocabulary and under the plugin's own name, so an operator sees
 //! exactly which asks this build could not serve and for whom.
 //!
-//! Scheduling is absent. One invocation opens one session and
-//! reports what the driver said to do next; who re-opens it after a
-//! [`DriveNext::Sleep`] is #3599's B2 `LoopStep` machine, and inventing a
-//! sleeper here would be inventing the loop this channel exists to be driven
-//! by.
+//! # What re-opens a session
+//!
+//! A driver that answers [`DriveNext::Sleep`] is asking to be woken again.
+//! [`sequence`] is what wakes it: it opens sessions one after another until
+//! the driver halts, a session fails, or the run meets a ceiling. The decision
+//! itself is `stella_autonomy::drive::next_session`, so this crate schedules
+//! and decides nothing.
 //!
 //! # Where a session goes once it ends
 //!
@@ -58,6 +60,7 @@ use crate::plugin_authz::PluginGates;
 use crate::plugin_cmd::roster::PluginRoster;
 
 pub(crate) mod capabilities;
+pub(crate) mod sequence;
 pub(crate) mod session_log;
 pub(crate) mod work;
 
@@ -65,7 +68,12 @@ pub(crate) mod work;
 ///
 /// `Debug` is safe to print: [`SubprocessDriver`]'s own is hand-written to
 /// name the environment variables it carries and never their values.
-#[derive(Debug)]
+///
+/// `Clone` because [`ResolvedDriver::serving`] consumes the value and one
+/// invocation now opens a sequence of sessions, each needing a gate of its
+/// own — a shared gate would give the second session the first one's spent
+/// call ceiling and the first one's refusals.
+#[derive(Debug, Clone)]
 pub(crate) struct ResolvedDriver {
     /// The manifest that declared it — the grant the gate is built from.
     manifest: PluginManifest,

--- a/crates/stella-cli/src/driver_plugin/sequence.rs
+++ b/crates/stella-cli/src/driver_plugin/sequence.rs
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! One driver session after another.
+//!
+//! A driver that answers `sleep` asks to be woken again. Nothing woke it
+//! before. `stella plugin drive` opened one session and returned. So a loop
+//! that could claim an issue and work it to a diff did that once and stopped.
+//!
+//! # Who decides, and who waits
+//!
+//! `stella_autonomy::drive::next_session` decides. This module opens the
+//! session, adds what it cost to the run, and does what that function says.
+//! The policy is written down once. Two hosts of this loop cannot disagree
+//! about it.
+//!
+//! # The port
+//!
+//! [`DriveHost`] is the seam. Starting a process, writing the ledger, waiting
+//! and printing all sit behind it. So a test drives many sessions with no
+//! subprocess and no clock. [`PluginDriveHost`] is the shipping side.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use stella_autonomy::drive::{DriveLimits, DriveStep, RunSoFar, SessionEnding, StopReason};
+use stella_plugin::DriveNext;
+
+use super::session_log::{DriverSessionOutcome, DriverSessionRecord};
+use crate::self_driving_cmd::budget::RunBudget;
+use crate::self_driving_cmd::config::LoopConfig;
+
+/// One session's ending, as the host saw it.
+pub(crate) struct SessionEnd {
+    /// What the driver said to do next, or why the session never said.
+    pub(crate) next: Result<DriveNext, String>,
+    /// Every ask this session could not serve, in order.
+    pub(crate) refusals: Vec<String>,
+}
+
+impl SessionEnd {
+    /// The ending in the vocabulary the decision function reads.
+    fn ending(&self) -> SessionEnding {
+        match &self.next {
+            Ok(DriveNext::Sleep { secs }) => SessionEnding::Sleep { secs: *secs },
+            Ok(DriveNext::Halt { reason }) => SessionEnding::Halt {
+                reason: reason.clone(),
+            },
+            Err(message) => SessionEnding::Failed {
+                message: message.clone(),
+            },
+        }
+    }
+}
+
+/// What a run of sessions needs from the host it runs in.
+pub(crate) trait DriveHost {
+    /// A session identifier the next session is opened under.
+    fn mint(&mut self) -> String;
+
+    /// Open one session and read back what the driver said.
+    fn open(&mut self, session: &str) -> SessionEnd;
+
+    /// Write the session down and say on screen how it ended.
+    fn settle(&mut self, session: &str, end: &SessionEnd);
+
+    /// What every session of this run has spent between them, in USD.
+    fn spent(&self) -> f64;
+
+    /// Wait before opening the next session.
+    fn wait(&mut self, secs: u32);
+}
+
+/// How a run of sessions ended, and how many it took.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RunEnd {
+    /// Why it stopped. A [`StopReason::Failed`] is the caller's error to
+    /// report; every other reason is an ordinary ending.
+    pub(crate) reason: StopReason,
+    /// How many sessions this invocation opened.
+    pub(crate) sessions: u32,
+}
+
+/// Open sessions until the driver stops asking for another one.
+pub(crate) fn run(host: &mut dyn DriveHost, limits: &DriveLimits) -> RunEnd {
+    let mut so_far = RunSoFar::default();
+    loop {
+        let session = host.mint();
+        let end = host.open(&session);
+        host.settle(&session, &end);
+
+        so_far.sessions = so_far.sessions.saturating_add(1);
+        so_far.spent_usd = host.spent();
+
+        match stella_autonomy::drive::next_session(&end.ending(), &so_far, limits) {
+            DriveStep::Stop { reason } => {
+                return RunEnd {
+                    reason,
+                    sessions: so_far.sessions,
+                };
+            }
+            DriveStep::Open { after_secs } => host.wait(after_secs),
+        }
+    }
+}
+
+/// The shipping host: a real plugin process per session, the real ledger, and
+/// a real wait.
+pub(crate) struct PluginDriveHost<'a> {
+    /// Where the ledger is written and where a work turn is cut.
+    workspace_root: &'a Path,
+    /// The installed plugin's manifest name.
+    plugin: &'a str,
+    /// The bound driver, re-served per session so each one gets a gate of its
+    /// own.
+    resolved: super::ResolvedDriver,
+    /// This workspace's own loop settings, for the work verbs.
+    config: LoopConfig,
+    /// The ceiling every session of this run shares.
+    budget: Arc<Mutex<RunBudget>>,
+    /// Whether the operator has already been told what this build serves. Said
+    /// once per run rather than once per session: it is a fact about the
+    /// build, and repeating it every fifteen minutes would bury the sessions.
+    announced: bool,
+}
+
+impl<'a> PluginDriveHost<'a> {
+    /// A host over one workspace and one installed driver.
+    pub(crate) fn new(
+        workspace_root: &'a Path,
+        plugin: &'a str,
+        resolved: super::ResolvedDriver,
+        config: LoopConfig,
+        budget: Arc<Mutex<RunBudget>>,
+    ) -> Self {
+        Self {
+            workspace_root,
+            plugin,
+            resolved,
+            config,
+            budget,
+            announced: false,
+        }
+    }
+
+    /// The program a record names.
+    fn program(&self) -> String {
+        self.resolved.program().to_string()
+    }
+
+    /// The capabilities one session is served through.
+    ///
+    /// Built per session because [`super::work::WorkSlot`] holds the one unit
+    /// a session may carry, and a slot shared between sessions would hand the
+    /// second one the first one's checkout. The budget behind it is shared,
+    /// which is the opposite choice for the opposite reason: a ceiling that
+    /// reset per session would cap nothing.
+    fn capabilities(&self) -> Box<dyn stella_runtime::wrapper::DriverCapabilities> {
+        Box::new(super::capabilities::HostDriverCapabilities::new(
+            self.plugin,
+            self.resolved.gates().cloned(),
+            Box::new(crate::issue_provider::GhIssueProvider::for_workspace(
+                self.workspace_root,
+            )),
+            self.config.clone(),
+            self.workspace_root.to_path_buf(),
+            super::work::WorkSlot::new(Box::new(super::work::SpawnedWorkRunner::new(
+                self.workspace_root.to_path_buf(),
+                self.config.clone(),
+                Arc::clone(&self.budget),
+            ))),
+        ))
+    }
+}
+
+impl DriveHost for PluginDriveHost<'_> {
+    fn mint(&mut self) -> String {
+        crate::plugin_cmd::session_id()
+    }
+
+    fn open(&mut self, session: &str) -> SessionEnd {
+        let bound = self.resolved.clone().serving(self.capabilities());
+        if !self.announced && bound.offers_calls() {
+            self.announced = true;
+            println!(
+                "  this build serves `backlog_next`, `backlog_claim`, `work_start`, \
+                 `work_status` and `work_abandon`; every other capability this run asks for \
+                 will be refused as unsupported"
+            );
+            if self
+                .budget
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .cap()
+                .is_none()
+            {
+                println!(
+                    "  no --spend-limit was given, so the turns this run asks for spend until \
+                     they finish"
+                );
+            }
+        }
+        let next = bound.open(session);
+        let refusals = bound.refusals();
+        SessionEnd { next, refusals }
+    }
+
+    fn settle(&mut self, session: &str, end: &SessionEnd) {
+        // Printed whichever way the session ended. A driver that asked for a
+        // capability and then failed is the case where the refusals matter
+        // most: they are usually why it failed.
+        for refusal in &end.refusals {
+            eprintln!("  ! {refusal}");
+        }
+        match &end.next {
+            Ok(DriveNext::Sleep { secs }) => {
+                println!("session {session} ended: sleep {secs}s before the next one");
+            }
+            Ok(DriveNext::Halt { reason }) => {
+                println!("session {session} ended: halt — {reason}");
+            }
+            Err(error) => eprintln!("session {session} ended: {error}"),
+        }
+        if let Err(error) = record(
+            self.workspace_root,
+            self.plugin,
+            session,
+            &self.program(),
+            end,
+        ) {
+            eprintln!("  ! {error}");
+        }
+    }
+
+    fn spent(&self) -> f64 {
+        self.budget
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .spent()
+    }
+
+    fn wait(&mut self, secs: u32) {
+        if secs == 0 {
+            return;
+        }
+        println!("  waiting {secs}s before the next session");
+        std::thread::sleep(Duration::from_secs(u64::from(secs)));
+    }
+}
+
+/// Append one session to the workspace's driver ledger.
+///
+/// A free function so a test host writes through the same call the shipping
+/// one does. A test then reads the ledger back off disk instead of asking a
+/// mock what it was told.
+pub(crate) fn record(
+    workspace_root: &Path,
+    plugin: &str,
+    session: &str,
+    program: &str,
+    end: &SessionEnd,
+) -> Result<(), String> {
+    super::session_log::record(
+        workspace_root,
+        &DriverSessionRecord {
+            at: crate::timefmt::rfc3339_utc_now(),
+            plugin: plugin.to_string(),
+            session_id: session.to_string(),
+            program: program.to_string(),
+            refusals: end.refusals.clone(),
+            outcome: DriverSessionOutcome::from_result(&end.next),
+        },
+    )
+}
+
+/// What a caller prints when the run is over.
+#[must_use]
+pub(crate) fn ending_line(reason: &StopReason, sessions: u32) -> String {
+    let plural = if sessions == 1 { "session" } else { "sessions" };
+    let opener = format!("run ended after {sessions} {plural}");
+    match reason {
+        StopReason::Halted { reason } => format!("{opener}: halt — {reason}"),
+        StopReason::Failed { message } => format!("{opener}: {message}"),
+        StopReason::BudgetSpent { cap, spent } => {
+            format!("{opener}: the run's ${cap:.2} spend limit is reached (${spent:.2} spent)")
+        }
+        StopReason::SessionCeiling { ceiling } => {
+            format!("{opener}: --max-sessions {ceiling} reached")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    /// A host that answers from a script and writes the real ledger.
+    ///
+    /// Everything a sequence can do is here: it opens sessions, records them
+    /// through `session_log`, charges what the script says each one spent, and
+    /// counts its waits instead of taking them.
+    struct ScriptedHost {
+        /// Where the ledger goes.
+        root: PathBuf,
+        /// What each session answers, in order. A run that asks for one more
+        /// than the script holds gets a halt saying so, which fails a test by
+        /// ending the run rather than by hanging it.
+        script: Vec<(SessionEnd, f64)>,
+        /// How many sessions have been opened.
+        opened: u32,
+        /// What the run has spent, folded in as each session ends.
+        spent: f64,
+        /// Every wait the sequence asked for, in seconds.
+        waits: Vec<u32>,
+    }
+
+    impl ScriptedHost {
+        fn new(root: PathBuf, script: Vec<(SessionEnd, f64)>) -> Self {
+            Self {
+                root,
+                script,
+                opened: 0,
+                spent: 0.0,
+                waits: Vec::new(),
+            }
+        }
+    }
+
+    impl DriveHost for ScriptedHost {
+        fn mint(&mut self) -> String {
+            format!("drive-test-{}", self.opened + 1)
+        }
+
+        fn open(&mut self, _session: &str) -> SessionEnd {
+            let index = self.opened as usize;
+            self.opened += 1;
+            if index >= self.script.len() {
+                return SessionEnd {
+                    next: Ok(DriveNext::Halt {
+                        reason: "the script ran out".into(),
+                    }),
+                    refusals: Vec::new(),
+                };
+            }
+            let (end, cost) = &self.script[index];
+            self.spent += cost;
+            SessionEnd {
+                next: end.next.clone(),
+                refusals: end.refusals.clone(),
+            }
+        }
+
+        fn settle(&mut self, session: &str, end: &SessionEnd) {
+            record(
+                &self.root,
+                "watcher",
+                session,
+                "/opt/pkgs/watcher/drive.sh",
+                end,
+            )
+            .expect("the ledger must be writable");
+        }
+
+        fn spent(&self) -> f64 {
+            self.spent
+        }
+
+        fn wait(&mut self, secs: u32) {
+            self.waits.push(secs);
+        }
+    }
+
+    fn temp_root(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "stella-driver-sequence-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp root");
+        root
+    }
+
+    fn sleeping(secs: u32) -> SessionEnd {
+        SessionEnd {
+            next: Ok(DriveNext::Sleep { secs }),
+            refusals: Vec::new(),
+        }
+    }
+
+    fn halting(reason: &str) -> SessionEnd {
+        SessionEnd {
+            next: Ok(DriveNext::Halt {
+                reason: reason.into(),
+            }),
+            refusals: Vec::new(),
+        }
+    }
+
+    fn limits() -> DriveLimits {
+        DriveLimits {
+            spend_cap: None,
+            max_sleep_secs: 24 * 60 * 60,
+            session_ceiling: None,
+        }
+    }
+
+    /// **The witness.** Before this module one invocation opened one session
+    /// and returned, so a driver that asked to sleep was never re-opened.
+    ///
+    /// Three sessions from one call: sleep, wake, sleep, wake, halt. The waits
+    /// are the ones the driver asked for, and the halt is what ends it.
+    #[test]
+    fn one_invocation_sleeps_reopens_and_stops_on_a_halt() {
+        let root = temp_root("sequence");
+        let mut host = ScriptedHost::new(
+            root.clone(),
+            vec![
+                (sleeping(900), 0.0),
+                (sleeping(30), 0.0),
+                (halting("backlog empty"), 0.0),
+            ],
+        );
+
+        let end = run(&mut host, &limits());
+
+        assert_eq!(host.opened, 3, "one invocation opened three sessions");
+        assert_eq!(
+            host.waits,
+            vec![900, 30],
+            "each sleep was honoured as asked"
+        );
+        assert_eq!(
+            end,
+            RunEnd {
+                reason: StopReason::Halted {
+                    reason: "backlog empty".into()
+                },
+                sessions: 3,
+            }
+        );
+    }
+
+    /// A halt reaches the ledger carrying its reason, and it is the last line
+    /// there: the sequence ended.
+    #[test]
+    fn a_halt_reaches_the_ledger_with_its_reason_and_ends_the_sequence() {
+        let root = temp_root("ledger");
+        let mut host = ScriptedHost::new(
+            root.clone(),
+            vec![(sleeping(5), 0.0), (halting("operator stop"), 0.0)],
+        );
+
+        run(&mut host, &limits());
+
+        let sessions = super::super::session_log::read_sessions(&root);
+        assert_eq!(sessions.len(), 2, "every session is written down");
+        assert_eq!(sessions[0].outcome, DriverSessionOutcome::Sleep { secs: 5 });
+        assert_eq!(
+            sessions[1].outcome,
+            DriverSessionOutcome::Halt {
+                reason: "operator stop".into()
+            },
+            "the halt's own reason is what the ledger holds"
+        );
+    }
+
+    /// The ceiling spans the run. Three sessions each spending four dollars
+    /// under a ten dollar cap stop at the third, not after each one is
+    /// separately under the cap.
+    #[test]
+    fn a_run_of_sessions_cannot_spend_past_the_cap() {
+        let root = temp_root("cap");
+        let mut host = ScriptedHost::new(
+            root,
+            vec![
+                (sleeping(1), 4.0),
+                (sleeping(1), 4.0),
+                (sleeping(1), 4.0),
+                (sleeping(1), 4.0),
+            ],
+        );
+
+        let end = run(
+            &mut host,
+            &DriveLimits {
+                spend_cap: Some(10.0),
+                ..limits()
+            },
+        );
+
+        assert_eq!(
+            host.opened, 3,
+            "the run stopped at the session that crossed the cap"
+        );
+        assert_eq!(
+            end.reason,
+            StopReason::BudgetSpent {
+                cap: 10.0,
+                spent: 12.0
+            }
+        );
+    }
+
+    /// A session that failed ends the run rather than being re-opened, and the
+    /// failure is still written down.
+    #[test]
+    fn a_failed_session_ends_the_run_and_is_still_recorded() {
+        let root = temp_root("failed");
+        let mut host = ScriptedHost::new(
+            root.clone(),
+            vec![(
+                SessionEnd {
+                    next: Err("driver \"watcher\" timed out".into()),
+                    refusals: vec!["plugin \"watcher\": backlog_file: unsupported".into()],
+                },
+                0.0,
+            )],
+        );
+
+        let end = run(&mut host, &limits());
+
+        assert_eq!(host.opened, 1);
+        assert!(matches!(end.reason, StopReason::Failed { .. }));
+        let sessions = super::super::session_log::read_sessions(&root);
+        assert_eq!(
+            sessions[0].outcome,
+            DriverSessionOutcome::Error {
+                message: "driver \"watcher\" timed out".into()
+            }
+        );
+        assert_eq!(
+            sessions[0].refusals,
+            vec!["plugin \"watcher\": backlog_file: unsupported".to_string()],
+            "a refused ask survives the session that made it"
+        );
+    }
+
+    /// `--max-sessions` bounds an invocation whose driver would sleep for ever.
+    #[test]
+    fn the_session_ceiling_stops_a_driver_that_never_halts() {
+        let root = temp_root("ceiling");
+        let mut host = ScriptedHost::new(
+            root,
+            vec![
+                (sleeping(1), 0.0),
+                (sleeping(1), 0.0),
+                (sleeping(1), 0.0),
+                (sleeping(1), 0.0),
+            ],
+        );
+
+        let end = run(
+            &mut host,
+            &DriveLimits {
+                session_ceiling: Some(2),
+                ..limits()
+            },
+        );
+
+        assert_eq!(host.opened, 2);
+        assert_eq!(end.reason, StopReason::SessionCeiling { ceiling: 2 });
+    }
+
+    /// Every ending says how many sessions it took and what stopped it.
+    #[test]
+    fn each_ending_names_itself_and_counts_the_sessions() {
+        assert_eq!(
+            ending_line(
+                &StopReason::Halted {
+                    reason: "done".into()
+                },
+                1
+            ),
+            "run ended after 1 session: halt — done"
+        );
+        assert_eq!(
+            ending_line(&StopReason::SessionCeiling { ceiling: 3 }, 3),
+            "run ended after 3 sessions: --max-sessions 3 reached"
+        );
+        assert_eq!(
+            ending_line(
+                &StopReason::BudgetSpent {
+                    cap: 10.0,
+                    spent: 12.0
+                },
+                2
+            ),
+            "run ended after 2 sessions: the run's $10.00 spend limit is reached ($12.00 spent)"
+        );
+        assert_eq!(
+            ending_line(
+                &StopReason::Failed {
+                    message: "timed out".into()
+                },
+                2
+            ),
+            "run ended after 2 sessions: timed out"
+        );
+    }
+}

--- a/crates/stella-cli/src/driver_plugin/session_log.rs
+++ b/crates/stella-cli/src/driver_plugin/session_log.rs
@@ -3,10 +3,11 @@
 
 //! Where a driver session's record goes.
 //!
-//! `stella plugin drive` opens one session and serves whatever the grant
+//! `stella plugin drive` opens a session and serves whatever the grant
 //! allows. Before this module, it printed the outcome and threw it away.
 //! The session id, every refused ask, and how the session ended were all
-//! gone once the terminal scrolled.
+//! gone once the terminal scrolled. One run opens many sessions
+//! ([`super::sequence`]). This file is where the whole run survives.
 //!
 //! # Which ledger, and why not the other two
 //!

--- a/crates/stella-cli/src/driver_plugin/work.rs
+++ b/crates/stella-cli/src/driver_plugin/work.rs
@@ -51,7 +51,7 @@
 //! here tests the code that ships.
 
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use stella_plugin::{HostCallFailure, HostCallRefusal, WorkReport, WorkState};
@@ -81,25 +81,31 @@ pub(crate) struct SpawnedWorkRunner {
     /// This workspace's own loop settings — the branch prefix, the commit
     /// signature, and which worker runs the turn.
     config: LoopConfig,
-    /// The session's ceiling, and what has gone against it.
+    /// The run's ceiling, and what has gone against it.
     ///
     /// Behind a lock. A driver may send two asks at once, and a budget that
     /// two turns both read as full is no budget. The lock is never held across
     /// an `await`: the value is copied out, spent, and put back.
-    budget: Mutex<RunBudget>,
+    ///
+    /// Shared rather than owned, because one invocation now opens a sequence
+    /// of sessions (`driver_plugin::sequence`) and each one builds a runner of
+    /// its own. A ceiling every session got a fresh copy of would cap one
+    /// session and nothing else, which is the cap `RunBudget`'s own header
+    /// says is no cap at all.
+    budget: Arc<Mutex<RunBudget>>,
 }
 
 impl SpawnedWorkRunner {
     /// A runner over one workspace, under `budget`.
-    pub(crate) fn new(root: PathBuf, config: LoopConfig, budget: RunBudget) -> Self {
+    pub(crate) fn new(root: PathBuf, config: LoopConfig, budget: Arc<Mutex<RunBudget>>) -> Self {
         Self {
             root,
             config,
-            budget: Mutex::new(budget),
+            budget,
         }
     }
 
-    /// The session's budget, as it stands.
+    /// The run's budget, as it stands.
     ///
     /// A poisoned lock is read through, not passed on. This is
     /// `DriverCallGate::refusals`'s rule. Losing the number because some other

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -128,15 +128,22 @@ pub enum PluginCmd {
         #[arg(value_name = "NAME")]
         name: String,
     },
-    /// Open one driver session against an installed plugin that declares
-    /// `[driver]`, and report what it says to do next.
+    /// Drive an installed plugin that declares `[driver]`: open a session,
+    /// re-open it whenever the driver asks to sleep, and stop when it halts.
     ///
-    /// One session per invocation: what re-opens it after a `sleep` is the
-    /// loop the driver is describing, not this verb (#3599 B2).
+    /// One invocation is the whole loop. It ends when the driver halts, when a
+    /// session fails, when `--spend-limit` is reached across every session, or
+    /// when `--max-sessions` is.
     Drive {
         /// The plugin's `name`, as `stella plugin list` prints it.
         #[arg(value_name = "NAME")]
         name: String,
+        /// Stop after this many sessions, however the driver ends them.
+        ///
+        /// The bound for a driver that always asks to sleep. Without it the run
+        /// ends only on a halt, a failure, or `--spend-limit`.
+        #[arg(long, value_name = "N")]
+        max_sessions: Option<u32>,
     },
 }
 
@@ -178,7 +185,12 @@ pub(crate) fn run_plugin(cmd: &PluginCmd, globals: &crate::cli::GlobalArgs) -> R
         // driver that asks for `work_start` spends the operator's provider
         // budget, and `--spend-limit` is what bounds it — the same flag, read
         // from the same place, as every other turn this binary runs.
-        PluginCmd::Drive { name } => drive(&root, name, TurnFlags::from_globals(globals)?),
+        PluginCmd::Drive { name, max_sessions } => drive(
+            &root,
+            name,
+            *max_sessions,
+            TurnFlags::from_globals(globals)?,
+        ),
     }
 }
 
@@ -187,7 +199,7 @@ pub(crate) fn run_plugin(cmd: &PluginCmd, globals: &crate::cli::GlobalArgs) -> R
 /// Minted the way `self_driving_cmd::state::new_run_id` mints a run id — a
 /// timestamp plus a salt off the clock's sub-second remainder and the process
 /// id — so two sessions started in the same second are still distinguishable.
-fn session_id() -> String {
+pub(crate) fn session_id() -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
@@ -195,113 +207,86 @@ fn session_id() -> String {
     format!("drive-{}-{salt:04x}", now.as_secs())
 }
 
-/// `stella plugin drive <name>` — open one driver session.
+/// `stella plugin drive <name>` — drive an installed plugin until it stops.
 ///
-/// The session's identifier is minted here and echoed into the driver's own
-/// telemetry, so a driver's records and the host's can be joined afterwards.
-/// Before this returns, the plugin, the refusals, and the ending are all
-/// written down through [`crate::driver_plugin::session_log::record`].
+/// One invocation opens a sequence of sessions: the driver ends each one with
+/// `sleep` or `halt`, and `stella_autonomy::drive::next_session` says whether
+/// another one follows and after how long.
+/// [`crate::driver_plugin::sequence`] does the opening, the waiting and the
+/// ledger; every session's identifier is minted here and echoed into the
+/// driver's own telemetry, so its records and the host's can be joined
+/// afterwards.
 ///
 /// `flags` is what a work turn inherits. A driver that asks for `work_start`
 /// spends the operator's provider budget, and `--spend-limit` is the ceiling
-/// on it. It is the session-wide flag, not one this verb defines: a second
-/// flag of that name would collide with the global clap propagates into every
-/// subcommand, which is what `no_subcommand_flag_reuses_a_global_name` refuses.
+/// on it — one ceiling for the whole run rather than one per session, which is
+/// what makes it a ceiling at all. It is the session-wide flag, not one this
+/// verb defines: a second flag of that name would collide with the global clap
+/// propagates into every subcommand, which is what
+/// `no_subcommand_flag_reuses_a_global_name` refuses. `max_sessions` is this
+/// verb's own bound, for a driver that would sleep for ever.
 ///
 /// # Errors
 ///
-/// Whatever [`crate::driver_plugin::bind_installed`] refuses, or the session's
+/// Whatever [`crate::driver_plugin::bind_installed`] refuses, or a session's
 /// own failure — a driver that could not be started, timed out, died, or ended
-/// without saying what should happen next.
-fn drive(workspace_root: &Path, name: &str, flags: TurnFlags) -> Result<(), String> {
+/// without saying what should happen next. A failure ends the run: the same
+/// host would meet it again the same way.
+fn drive(
+    workspace_root: &Path,
+    name: &str,
+    max_sessions: Option<u32>,
+    flags: TurnFlags,
+) -> Result<(), String> {
     let name = checked_name(name)?;
     let mut warn = |line: String| eprintln!("  ! {line}");
     let resolved = crate::driver_plugin::resolve(workspace_root, name, &mut warn)?;
-    // Saved now, before `serving()` consumes `resolved`: the record below
-    // needs it once the session has closed.
-    let program = resolved.program().to_string();
-    println!("driver \"{name}\": starting `{program}`");
+    println!("driver \"{name}\": starting `{}`", resolved.program());
 
-    let session = session_id();
-    // The capabilities are built here rather than inside the binder because
-    // this is where the workspace is: the tracker adapter and the loop's own
-    // configuration are both facts about the directory `stella` was run in.
+    // The capabilities are built per session rather than inside the binder
+    // because this is where the workspace is: the tracker adapter and the
+    // loop's own configuration are both facts about the directory `stella` was
+    // run in.
     let config = crate::self_driving_cmd::config::load(workspace_root);
     // The ceiling the operator named, narrowed per turn to what is left of it
-    // rather than handed down whole, which is `RunBudget`'s own rule.
-    let capped = flags.spend_limit.is_some();
-    let budget = crate::self_driving_cmd::budget::RunBudget::new(flags);
-    let capabilities = Box::new(
-        crate::driver_plugin::capabilities::HostDriverCapabilities::new(
-            name,
-            resolved.gates().cloned(),
-            Box::new(crate::issue_provider::GhIssueProvider::for_workspace(
-                workspace_root,
-            )),
-            config.clone(),
-            workspace_root.to_path_buf(),
-            crate::driver_plugin::work::WorkSlot::new(Box::new(
-                crate::driver_plugin::work::SpawnedWorkRunner::new(
-                    workspace_root.to_path_buf(),
-                    config,
-                    budget,
-                ),
-            )),
-        ),
-    );
-    let bound = resolved.serving(capabilities);
-    // Said before the session rather than inferred from the refusals after it,
-    // so an operator learns which asks will degrade from the host rather than
-    // from a driver's own halt message.
-    if bound.offers_calls() {
-        println!(
-            "  this build serves `backlog_next`, `backlog_claim`, `work_start`, `work_status` \
-             and `work_abandon`; every other capability this session asks for will be refused \
-             as unsupported"
-        );
-        if !capped {
-            println!(
-                "  no --spend-limit was given, so a turn this session asks for spends until it \
-                 finishes"
-            );
-        }
-    }
-    let next = bound.open(&session);
-    let refusals = bound.refusals();
+    // rather than handed down whole, which is `RunBudget`'s own rule. Shared
+    // across the run's sessions, so what an earlier one spent is gone from
+    // what a later one may.
+    let budget = std::sync::Arc::new(std::sync::Mutex::new(
+        crate::self_driving_cmd::budget::RunBudget::new(flags),
+    ));
+    let limits = stella_autonomy::drive::DriveLimits {
+        spend_cap: budget
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .cap(),
+        // The host's own clamp, so the wait honoured is the one the socket
+        // already reduced a greedy ask to.
+        max_sleep_secs: stella_runtime::wrapper::MAX_SLEEP_SECS,
+        session_ceiling: max_sessions,
+    };
 
-    // Printed whichever way the session ended. A driver that asked for a
-    // capability and then failed is the case where the refusals matter most:
-    // they are usually why it failed.
-    for refusal in &refusals {
-        eprintln!("  ! {refusal}");
-    }
-
-    // Written down whichever way the session ended. A write that fails is
-    // reported, but never fails the session — the same rule
-    // `self_driving_cmd::audit` uses for its own ledger.
-    if let Err(error) = crate::driver_plugin::session_log::record(
+    let mut host = crate::driver_plugin::sequence::PluginDriveHost::new(
         workspace_root,
-        &crate::driver_plugin::session_log::DriverSessionRecord {
-            at: crate::timefmt::rfc3339_utc_now(),
-            plugin: name.to_string(),
-            session_id: session.clone(),
-            program,
-            refusals,
-            outcome: crate::driver_plugin::session_log::DriverSessionOutcome::from_result(&next),
-        },
-    ) {
-        eprintln!("  ! {error}");
-    }
+        name,
+        resolved,
+        config,
+        std::sync::Arc::clone(&budget),
+    );
+    let end = crate::driver_plugin::sequence::run(&mut host, &limits);
 
-    match next? {
-        stella_plugin::DriveNext::Sleep { secs } => {
-            println!("session {session} ended: sleep {secs}s before the next one");
-        }
-        stella_plugin::DriveNext::Halt { reason } => {
-            println!("session {session} ended: halt — {reason}");
+    match end.reason {
+        // The one ending that is an error: a session the host could not carry
+        // to an answer. `sequence` has already printed and recorded it.
+        stella_autonomy::drive::StopReason::Failed { message } => Err(message),
+        reason => {
+            println!(
+                "{}",
+                crate::driver_plugin::sequence::ending_line(&reason, end.sessions)
+            );
+            Ok(())
         }
     }
-    Ok(())
 }
 
 /// The directory a tier installs into, or a reason it cannot be resolved.

--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -1193,11 +1193,15 @@ fn driving_manifest_text(name: &str) -> String {
 }
 
 /// A driver plugin that can actually run. `stella plugin drive` starts
-/// `drive.sh`, which reads the request and answers with a fixed `sleep`.
+/// `drive.sh`, which reads the request and answers with a `sleep` of
+/// `sleep_secs`.
 /// A plain shell script, not the `stella-runtime` fixture binary: that one
 /// belongs to another crate, so its `CARGO_BIN_EXE_*` is not visible here.
+///
+/// `sleep_secs` is a parameter because a run of sessions waits between them:
+/// a test that opens several passes zero, so it costs no wall clock.
 #[cfg(unix)]
-fn driving_package(dir: &Path, name: &str) -> PathBuf {
+fn driving_package(dir: &Path, name: &str, sleep_secs: u32) -> PathBuf {
     use std::os::unix::fs::PermissionsExt;
 
     let source = dir.join(format!("src-{name}"));
@@ -1210,9 +1214,11 @@ fn driving_package(dir: &Path, name: &str) -> PathBuf {
     let script = source.join("drive.sh");
     std::fs::write(
         &script,
-        "#!/bin/sh\n\
-         read -r _line\n\
-         printf '{\"point\":\"drive\",\"body\":{\"next\":{\"sleep\":{\"secs\":9}}}}\\n'\n",
+        format!(
+            "#!/bin/sh\n\
+             read -r _line\n\
+             printf '{{\"point\":\"drive\",\"body\":{{\"next\":{{\"sleep\":{{\"secs\":{sleep_secs}}}}}}}}}\\n'\n"
+        ),
     )
     .expect("fixture driver script");
     std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
@@ -1236,7 +1242,7 @@ fn a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended() 
     unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
 
     let root = temp_root("drive-record");
-    let source = driving_package(&root, "watcher");
+    let source = driving_package(&root, "watcher", 9);
     let settings = Settings::default();
     install(&root, &source, PluginScope::Project, true, &settings).expect("install must succeed");
 
@@ -1245,9 +1251,12 @@ fn a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended() 
         "nothing recorded before any session ran"
     );
 
-    // No ceiling and no routing: this fixture asks for no capability, so it
-    // spends nothing and there is nothing for a ceiling to bound.
-    drive(&root, "watcher", TurnFlags::default()).expect("a session that sleeps is not an error");
+    // One session, because this fixture never halts and the run would
+    // otherwise re-open it for as long as the test ran. No spend ceiling and
+    // no routing: it asks for no capability, so it spends nothing and there is
+    // nothing for a ceiling to bound.
+    drive(&root, "watcher", Some(1), TurnFlags::default())
+        .expect("a session that sleeps is not an error");
 
     let sessions = crate::driver_plugin::session_log::read_sessions(&root);
     assert_eq!(sessions.len(), 1, "{sessions:?}");
@@ -1263,6 +1272,50 @@ fn a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended() 
         entry.outcome,
         crate::driver_plugin::session_log::DriverSessionOutcome::Sleep { secs: 9 }
     );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// **The witness.** A driver that answers `sleep` is asking to be woken
+/// again, and `stella plugin drive` is what wakes it: one call opens a session
+/// per sleep until something stops the run.
+///
+/// One `drive` call against a real installed package, through the real
+/// transport, with a driver that only ever asks to sleep. Three records on
+/// disk is three sessions from one invocation, and each carries a session id
+/// of its own — which is what says three processes ran rather than one record
+/// being written three times.
+#[cfg(unix)]
+#[test]
+fn one_invocation_opens_a_session_for_each_sleep_the_driver_asks_for() {
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT"]);
+    // SAFETY: the env lock above is held for the whole mutate-read-restore
+    // window, and `EnvRestore` puts the prior value back on drop.
+    unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
+
+    let root = temp_root("drive-sequence");
+    // Zero seconds, so the run's waits cost the test nothing.
+    let source = driving_package(&root, "sleeper", 0);
+    let settings = Settings::default();
+    install(&root, &source, PluginScope::Project, true, &settings).expect("install must succeed");
+
+    drive(&root, "sleeper", Some(3), TurnFlags::default())
+        .expect("a run that reaches its session ceiling is not an error");
+
+    let sessions = crate::driver_plugin::session_log::read_sessions(&root);
+    assert_eq!(sessions.len(), 3, "{sessions:?}");
+    for entry in &sessions {
+        assert_eq!(
+            entry.outcome,
+            crate::driver_plugin::session_log::DriverSessionOutcome::Sleep { secs: 0 }
+        );
+    }
+    let ids: std::collections::BTreeSet<&str> = sessions
+        .iter()
+        .map(|entry| entry.session_id.as_str())
+        .collect();
+    assert_eq!(ids.len(), 3, "each session was opened under its own id");
 
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/stella-cli/src/tests.rs
+++ b/crates/stella-cli/src/tests.rs
@@ -573,8 +573,18 @@ fn plugin_drive_reads_the_session_wide_spend_limit() {
     assert_eq!(cli.globals.spend_limit, Some(25.0));
     match cli.command {
         Some(Command::Plugin {
-            cmd: plugin_cmd::PluginCmd::Drive { ref name },
-        }) => assert_eq!(name, "selfdriving"),
+            cmd:
+                plugin_cmd::PluginCmd::Drive {
+                    ref name,
+                    max_sessions,
+                },
+        }) => {
+            assert_eq!(name, "selfdriving");
+            assert_eq!(
+                max_sessions, None,
+                "the run is bounded by the spend limit alone unless --max-sessions is given"
+            );
+        }
         _ => panic!("expected the parse to bind `plugin drive selfdriving`"),
     }
 }

--- a/plugins/stella-selfdriving/README.md
+++ b/plugins/stella-selfdriving/README.md
@@ -10,7 +10,9 @@ stella plugin drive stella-selfdriving
 
 The install prints the whole grant and asks. With no terminal attached it
 prints the same text and refuses instead of assuming an answer. The drive
-opens one session against the program.
+opens a session against the program, re-opens it whenever the program asks to
+sleep, and stops when it halts — or when `--spend-limit` or `--max-sessions`
+is reached.
 
 ## What this is
 

--- a/plugins/stella-selfdriving/main.py
+++ b/plugins/stella-selfdriving/main.py
@@ -8,8 +8,9 @@ an SDK means the protocol is too hard. This file is the whole program.
 # What it is
 
 A driver, not a wrapper. It never runs inside a turn. It starts them. The host
-opens one session. This program says what a cycle should do, asks the host to
-do it, and says what should happen next:
+opens a session, and opens another one each time this program answers `sleep`.
+This program says what a cycle should do, asks the host to do it, and says what
+should happen next:
 
     host   {"point": "drive", "body": {"session": "cycle-7"}}
  -> plugin {"call": "backlog_next", "id": 1}

--- a/plugins/stella-selfdriving/plugin.toml
+++ b/plugins/stella-selfdriving/plugin.toml
@@ -7,8 +7,9 @@
 # would be true.
 #
 # Stella starts it. `[driver.process]` at the foot of this file names
-# `main.py`, and `stella plugin drive stella-selfdriving` opens one session
-# against it (#3783, #6063). The program asks for the capabilities listed in
+# `main.py`, and `stella plugin drive stella-selfdriving` opens a session
+# against it — and another one whenever the program asks to sleep, until it
+# halts (#3783, #6063). The program asks for the capabilities listed in
 # `[driver] calls` and gets exactly those; anything else comes back refused,
 # and Stella performs what it does serve as this plugin rather than as you.
 #

--- a/website/content/docs/commands/plugin.mdx
+++ b/website/content/docs/commands/plugin.mdx
@@ -15,7 +15,7 @@ stella plugin list
 stella plugin doctor
 stella plugin panel <name> [--allow|--deny]
 stella plugin remove <name>
-stella plugin drive <name>
+stella plugin drive <name> [--max-sessions N]
 ```
 
 ## What a plugin declares
@@ -183,7 +183,18 @@ Its hooks stop working right away. stella reads the full list of plugins from di
 stella plugin drive selfdriving
 ```
 
-Opens **one driver session** with an installed plugin that has a `[driver]` block. It prints what the plugin says to do next: either `sleep <n>s` or `halt — <reason>`.
+Drives an installed plugin that has a `[driver]` block. It opens a session, prints what the plugin says to do next, and acts on it: `sleep <n>s` waits that long and opens another session, and `halt — <reason>` ends the run. One command is the whole loop.
+
+A run ends four ways:
+
+| Ending | What happened |
+| --- | --- |
+| halt | The driver said it was done, and gave a reason. |
+| failure | A session could not be carried to an answer: the program would not start, timed out, or died. The command exits non-zero. |
+| spend limit | `--spend-limit` is reached. The cap covers every session of the run together, not one each. |
+| session limit | `--max-sessions N` is reached. Use it to bound a driver that only ever asks to sleep. |
+
+Every session is written to `.stella/private/driver-sessions.jsonl`, with its own id and how it ended, so a run you were not watching can be read back afterwards.
 
 A driver works differently from every other plugin type on this page. A `[loop]` plugin is asked for input during a turn that's already running. A driver has no turn to join, because its job is to start turns. Because of this, a driver has no participation grade; `participation = "none"` is the only value allowed. Its own permissions live in a separate block:
 
@@ -202,15 +213,15 @@ Drivers use `[driver.process]` instead of `[runtime]`, because these are two dif
 
 **A `[driver]` block with no `[driver.process]` is just a description, not a working program.** It shows what a driver like this would ask for, but stella doesn't start anything. The plugin `plugins/stella-selfdriving` works this way, and the install prompt tells you so directly.
 
-Every action a driver asks for is done **by stella itself**, not by the plugin. The plugin never holds its own API keys or tokens. Right now stella performs five of them: `backlog_next` reads the ranked defect queue, `backlog_claim` takes a lease on one issue, and `work_start` / `work_status` / `work_abandon` run one issue through a turn in a checkout of its own. Every other action returns `unsupported`, so a driver that asks for one is told no, and it explains why. More actions will work over time. Also note: running `stella plugin drive` only opens one session. Something else, the loop itself, is what reopens a session after it goes to sleep.
+Every action a driver asks for is done **by stella itself**, not by the plugin. The plugin never holds its own API keys or tokens. Right now stella performs five of them: `backlog_next` reads the ranked defect queue, `backlog_claim` takes a lease on one issue, and `work_start` / `work_status` / `work_abandon` run one issue through a turn in a checkout of its own. Every other action returns `unsupported`, so a driver that asks for one is told no, and it explains why. More actions will work over time.
 
 `work_start` spends money, so give it a ceiling:
 
 ```bash
-stella plugin drive selfdriving --spend-limit 25
+stella plugin drive selfdriving --spend-limit 25 --max-sessions 20
 ```
 
-`--spend-limit` is the session-wide flag, so it works before or after the command name. The number is the whole session's cap in US dollars, and each turn gets what is left of it. With no `--spend-limit`, spend is added up and reported and nothing is refused.
+`--spend-limit` is the session-wide flag, so it works before or after the command name. The number is the whole run's cap in US dollars — every session of it added together — and each turn gets what is left of it. When the cap is reached the run stops between sessions rather than in the middle of one. With no `--spend-limit`, spend is added up and reported and nothing is refused, which is when `--max-sessions` is the bound worth setting.
 
 ## Scopes
 


### PR DESCRIPTION
## What & why

`stella plugin drive` opened one session and returned. A driver that answered `{"next": {"sleep": {"secs": 900}}}` was asking to be woken in fifteen minutes, and nothing woke it. Now that `backlog_claim` and the three `work` verbs are served, that cost something real: one invocation took one issue, worked it to a diff, and stopped. A person had to run the command again for the next issue, which is what `scripts/self-driving.sh` exists to avoid.

Three pieces:

**`stella_autonomy::drive` — the decision.** `next_session(ending, run_so_far, limits)` says whether to open another session and after how long. Pure: no clock, no randomness, no I/O, so a test drives a sequence in no time at all and two hosts of the same loop cannot disagree about the policy. The precedence is written down in the function's own doc comment. A halt is read before every ceiling, so nothing outvotes it. The wait it returns is already clamped to `DriveLimits::max_sleep_secs`, which the CLI fills from `stella_runtime::wrapper::MAX_SLEEP_SECS` — the same ceiling the socket applies, named here so the function can be tested against it rather than trusting its caller. A new module rather than an addition to `lib.rs`, because `stella-autonomy` has no god files and must keep none.

**`driver_plugin::sequence` — the host.** It opens the session, adds what it cost to the run, and does what the decision says. `DriveHost` is the seam: starting a process, writing the ledger, waiting and printing all sit behind it, so the sequence tests use no subprocess and no clock. `PluginDriveHost` is the shipping side, and it re-serves the resolved driver per session so each one gets a fresh gate — a shared gate would hand the second session the first one's spent call ceiling and its refusals.

**The spend ceiling now spans the run.** `RunBudget` moved behind an `Arc<Mutex<_>>` shared by every session's `SpawnedWorkRunner`. A copy per session would have capped one session and nothing else, which is the defect `RunBudget`'s own header was written for, reached through a different door. `--max-sessions N` is the other bound, for a driver that only ever asks to sleep; without it a run ends only on a halt, a failure, or `--spend-limit`.

A halt reaches `.stella/private/driver-sessions.jsonl` with its reason, and so does every other session of the run — each with its own id, so a run nobody was watching reads back afterwards.

The exemplar for the port shape is this crate's own `driver_plugin::work::WorkRunner`: one trait, the side effects behind it, the shipping implementation and a scripted one for tests.

Closes #6283

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

Three, at three altitudes:

- `stella_autonomy::drive::tests::a_sleep_asks_for_another_session_after_the_wait_it_named` — the module did not exist, so nothing answered "open another one?".
- `driver_plugin::sequence::tests::one_invocation_sleeps_reopens_and_stops_on_a_halt` — one `run` call, three sessions, waits of 900s and 30s honoured as asked, halt ends it.
- `plugin_cmd::tests::one_invocation_opens_a_session_for_each_sleep_the_driver_asks_for` — the end-to-end one. One `drive` call against a real installed package, through the real transport, with a driver that only ever asks to sleep. It reads three records back off disk, each with its own session id.

**Proof the last one fails on the old behaviour**: with `sequence::run`'s `DriveStep::Open` arm replaced by an immediate return (one session per invocation, which is what `main` does), it fails `left: 1, right: 3`. Restored, it passes. Ran locally: `cargo test -p stella-cli --bins one_invocation_opens_a_session_for_each_sleep`.

Also covered: `a_halt_reaches_the_ledger_with_its_reason_and_ends_the_sequence`, `a_run_of_sessions_cannot_spend_past_the_cap` (four sessions at $4 under a $10 cap stop at the third), `a_failed_session_ends_the_run_and_is_still_recorded`, `the_session_ceiling_stops_a_driver_that_never_halts`.

## The gate

- [x] `cargo fmt --check` — via `make guards-fast`, green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — run scoped per CLAUDE.md ("CI builds and tests; this laptop does not"): `cargo clippy -p stella-autonomy --all-targets -- -D warnings` and the same for `stella-cli`, both clean. The workspace run is this PR's CI.
- [x] `cargo test --workspace` — again scoped: `cargo test -p stella-autonomy` (231 + 4 passed) and `cargo test -p stella-cli --bins` (3003 passed). Plus `make doc-warnings CARGO_SCOPE="-p stella-autonomy -p stella-cli"` under a clean target dir.
- [x] Docs updated where behavior/flags changed — `website/content/docs/commands/plugin.mdx` (synopsis, the four ways a run ends, `--spend-limit` now spanning the run), the `Drive` variant's clap help, `plugins/stella-selfdriving`'s README / `plugin.toml` / `main.py` headers, `crates/stella-autonomy/README.md`'s layout table, and `driver_plugin`'s own header, which used to say scheduling was absent.
- [x] CLA signed
- [x] `Closes #6283` appears both above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: the prose claims that said one invocation opens one session — in `driver_plugin`'s header, `session_log`'s header, `plugins/stella-selfdriving`'s README, `plugin.toml` and `main.py`, and the docs page. Stale comments are bugs here, and these were about to become stale in the same change.
- [x] Filed, with the reason a fix could not ride this PR: **nothing was deferred**

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] New cross-boundary types round-trip through serde (test included) — `drive::tests::the_types_round_trip_through_json` covers `SessionEnding`, `DriveStep`, `RunSoFar` and `DriveLimits`, every one of which crosses from `stella-autonomy` into `stella-cli`.

## Anything reviewers should know?

**`stella plugin drive` no longer returns after one session.** That is the change, and it is a behaviour change for anything scripting the verb. `--max-sessions 1` is the old behaviour exactly. The ways a run ends are the table in the docs page.

**A failed session ends the run rather than being retried.** The same host would meet the same failure the same way, and a driver that cannot start is not a driver that needs another try — retry policy for a transport fault would be a separate decision with its own evidence. The failure is still written to the ledger, and the command still exits non-zero.

**`session_ceiling` and `spend_cap` are checked after a session, never during one.** Invariant 6's boundary rule, one level up: a run is stopped between sessions so it never cuts a work turn down where it stands.

## Summary by Sourcery

Make `stella plugin drive` continue a driver run across sleep requests while enforcing run-wide limits and recording each session.

New Features:
- Re-open driver plugin sessions after sleep responses, allowing one `stella plugin drive` invocation to run a complete sequence until it halts or reaches a limit.
- Add `--max-sessions` to bound runs whose drivers continue requesting sleep.
- Persist every session and its ending in the driver session ledger with distinct session identifiers.

Bug Fixes:
- Ensure driver-requested sleep responses are acted on instead of leaving the driver dormant after the first session.
- Prevent spend limits from resetting between sessions by applying the budget across the entire run.

Enhancements:
- Separate pure session-sequencing policy from host-side process execution, waiting, output, and ledger effects.
- End runs deterministically on halts, failures, spend ceilings, or session ceilings, while clamping requested waits to the runtime maximum.
- Refresh per-session driver capabilities while sharing the run-wide spending budget.

Documentation:
- Update CLI, plugin, self-driving plugin, and autonomy documentation to describe multi-session driving, run endings, and the new session limit.

Tests:
- Add unit, sequence, ledger, CLI parsing, and end-to-end coverage for repeated sessions, waits, halts, failures, run-wide spending limits, and session ceilings.