### PR TITLE
ci: ask the merged-lock question in both directions, and again when main moves

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -51,13 +51,20 @@ name: auto-tag
 # reporting success. It stays only as a fallback for a repository that still
 # grants a bypass.
 #
-# Nothing required asks whether the branch and main compose, because `strict`
-# is off and every check runs on the branch rather than on the merge result. So
-# the last step re-asks the lockfile question against the MERGE RESULT before
-# merging: `Cargo.lock` is a shared cell, and a sync branch cut before a new
-# crate landed composes into a lock that resolves for neither side (#3336).
+# `Cargo.lock` is a shared cell, and a sync branch cut before a new crate
+# landed composes into a lock that resolves for neither side (#3336). Every
+# check on the branch ran when the branch last changed, and `strict` is off, so
+# main can move after that and nothing makes the branch catch up. The last step
+# re-asks the lockfile question against the MERGE RESULT before merging.
 # scripts/sync-versions.sh asks the same question about its own output at both
 # call sites, so the tag cannot carry an unresolvable lock either.
+#
+# That covers this workflow's own branch merging into main. The same collision
+# lands from the other direction, and this step never saw it: a branch adding a
+# crate merges after a bump it was cut before (#5943). Both directions ask
+# scripts/check-merge-lockfile-sync.sh now — `ci.yml` runs it on every pull
+# request, and `lock-recheck.yml` runs it again for open pull requests each
+# time main moves.
 #
 # GATED ON GREEN CI. This runs via `workflow_run` after the `ci` workflow
 # finishes on main, and only tags when that run *succeeded* — a commit that
@@ -581,9 +588,9 @@ jobs:
           # shape is AGENTS.md § Gotchas' shared-cell collision, and #3332's
           # post-merge canary is the backstop for when it still gets through).
           #
-          # No required check asks it. `strict` is off on main's protection, so
-          # a sync branch is never made to catch up before it merges, and every
-          # check above ran on the branch rather than on the merge result. The
+          # The checks above ran when the branch last changed. `strict` is
+          # off on main's protection, so a sync branch is never made to catch
+          # up, and main can move between that run and this merge. The
           # question has to be asked here or it is not asked at all.
           #
           # Refusing rather than rebuilding the branch on the new tip: a rebuilt
@@ -592,18 +599,15 @@ jobs:
           # merge moved main starts another auto-tag run, which force-updates
           # this same branch from the then-current tip. The version write-back
           # is deferred, never dropped, and main stays green.
-          git fetch origin main
+          #
+          # The merge, the check and the restore live in
+          # scripts/check-merge-lockfile-sync.sh, so this path and the two
+          # pointed the other way — ci.yml's pull request step and
+          # lock-recheck.yml's sweep — cannot disagree about the question, and
+          # the logic is covered by scripts/test-merge-lockfile-sync.sh rather
+          # than by a run of this workflow (#5943).
           merge_verdict=0
-          if git merge --no-commit --no-ff FETCH_HEAD >/dev/null 2>&1; then
-            ./scripts/check-lockfile-sync.sh || merge_verdict=$?
-          else
-            merge_verdict=1
-            echo "::warning::${BRANCH} no longer merges cleanly into main."
-          fi
-          # --abort is a no-op error when main was already an ancestor (nothing
-          # was merged); the reset puts the tree back either way.
-          git merge --abort 2>/dev/null || true
-          git reset --hard HEAD >/dev/null
+          ./scripts/check-merge-lockfile-sync.sh origin/main || merge_verdict=$?
 
           # #3842: the refusal below used to be invisible outside this run's
           # log. `exit 0` is right — a stale sync branch is routine and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -622,6 +622,27 @@ jobs:
           ./scripts/check-lockfile-sync.sh \
             || { echo "::error::Cargo.lock is out of sync with the manifests. Run 'cargo check --workspace' and commit the updated Cargo.lock."; exit 1; }
 
+      # The step above reads one tree. `Cargo.lock` is a shared cell, so two
+      # branches can each write it right and still land a tree cargo cannot
+      # resolve — which is what broke `main` on 2026-09-06, when a branch
+      # adding the `stella-learn` crate merged eight minutes after a release
+      # sync bumped every version (#5943, #5939).
+      #
+      # This checkout is `refs/pull/N/merge`, so it already holds the merge
+      # GitHub computed when the pull request last changed. `main` moves after
+      # that, and `strict` is off, so nothing makes the branch catch up. The
+      # guard fetches `main` as it stands now and merges it in before asking,
+      # then puts the tree back.
+      #
+      # It answers for the `main` of the moment this runs, which is the best a
+      # pull request event can do. `lock-recheck.yml` is what re-asks: it runs
+      # this same guard when `main` moves and sends the answer back here.
+      - name: Cargo.lock still resolves once main is merged in
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' && github.event_name == 'pull_request' }}
+        run: |
+          ./scripts/check-merge-lockfile-sync.sh \
+            || { echo "::error::Merging main into this branch leaves Cargo.lock unresolvable. Merge main and commit the regenerated Cargo.lock."; exit 1; }
+
       - name: cargo fmt --check
         if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
         run: cargo fmt --check

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -284,6 +284,14 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./scripts/test-lockfile-sync.sh
 
