### PR TITLE
feat(gate): catch a cargo flag pair no workflow would have run

### DIFF
--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -130,6 +130,17 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: python3 ./scripts/check-closing-keywords.py
 
+      # Here rather than in ci.yml, and for a sharper version of the reason
+      # the four above are: the only workflow that runs `doc-warnings-schema`
+      # is `wire-schema.yml`, and that workflow's `paths:` filter cannot be
+      # started by a `Makefile` edit. So the recipe's own runner never saw the
+      # recipe change, and `cargo clean --doc $(SCHEMA_CRATES)` merged green
+      # and stayed dead (#5947, #5992). This job has no `paths:` filter and no
+      # `needs`-gated `if:`, so a Makefile-only pull request reaches it.
+      - name: no recipe hands cargo a flag pair cargo refuses
+        if: ${{ !cancelled() }}
+        run: python3 ./scripts/check-cargo-flags.py
+
       # The steps above run here because this trigger carries no `paths:`
       # filter at all -- that is what lets them fire on a scripts-only pull
       # request. Nothing enforced that absence except a comment, so this reads
@@ -259,6 +270,10 @@ jobs:
       - name: dev-env setup script and its fmt-file hook
         if: ${{ !cancelled() }}
         run: ./scripts/test-dev-env.sh
+
+      - name: cargo-flags guard failure directions, variable expansion included
+        if: ${{ !cancelled() }}
+        run: python3 ./scripts/test-cargo-flags.py
 
       - name: gate-parity guard failure directions
         if: ${{ !cancelled() }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,8 +212,10 @@ gate steps ci.yml's job cannot — `prose`, `line-citations`, `hue-separation`,
 `transcript-surfaces` and `cargo-flags`; it is skipped for a prose-only diff,
 which is the diff `prose` exists to judge — alongside the hermetic suites that
 prove a guard can still fail (#3820, #4427). `cargo-flags` is there for a
-sharper version of the same reason: it reads the `Makefile`, and no workflow
-that runs a Makefile recipe can be started by a Makefile edit, which is how
+sharper version of the same reason: it reads the `Makefile`, and the one
+workflow that runs `doc-warnings-schema` cannot be started by a `Makefile`
+edit at all — its `paths:` list asks whether the diff could have made
+`docs/wire/` stale, which a recipe edit cannot. That is how
 `doc-warnings-schema` came to ship a first line cargo refuses and stay dead
 for seven hours with every run green. Which workflow runs a step is a
 judgement; *that* one does is checked, by `gate-parity` against every `run:`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,10 +111,13 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #   + schema-tier-parity (a -schema step runs at the
                          #     same rung as its base step; #5139)
                          #   + guard-trigger-coverage (prose, hue-separation,
-                         #     transcript-surfaces and closing-keywords each
+                         #     transcript-surfaces, closing-keywords and
+                         #     cargo-flags each
                          #     run, in some workflow, from a job neither a
                          #     paths: filter nor a needs.*.outputs.*-gated
                          #     if: can skip)
+                         #   + cargo-flags (no Makefile recipe hands cargo a
+                         #     flag pair cargo refuses; #5992)
                          #   + priority-scheme (the issue priority scheme is
                          #     stated once, in SCR-005, and the triage guard's
                          #     regex covers exactly the levels it names)
@@ -185,8 +188,8 @@ leaving `main` red for everyone (#1883).
 
 CI enforces the same steps split across four workflows:
 `/.github/workflows/ci.yml`'s required job runs everything except `invariants`,
-`doc-links`, `prose`, `line-citations`, `hue-separation` and
-`transcript-surfaces`, and adds a
+`doc-links`, `prose`, `line-citations`, `hue-separation`,
+`transcript-surfaces` and `cargo-flags`, and adds a
 `Cargo.lock` sync check, `stella context
 validate`, a release smoke build (thin LTO), and the deleted-test guard
 (`scripts/check-deleted-tests.sh`);
@@ -205,10 +208,14 @@ of the other two (#1439) — and `doc-warnings-schema` beside it, because
 that describes the wire format sits behind an off-by-default `schema` one, so
 rustdoc compiled none of them anywhere (#4584); this workflow already builds
 those three crates with the feature on; and `guard-self-tests.yml` runs the
-gate steps ci.yml's job cannot — `prose`, `line-citations`, `hue-separation`
-and `transcript-surfaces`; it is skipped for a prose-only diff, which is the
-diff `prose` exists to judge — alongside the hermetic suites that prove a
-guard can still fail (#3820, #4427). Which workflow runs a step is a
+gate steps ci.yml's job cannot — `prose`, `line-citations`, `hue-separation`,
+`transcript-surfaces` and `cargo-flags`; it is skipped for a prose-only diff,
+which is the diff `prose` exists to judge — alongside the hermetic suites that
+prove a guard can still fail (#3820, #4427). `cargo-flags` is there for a
+sharper version of the same reason: it reads the `Makefile`, and no workflow
+that runs a Makefile recipe can be started by a Makefile edit, which is how
+`doc-warnings-schema` came to ship a first line cargo refuses and stay dead
+for seven hours with every run green. Which workflow runs a step is a
 judgement; *that* one does is checked, by `gate-parity` against every `run:`
 in `.github/workflows/`. That check stops at "does some workflow run it" — it
 says nothing about which files reach it, so a `paths:` filter narrowing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ python3 ./scripts/check-adr-numbering.py
 ./scripts/check-schema-tier-parity.sh
 python3 ./scripts/check-guard-trigger-coverage.py
 python3 ./scripts/check-priority-scheme.py
+python3 ./scripts/check-cargo-flags.py
 ./scripts/check-left-behind.sh
 python3 ./scripts/check-retired-model-keys.py
 ./scripts/check-stat-portability.sh

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     adr-numbering \
                     command-docs website-inputs brand-case file-size god-files gate-parity \
                     schema-tier-parity \
-                    guard-trigger-coverage priority-scheme left-behind \
+                    guard-trigger-coverage priority-scheme cargo-flags left-behind \
                     retired-model-keys \
                     stat-portability module-reachability core-reachability \
                     typed-errors \
@@ -836,6 +836,24 @@ guard-trigger-coverage: ## Assert prose/hue-separation/transcript-surfaces each 
 .PHONY: guard-trigger-coverage-test
 guard-trigger-coverage-test: ## Test the guard-trigger-coverage guard's failure directions (hermetic; not part of `gate`)
 	@python3 ./scripts/test-guard-trigger-coverage.py
+
+# The guard for the recipes in this file. `doc-warnings-schema` ran
+# `cargo clean --doc $(SCHEMA_CRATES)` for as long as that line stood, and
+# cargo refuses the pair before it does anything, so the step was dead and
+# nothing said so (#5947, repaired in #5993). It ran nowhere a Makefile edit
+# could reach: its only workflow is `wire-schema.yml`, whose `paths:` list
+# answers "can this diff have invalidated `docs/wire/`", which a Makefile edit
+# cannot -- and widening that list would misdirect the pre-push hook, which
+# derives its rung from it. So the cover comes from here instead: this needs
+# no toolchain, and `guard-self-tests.yml` runs it with no `paths:` filter at
+# all (#5992).
+.PHONY: cargo-flags
+cargo-flags: ## Assert no recipe hands cargo a flag pair cargo refuses (#5992)
+	@python3 ./scripts/check-cargo-flags.py
+
+.PHONY: cargo-flags-test
+cargo-flags-test: ## Test the cargo-flags guard's failure directions (hermetic; not part of `gate`)
+	@python3 ./scripts/test-cargo-flags.py
 
 .PHONY: priority-scheme
 priority-scheme: ## Assert the issue priority scheme is stated once, in SCR-005 (#5216)

--- a/scripts/check-cargo-flags.py
+++ b/scripts/check-cargo-flags.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Guard: no Makefile recipe hands cargo a flag pair cargo refuses.
+
+For seven hours the first line of `doc-warnings-schema` read
+`cargo clean --doc $(SCHEMA_CRATES)`. Cargo turns that pair down at once:
+
+    $ cargo clean --doc -p stella-protocol
+    error: --doc cannot be used with -p
+
+The recipe died on that line every time. The whole step was dead with it.
+
+No check saw it, and that is the part worth fixing. One workflow runs
+`doc-warnings-schema`, and that is `wire-schema.yml`. Its `paths:` list asks
+one thing: could this diff have made the files under `docs/wire/` stale? A
+`Makefile` edit cannot. So the `Makefile` is not on that list, and it must
+not go on it. The pre-push hook picks its rung from the same list, through
+`scripts/wire-schema-paths.sh`, and a wider list would send the hook up a
+rung for no reason. The upshot: the one runner of the recipe never sees the
+recipe change. The diff that broke this line touched the `Makefile` and
+nothing else. Its own run did not execute a word of what it had rewritten,
+and it merged green.
+
+This shuts the hole from the other side. It needs no toolchain, so it sits at
+`guards-fast`. It runs in the job in `guard-self-tests.yml` that has no
+`paths:` filter, which fires on every pull request.
+
+What it checks: every cargo command in every Makefile recipe, against a table
+of flag pairs cargo refuses. Each row quotes what cargo said, on the
+toolchain `rust-toolchain.toml` pins.
+
+What it does not check: whether a recipe that runs does the right thing. A
+flag pair cargo takes and a command that works are two claims. Only the first
+can be settled with no toolchain.
+
+Make does the expanding. Recipes reach cargo through variables, and
+`$(SCHEMA_CRATES)` is how the refused `-p` got in, so this asks
+`make --dry-run` for the commands instead of expanding them again here. A
+second expander is a second thing to keep right, and the bug lives in that
+very gap.
+
+Usage:
+
+    ./scripts/check-cargo-flags.py [--makefile PATH]
+
+`--makefile` aims the run at another tree. That is what lets
+`scripts/test-cargo-flags.py` build fixture Makefiles and watch this guard
+fail on them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# ── The table ────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Refusal:
+    """One flag combination cargo rejects, and the words it rejects it with."""
+
+    subcommand: str
+    requires: tuple[str, ...]
+    forbids: tuple[str, ...]
+    cargo_says: str
+    remedy: str
+
+
+# Add a row only after you run the pair and read the error. A made-up row
+# bans a spelling cargo may well take. That costs an author a day.
+REFUSALS = (
+    Refusal(
+        subcommand="clean",
+        requires=("--doc",),
+        forbids=("-p", "--package"),
+        cargo_says="--doc cannot be used with -p",
+        remedy=(
+            "Drop the package filter. `cargo clean --doc` takes the whole "
+            "doc tree of one target directory, so scope it with "
+            "CARGO_TARGET_DIR instead."
+        ),
+    ),
+)
+
+# Words that can sit in front of a command without being the command. Shell
+# keywords, plus the `VAR=value` form the recipes here use.
+KEYWORDS = frozenset(
+    {"!", "(", "{", "do", "elif", "else", "exec", "if", "then", "time", "while"}
+)
+
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# A target line is a name and a colon. No `=` may follow the colon, since
+# `:=` and `::=` set a variable. A leading dot marks a directive.
+TARGET_LINE = re.compile(r"^(?P<name>[A-Za-z0-9_][A-Za-z0-9_.-]*)\s*:(?![=:])")
+
+
+class GuardError(Exception):
+    """A condition that stops the parse rather than narrowing it."""
+
+
+# ── Reading the Makefile ─────────────────────────────────────────────────────
+
+
+def targets_running_cargo(makefile: Path) -> list[str]:
+    """Every target whose recipe mentions cargo, in file order.
+
+    A textual scan, because it only has to find candidate names -- make
+    expands them below, and a target whose recipe turns out to run no cargo
+    costs one printed line and nothing else.
+    """
+    found: list[str] = []
+    current: str | None = None
+    mentions_cargo = False
+
+    def close() -> None:
+        nonlocal current, mentions_cargo
+        if current is not None and mentions_cargo and current not in found:
+            found.append(current)
+        current = None
+        mentions_cargo = False
+
+    for raw in makefile.read_text(encoding="utf-8").splitlines():
+        if raw.startswith("\t"):
+            if "cargo" in raw:
+                mentions_cargo = True
+            continue
+        close()
+        match = TARGET_LINE.match(raw)
+        if match:
+            current = match.group("name")
+    close()
+    return found
+
+
+def expand(makefile: Path, targets: list[str]) -> str:
+    """The recipe lines make would run, with every variable already expanded.
+
+    One invocation for every target rather than one each: make parses the file
+    once, and the file's `$(shell ...)` variables run once with it.
+    """
+    if not targets:
+        return ""
+    env = dict(os.environ)
+    # A parent make exports its own flags. A jobserver is noise for a run
+    # that only prints.
+    env.pop("MAKEFLAGS", None)
+    env.pop("MFLAGS", None)
+    env.pop("MAKELEVEL", None)
+    result = subprocess.run(
+        ["make", "-f", makefile.name, "--dry-run", "--no-print-directory", *targets],
+        cwd=makefile.parent,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise GuardError(
+            f"`make --dry-run` failed for {makefile}:\n{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def logical_lines(printed: str) -> list[str]:
+    """Recipe lines, with backslash continuations joined back together."""
+    joined: list[str] = []
+    pending = ""
+    for line in printed.splitlines():
+        pending += line
+        if pending.endswith("\\"):
+            pending = pending[:-1] + " "
+            continue
+        joined.append(pending.replace("\t", " "))
+        pending = ""
+    if pending:
+        joined.append(pending.replace("\t", " "))
+    return joined
+
+
+# ── Reading a command out of a line ──────────────────────────────────────────
+
+
+def simple_commands(line: str) -> list[str]:
+    """Split a recipe line on the shell operators that end a command.
+
+    Quotes are honoured, so an operator inside a quoted string stays part of
+    it. Only `;`, `|`, `&` and their doubled forms separate; a redirection
+    does not, and neither does anything inside `$(...)`, which is left whole
+    because a command substitution running cargo is still a command this
+    reads.
+    """
+    parts: list[str] = []
+    buffer: list[str] = []
+    quote: str | None = None
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if quote is not None:
+            buffer.append(char)
+            if char == "\\" and quote == '"' and index + 1 < len(line):
+                index += 1
+                buffer.append(line[index])
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in ("'", '"'):
+            quote = char
+            buffer.append(char)
+            index += 1
+            continue
+        if char == "\\" and index + 1 < len(line):
+            buffer.append(char)
+            index += 1
+            buffer.append(line[index])
+            index += 1
+            continue
+        if char in (";", "|", "&"):
+            parts.append("".join(buffer))
+            buffer = []
+            index += 1
+            if index < len(line) and line[index] == char:
+                index += 1
+            continue
+        buffer.append(char)
+        index += 1
+    parts.append("".join(buffer))
+    return [part for part in parts if part.strip()]
+
+
+def cargo_argv(command: str) -> list[str] | None:
+    """The cargo invocation in this command, or None when there is not one.
+
+    Leading environment assignments and shell keywords are stepped over. A
+    command that merely names cargo in an argument -- a `printf` telling
+    somebody to run `cargo install cargo-deny`, a script called
+    `check-cargo-install-pins.sh` -- is not one.
+    """
+    if "cargo" not in command:
+        return None
+    try:
+        tokens = shlex.split(command)
+    except ValueError as error:
+        raise GuardError(
+            f"could not read this recipe command as shell words: {command!r}\n"
+            f"  {error}\n"
+            "  Teach this parse the shape rather than letting it skip a line: "
+            "a skipped line is an unchecked cargo invocation."
+        ) from error
+    while tokens and (tokens[0] in KEYWORDS or ASSIGNMENT.match(tokens[0])):
+        tokens.pop(0)
+    if not tokens or Path(tokens[0]).name != "cargo":
+        return None
+    return tokens
+
+
+def subcommand_and_flags(argv: list[str]) -> tuple[str, list[str]]:
+    """The cargo subcommand, and the flags cargo itself is asked to read.
+
+    Everything after a bare `--` belongs to the tool cargo runs -- the
+    `-- -D warnings` every clippy recipe ends with -- so the scan stops there.
+    """
+    rest = argv[1:]
+    while rest and rest[0].startswith("+"):
+        rest.pop(0)
+    if not rest:
+        return "", []
+    subcommand = ""
+    flags: list[str] = []
+    for token in rest:
+        if token == "--":
+            break
+        if token.startswith("-"):
+            flags.append(token.split("=", 1)[0])
+        elif not subcommand:
+            subcommand = token
+    return subcommand, flags
+
+
+# ── The verdict ──────────────────────────────────────────────────────────────
+
+
+def offences(command: str) -> list[tuple[Refusal, str]]:
+    argv = cargo_argv(command)
+    if argv is None:
+        return []
+    subcommand, flags = subcommand_and_flags(argv)
+    if not subcommand:
+        return []
+    hits: list[tuple[Refusal, str]] = []
+    for refusal in REFUSALS:
+        if refusal.subcommand != subcommand:
+            continue
+        if not all(flag in flags for flag in refusal.requires):
+            continue
+        clash = next((flag for flag in refusal.forbids if flag in flags), None)
+        if clash is not None:
+            hits.append((refusal, clash))
+    return hits
+
+
+def check(makefile: Path) -> int:
+    targets = targets_running_cargo(makefile)
+    printed = expand(makefile, targets)
+    failures: list[str] = []
+    checked = 0
+    for line in logical_lines(printed):
+        for command in simple_commands(line):
+            if cargo_argv(command) is None:
+                continue
+            checked += 1
+            for refusal, clash in offences(command):
+                failures.append(
+                    f"FAIL — cargo refuses this recipe command:\n"
+                    f"       {command.strip()}\n"
+                    f"       cargo says: error: {refusal.cargo_says}\n"
+                    f"       `{' '.join(refusal.requires)}` cannot be used "
+                    f"with `{clash}` on `cargo {refusal.subcommand}`.\n"
+                    f"       {refusal.remedy}"
+                )
+
+    for failure in failures:
+        print(f"check-cargo-flags: {failure}", file=sys.stderr)
+    if failures:
+        print(
+            "check-cargo-flags: a recipe that dies on its first line is a gate "
+            "step that never ran.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"check-cargo-flags: OK — {checked} cargo invocations across "
+        f"{len(targets)} recipes, none carrying a flag pair cargo refuses."
+    )
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--makefile",
+        default=str(Path(__file__).resolve().parent.parent / "Makefile"),
+        help="the Makefile to read (default: this repository's).",
+    )
+    args = parser.parse_args(argv)
+    makefile = Path(args.makefile).resolve()
+    if not makefile.is_file():
+        print(f"check-cargo-flags: {makefile} does not exist.", file=sys.stderr)
+        return 2
+    try:
+        return check(makefile)
+    except GuardError as error:
+        print(f"check-cargo-flags: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -166,6 +166,7 @@ step_command() {
   light-clamp) echo 'check-light-clamp' ;;
   transcript-surfaces) echo 'check-transcript-surfaces' ;;
   guard-trigger-coverage) echo 'check-guard-trigger-coverage' ;;
+  cargo-flags) echo 'check-cargo-flags' ;;
   priority-scheme) echo 'check-priority-scheme' ;;
   prose) echo 'check-prose' ;;
   line-citations) echo 'check-line-citations' ;;

--- a/scripts/check-guard-trigger-coverage.py
+++ b/scripts/check-guard-trigger-coverage.py
@@ -64,6 +64,10 @@ WATCHED_GUARDS = (
     "check-hue-separation.py",
     "check-transcript-surfaces.py",
     "check-closing-keywords.py",
+    # Watched for its own reason. It reads the `Makefile`. No workflow that
+    # runs a Makefile recipe can be started by a Makefile edit. A `paths:`
+    # filter here would put this guard back in the hole it closes.
+    "check-cargo-flags.py",
 )
 
 WORKFLOWS_DIR = "workflows"

--- a/scripts/test-cargo-flags.py
+++ b/scripts/test-cargo-flags.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Self-test: `scripts/check-cargo-flags.py` can still fail.
+
+A ratchet that has quietly stopped being able to fail reports green forever,
+which is worse than not having one. Every case below builds a fixture
+Makefile in a temporary directory and runs the guard against it with
+`--makefile`, so nothing here reads or writes this repository -- except the
+last case, which runs the guard on the live tree and expects a pass.
+
+The case that matters most is the one the guard was written for: the refused
+flag arriving through a make variable rather than spelled out. That is how
+`cargo clean --doc $(SCHEMA_CRATES)` shipped, and a guard that read the
+Makefile text instead of asking make to expand it would miss it.
+
+    ./scripts/test-cargo-flags.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+GUARD = Path(__file__).resolve().parent / "check-cargo-flags.py"
+REPO_MAKEFILE = Path(__file__).resolve().parent.parent / "Makefile"
+
+failures: list[str] = []
+passes = 0
+
+
+def run(makefile: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GUARD), "--makefile", str(makefile)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def case(name: str, body: str, want_code: int, want_text: str = "") -> None:
+    """Write a fixture Makefile, run the guard, and hold it to one verdict."""
+    global passes
+    with tempfile.TemporaryDirectory(prefix="stella-cargo-flags-") as directory:
+        makefile = Path(directory) / "Makefile"
+        makefile.write_text(body, encoding="utf-8")
+        result = run(makefile)
+    output = result.stdout + result.stderr
+    if result.returncode != want_code:
+        failures.append(
+            f"{name}: exit {result.returncode}, wanted {want_code}\n{output}"
+        )
+        return
+    if want_text and want_text not in output:
+        failures.append(f"{name}: output never said {want_text!r}\n{output}")
+        return
+    passes += 1
+
+
+# C1 — the defect itself, reaching cargo through a variable.
+case(
+    "C1 refused pair via a variable",
+    "CRATES := -p one -p two\n"
+    ".PHONY: docs\n"
+    "docs:\n"
+    "\tcargo clean --doc $(CRATES)\n",
+    1,
+    "--doc cannot be used with -p",
+)
+
+# C2 — the same pair spelled out, and in its long form.
+case(
+    "C2 refused pair spelled out",
+    ".PHONY: docs\ndocs:\n\tcargo clean --doc --package one\n",
+    1,
+    "--doc cannot be used with -p",
+)
+
+# C3 — the repaired recipe. The scope moves to the target directory, which is
+# what the live Makefile does.
+case(
+    "C3 the repaired recipe passes",
+    ".PHONY: docs\ndocs:\n\tCARGO_TARGET_DIR=target/doc-schema cargo clean --doc\n",
+    0,
+    "none carrying a flag pair cargo refuses",
+)
+
+# C4 — either flag alone is fine, and so is the pair on another subcommand.
+case(
+    "C4 neither flag alone is an offence",
+    ".PHONY: a b c\n"
+    "a:\n\tcargo clean --doc\n"
+    "b:\n\tcargo clean -p one\n"
+    "c:\n\tcargo doc -p one --no-deps\n",
+    0,
+)
+
+# C5 — cargo named in an argument is not a cargo invocation. A false positive
+# here would fire on the live tree, where a help message names `cargo install
+# cargo-deny` and a guard script is called `check-cargo-install-pins.sh`.
+case(
+    "C5 cargo inside an argument is not an invocation",
+    ".PHONY: talk\n"
+    "talk:\n"
+    "\tprintf 'run: cargo clean --doc -p one\\n'\n"
+    "\t./scripts/check-cargo-install-pins.sh\n",
+    0,
+)
+
+# C6 — flags after a bare `--` belong to the tool cargo runs, not to cargo.
+case(
+    "C6 flags after -- are not cargo's",
+    ".PHONY: lint\nlint:\n\tcargo clean --doc -- -p one\n",
+    0,
+)
+
+# C7 — a Makefile make itself refuses stops the run. Reporting a read it could
+# not finish as a pass is the one outcome a guard must never have.
+case(
+    "C7 a Makefile make refuses is reported, not passed",
+    ".PHONY: broken\nbroken: no-rule-makes-this\n\tcargo clean --doc\n",
+    2,
+    "make --dry-run` failed",
+)
+
+# C8 — a Makefile that is not there.
+with tempfile.TemporaryDirectory(prefix="stella-cargo-flags-") as empty:
+    absent = run(Path(empty) / "Makefile")
+    if absent.returncode == 2:
+        passes += 1
+    else:
+        failures.append(
+            f"C8 missing Makefile: exit {absent.returncode}, wanted 2\n"
+            f"{absent.stdout}{absent.stderr}"
+        )
+
+# C9 — the live tree passes. Without this the suite could go green on a guard
+# that fails on everything.
+live = run(REPO_MAKEFILE)
+if live.returncode == 0:
+    passes += 1
+else:
+    failures.append(
+        f"C9 live Makefile: exit {live.returncode}, wanted 0\n{live.stdout}{live.stderr}"
+    )
+
+for failure in failures:
+    print(f"test-cargo-flags: FAIL — {failure}", file=sys.stderr)
+
+if failures:
+    print(f"test-cargo-flags: {len(failures)} of {passes + len(failures)} cases failed.")
+    sys.exit(1)
+
+print(f"test-cargo-flags: OK — {passes} cases.")


### PR DESCRIPTION
## What & why

`doc-warnings-schema` shipped `cargo clean --doc $(SCHEMA_CRATES)` as its first
line. Cargo refuses that pair outright:

```
$ cargo clean --doc -p stella-protocol
error: --doc cannot be used with -p
```

So the recipe exited 101 on line one every time it ran, and the whole gate step
was dead for seven hours with every run reporting green. That line is repaired
already. This PR is about why nothing noticed.

**Root cause.** `doc-warnings-schema` runs in exactly one workflow,
`.github/workflows/wire-schema.yml`, whose `paths:` list answers one question:
could this diff have made the generated files under `docs/wire/` stale? A
Makefile edit cannot, so `Makefile` is not on that list — and putting it there
is the wrong repair, because `scripts/wire-schema-paths.sh` derives
`.githooks/pre-push`'s rung choice from the same list, and a wider list would
send the hook up a rung on a false premise. The result is that the recipe's only
runner never sees the recipe change.

**The fix** is the issue's second option: a static guard that needs no
toolchain, so it can run everywhere.

- `scripts/check-cargo-flags.py` — asks `make --dry-run` for the recipe lines of
  every target whose recipe mentions cargo, then holds each cargo command in
  them to a table of flag pairs cargo refuses. Make does the expanding, which is
  what makes the defect visible: the refused `-p` arrived through
  `$(SCHEMA_CRATES)`, and a guard reading the Makefile text would have missed it.
  Each table row quotes the error cargo actually printed on the pinned
  toolchain; the header says plainly that a flag pair cargo accepts is not the
  same claim as a recipe that does the right thing.
- Wired into `GATE_GUARDS_FAST` as `cargo-flags`, and run in
  `guard-self-tests.yml`'s `gate-steps` job — the job with no `paths:` filter and
  no `needs`-gated `if:`, so a Makefile-only pull request reaches it.
- Added to `check-guard-trigger-coverage.py`'s watch list, so a later `paths:`
  filter over that workflow cannot reopen the hole quietly.
- `wire-schema.yml`, `scripts/wire-schema-paths.sh` and `.githooks/pre-push` are
  untouched.

Closes #5992

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

The witness is the defect itself. On this branch, restoring the broken line:

```
$ python3 scripts/check-cargo-flags.py
check-cargo-flags: FAIL — cargo refuses this recipe command:
       CARGO_TARGET_DIR=target/doc-schema cargo clean --doc -p stella-protocol -p stella-plugin -p stella-serve
       cargo says: error: --doc cannot be used with -p
       `--doc` cannot be used with `-p` on `cargo clean`.
exit=1
```

and with the line as it stands today:

```
$ python3 scripts/check-cargo-flags.py
check-cargo-flags: OK — 32 cargo invocations across 29 recipes, none carrying a flag pair cargo refuses.
```

`scripts/test-cargo-flags.py` holds that in nine hermetic cases against fixture
Makefiles in a temporary directory: the refused pair reaching cargo through a
make variable, the same pair spelled out, the repaired form, either flag alone,
cargo named only inside an argument, flags after a bare `--`, a Makefile make
itself refuses (reported, never passed), a missing Makefile, and the live tree
still passing. `python3 scripts/test-cargo-flags.py` → `OK — 9 cases`.

CI demonstrates the trigger half directly: this PR's own diff includes
`Makefile`, and the `gate steps no other workflow runs` job runs the new guard
on it.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`, green)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — no Rust changed;
      CI runs it
- [ ] `cargo test --workspace` — no Rust changed; CI runs it
- [x] Docs updated: AGENTS.md's gate block and workflow prose, CONTRIBUTING.md's
      gate fence — `gate-parity` enforces the trio and passes (58 steps)
- [x] CLA signed
- [x] `Closes #5992` appears above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: none
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

The issue names a second, complementary option — giving `doc-warnings-schema` a
job whose trigger includes `Makefile`. It is not taken here and nothing is
filed for it: the guard in this PR closes the definition of done, and a second
workflow would buy a toolchain install and a three-crate rustdoc build on every
Makefile edit for a class of defect this catches statically. If a recipe defect
that is not a flag-shape error ever gets through, that is the moment to weigh
the cost.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The refusal table has one row today, and that is on purpose: a row goes in only
after somebody runs the pair and reads cargo's error. An invented row would ban
a spelling cargo may well accept, which is the direction that costs an author a
day. The row here was verified on the toolchain `rust-toolchain.toml` pins.

## Summary by Sourcery

Add an always-reachable cargo flag guard to catch Makefile recipes that cargo rejects before their workflow can run.

New Features:
- Add a static guard that detects cargo command flag combinations rejected by the pinned toolchain, including flags introduced through Make expansion.

Bug Fixes:
- Prevent Makefile recipes from silently shipping cargo invocations that fail immediately on unsupported flag combinations.

Enhancements:
- Run the cargo flag guard in an unfiltered self-test workflow so Makefile-only changes are covered.
- Include cargo-flag coverage in gate parity and workflow trigger coverage checks.

CI:
- Add hermetic self-tests covering rejected flag pairs, variable expansion, parsing boundaries, Makefile failures, missing files, and the live Makefile.

Documentation:
- Document the new cargo-flags gate and its workflow coverage in AGENTS.md and CONTRIBUTING.md.

Tests:
- Add nine self-test cases proving the guard detects failures and avoids false positives.