### PR TITLE
fix(stella-cli): give a tool-outcome observation a per-occurrence source_ref

### DIFF
--- a/crates/stella-cli/src/memory/evidence.rs
+++ b/crates/stella-cli/src/memory/evidence.rs
@@ -53,10 +53,27 @@ fn bounded(text: &str) -> String {
 }
 
 /// Append an observation for one failed tool call.
+///
+/// `occurrence` is the failure's place among the failures of one execution.
+/// It makes the `source_ref` name *this* call rather than the tool, which is
+/// the shape [`ObservationRecord::source_ref`] documents.
+///
+/// The miner reads that field to find the observations behind a candidate
+/// ([`super::rules_mining::induce_rule_proposals`]). One reference per tool
+/// pointed all five of a tool's failures at one observation, so five tasks
+/// scored as one and the proposal never cleared the three-task floor.
+///
+/// Clustering does not read this field. Both miners cluster on the observation
+/// *text*, so repeated failures of one tool still land in one candidate.
+///
+/// The ordinal is stable: the failures of a finished execution come back in
+/// `seq` order. Replay needs that, because the record id is derived from the
+/// content this field is part of.
 pub(super) fn tool_outcome_observation(
     store: &ContextStore,
     tool: &str,
     error: &str,
+    occurrence: usize,
     task_id: &str,
     observed_at: &str,
 ) -> Option<AppendOutcome> {
@@ -64,12 +81,10 @@ pub(super) fn tool_outcome_observation(
         return None;
     }
     let text = format!("tool {tool} failed: {}", error.trim());
-    // Keyed on the tool, so repeated failures of the same tool cluster into one
-    // candidate rather than each becoming its own singleton.
     append(
         store,
         ObservationSource::ToolOutcome,
-        format!("tool:{tool}"),
+        format!("tool:{tool}#{occurrence}"),
         task_id,
         &text,
         observed_at,
@@ -80,7 +95,7 @@ pub(super) fn tool_outcome_observation(
 fn append(
     store: &ContextStore,
     source: ObservationSource,
-    candidate_id: String,
+    source_ref: String,
     task_id: &str,
     text: &str,
     observed_at: &str,
@@ -94,7 +109,7 @@ fn append(
     let redaction = redact_secrets(&bounded(text));
     let record = ObservationRecord::new(
         source,
-        candidate_id,
+        source_ref,
         task_id.to_string(),
         redaction.text,
         Vec::new(),

--- a/crates/stella-cli/src/memory/evidence/tests.rs
+++ b/crates/stella-cli/src/memory/evidence/tests.rs
@@ -27,7 +27,7 @@ fn observations(store: &ContextStore) -> Vec<ObservationRecord> {
 #[test]
 fn a_failed_tool_call_becomes_a_tool_outcome_observation() {
     let (_dir, store) = store();
-    let outcome = tool_outcome_observation(&store, "run_tests", "linker not found", "task1", AT);
+    let outcome = tool_outcome_observation(&store, "run_tests", "linker not found", 0, "task1", AT);
 
     assert_eq!(outcome, Some(AppendOutcome::Appended));
     let observations = observations(&store);
@@ -39,13 +39,14 @@ fn a_failed_tool_call_becomes_a_tool_outcome_observation() {
 #[test]
 fn repeated_failures_of_one_tool_cluster_under_one_candidate() {
     let (_dir, store) = store();
-    // Different tasks, same tool: the candidate id must be the tool so the
-    // miner sees recurrence rather than two unrelated singletons.
-    tool_outcome_observation(&store, "run_tests", "linker not found", "task1", AT);
+    // Different tasks, same tool. Clustering runs on the text, which is what
+    // both miners key on, so the two land in one candidate.
+    tool_outcome_observation(&store, "run_tests", "linker not found", 0, "task1", AT);
     tool_outcome_observation(
         &store,
         "run_tests",
         "linker not found",
+        0,
         "task2",
         "2026-07-27T00:00:00Z",
     );
@@ -53,8 +54,8 @@ fn repeated_failures_of_one_tool_cluster_under_one_candidate() {
     let observations = observations(&store);
     assert_eq!(observations.len(), 2);
     assert_eq!(
-        observations[0].source_ref, observations[1].source_ref,
-        "same tool must share a source ref so failures cluster"
+        observations[0].text, observations[1].text,
+        "the shared text is what clusters two failures into one candidate"
     );
     assert_ne!(
         observations[0].task_id, observations[1].task_id,
@@ -62,15 +63,46 @@ fn repeated_failures_of_one_tool_cluster_under_one_candidate() {
     );
 }
 
+/// A reference names the occurrence, so the miner can tell two failures apart.
+///
+/// Sharing one `tool:<name>` across every failure of a tool made
+/// `induce_rule_proposals` resolve five occurrences to the first observation it
+/// found, scoring one distinct task where there were five.
+#[test]
+fn two_failures_of_one_tool_carry_two_source_refs() {
+    let (_dir, store) = store();
+    tool_outcome_observation(&store, "run_tests", "linker not found", 0, "task1", AT);
+    tool_outcome_observation(&store, "run_tests", "linker not found", 1, "task1", AT);
+
+    let observations = observations(&store);
+    assert_eq!(observations.len(), 2);
+    assert_ne!(
+        observations[0].source_ref,
+        observations[1].source_ref,
+        "two failures are two references: {:?}",
+        observations
+            .iter()
+            .map(|o| o.source_ref.as_str())
+            .collect::<Vec<_>>()
+    );
+    for observation in &observations {
+        assert!(
+            observation.source_ref.starts_with("tool:run_tests#"),
+            "the shape ObservationRecord::source_ref documents: {}",
+            observation.source_ref
+        );
+    }
+}
+
 #[test]
 fn re_appending_the_same_evidence_is_a_replay() {
     let (_dir, store) = store();
     assert_eq!(
-        tool_outcome_observation(&store, "run_tests", "linker not found", "task1", AT),
+        tool_outcome_observation(&store, "run_tests", "linker not found", 0, "task1", AT),
         Some(AppendOutcome::Appended)
     );
     assert_eq!(
-        tool_outcome_observation(&store, "run_tests", "linker not found", "task1", AT),
+        tool_outcome_observation(&store, "run_tests", "linker not found", 0, "task1", AT),
         Some(AppendOutcome::AlreadyPresent),
         "content-derived ids must absorb a re-scan as a replay"
     );
@@ -86,6 +118,7 @@ fn a_secret_in_a_tool_error_is_redacted_before_it_is_stored() {
         &store,
         "shell",
         "curl failed: Authorization: Bearer sk-ant-api03-SECRETVALUE1234567890",
+        0,
         "task1",
         AT,
     );
@@ -104,7 +137,7 @@ fn a_secret_in_a_tool_error_is_redacted_before_it_is_stored() {
 fn an_unbounded_tool_error_is_truncated_visibly() {
     let (_dir, store) = store();
     let wall_of_text = "e".repeat(5_000);
-    tool_outcome_observation(&store, "build", &wall_of_text, "task1", AT);
+    tool_outcome_observation(&store, "build", &wall_of_text, 0, "task1", AT);
 
     let observations = observations(&store);
     let text = &observations[0].text;

--- a/crates/stella-cli/src/memory/replay/cc_adapter.rs
+++ b/crates/stella-cli/src/memory/replay/cc_adapter.rs
@@ -60,6 +60,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use stella_context::parse_rfc3339;
 use stella_learn::redact::redact_secrets;
 
 use super::trace::{
@@ -304,14 +305,12 @@ fn extract(line: &Line) -> Extracted {
 /// credential. Then, if the redaction *fired*, the command is dropped rather
 /// than emitted with a `[redacted]` hole in it.
 ///
-/// Dropping rather than keeping the redacted form is the conservative choice and
-/// costs almost nothing: a command that carried a credential is a one-off by
-/// nature (an `export`, a `curl` with a bearer token), so it was never going to
-/// be a recurring shape worth minting a tool from. What it *would* have done is
-/// put a partly-redacted credential context into a file, and the redactor's
-/// prefix list is a good filter rather than a complete one — a token shape it
-/// has not seen would survive. The foundry loses nothing; the gate keeps its
-/// margin.
+/// Dropping costs almost nothing. A command that carried a credential is a
+/// one-off by nature — an `export`, a `curl` with a bearer token — so it was
+/// never a recurring shape worth minting a tool from. Keeping it would put a
+/// partly-redacted credential into a file. The redactor's prefix list is a good
+/// filter, not a complete one, and a token shape it has not seen would survive.
+/// The foundry loses nothing; the gate keeps its margin.
 fn safe_command(command: &str) -> Option<String> {
     let trimmed = command.trim();
     if trimmed.is_empty() {
@@ -322,40 +321,6 @@ fn safe_command(command: &str) -> Option<String> {
         return None;
     }
     Some(redaction.text)
-}
-
-/// Parse an RFC-3339 timestamp to Unix seconds.
-///
-/// Hand-rolled to the exact shape Claude Code writes
-/// (`YYYY-MM-DDTHH:MM:SS[.mmm]Z`) rather than pulling in a date crate for one
-/// caller. Anything else returns `None` and the turn falls back to its
-/// neighbours' clamp — a wrong timestamp is worse than a missing one, because
-/// the trace's whole timeline is derived from these.
-fn parse_rfc3339(text: &str) -> Option<i64> {
-    let bytes = text.as_bytes();
-    if bytes.len() < 19 {
-        return None;
-    }
-    let num = |from: usize, to: usize| text.get(from..to)?.parse::<i64>().ok();
-    let (year, month, day) = (num(0, 4)?, num(5, 7)?, num(8, 10)?);
-    let (hour, minute, second) = (num(11, 13)?, num(14, 16)?, num(17, 19)?);
-    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
-        return None;
-    }
-    Some(days_from_civil(year, month, day) * 86_400 + hour * 3_600 + minute * 60 + second)
-}
-
-/// Days since 1970-01-01, by Howard Hinnant's `days_from_civil` — the exact
-/// inverse of the `civil_from_days` `stella-context`'s clock already uses, so
-/// the two agree at every boundary by construction rather than by testing.
-fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
-    let year = if month <= 2 { year - 1 } else { year };
-    let era = if year >= 0 { year } else { year - 399 } / 400;
-    let yoe = year - era * 400;
-    let mp = (month + 9) % 12;
-    let doy = (153 * mp + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    era * 146_097 + doe - 719_468
 }
 
 /// The environment variable that opts a local run in.

--- a/crates/stella-cli/src/memory/replay/cc_adapter/tests.rs
+++ b/crates/stella-cli/src/memory/replay/cc_adapter/tests.rs
@@ -233,8 +233,8 @@ fn a_backwards_timestamp_is_clamped_so_the_trace_still_loads() {
     );
 }
 
-/// The date arithmetic is the exact inverse of the one `stella-context`'s clock
-/// uses, so the two agree at every boundary by construction.
+/// The adapter reads a timestamp with the inverse of the formatter that wrote
+/// it. Both live in `stella-context`, so the two cannot drift apart.
 #[test]
 fn timestamps_round_trip_through_the_clocks_own_formatter() {
     for instant in [0i64, 1_600_000_000, 1_783_501_200, 1_582_934_400] {

--- a/crates/stella-cli/src/memory/rules_mining.rs
+++ b/crates/stella-cli/src/memory/rules_mining.rs
@@ -84,16 +84,19 @@ fn as_raw_observations(observations: &[ObservationRecord]) -> Vec<RawObservation
         .collect()
 }
 
-/// The `occurred_at` an observation was minted with, recovered from
-/// `source_ref` (`reflection:<unix secs>`) — the same recovery the skills path
-/// does, and for the same reason: this integer is quoted verbatim into the
-/// artifact's evidence lines.
+/// The instant an observation was minted, read from its `observed_at`.
+///
+/// [`ObservationRecord::source_ref`] is documented as an opaque back-reference,
+/// and one source spells it in a shape with no timestamp in it at all
+/// (`tool:<name>#<n>`), so parsing the reference recovers `0` for every
+/// tool-outcome observation and stamps the proposal at the epoch. `observed_at`
+/// is the field that carries the instant. A reflection observation is minted
+/// with `observed_at == format_rfc3339(occurred_at)`
+/// (`super::observations`'s `append_observation`), so this returns the same
+/// number for that source either way.
 fn occurred_at_of(observation: &ObservationRecord) -> u64 {
-    observation
-        .source_ref
-        .rsplit(':')
-        .next()
-        .and_then(|n| n.parse().ok())
+    stella_context::parse_rfc3339(&observation.observed_at)
+        .and_then(|secs| u64::try_from(secs).ok())
         .unwrap_or(0)
 }
 
@@ -131,11 +134,21 @@ pub(crate) fn induce_rule_proposals(
         // evidence grade is folded from them, and a grade cannot be folded
         // from an id (#2782).
         let mut supporting: Vec<&ObservationRecord> = Vec::new();
+        // Each evidence entry claims one observation and no other entry may
+        // claim it again. The miner emits one entry per occurrence in the
+        // cluster, so the counts line up — and a source that reuses a
+        // `source_ref` across occurrences then spreads over the observations
+        // behind it instead of collapsing onto the first match, which is what
+        // made five tool failures across five tasks score one distinct task.
+        let mut claimed = vec![false; observations.len()];
         for evidence in &candidate.evidence {
-            if let Some(observation) = observations.iter().find(|o| {
-                o.source_ref == evidence.reference
+            let matched = observations.iter().enumerate().find(|(index, o)| {
+                !claimed[*index]
+                    && o.source_ref == evidence.reference
                     && o.text.chars().take(160).collect::<String>() == evidence.snippet
-            }) {
+            });
+            if let Some((index, observation)) = matched {
+                claimed[index] = true;
                 tasks.insert(observation.task_id.as_str());
                 supporting.push(observation);
             }

--- a/crates/stella-cli/src/memory/rules_mining/tests.rs
+++ b/crates/stella-cli/src/memory/rules_mining/tests.rs
@@ -64,12 +64,12 @@ fn published_path(root: &Path, candidate: &RuleCandidate) -> std::path::PathBuf 
 
 /// A mined rule is prompt-only, whatever the miner inferred.
 ///
-/// The guard is stripped unconditionally rather than relying on the fact that
-/// reflection observations carry no files today: `infer_guard` only fires for
-/// `memory_kind == "gotcha"` with file evidence, so it currently returns `None`
-/// by accident of the input. A future observation source with files would start
-/// arming guards silently, which is why this asserts the *stripping*, by
-/// handing `without_inferred_guard` a candidate that definitely has one.
+/// The guard is stripped every time. Today it would be `None` anyway:
+/// `infer_guard` fires only for `memory_kind == "gotcha"` with file evidence,
+/// and reflection observations carry no files. That is an accident of the
+/// input. A later source with files would start arming guards in silence. So
+/// this asserts the *stripping*, by handing `without_inferred_guard` a
+/// candidate that definitely has one.
 #[test]
 fn an_inferred_rule_is_never_blocking() {
     let with_guard = RuleCandidate {
@@ -332,8 +332,8 @@ fn mined_rules_land_where_the_loader_reads() {
     published_path(dir.path(), &candidate);
 
     // The unfiltered loader keys raw files by filename, and a record file's
-    // name is its lineage — assert the lesson landed under it, which is the
-    // visibility the miner's own no-clobber dedup depends on.
+    // name is its lineage. Assert the lesson landed under it. That visibility
+    // is what the miner's own no-clobber dedup depends on.
     let loaded = crate::rules::load_workspace_rules_unfiltered(dir.path());
     assert!(
         loaded
@@ -495,5 +495,161 @@ fn a_rule_with_no_grade_at_all_is_refused_as_absent() {
     assert!(
         crate::rules::load_workspace_rules_unfiltered(dir.path()).is_empty(),
         "an ungraded rule reached the loader anyway"
+    );
+}
+
+// ---- GATE: measured evidence can actually reach the writer ----
+
+/// Seed one tool's failures across `tasks`, through the real constructor, and
+/// read back what the ledger holds.
+///
+/// The constructor rather than a hand-built record. The defect these tests
+/// cover is in the `source_ref` it writes, so a literal record would assert
+/// the fix against a fixture that already had it.
+fn tool_failures_across(store: &ContextStore, tasks: &[u64]) -> Vec<ObservationRecord> {
+    for task in tasks {
+        crate::memory::evidence::tool_outcome_observation(
+            store,
+            "run_tests",
+            "linker `cc` not found",
+            0,
+            &format!("task:{task}"),
+            &stella_context::format_rfc3339(*task as i64),
+        );
+    }
+    store
+        .records_of_kind(
+            stella_records::context_record::ContextRecordKind::Observation.as_str(),
+            100,
+        )
+        .expect("read the ledger")
+        .into_iter()
+        .filter_map(|row| serde_json::from_str(&row.body).ok())
+        .collect()
+}
+
+/// **The witness.** Five failures of one tool in five tasks are five tasks.
+///
+/// Induction finds a candidate's evidence through `source_ref`. Give every
+/// failure of one tool the same reference and all five entries match the first
+/// observation. Then `distinct_tasks` is 1, `is_eligible` refuses the proposal
+/// against the three-task floor, and the one grade that pays for a directive
+/// can never publish one.
+#[test]
+fn five_tool_failures_in_five_tasks_score_five_distinct_tasks() {
+    let (_dir, store) = store();
+    let observations = tool_failures_across(&store, &[100, 200, 300, 400, 500]);
+    assert_eq!(observations.len(), 5, "five occurrences reached the ledger");
+
+    let induced = induce_rule_proposals(&store, &observations, &[], &MineConfig::default());
+    assert_eq!(induced.len(), 1, "one tool, one candidate");
+    let proposal = &induced[0].proposal;
+
+    assert_eq!(
+        proposal.score.distinct_tasks, 5,
+        "five tasks scored as {}: {:?}",
+        proposal.score.distinct_tasks, proposal.score
+    );
+    assert_eq!(proposal.score.occurrences, 5);
+    assert!(proposal.is_eligible(3, 3), "{:?}", proposal.score);
+    assert_eq!(
+        proposal.supporting_observations.len(),
+        5,
+        "the pool is five records, not five copies of one"
+    );
+    assert_eq!(
+        proposal.provenance,
+        Some(ProvenanceGrade::EnvironmentObservation),
+        "a pool of tool outcomes folds to the grade a directive costs"
+    );
+}
+
+/// The evidence lines carry the instants the failures happened.
+///
+/// `occurred_at_of` read the numeric tail of `source_ref`, and
+/// `tool:<name>#<n>` has no timestamp in it, so every tool-outcome proposal was
+/// stamped at the Unix epoch.
+#[test]
+fn a_tool_outcome_proposal_is_stamped_at_the_instant_it_happened() {
+    let (_dir, store) = store();
+    let observations = tool_failures_across(&store, &[100, 200, 300, 400, 500]);
+    let induced = induce_rule_proposals(&store, &observations, &[], &MineConfig::default());
+
+    assert_eq!(
+        induced[0].proposal.observed_at,
+        stella_context::format_rfc3339(500),
+        "the newest occurrence is what stamps the proposal"
+    );
+    assert_eq!(
+        induced[0]
+            .candidate
+            .evidence
+            .iter()
+            .map(|e| e.occurred_at)
+            .collect::<std::collections::BTreeSet<_>>(),
+        [100, 200, 300, 400, 500].into_iter().collect(),
+        "every evidence line carries its own instant"
+    );
+}
+
+/// The door the evidence gate leaves open, opened: measured evidence publishes
+/// a rule where reflection prose is refused, both through the real induction.
+#[test]
+fn a_measured_proposal_publishes_a_rule_a_reflection_mined_one_cannot() {
+    let (_dir, store) = store();
+    let root = tempfile::tempdir().expect("workspace");
+
+    let observations = tool_failures_across(&store, &[100, 200, 300, 400, 500]);
+    let induced = induce_rule_proposals(&store, &observations, &[], &MineConfig::default());
+    let measured = &induced[0];
+    // The loop only offers an eligible proposal to the writer
+    // (`memory::learning`'s `induce_rules`), so a collapsed task count stops
+    // this path before the gate ever sees it.
+    assert!(
+        measured.proposal.is_eligible(3, 3),
+        "{:?}",
+        measured.proposal.score
+    );
+    assert!(matches!(
+        write_rule(
+            root.path(),
+            &measured.candidate,
+            measured.proposal.provenance,
+            PublicationAuthority::Agent,
+        )
+        .expect("publishable"),
+        RulePublication::Written(_)
+    ));
+
+    // The same five-task shape, mined from reflection prose. Spanning five
+    // tasks lifts the pool to `TrajectoryAbstraction`, and the lift caps
+    // there — so however often a lesson recurs it still cannot pay for a
+    // directive.
+    let prose = across_turns(LESSON, &[100, 200, 300, 400, 500]);
+    let induced = induce_rule_proposals(&store, &prose, &[], &MineConfig::default());
+    let critiqued = &induced[0];
+    assert_eq!(
+        critiqued.proposal.provenance,
+        Some(ProvenanceGrade::TrajectoryAbstraction)
+    );
+    assert_eq!(
+        write_rule(
+            root.path(),
+            &critiqued.candidate,
+            critiqued.proposal.provenance,
+            PublicationAuthority::Agent,
+        )
+        .expect("a refusal is an answer, not a failure"),
+        RulePublication::Refused(PromotionRefusal::EvidenceTooWeak {
+            impact: stella_protocol::provenance::ImpactClass::SteeringDirective,
+            required: ProvenanceGrade::EnvironmentObservation,
+            actual: ProvenanceGrade::TrajectoryAbstraction,
+        })
+    );
+
+    assert_eq!(
+        crate::rules::load_workspace_rules_unfiltered(root.path()).len(),
+        1,
+        "exactly the measured rule reached the loader"
     );
 }

--- a/crates/stella-cli/src/memory/uses.rs
+++ b/crates/stella-cli/src/memory/uses.rs
@@ -234,9 +234,14 @@ fn extract_one(store: &Store, context: &ContextStore, execution: &FinishedExecut
 
     // The third source. Declared in Phase 1, unwritten until now.
     if let Ok(failures) = store.failed_tool_calls_for_execution(execution.execution_id) {
-        for (tool, error) in &failures {
-            if super::evidence::tool_outcome_observation(context, tool, error, &task, &at)
-                == Some(AppendOutcome::Appended)
+        // The ordinal names the occurrence.
+        // `failed_tool_calls_for_execution` orders by `seq` over a finished
+        // execution. So a second pass over the same execution derives the same
+        // references, and the ledger takes it as a replay.
+        for (occurrence, (tool, error)) in failures.iter().enumerate() {
+            if super::evidence::tool_outcome_observation(
+                context, tool, error, occurrence, &task, &at,
+            ) == Some(AppendOutcome::Appended)
             {
                 appended += 1;
             }

--- a/crates/stella-context/src/clock.rs
+++ b/crates/stella-context/src/clock.rs
@@ -120,6 +120,46 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
     (year, month, day)
 }
 
+/// Parse an RFC-3339 UTC timestamp back to Unix seconds — [`format_rfc3339`]
+/// inverted.
+///
+/// Reads the shape this module writes (`YYYY-MM-DDTHH:MM:SSZ`). It also reads
+/// the `…:SS.mmmZ` form other producers write, and drops the fraction.
+///
+/// Anything else is `None`. A time with an offset such as `+02:00` is one of
+/// those. Callers sort records by this number, so a missing answer costs less
+/// than a wrong one.
+pub fn parse_rfc3339(text: &str) -> Option<i64> {
+    if !text.is_char_boundary(19) {
+        return None;
+    }
+    let num = |from: usize, to: usize| text.get(from..to)?.parse::<i64>().ok();
+    let (year, month, day) = (num(0, 4)?, num(5, 7)?, num(8, 10)?);
+    let (hour, minute, second) = (num(11, 13)?, num(14, 16)?, num(17, 19)?);
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    // A leap second renders as :60 and is a real instant to accept; anything
+    // past these is not a time.
+    if hour > 23 || minute > 59 || second > 60 {
+        return None;
+    }
+    Some(days_from_civil(year, month, day) * 86_400 + hour * 3_600 + minute * 60 + second)
+}
+
+/// Days since 1970-01-01 for a civil date — Howard Hinnant's
+/// `days_from_civil`. It is the exact inverse of [`civil_from_days`], so the
+/// two agree at every month, year and era edge.
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let year = if month <= 2 { year - 1 } else { year };
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let yoe = year - era * 400;
+    let mp = (month + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -165,6 +205,46 @@ mod tests {
         assert_eq!(clock.now_unix_secs(), 1_060);
         clock.set(42);
         assert_eq!(clock.now_rfc3339(), format_rfc3339(42));
+    }
+
+    #[test]
+    fn every_rendered_instant_parses_back_to_itself() {
+        for instant in [
+            0i64,
+            -1,
+            1_582_934_399,
+            1_582_934_400,
+            1_600_000_000,
+            1_783_501_200,
+        ] {
+            let rendered = format_rfc3339(instant);
+            assert_eq!(
+                parse_rfc3339(&rendered),
+                Some(instant),
+                "{rendered} did not round trip"
+            );
+        }
+    }
+
+    #[test]
+    fn a_fractional_second_parses_to_its_whole_second() {
+        assert_eq!(
+            parse_rfc3339("2020-09-13T12:26:40.123Z"),
+            Some(1_600_000_000)
+        );
+    }
+
+    #[test]
+    fn text_that_is_not_a_timestamp_is_refused_rather_than_guessed() {
+        assert_eq!(parse_rfc3339("not a timestamp"), None);
+        assert_eq!(parse_rfc3339("2026-13-01T00:00:00Z"), None);
+        assert_eq!(parse_rfc3339("2026-01-32T00:00:00Z"), None);
+        assert_eq!(parse_rfc3339("2026-01-01T24:00:00Z"), None);
+        assert_eq!(parse_rfc3339(""), None);
+        // Shorter than a time field, so the byte slice would run off the end.
+        assert_eq!(parse_rfc3339("2026-01-01T00:00:0"), None);
+        // A multi-byte character straddling the seconds field must not panic.
+        assert_eq!(parse_rfc3339("2026-01-01T00:00:é"), None);
     }
 
     #[test]

--- a/crates/stella-context/src/lib.rs
+++ b/crates/stella-context/src/lib.rs
@@ -70,7 +70,7 @@ mod warm;
 mod writeback;
 
 pub use ann::{AnnIndexPolicy, AnnIndexReport, AnnIndexState};
-pub use clock::{Clock, FixedClock, SystemClock, format_rfc3339};
+pub use clock::{Clock, FixedClock, SystemClock, format_rfc3339, parse_rfc3339};
 pub use embed::{
     EmbedError, Embedder, EmbedderFingerprint, Embedding, HashEmbedder, SimilarityPosture,
 };


### PR DESCRIPTION
## What & why

A tool outcome is the only observation source that grades
`ProvenanceGrade::EnvironmentObservation` (`stella-records`'s
`observation_grade`), and that is the grade a steering directive costs. PR
#5894 wired the evidence gate into rule publication, so this is now the only
evidence that can publish a mined rule at all.

It could not get there. `memory/evidence.rs`'s `tool_outcome_observation`
wrote `tool:<name>` as the `source_ref` — one value per tool, not one per
occurrence — and `memory/rules_mining.rs`'s `induce_rule_proposals` resolves a
candidate's evidence back to observations through that field with `find`. Five
failures of one tool across five tasks share one reference and one text, so all
five evidence entries resolved to the **same** observation: `distinct_tasks`
scored 1, `ProposalRecord::is_eligible` refused it against the three-task
floor, and the door the gate leaves open never opened.

`tool_outcome_observation` now takes the failure's ordinal within its
execution and writes `tool:<name>#<n>` — the shape `ObservationRecord`'s own
doc comment already documented, and which the code contradicted. The ordinal
is stable: `Store::failed_tool_calls_for_execution` returns a finished
execution's failures in `seq` order, so a re-scan derives the same references
and the ledger absorbs it as a replay (`re_appending_the_same_evidence_is_a_replay`
still passes).

Clustering is untouched — both miners cluster on the observation *text*
(`stella_learn::mining::cluster_observations`), never on this field — so
repeated failures of one tool still land in one candidate.

Closes #5897

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-cli/src/memory/rules_mining/tests.rs`:

- `five_tool_failures_in_five_tasks_score_five_distinct_tasks` — seeds five
  `ToolOutcome` observations across five `task_id`s **through the real
  constructor**, reads them back from the ledger, and asserts
  `distinct_tasks == 5`, five supporting observations, and a folded grade of
  `EnvironmentObservation`.
- `a_tool_outcome_proposal_is_stamped_at_the_instant_it_happened` — the
  proposal carries the newest occurrence's instant, and every evidence line
  carries its own.
- `a_measured_proposal_publishes_a_rule_a_reflection_mined_one_cannot` — the
  end-to-end case: the measured proposal is eligible and `write_rule` writes
  it; a reflection-mined proposal over the same five-task shape folds to
  `TrajectoryAbstraction` (the lift caps there) and is refused. One rule
  reaches the loader.

**Measured against the old behaviour, not asserted.** I restored the three old
lines (`format!("tool:{tool}")`, the `source_ref`-tail `occurred_at_of`, the
unclaimed `find`) and ran the same tests:

```
five_tool_failures_in_five_tasks_score_five_distinct_tasks ... FAILED
  left: 1   right: 5
a_tool_outcome_proposal_is_stamped_at_the_instant_it_happened ... FAILED
  left: "1970-01-01T00:00:00Z"   right: "1970-01-01T00:08:20Z"
```

`crates/stella-cli/src/memory/evidence/tests.rs` adds
`two_failures_of_one_tool_carry_two_source_refs`, which pins the shape at the
producer.

## Extra fixes in this PR

Both were found while checking whether the admitted grade is reachable end to
end, and neither could be left behind without the first fix being incomplete.

1. **`occurred_at_of` stamped every tool-outcome proposal at the Unix epoch.**
   It parsed the numeric tail of `source_ref`, and `tool:<name>#<n>` has no
   timestamp in it — `ObservationRecord::source_ref` is documented as *opaque*,
   so reading a timestamp out of it was never sound. It reads `observed_at`
   now, which is the field that carries the instant. A reflection observation
   is minted with `observed_at == format_rfc3339(occurred_at)`
   (`memory/observations.rs`'s `append_observation`), so the number for that
   source is unchanged and no skill or rule file on disk moves a byte.

2. **The back-resolution collapsed duplicate references.** Each evidence entry
   now claims one observation and no other entry may claim it again, so a
   source that reuses a reference across occurrences spreads over the
   observations behind it rather than folding onto the first match. This is
   issue #5897's point 3.

## New shared code, and a duplicate deleted

`stella_context::parse_rfc3339` is new — the inverse of the `format_rfc3339`
in the same module, which is what wrote every `observed_at` this reads. It is
covered by a round-trip test over the instants `format_rfc3339`'s own tests
use, plus the refusal cases (a bad month, a bad day, hour 24, a string too
short, a multi-byte character straddling the seconds field).

`memory/replay/cc_adapter.rs` carried a private `parse_rfc3339` and its own
`days_from_civil`, whose doc comment already said it was "the exact inverse of
the `civil_from_days` `stella-context`'s clock already uses". Both are deleted
and the adapter takes the shared one, so that claim is now structural rather
than a comment. No test was deleted:
`timestamps_round_trip_through_the_clocks_own_formatter` still runs, against
the shared function.

No new dependency.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings`, and the same
      for `stella-context` (the workspace build is CI's job — CLAUDE.md, "CI
      builds and tests; this laptop does not")
- [x] `cargo test -p stella-cli memory::` — 367 passed, 0 failed
- [x] `cargo test -p stella-context` — 188 passed, 0 failed
- [x] `make guards-fast` green, `python3 scripts/check-prose.py` green (the
      reading-grade ratchet fired on six files this diff touches; the prose was
      shortened rather than baselined)
- [x] `make doc-warnings CARGO_SCOPE="-p stella-cli"` and the same for
      `stella-context`
- [x] Doc comments updated where behaviour changed — `tool_outcome_observation`,
      `occurred_at_of`, and the `evidence.rs` comment that said the reference was
      "keyed on the tool" so failures cluster, which was never how clustering
      worked
- [x] `Closes #5897` appears above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: the epoch timestamp and the collapsing
      back-resolution, both named above
- [x] Nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary type

## Anything reviewers should know?

**The skills miner shares the collapse and is fixed by the same change.**
`memory/proposals.rs`'s `induce_proposals` resolves evidence through
`source_ref` with the same `find`, over the same observation pool
(`memory/learning.rs`'s `auto_create_skills_typed` hands both miners one
list). Distinct references fix it there too. I did not add the claim-once loop
to that copy — the collapse it guards against no longer has a producer, and
that file's `occurred_at_of` carries a byte-stability constraint about skill
files already on disk that this PR has no reason to touch.

**One test's assertion is inverted, deliberately.**
`repeated_failures_of_one_tool_cluster_under_one_candidate` asserted that two
failures of one tool *share* a `source_ref`, "so failures cluster". That was
never true of clustering, which reads the text. It keeps its name and now
asserts the shared text, which is the thing that actually makes them one
candidate.

## Summary by Sourcery

Preserve distinct tool-failure evidence through mining so eligible environment-observation proposals can publish rules.

Bug Fixes:
- Give each failed tool-call observation a stable per-occurrence source reference so repeated failures across tasks retain distinct evidence and can satisfy rule-publication thresholds.
- Preserve observation and evidence timestamps by deriving proposal times from observed_at instead of opaque source references.
- Prevent duplicate evidence references from resolving repeatedly to the same observation.

Enhancements:
- Share RFC-3339 parsing between stella-context and the Claude Code replay adapter, removing duplicate timestamp logic.

Documentation:
- Update documentation and tests to reflect occurrence-based source references and text-based clustering.

Tests:
- Add producer and end-to-end witness coverage for distinct task scoring, timestamp propagation, measured rule publication, and weaker reflection-based proposals.