+      - name: the merged-lock guard against a two-branch collision (#5943)
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-merge-lockfile-sync.sh
+
+      - name: which open pull requests a lock re-check sends back to ci (#5943)
+        if: ${{ !cancelled() }}
+        run: ./scripts/test-recheck-lock-compositions.sh
+
       - name: the red-main hold, blocking branch included
         if: ${{ !cancelled() }}
         run: ./scripts/test-main-red-hold.sh

--- a/.github/workflows/lock-recheck.yml
+++ b/.github/workflows/lock-recheck.yml
@@ -1,0 +1,64 @@
+name: lock-recheck
+
+# Re-ask the merged-lock question when `main` moves (#5943).
+#
+# `ci.yml` asks whether `Cargo.lock` still resolves once a pull request and
+# `main` are merged. That answer is about the `main` of the moment it ran.
+# `strict` is off, so nothing makes a branch catch up, and the green stands
+# after `main` moves under it.
+#
+# On 2026-09-06 a release sync bumped every version at 09:51. A branch adding
+# the `stella-learn` crate merged at 09:59 with a lock entry at the old
+# version and a check from before the bump. Every `--locked` build on `main`
+# failed, and three sessions each wrote the same repair (#5939).
+#
+# This workflow is the missing event. `scripts/recheck-lock-compositions.sh`
+# asks the question again for each open pull request and runs `ci` again on
+# the ones whose answer changed. The new run reports under the same name on
+# the same commit, so the required check goes red and the merge waits.
+#
+# Same shape as `dod-recheck.yml` and `main-red-clear.yml`, for the same bug
+# one gate over: a check that was right when it ran, on a commit with no event
+# left to correct it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "**/Cargo.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # To read each open pull request's number and head commit.
+  pull-requests: read
+  # To run `ci` again on a pull request whose answer changed.
+  actions: write
+
+# One sweep at a time. A cancelled sweep costs nothing: the next push asks the
+# same questions of the same pull requests.
+concurrency:
+  group: lock-recheck
+  cancel-in-progress: true
+
+jobs:
+  recheck:
+    name: open pull requests still compose with main
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The sweep merges each pull request head into this tip, so it needs
+          # a merge base for every open branch. A shallow clone has none.
+          fetch-depth: 0
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - name: Ask every open pull request whether its lock still composes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/recheck-lock-compositions.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -570,6 +570,26 @@ partitioning by crate, directory or owner, ask whether anything in the set has
 to change atomically. `rg -l 'INTENTIONALLY DUPLICATED'` names today's only
 such twin.
 
+A tenth, `lock-recheck.yml`, re-asks one pre-merge question after `main`
+moves. `ci.yml` checks out `refs/pull/N/merge`, so its `Cargo.lock` step
+already reads the merge result — but the merge GitHub computed when the pull
+request last changed, and `strict` is off, so a green check outlives the tip it
+was true of. On 2026-09-06 a release sync bumped every version at 09:51, a
+branch adding the `stella-learn` crate merged at 09:59 with a lock entry at the
+old version, and every `--locked` build on `main` broke (`#5939`). Nothing was
+wrong with either tree. `scripts/recheck-lock-compositions.sh` runs on a push
+to `main` that writes the lock or a manifest, merges each open pull request
+head into the new tip, and runs `ci` again on the ones whose merged lock stops
+resolving. The new run reports under the same name on the same commit, so the
+required check goes red and the merge waits. A pull request that writes no lock
+is skipped without asking, which is what bounds the cost. It fails open at every
+unknown. `scripts/check-merge-lockfile-sync.sh` is the shared question, asked
+from all three sides now — the sweep, `ci.yml`'s pull request step, and
+`auto-tag.yml`'s own merge, which asked it of the sync branch alone until `#5943`.
+`make merge-lockfile-sync` asks by hand; `make merge-lockfile-sync-test` and
+`make recheck-lock-compositions-test` cover both, the two-branch collision
+built rather than described.
+
 **A stacked PR's evidence is the same CI run — but confirm it started.** No
 workflow's `pull_request:` trigger carries a `branches:` filter (`push:`
 triggers do, and only for the workflows above's own post-merge behavior), so a
@@ -1655,11 +1675,13 @@ seconds; `cargo test --workspace` rebuilds everything.
   the lockfile is one shared cell every version-bumping PR writes, exactly like
   `scripts/file-size-baseline.txt` above. That happened twice on 2026-08-16
   (#3311, then the 0.9.50 sync against it) and left `main` red for every
-  `--locked` build. Nothing pre-merge can see it, because neither author's tree
-  is wrong — which is why `main-canary.yml` re-asks the same question after the
-  merge and files an issue when the answer changed (#3332). The two halves are
-  deliberately separate: one stops you shipping a stale lock, the other bounds
-  how long `main` stays broken when nobody did.
+  `--locked` build. One tree cannot see it, because neither author's tree is
+  wrong. `scripts/check-merge-lockfile-sync.sh` merges the two and then asks,
+  and `lock-recheck.yml` asks again each time `main` moves (`#5943`); the answer
+  is still a snapshot, so `main-canary.yml` re-asks after the merge and files an
+  issue when it changed (#3332). The halves are separate on purpose: one stops
+  you shipping a stale lock, one stops a stale green merging, and the last
+  bounds how long `main` stays broken when both miss.
 - **A grep over cargo's output is not a build result; the exit code is.**
   Cargo colourises when it thinks it is talking to a terminal, which puts the
   escape *before* the word — a line that reads

--- a/Makefile
+++ b/Makefile
@@ -909,6 +909,22 @@ lockfile-sync: ## Assert Cargo.lock resolves against the manifests as committed 
 lockfile-sync-test: ## Test the lockfile guard against synthetic skewed workspaces (hermetic; not part of `gate`)
 	./scripts/test-lockfile-sync.sh
 
+.PHONY: merge-lockfile-sync
+merge-lockfile-sync: ## Assert Cargo.lock still resolves once origin/main is merged in (#5943)
+	@./scripts/check-merge-lockfile-sync.sh
+
+.PHONY: merge-lockfile-sync-test
+merge-lockfile-sync-test: ## Test the merged-lock guard against a two-branch collision (hermetic; not part of `gate`)
+	./scripts/test-merge-lockfile-sync.sh
+
+.PHONY: recheck-lock-compositions
+recheck-lock-compositions: ## Print which open PRs a lock re-check would send back to ci (#5943)
+	@./scripts/recheck-lock-compositions.sh --dry-run
+
+.PHONY: recheck-lock-compositions-test
+recheck-lock-compositions-test: ## Test the lock re-check sweep, its fail-open branches included (hermetic; not part of `gate`)
+	./scripts/test-recheck-lock-compositions.sh
+
 .PHONY: release-lockfile-test
 release-lockfile-test: ## Test that the release version stamp leaves Cargo.lock resolvable, new members included (hermetic; not part of `gate`)
 	./scripts/test-release-lockfile.sh

--- a/scripts/check-merge-lockfile-sync.sh
+++ b/scripts/check-merge-lockfile-sync.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# Guard: `Cargo.lock` still resolves once this checkout takes in `main` (`#5943`).
+#
+# `Cargo.lock` is a shared cell. Two branches can each write it right and
+# still land a tree cargo cannot resolve. `check-lockfile-sync.sh` reads one
+# tree, so it cannot see that. This one merges first, then asks it.
+#
+# On 2026-09-06 the sync to `0.9.330` merged at 09:51. The branch adding the
+# `stella-learn` crate merged at 09:59 with a lock entry at `0.9.329`. Git had
+# no clash to report. Every `--locked` build on `main` broke, and three
+# sessions each wrote the same repair (`#5939`).
+#
+# `auto-tag.yml` asked this question of its own sync branch and nothing else,
+# so the break landed from the other side. This is that check, made shared and
+# pointed both ways: `ci.yml` runs it on every pull request, `auto-tag.yml`
+# runs it before the write-back merges, and `recheck-lockfile-compositions.sh`
+# runs it again for open pull requests each time `main` moves.
+#
+# The answer goes stale. A pull request is green against the `main` of the
+# moment it ran, and `strict` is off, so no rule makes it catch up. The sweep
+# above is what re-asks. Read its header for how a stale green is replaced.
+#
+# The merge is undone before this exits, whatever happens. It refuses to start
+# on a dirty tree, so it can never eat your work.
+#
+# Usage. The ref to merge in, `origin/main` by default.
+#
+#   `scripts/check-merge-lockfile-sync.sh`
+#   `scripts/check-merge-lockfile-sync.sh other/branch`
+#   `scripts/check-merge-lockfile-sync.sh --no-fetch main`
+#   `scripts/check-merge-lockfile-sync.sh --repo-dir DIR`
+#
+# `--repo-dir` is there for `scripts/test-merge-lockfile-sync.sh`. It builds a
+# throwaway repo with two branches, so the failing branch is shown and not
+# just claimed. A guard nobody has seen fail reads like one that always
+# passes.
+#
+# Exit 0 means the merged lock resolves. Exit 1 means it does not, or the two
+# trees clash. Exit 2 means the guard could not run at all.
+set -euo pipefail
+
+repo_dir=""
+ref=""
+fetch=1
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --no-fetch)
+    fetch=0
+    shift
+    ;;
+  --repo-dir)
+    [ $# -ge 2 ] || {
+      echo "check-merge-lockfile-sync: --repo-dir needs a directory" >&2
+      exit 2
+    }
+    repo_dir="$2"
+    shift 2
+    ;;
+  -h | --help)
+    # The whole comment block, cut off at its first line of code. A line
+    # number here goes stale the first time the header grows.
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+    exit 0
+    ;;
+  -*)
+    echo "check-merge-lockfile-sync: unknown argument '$1'" >&2
+    exit 2
+    ;;
+  *)
+    if [ -n "$ref" ]; then
+      echo "check-merge-lockfile-sync: one ref, not two ('$ref' and '$1')" >&2
+      exit 2
+    fi
+    ref="$1"
+    shift
+    ;;
+  esac
+done
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+[ -n "$ref" ] || ref="origin/main"
+[ -n "$repo_dir" ] || repo_dir="$(cd "$script_dir/.." && pwd)"
+
+if [ ! -d "$repo_dir" ]; then
+  echo "check-merge-lockfile-sync: no such directory: $repo_dir" >&2
+  exit 2
+fi
+cd "$repo_dir"
+
+# The verdict is decided before a word is printed (`#1815`). A guard that
+# prints as it scans dies part way through when its reader quits early, as
+# `| head -1` does. Under `set -euo pipefail` that half state becomes the
+# exit code.
+report=""
+note() { report="${report}check-merge-lockfile-sync: $1"$'\n'; }
+emit() {
+  trap '' PIPE
+  printf '%s' "$report" >&2 || true
+}
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  note "FAIL — $repo_dir is not a git checkout, so no merge can be tried."
+  emit
+  exit 2
+fi
+
+# A merge already in flight, or a tree with edits in it, would leave the undo
+# below to guess what to put back. Refuse instead.
+git_dir="$(git rev-parse --git-dir)"
+for marker in MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD rebase-merge rebase-apply; do
+  if [ -e "$git_dir/$marker" ]; then
+    note "FAIL — a merge, rebase or cherry-pick is already in flight here."
+    note "     Finish or abort it, then run this again."
+    emit
+    exit 2
+  fi
+done
+
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+  note "FAIL — the working tree has changes in it. This guard merges into the"
+  note "     tree and then undoes it, so it will not start on top of your"
+  note "     edits. Commit or stash them first."
+  emit
+  exit 2
+fi
+
+# Fetch by hand. Do not trust a stale remote ref. The point is to ask about
+# the tip as it stands now, not the one this clone last saw.
+if [ "$fetch" -eq 1 ]; then
+  remote="${ref%%/*}"
+  branch="${ref#*/}"
+  if [ "$remote" = "$ref" ] || [ -z "$branch" ]; then
+    note "FAIL — '$ref' is not a <remote>/<branch> ref. Pass one, or pass"
+    note "     --no-fetch to read a ref this clone already holds."
+    emit
+    exit 2
+  fi
+  if ! git fetch --no-tags --quiet "$remote" "$branch" 2>/dev/null; then
+    note "FAIL — could not fetch $branch from $remote."
+    emit
+    exit 2
+  fi
+  ref="FETCH_HEAD"
+fi
+
+if ! other="$(git rev-parse --verify --quiet "${ref}^{commit}")"; then
+  note "FAIL — '$ref' does not name a commit here."
+  emit
+  exit 2
+fi
+
+# CI hands us a shallow clone. `ci.yml` checks out two commits. That is right
+# for the guards that read two trees, and too little to merge with. Deepen
+# only when the merge base is missing, so a full clone pays nothing.
+if ! git merge-base HEAD "$other" >/dev/null 2>&1; then
+  if [ "$(git rev-parse --is-shallow-repository 2>/dev/null || echo false)" = "true" ]; then
+    git fetch --no-tags --quiet --deepen=500 "${remote:-origin}" >/dev/null 2>&1 || true
+    if ! git merge-base HEAD "$other" >/dev/null 2>&1; then
+      git fetch --no-tags --quiet --unshallow >/dev/null 2>&1 || true
+    fi
+  fi
+fi
+if ! git merge-base HEAD "$other" >/dev/null 2>&1; then
+  note "FAIL — HEAD and $(git rev-parse --short "$other") share no history"
+  note "     this clone can see, so the merged tree cannot be built."
+  emit
+  exit 2
+fi
+
+# Put the tree back on every exit path, the failing ones included. Inline
+# rather than in a function, so nothing reads as dead code to a linter.
+head_sha="$(git rev-parse HEAD)"
+trap 'git merge --abort >/dev/null 2>&1 || true
+      git reset --hard "$head_sha" >/dev/null 2>&1 || true' EXIT
+
+short="$(git rev-parse --short "$other")"
+
+# Nothing to merge when the ref is already in. The one-tree guard has
+# answered for this tree, and a merge here would do nothing.
+if git merge-base --is-ancestor "$other" HEAD; then
+  emit
+  printf 'check-merge-lockfile-sync: OK — HEAD already holds %s; nothing to merge.\n' "$short" || true
+  exit 0
+fi
+
+if ! git merge --no-commit --no-ff "$other" >/dev/null 2>&1; then
+  note "FAIL — this checkout does not merge cleanly with $short."
+  note ""
+  note "Merge it and fix the conflict, then run this again."
+  emit
+  exit 1
+fi
+
+verdict=0
+# Always `--manifest-dir`. The guard next door works out its own repo root
+# from its path when nobody hands it one. A run against a fixture tree would
+# then read this repo and report on the wrong lock.
+merged_report="$("$script_dir/check-lockfile-sync.sh" --manifest-dir "$repo_dir" 2>&1)" || verdict=$?
+
+if [ "$verdict" -eq 0 ]; then
+  emit
+  printf 'check-merge-lockfile-sync: OK — the lock still resolves once %s is in.\n' "$short" || true
+  exit 0
+fi
+
+note "FAIL — the lock does not resolve once $short is merged in."
+note "     Both trees are fine alone. The two writes collide."
+note ""
+note "The single-tree guard said:"
+while IFS= read -r line; do
+  note "     $line"
+done <<<"$merged_report"
+note ""
+note "Fix it by taking the other side in and relocking:"
+note ""
+note "       git merge $short"
+note "       cargo metadata --format-version 1 >/dev/null"
+note "       git add Cargo.lock"
+note ""
+note "Landing this as it stands breaks every --locked build on main (`#5943`)."
+emit
+exit 1

--- a/scripts/check-merge-lockfile-sync.sh
+++ b/scripts/check-merge-lockfile-sync.sh
@@ -21,6 +21,10 @@
 # moment it ran, and `strict` is off, so no rule makes it catch up. The sweep
 # above is what re-asks. Read its header for how a stale green is replaced.
 #
+# A pair that will not merge at all gets exit 1 too. Such a branch cannot land
+# either way, so the red costs it nothing. A green here would be an answer
+# this guard did not earn.
+#
 # The merge is undone before this exits, whatever happens. It refuses to start
 # on a dirty tree, so it can never eat your work.
 #

--- a/scripts/check-merge-lockfile-sync.sh
+++ b/scripts/check-merge-lockfile-sync.sh
@@ -21,9 +21,9 @@
 # moment it ran, and `strict` is off, so no rule makes it catch up. The sweep
 # above is what re-asks. Read its header for how a stale green is replaced.
 #
-# A pair that will not merge at all gets exit 1 too. Such a branch cannot land
-# either way, so the red costs it nothing. A green here would be an answer
-# this guard did not earn.
+# A pair that will not merge at all gets exit 1 too, with git's own words in
+# the report. Such a branch cannot land either way, so the red costs it
+# nothing. A green here would be an answer this guard did not earn.
 #
 # The merge is undone before this exits, whatever happens. It refuses to start
 # on a dirty tree, so it can never eat your work.
@@ -189,10 +189,22 @@ if git merge-base --is-ancestor "$other" HEAD; then
   exit 0
 fi
 
-if ! git merge --no-commit --no-ff "$other" >/dev/null 2>&1; then
-  note "FAIL — this checkout does not merge cleanly with $short."
+# An identity of its own. No commit is made and the merge is undone, so this
+# reaches nothing that lasts. Without it a box that has none — a CI runner is
+# one — fails the merge on "Committer identity unknown", and the guard would
+# read that as a clash and fail every branch it looked at.
+merge_error=""
+if ! merge_error="$(git -c user.name="stella merged-lock guard" \
+  -c user.email="guard@localhost" \
+  merge --no-commit --no-ff "$other" 2>&1)"; then
+  note "FAIL — this checkout does not merge with $short."
   note ""
-  note "Merge it and fix the conflict, then run this again."
+  note "git said:"
+  while IFS= read -r line; do
+    note "     $line"
+  done <<<"$merge_error"
+  note ""
+  note "Merge it and settle that, then run this again."
   emit
   exit 1
 fi

--- a/scripts/lib/lock-composition-fixture.sh
+++ b/scripts/lib/lock-composition-fixture.sh
@@ -15,10 +15,18 @@
 # Merge `feature` into `main` and the break shows up. Git finds no clash.
 # The merged root says 0.2.0. The merged lock still says `mike` 0.1.0.
 # The last two branches are the controls. They must stay green.
+#
+# The clash has to stay away, or the fixture tests the wrong thing. Git calls
+# two edits a clash when they land near each other, and how near depends on
+# the git build. So `mike` is added where its new lines sit far from any line
+# the sync moved. Six `noop` crates pin their own versions. The sync leaves
+# those alone, and they pad both the lock and the member list. The builder
+# then tries the merge and says so if it ever clashes again.
 
-# Each crate depends on the ones named after it. That gives its lock entry a
-# list of deps. A short entry would sit next to the version line of the next
-# crate. Git would call that a clash. That is not the shape we want.
+_lock_fixture_pad="noop1 noop2 noop3 noop4 noop5 noop6"
+
+# A crate at the shared workspace version. It depends on every crate named
+# after it, which gives its lock entry a long list of deps.
 _lock_fixture_member() {
   dir="$1"
   name="$2"
@@ -34,6 +42,24 @@ _lock_fixture_member() {
     for dep in "$@"; do
       echo "$dep = { path = \"../$dep\" }"
     done
+  } >"$dir/crates/$name/Cargo.toml"
+  echo "pub fn hello() {}" >"$dir/crates/$name/src/lib.rs"
+}
+
+# A crate that pins its own version. The sync never rewrites its lines, so it
+# is safe padding between an added entry and a moved one.
+_lock_fixture_pinned() {
+  dir="$1"
+  name="$2"
+  mkdir -p "$dir/crates/$name/src"
+  {
+    echo '[package]'
+    echo "name = \"$name\""
+    echo 'version = "1.0.0"'
+    echo 'edition.workspace = true'
+    echo
+    echo '[dependencies]'
+    echo 'zulu = { path = "../zulu" }'
   } >"$dir/crates/$name/Cargo.toml"
   echo "pub fn hello() {}" >"$dir/crates/$name/src/lib.rs"
 }
@@ -65,20 +91,29 @@ lock_fixture_git() { git -C "$1" -c user.email=t@example.com -c user.name=T "${@
 build_lock_fixture() {
   dir="$1"
   mkdir -p "$dir"
-  git -C "$dir" init -q -b main
+  git -C "$dir" init -q
 
-  _lock_fixture_root "$dir" "0.1.0" alpha kilo zulu
-  _lock_fixture_member "$dir" alpha kilo zulu
-  _lock_fixture_member "$dir" kilo zulu
+  # shellcheck disable=SC2086 # the pad list is a word list on purpose.
+  set -- alpha kilo $_lock_fixture_pad zulu
+  _lock_fixture_root "$dir" "0.1.0" "$@"
+  # shellcheck disable=SC2086
+  _lock_fixture_member "$dir" alpha kilo $_lock_fixture_pad zulu
+  # shellcheck disable=SC2086
+  _lock_fixture_member "$dir" kilo $_lock_fixture_pad zulu
+  for pad in $_lock_fixture_pad; do
+    _lock_fixture_pinned "$dir" "$pad"
+  done
   _lock_fixture_member "$dir" zulu
   _lock_fixture_relock "$dir"
   lock_fixture_git "$dir" add -A
   lock_fixture_git "$dir" commit -qm "base"
+  lock_fixture_git "$dir" branch -q -M main
 
-  # Right about all it can see. `mike` sorts between `kilo` and `zulu`. Every
+  # Right about all it can see. `mike` sorts between `kilo` and `noop1`. Every
   # version in its lock matches every version in its manifests.
   lock_fixture_git "$dir" checkout -q -b feature
-  _lock_fixture_root "$dir" "0.1.0" alpha kilo mike zulu
+  # shellcheck disable=SC2086
+  _lock_fixture_root "$dir" "0.1.0" alpha kilo mike $_lock_fixture_pad zulu
   _lock_fixture_member "$dir" mike zulu
   _lock_fixture_relock "$dir"
   lock_fixture_git "$dir" add -A
@@ -90,7 +125,8 @@ build_lock_fixture() {
   lock_fixture_git "$dir" commit -qm "add a readme"
 
   lock_fixture_git "$dir" checkout -q main
-  _lock_fixture_root "$dir" "0.2.0" alpha kilo zulu
+  # shellcheck disable=SC2086
+  _lock_fixture_root "$dir" "0.2.0" alpha kilo $_lock_fixture_pad zulu
   _lock_fixture_relock "$dir"
   lock_fixture_git "$dir" add -A
   lock_fixture_git "$dir" commit -qm "sync versions to 0.2.0"
@@ -98,7 +134,8 @@ build_lock_fixture() {
   # Cut after the sync. Its new crate is locked at the version `main` now
   # holds. It writes the lock and still merges clean.
   lock_fixture_git "$dir" checkout -q -b caught-up main
-  _lock_fixture_root "$dir" "0.2.0" alpha kilo november zulu
+  # shellcheck disable=SC2086
+  _lock_fixture_root "$dir" "0.2.0" alpha kilo $_lock_fixture_pad november zulu
   _lock_fixture_member "$dir" november zulu
   _lock_fixture_relock "$dir"
   lock_fixture_git "$dir" add -A
@@ -110,4 +147,19 @@ build_lock_fixture() {
   echo "the crates are at 0.2.0" >"$dir/NOTES.md"
   lock_fixture_git "$dir" add -A
   lock_fixture_git "$dir" commit -qm "note the version"
+
+  # The whole point is a pair git merges with no clash. Say so here, where the
+  # cause is plain, rather than letting a case fail for the wrong reason.
+  if ! lock_fixture_git "$dir" merge --no-commit --no-ff feature >/dev/null 2>&1; then
+    echo "lock-composition-fixture: this git calls the two branches a clash." >&2
+    echo "     The fixture then builds some other shape, not the one under" >&2
+    echo "     test. Pad the added entry further from the lines the sync" >&2
+    echo "     moves." >&2
+    lock_fixture_git "$dir" merge --abort >/dev/null 2>&1 || true
+    lock_fixture_git "$dir" reset --hard >/dev/null 2>&1 || true
+    return 1
+  fi
+  lock_fixture_git "$dir" merge --abort >/dev/null 2>&1 || true
+  lock_fixture_git "$dir" reset --hard >/dev/null
+  lock_fixture_git "$dir" checkout -q main
 }

--- a/scripts/lib/lock-composition-fixture.sh
+++ b/scripts/lib/lock-composition-fixture.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# The two-branch lock clash, built as a throwaway git repo (`#5943`).
+#
+# Shared by `scripts/test-merge-lockfile-sync.sh` and
+# `scripts/test-recheck-lock-compositions.sh`. Sourced, never run.
+#
+# `build_lock_fixture DIR` leaves DIR on `main` with four branches.
+#
+# `main` holds every crate at 0.2.0 and a fresh lock. That is the sync.
+# `feature` adds the `mike` crate at 0.1.0. It was cut before the sync.
+# `caught-up` adds the `november` crate. It was cut after the sync.
+# `docs-only` writes a README and no manifest.
+#
+# Merge `feature` into `main` and the break shows up. Git finds no clash.
+# The merged root says 0.2.0. The merged lock still says `mike` 0.1.0.
+# The last two branches are the controls. They must stay green.
+
+# Each crate depends on the ones named after it. That gives its lock entry a
+# list of deps. A short entry would sit next to the version line of the next
+# crate. Git would call that a clash. That is not the shape we want.
+_lock_fixture_member() {
+  dir="$1"
+  name="$2"
+  shift 2
+  mkdir -p "$dir/crates/$name/src"
+  {
+    echo '[package]'
+    echo "name = \"$name\""
+    echo 'version.workspace = true'
+    echo 'edition.workspace = true'
+    echo
+    echo '[dependencies]'
+    for dep in "$@"; do
+      echo "$dep = { path = \"../$dep\" }"
+    done
+  } >"$dir/crates/$name/Cargo.toml"
+  echo "pub fn hello() {}" >"$dir/crates/$name/src/lib.rs"
+}
+
+_lock_fixture_root() {
+  dir="$1"
+  version="$2"
+  shift 2
+  {
+    echo '[workspace]'
+    echo 'resolver = "2"'
+    echo 'members = ['
+    for member in "$@"; do
+      echo "  \"crates/$member\","
+    done
+    echo ']'
+    echo
+    echo '[workspace.package]'
+    echo "version = \"$version\""
+    echo 'edition = "2021"'
+  } >"$dir/Cargo.toml"
+}
+
+_lock_fixture_relock() { (cd "$1" && cargo generate-lockfile --offline >/dev/null 2>&1); }
+
+# git with a name of its own. A box with no global one still runs this.
+lock_fixture_git() { git -C "$1" -c user.email=t@example.com -c user.name=T "${@:2}"; }
+
+build_lock_fixture() {
+  dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+
+  _lock_fixture_root "$dir" "0.1.0" alpha kilo zulu
+  _lock_fixture_member "$dir" alpha kilo zulu
+  _lock_fixture_member "$dir" kilo zulu
+  _lock_fixture_member "$dir" zulu
+  _lock_fixture_relock "$dir"
+  lock_fixture_git "$dir" add -A
+  lock_fixture_git "$dir" commit -qm "base"
+
+  # Right about all it can see. `mike` sorts between `kilo` and `zulu`. Every
+  # version in its lock matches every version in its manifests.
+  lock_fixture_git "$dir" checkout -q -b feature
+  _lock_fixture_root "$dir" "0.1.0" alpha kilo mike zulu
+  _lock_fixture_member "$dir" mike zulu
+  _lock_fixture_relock "$dir"
+  lock_fixture_git "$dir" add -A
+  lock_fixture_git "$dir" commit -qm "add the mike crate"
+
+  lock_fixture_git "$dir" checkout -q -b docs-only main
+  echo "hello" >"$dir/README.md"
+  lock_fixture_git "$dir" add -A
+  lock_fixture_git "$dir" commit -qm "add a readme"
+
+  lock_fixture_git "$dir" checkout -q main
+  _lock_fixture_root "$dir" "0.2.0" alpha kilo zulu
+  _lock_fixture_relock "$dir"
+  lock_fixture_git "$dir" add -A
+  lock_fixture_git "$dir" commit -qm "sync versions to 0.2.0"
+
+  # Cut after the sync. Its new crate is locked at the version `main` now
+  # holds. It writes the lock and still merges clean.
+  lock_fixture_git "$dir" checkout -q -b caught-up main
+  _lock_fixture_root "$dir" "0.2.0" alpha kilo november zulu
+  _lock_fixture_member "$dir" november zulu
+  _lock_fixture_relock "$dir"
+  lock_fixture_git "$dir" add -A
+  lock_fixture_git "$dir" commit -qm "add the november crate"
+
+  # `main` moves once more. Now `caught-up` is behind it and has a real merge
+  # to make, not a fast-forward the guard skips.
+  lock_fixture_git "$dir" checkout -q main
+  echo "the crates are at 0.2.0" >"$dir/NOTES.md"
+  lock_fixture_git "$dir" add -A
+  lock_fixture_git "$dir" commit -qm "note the version"
+}

--- a/scripts/recheck-lock-compositions.sh
+++ b/scripts/recheck-lock-compositions.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+#
+# Re-ask the merged-lock question for every open pull request (`#5943`).
+#
+# `ci.yml` asks whether `Cargo.lock` still resolves once the pull request and
+# `main` are merged. That answer is true of the `main` of the moment it ran.
+# `strict` is off, so nothing makes a branch catch up. The green then stands
+# after `main` moves under it.
+#
+# That is how `main` broke on 2026-09-06. A release sync bumped every version
+# and wrote a fresh lock at 09:51. A branch adding the `stella-learn` crate
+# merged at 09:59. Its lock entry was at the old version, and its check was
+# from before the bump. Every `--locked` build failed. Three sessions each
+# wrote the same repair (`#5939`).
+#
+# This is the missing event. It runs when `main` moves. It asks the question
+# again for each open pull request. It runs `ci` again on the ones whose
+# answer changed. That new run lands under the same name on the same commit.
+# So the required check goes red and the merge waits.
+# `refresh-main-red-holds.sh` uses the same shape for a stale hold.
+#
+# ## What bounds the fan-out
+#
+# A pull request that writes no `Cargo.lock` cannot add a stale entry to it.
+# It is skipped without asking. Of the rest, only one whose merged lock fails
+# to resolve is run again. A quiet day costs one `git fetch` per open pull
+# request and nothing else.
+#
+# ## Fails open, out loud
+#
+# Every unknown prints a note and exits 0. A red job here would call a pull
+# request broken when nobody asked that. Its own checks are the one thing
+# allowed to answer.
+#
+# Usage.
+#
+#   `scripts/recheck-lock-compositions.sh`
+#   `scripts/recheck-lock-compositions.sh --dry-run`
+#   `scripts/recheck-lock-compositions.sh --limit 50`
+#
+# Needs `gh`, `git` and a plain shell. So it runs on a bare CI runner.
+set -uo pipefail
+
+workflow="ci.yml"
+limit=100
+dry_run=0
+repo_dir=""
+fixture_open_prs=""
+fixture_runs=""
+use_fixture=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --dry-run)
+    dry_run=1
+    shift
+    ;;
+  --limit)
+    [ $# -ge 2 ] || {
+      echo "recheck-lock-compositions: --limit needs a number" >&2
+      exit 2
+    }
+    limit="$2"
+    shift 2
+    ;;
+  --repo-dir)
+    [ $# -ge 2 ] || {
+      echo "recheck-lock-compositions: --repo-dir needs a directory" >&2
+      exit 2
+    }
+    repo_dir="$2"
+    shift 2
+    ;;
+  # Test-only seams. Either one stubs every lookup and holds back the re-run.
+  # So a case cannot half-reach the network. Same rule as the fixtures in
+  # `dod-recheck.sh`.
+  --fixture-open-prs)
+    [ $# -ge 2 ] || {
+      echo "recheck-lock-compositions: --fixture-open-prs needs a value" >&2
+      exit 2
+    }
+    fixture_open_prs="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  --fixture-runs)
+    [ $# -ge 2 ] || {
+      echo "recheck-lock-compositions: --fixture-runs needs a value" >&2
+      exit 2
+    }
+    fixture_runs="$2"
+    use_fixture=1
+    shift 2
+    ;;
+  -h | --help)
+    # The whole block after the shebang, cut off at its first line of code. A
+    # line number here goes stale the first time the header grows.
+    awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
+    exit 0
+    ;;
+  *)
+    echo "recheck-lock-compositions: unknown argument '$1'" >&2
+    exit 2
+    ;;
+  esac
+done
+
+[ "$use_fixture" -eq 1 ] && dry_run=1
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+guard="$script_dir/check-merge-lockfile-sync.sh"
+[ -n "$repo_dir" ] || repo_dir="$(cd "$script_dir/.." && pwd)"
+
+note() { printf 'recheck-lock-compositions: %s\n' "$*" >&2 || true; }
+say() {
+  # Ignore SIGPIPE and drop the write. A reader that shuts the pipe must not
+  # turn this into a failure. That is the `#1815` shape.
+  trap '' PIPE
+  printf 'recheck-lock-compositions: %s\n' "$*" || true
+}
+
+if [ ! -d "$repo_dir" ]; then
+  note "no such directory: $repo_dir, so nothing was asked."
+  exit 0
+fi
+
+if [ "$use_fixture" -eq 0 ] && ! command -v gh >/dev/null 2>&1; then
+  note "gh is not installed, so no pull request could be read."
+  exit 0
+fi
+
+# ── The open pull requests, one per line: number, then head commit ───────────
+if [ "$use_fixture" -eq 1 ]; then
+  open_prs="$fixture_open_prs"
+elif ! open_prs="$(gh pr list --state open --limit "$limit" \
+  --json number,headRefOid \
+  --jq '.[] | "\(.number) \(.headRefOid)"' 2>/dev/null)"; then
+  note "could not list the open pull requests, so nothing was asked."
+  exit 0
+fi
+
+if [ -z "$open_prs" ]; then
+  say "no open pull requests."
+  exit 0
+fi
+
+# The last `ci` run on this head. Three answers, not two. "Nothing to run
+# again" and "the lookup did not answer" are different facts. One empty
+# string for both reads a dead lookup as a pull request with no run.
+run_for() {
+  head="$1"
+  if [ "$use_fixture" -eq 1 ]; then
+    printf '%s\n' "$fixture_runs" |
+      awk -v head="$head" '$1 == head { print $2; hit = 1; exit }
+                           END { if (!hit) print "none" }'
+    return 0
+  fi
+  if ! answer="$(gh api \
+    "repos/{owner}/{repo}/actions/workflows/$workflow/runs?head_sha=$head&per_page=20" \
+    --jq 'if (.workflow_runs | length) == 0 then "none"
+          elif .workflow_runs[0].status == "completed" then (.workflow_runs[0].id | tostring)
+          else "pending" end' 2>/dev/null)"; then
+    printf '?\n'
+    return 0
+  fi
+  case "$answer" in
+  "") printf '?\n' ;;
+  *) printf '%s\n' "$answer" ;;
+  esac
+}
+
+asked=0
+rerun=0
+
+while IFS=' ' read -r number head; do
+  [ -n "${number:-}" ] || continue
+  [ -n "${head:-}" ] || continue
+
+  if [ "$use_fixture" -eq 0 ]; then
+    if ! git -C "$repo_dir" fetch --no-tags --quiet origin "refs/pull/$number/head" 2>/dev/null; then
+      note "#$number: could not fetch its head, so it was not asked."
+      continue
+    fi
+  fi
+  if ! git -C "$repo_dir" rev-parse --verify --quiet "${head}^{commit}" >/dev/null; then
+    note "#$number: $head is not a commit here, so it was not asked."
+    continue
+  fi
+
+  # A pull request that writes no lock cannot add a stale entry to one.
+  if ! base="$(git -C "$repo_dir" merge-base HEAD "$head" 2>/dev/null)" || [ -z "$base" ]; then
+    note "#$number: shares no history with this checkout, so it was not asked."
+    continue
+  fi
+  files="$(git -C "$repo_dir" diff --name-only "$base" "$head" 2>/dev/null || true)"
+  case $'\n'"$files"$'\n' in
+  *$'\n'Cargo.lock$'\n'*) ;;
+  *) continue ;;
+  esac
+
+  asked=$((asked + 1))
+  verdict=0
+  "$guard" --repo-dir "$repo_dir" --no-fetch "$head" >/dev/null 2>&1 || verdict=$?
+
+  if [ "$verdict" -eq 0 ]; then
+    say "#$number: its lock still resolves against this tip."
+    continue
+  fi
+  if [ "$verdict" -ne 1 ]; then
+    note "#$number: the guard could not answer, so nothing was run again."
+    continue
+  fi
+
+  run_id="$(run_for "$head")"
+  case "$run_id" in
+  none)
+    say "#$number: its lock is stale against this tip, and it has no ci run to run again."
+    continue
+    ;;
+  pending)
+    say "#$number: its lock is stale against this tip, and its ci run is still going."
+    continue
+    ;;
+  "?")
+    note "#$number: could not read its ci runs, so nothing was run again."
+    continue
+    ;;
+  esac
+
+  if [ "$dry_run" -eq 1 ]; then
+    say "#$number: would run ci run $run_id again — its lock is stale against this tip."
+    rerun=$((rerun + 1))
+    continue
+  fi
+  if gh run rerun "$run_id" >/dev/null 2>&1; then
+    say "#$number: ran ci run $run_id again — its lock is stale against this tip."
+    rerun=$((rerun + 1))
+  else
+    note "#$number: could not run ci run $run_id again."
+  fi
+done <<EOF
+$open_prs
+EOF
+
+say "asked $asked pull request(s) that write the lock; $rerun need ci again."
+exit 0

--- a/scripts/test-merge-lockfile-sync.sh
+++ b/scripts/test-merge-lockfile-sync.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Tests for `scripts/check-merge-lockfile-sync.sh` (`#5943`).
+#
+# Hermetic. The fixture is a throwaway git repo with a tiny cargo workspace in
+# it. So nothing here needs a network or this repo's own lock.
+# `scripts/lib/lock-composition-fixture.sh` builds it and says what each
+# branch is for.
+#
+# The case that matters is the one that broke `main` on 2026-09-06. A release
+# sync bumps every version and writes a fresh lock. A branch cut before it
+# adds a new crate. Its lock names that crate at the old version. Both trees
+# pass the one-tree guard. Git merges them with no clash. The merged lock
+# resolves for neither side.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+guard="$repo_root/scripts/check-merge-lockfile-sync.sh"
+single="$repo_root/scripts/check-lockfile-sync.sh"
+
+# shellcheck source=scripts/lib/lock-composition-fixture.sh
+. "$repo_root/scripts/lib/lock-composition-fixture.sh"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "skip test-merge-lockfile-sync — no cargo toolchain on PATH"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+repo="$tmp/repo"
+build_lock_fixture "$repo"
+
+# Run a command. Check the exit code, and that the output holds `needle`.
+expect() {
+  name="$1"
+  want_code="$2"
+  needle="$3"
+  shift 3
+  set +e
+  out="$("$@" 2>&1)"
+  code=$?
+  set -e
+  if [ "$code" -ne "$want_code" ]; then
+    echo "FAIL  $name — exit $code, wanted $want_code"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+  fi
+  case "$out" in
+  *"$needle"*) ;;
+  *)
+    echo "FAIL  $name — output did not hold: $needle"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+    ;;
+  esac
+  echo "ok    $name"
+  pass=$((pass + 1))
+}
+
+record() {
+  if [ "$2" = "ok" ]; then
+    echo "ok    $1"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $1 — $2"
+    fail=$((fail + 1))
+  fi
+}
+
+# The branch is green on its own. That is the whole problem.
+# Nothing about the branch is wrong. This is the pass that let the break
+# through, so it is pinned first. A red here would mean the fixture is not
+# the shape we want.
+lock_fixture_git "$repo" checkout -q feature
+expect "the branch alone passes the single-tree guard" 0 "OK — Cargo.lock resolves" \
+  "$single" --manifest-dir "$repo"
+
+# And the two of them merged do not resolve.
+expect "a new member behind a bump is caught from the branch" 1 "does not resolve once" \
+  "$guard" --repo-dir "$repo" --no-fetch main
+
+# The same question from the other side. That side is `auto-tag.yml`.
+lock_fixture_git "$repo" checkout -q main
+expect "the same pair is caught from main" 1 "does not resolve once" \
+  "$guard" --repo-dir "$repo" --no-fetch feature
+
+# A branch cut after the bump writes the lock and still merges clean.
+lock_fixture_git "$repo" checkout -q caught-up
+expect "a member added after the bump passes" 0 "the lock still resolves" \
+  "$guard" --repo-dir "$repo" --no-fetch main
+
+# A branch that writes no manifest merges clean.
+lock_fixture_git "$repo" checkout -q docs-only
+expect "a branch touching no manifest passes" 0 "the lock still resolves" \
+  "$guard" --repo-dir "$repo" --no-fetch main
+
+# A ref already in HEAD is nothing to merge.
+lock_fixture_git "$repo" checkout -q main
+expect "a ref already held is reported as such" 0 "already holds" \
+  "$guard" --repo-dir "$repo" --no-fetch main
+
+# The tree comes back, even from the failing branch.
+# The guard merges into the working tree. A run that left half a merge in it
+# would cost an author their checkout. So the undo is proven, not assumed.
+lock_fixture_git "$repo" checkout -q feature
+before="$(git -C "$repo" rev-parse HEAD)"
+set +e
+"$guard" --repo-dir "$repo" --no-fetch main >/dev/null 2>&1
+set -e
+after="$(git -C "$repo" rev-parse HEAD)"
+dirt="$(git -C "$repo" status --porcelain)"
+if [ "$before" = "$after" ] && [ -z "$dirt" ]; then
+  record "a failing run leaves the tree where it found it" ok
+else
+  record "a failing run leaves the tree where it found it" "HEAD or the tree moved"
+fi
+
+# It will not start on top of your edits.
+echo "scratch" >"$repo/scratch.txt"
+expect "a dirty tree is refused, not merged over" 2 "working tree has changes" \
+  "$guard" --repo-dir "$repo" --no-fetch main
+rm -f "$repo/scratch.txt"
+
+# A bad argument is a usage error, never a silent pass.
+expect "an unknown argument exits 2" 2 "unknown argument" "$guard" --nope
+expect "two refs exit 2" 2 "one ref, not two" \
+  "$guard" --repo-dir "$repo" --no-fetch main other
+expect "--repo-dir with no value exits 2" 2 "needs a directory" "$guard" --repo-dir
+expect "a missing repo exits 2" 2 "no such directory" \
+  "$guard" --repo-dir "$tmp/nowhere" --no-fetch main
+expect "a bare ref name with fetch on exits 2" 2 "not a <remote>/<branch> ref" \
+  "$guard" --repo-dir "$repo" main
+expect "a directory that is not a checkout exits 2" 2 "not a git checkout" \
+  "$guard" --repo-dir "$tmp" --no-fetch main
+
+# The verdict lives through a reader that shuts the pipe (`#1815`).
+lock_fixture_git "$repo" checkout -q feature
+set +e
+"$guard" --repo-dir "$repo" --no-fetch main 2>&1 | head -1 >/dev/null
+code=${PIPESTATUS[0]}
+set -e
+if [ "$code" -eq 1 ]; then
+  record "a truncated reader still gets exit 1" ok
+else
+  record "a truncated reader still gets exit 1" "exit was $code"
+fi
+
+echo
+echo "test-merge-lockfile-sync: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/test-recheck-lock-compositions.sh
+++ b/scripts/test-recheck-lock-compositions.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# Tests for `scripts/recheck-lock-compositions.sh` (`#5943`).
+#
+# Hermetic. The fixture is the repo the merge guard's own tests use, built by
+# `scripts/lib/lock-composition-fixture.sh`. The seams `--fixture-open-prs`
+# and `--fixture-runs` stand in for `gh`. So no case here can reach the
+# network, and none can run a real workflow again.
+#
+# The sweep makes three calls, and each one is pinned below. Which pull
+# requests are worth asking about. Which of those merge into a lock that will
+# not resolve. And whether a run exists to carry the answer.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+sweep="$repo_root/scripts/recheck-lock-compositions.sh"
+
+# shellcheck source=scripts/lib/lock-composition-fixture.sh
+. "$repo_root/scripts/lib/lock-composition-fixture.sh"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "skip test-recheck-lock-compositions — no cargo toolchain on PATH"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+repo="$tmp/repo"
+build_lock_fixture "$repo"
+
+stale="$(git -C "$repo" rev-parse feature)"
+fine="$(git -C "$repo" rev-parse caught-up)"
+prose="$(git -C "$repo" rev-parse docs-only)"
+
+expect() {
+  name="$1"
+  want_code="$2"
+  needle="$3"
+  shift 3
+  set +e
+  out="$("$@" 2>&1)"
+  code=$?
+  set -e
+  if [ "$code" -ne "$want_code" ]; then
+    echo "FAIL  $name — exit $code, wanted $want_code"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+  fi
+  case "$out" in
+  *"$needle"*) ;;
+  *)
+    echo "FAIL  $name — output did not hold: $needle"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+    ;;
+  esac
+  echo "ok    $name"
+  pass=$((pass + 1))
+}
+
+refuse() {
+  name="$1"
+  needle="$2"
+  shift 2
+  set +e
+  out="$("$@" 2>&1)"
+  code=$?
+  set -e
+  case "$out" in
+  *"$needle"*)
+    if [ "$code" -eq 0 ]; then
+      echo "FAIL  $name — it said the right thing and then exited 0"
+      fail=$((fail + 1))
+      return
+    fi
+    ;;
+  *)
+    echo "FAIL  $name — output did not hold: $needle"
+    printf '      %s\n' "$out"
+    fail=$((fail + 1))
+    return
+    ;;
+  esac
+  echo "ok    $name"
+  pass=$((pass + 1))
+}
+
+# A stale lock with a finished run gets that run again.
+expect "a stale composition is sent back to ci" 0 "would run ci run 111 again" \
+  "$sweep" --repo-dir "$repo" \
+  --fixture-open-prs "11 $stale" \
+  --fixture-runs "$stale 111"
+
+# A branch cut after the bump is left alone.────
+expect "a composing branch is left alone" 0 "its lock still resolves" \
+  "$sweep" --repo-dir "$repo" \
+  --fixture-open-prs "12 $fine" \
+  --fixture-runs "$fine 222"
+
+# A branch that writes no lock is never even asked.────
+# This is what bounds the fan-out. Most open pull requests take this path. A
+# sweep then costs one fetch and nothing more.
+expect "a branch that writes no lock is skipped" 0 "asked 0 pull request(s)" \
+  "$sweep" --repo-dir "$repo" \
+  --fixture-open-prs "13 $prose" \
+  --fixture-runs "$prose 333"
+
+# A run still going is reported, not forced.─────
+# A live run cannot be run again. It will report on its own. Saying so beats
+# a silent skip.
+expect "a run still going is named, not touched" 0 "its ci run is still going" \
+  "$sweep" --repo-dir "$repo" \
+  --fixture-open-prs "14 $stale" \
+  --fixture-runs "$stale pending"
+
+# A head with no run at all is reported.──────
+expect "a head with no ci run is named" 0 "no ci run to run again" \
+  "$sweep" --repo-dir "$repo" \
+  --fixture-open-prs "15 $stale" \
+  --fixture-runs "other 999"
+
+# A lookup that did not answer is not read as a pass.────
+expect "an unreadable run lookup says so" 0 "could not read its ci runs" \
+  "$sweep" --repo-dir "$repo" \
+  --fixture-open-prs "16 $stale" \
+  --fixture-runs "$stale ?"
+
+# Several at once. The count is of the ones worth asking.
+expect "the summary counts only the lock writers" 0 "asked 2 pull request(s) that write the lock; 1 need ci again" \
+  "$sweep" --repo-dir "$repo" \
+  --fixture-open-prs "$(printf '11 %s\n12 %s\n13 %s\n' "$stale" "$fine" "$prose")" \
+  --fixture-runs "$stale 111"
+
+# A head this checkout does not hold is named, not guessed at.
+expect "an unknown head is named" 0 "is not a commit here" \
+  "$sweep" --repo-dir "$repo" \
+  --fixture-open-prs "17 0000000000000000000000000000000000000000" \
+  --fixture-runs "none none"
+
+# No open pull requests is a clean answer.──────
+expect "an empty list says so" 0 "no open pull requests" \
+  "$sweep" --repo-dir "$repo" --fixture-open-prs "" --fixture-runs ""
+
+# Every unknown fails open.──────────
+# A red job here would call a pull request broken when nobody asked that. Its
+# own checks are the one thing allowed to answer.
+expect "a missing repo exits 0 and says why" 0 "no such directory" \
+  "$sweep" --repo-dir "$tmp/nowhere" --fixture-open-prs "11 $stale" --fixture-runs ""
+
+# A bad argument is a usage error, never a silent pass.
+refuse "an unknown argument is refused" "unknown argument" "$sweep" --nope
+refuse "--limit with no value is refused" "needs a number" "$sweep" --limit
+refuse "--repo-dir with no value is refused" "needs a directory" "$sweep" --repo-dir
+
+echo
+echo "test-recheck-lock-compositions: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

`Cargo.lock` is a shared cell. Two branches can each write it correctly and still land a tree cargo cannot resolve. `auto-tag.yml` asked that question of its own `bot/version-sync` branch and of nothing else, so the identical break landed from the other direction on 2026-09-06: the sync to `0.9.330` merged at 09:51, the branch adding the `stella-learn` crate merged at 09:59 carrying a lock entry at `0.9.329`, every `--locked` build on `main` failed, and three sessions each wrote the same repair (`#5939`).

Three changes:

1. **The question becomes shared.** The merge, the check and the undo move into `scripts/check-merge-lockfile-sync.sh`. `auto-tag.yml` calls it before the write-back merges (replacing its inlined copy, which nothing tested), `ci.yml`'s required job calls it on every pull request, and the sweep below calls it. It refuses to start on a dirty tree and puts the tree back on every exit path, the failing ones included.

2. **The stale answer gets re-asked.** This is the half the issue's "Why no pre-merge check saw it" section is really about. `ci.yml` checks out `refs/pull/N/merge`, so it already reads a merge result — but the merge GitHub computed when the pull request last changed. `strict` is off, so a green check outlives the `main` it was true of, and nothing re-asks. `lock-recheck.yml` is the missing event: on a push to `main` that writes the lock or a manifest, `scripts/recheck-lock-compositions.sh` merges each open pull request head into the new tip and runs `ci` again on the ones whose merged lock stops resolving. The new run reports under the same name on the same commit, so the required `ci` context goes red and the merge waits. That is the shape `refresh-main-red-holds.sh` and `dod-recheck.sh` already use for a stale check, and it needs no branch-protection change.

3. **`auto-tag.yml`'s header stops overstating what it covers.** It said every check runs on the branch rather than on the merge result. That was wrong about which trees are read and right only about staleness. It now says which directions are covered and names the two callers pointed the other way.

**What bounds the cost.** A pull request that writes no `Cargo.lock` cannot add a stale entry to it, so the sweep skips it without asking — one `git fetch` per open pull request on a quiet day, and a `ci` re-run only where `main` is genuinely about to break. Every unknown in the sweep prints a note and exits 0.

**What this deliberately does not do.** The issue's direction 1 (turn `strict` on) and direction 3 (a post-merge auto-repair) are both maintainer calls — `scripts/main-canary.sh`'s header says in as many words that changing the "it does not open a fix PR" tradeoff is a decision to take on purpose, not by extending that script. This is direction 1 narrowed to the case that actually collides: the pull requests that write the shared cell are made to answer again, and nothing else pays.

Closes #5943

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`scripts/test-merge-lockfile-sync.sh` builds the two-branch collision as a throwaway git repo (a release sync on `main`, a new member on a branch cut before it) and asserts:

- `check-lockfile-sync.sh` **passes** on the branch alone — the false negative the issue names, pinned so a red there means the fixture is not the shape being tested;
- `check-merge-lockfile-sync.sh` **fails** on the pair, from the branch side and from `main`'s side;
- a member added *after* the bump, and a branch that writes no manifest, both still pass;
- the tree comes back from a failing run, a dirty tree is refused, and the verdict survives `| head -1`.

It fails on `main` for the plainest reason: the script it exercises does not exist there. `scripts/test-recheck-lock-compositions.sh` drives the sweep through every branch it has — stale, composing, not-a-lock-writer, run still going, no run, unreadable lookup, unknown head, missing repo — with `gh` stubbed by two fixture seams so no case can reach the network.

Both run in `guard-self-tests.yml`. Locally: 15 passed / 0 failed and 13 passed / 0 failed.

The guard was also run for real against `origin/main` from this branch: `OK — the lock still resolves once c92a9e5b8 is in`, with `git status --porcelain` empty afterwards.

## The gate

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [x] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #5943` appears **both** above and as a commit trailer

No Rust changed, so the two workspace boxes are CI's to tick — this laptop does not run them (CLAUDE.md, "CI builds and tests; this laptop does not"). Run locally: `make guards-fast` (green, including `shellcheck` over the three new scripts), `python3 scripts/check-prose.py` (green), `./scripts/check-gate-parity.sh`, `python3 scripts/check-guard-trigger-coverage.py`, and both new self-tests.

AGENTS.md gains the tenth workflow's paragraph, and its `Cargo.lock` gotcha no longer claims nothing pre-merge can see the collision — it can now, from a merged tree, and the remaining gap is named as staleness.

## Fix over file

- [x] Extra fixes in this PR: `auto-tag.yml`'s inlined merge-and-check had no test of its own and its header comment was wrong about which trees the required checks read; both are fixed here — **or** none
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

The sweep runs `ci` again on somebody else's pull request. That is the one authority question in this PR, and it is bounded three ways: it only fires for a pull request that writes `Cargo.lock`, only when merging it into the new tip leaves an unresolvable lock, and it starts an existing run again rather than pushing anything to the branch. `gh run rerun` replays the recorded merge commit, which is fine here: the new `ci` step fetches `origin/main` at run time and merges it in, so a replayed run still asks the current question.

No test was deleted in this PR.

## Summary by Sourcery

Prevent stale or conflicting Cargo.lock updates from merging by sharing merged-lock validation across workflows and rechecking affected pull requests whenever main changes.

New Features:
- Add pull-request CI coverage for lockfile composition after merging the current main branch.
- Recheck open lockfile-writing pull requests and rerun their CI when changes to main make their merged lockfile invalid.

Bug Fixes:
- Prevent incompatible Cargo.lock updates from landing when changes arrive from either branch direction.
- Replace the auto-tag workflow’s duplicated merge-lock validation with the shared guard.

Enhancements:
- Centralize merged-lock validation with safe cleanup, dirty-tree protection, and support for CI and local use.
- Add bounded, fail-open handling for pull-request lock composition sweeps.

Build:
- Add Makefile targets for merged-lock validation and recheck testing.

CI:
- Add the lock-recheck workflow and hermetic self-tests for merged-lock validation and stale composition detection.

Documentation:
- Document the lockfile composition guard, stale-check behavior, workflow coverage, and operational commands in AGENTS.md.

Tests:
- Add synthetic two-branch collision coverage, cleanup and refusal checks, and recheck-sweep scenarios.