### PR TITLE
fix(scripts): stop a queued ci run reading as a verified main

### DIFF
--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -114,29 +114,51 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/refresh-main-red-holds.sh
 
-      # The other half of the same question, and the one nothing asked: is
-      # there a commit on `main` that nothing VERIFIED — as distinct from one
-      # a check said no about (#5027)?
-      #
-      # This canary only files when its own job runs and fails, so a
-      # `startup_failure`, a cancellation, or a run that was never created
-      # produces no issue at all. On 2026-08-26 four commits landed during a
-      # runner outage and `main` sat unchecked for 85 minutes with every
-      # surface reading green.
-      #
-      # `!cancelled()` so it still reports when the reconciliation above
-      # failed: a red `main` that ALSO carries unverified commits is worse
-      # than either, and the reader should see both. It fails open at every
-      # unknown, so it cannot itself become the thing blocking a repair.
+  # The other half of the same question, and the one nothing asked: is there a
+  # commit on `main` that nothing VERIFIED — as distinct from one a check said
+  # no about (#5027)?
+  #
+  # The canary above files only when its own job runs and fails, so a
+  # `startup_failure`, a cancellation, or a run that was never created produces
+  # no issue at all. On 2026-08-26 four commits landed during a runner outage
+  # and `main` sat unchecked for 85 minutes with every surface reading green.
+  #
+  # ── Its own job, because it must not queue behind the compile (#5964) ───────
+  #
+  # This was the third step of the job above, so the answer about whether main
+  # has been checked arrived only after a toolchain install, a cache restore
+  # and `cargo check --workspace` — minutes, on a run that a busy tree has
+  # already held for twenty-five. It also died with that job: a 15-minute
+  # timeout on the compile took the report with it, and the report is the half
+  # that costs seconds.
+  #
+  # Nothing here compiles, so it takes neither the toolchain nor the cache.
+  # This does not make the answer immune to a full Actions queue — hosted
+  # runners have no priority lane, and nothing in this repository can give it
+  # one — but it does stop the answer waiting on this repository's own
+  # slowest job once a runner is free.
+  verified:
+    name: main carries no unverified commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # `--limit 10` reads ten commits, and the default shallow checkout gives
+      # it one. Every CI run of this script has reported on the tip alone —
+      # "each of the last 1 commit(s)" — while the outage it was written for
+      # buried four in a row (#5964). Thirty is depth enough for the window the
+      # script asks about, and cheap next to a full history.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 30
+
       - name: Every recent commit on main has a completed ci run
-        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # `--announce` opens/refreshes/closes a `main-unverified`-labelled
-        # issue on the same shape as the reconciliation step above — before
-        # this the finding printed into this step's log and reached nobody
-        # (#5731, #5811, #5856). Its own label, not `main-red`: "nothing
-        # verified this commit" is a different state from "a check said no
-        # about this commit", and main-red-hold.yml reads only `main-red`, so
-        # this never blocks a merge on an absence of information.
+        # issue on the same shape as the reconciliation job above — before
+        # this the finding printed into a step log and reached nobody (#5731,
+        # #5811, #5856). Its own label, not `main-red`: "nothing verified this
+        # commit" is a different state from "a check said no about this
+        # commit", and main-red-hold.yml reads only `main-red`, so this never
+        # blocks a merge on an absence of information.
         run: ./scripts/check-main-verified.sh --announce

--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -141,6 +141,12 @@ jobs:
     name: main carries no unverified commit
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Narrower than the workflow's block, which the job above needs: this one
+    # reads run history and writes one labelled issue. It re-runs nobody's
+    # hold, so it has no business with `actions` or `pull-requests`.
+    permissions:
+      contents: read
+      issues: write
     steps:
       # `--limit 10` reads ten commits, and the default shallow checkout gives
       # it one. Every CI run of this script has reported on the tip alone —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,7 @@ number, so 0031's renumber hunted seven of those by hand (`#5930`).
 `docs/adr/README.md` § "The number is a shared cell" carries the rest,
 including why id citations for ADRs are a stated non-goal today.
 
-It answers "is `main` **known broken**". A second step in the same workflow —
+It answers "is `main` **known broken**". A second job in the same workflow —
 `scripts/check-main-verified.sh` (`make main-verified`) — answers the question
 nothing else here asks: is there a commit on `main` that nothing **verified**?
 Those are different states, and every other mechanism reads the second as
@@ -300,9 +300,31 @@ failing run is a **verified** commit and stays the canary's business; this
 reports only the absence of an answer, and fails open at every unknown so it
 can never be the thing blocking a repair.
 
-**Both steps file, under different labels.** The first step's `--announce`
-opened an issue; the second printed its finding into the step's own log and
-exited 1, and the composition step above it can pass on the same run — so the
+**A run still going is not an answer either.** Counting one as an answer is
+what this script did for the whole 45-minute stuck window, and it then printed
+"each of the last N commits on main has a completed ci run" over commits with
+no completed run. That window fills up under ordinary load, not only during an
+outage: fourteen open pull requests fanning out across these workflows put
+every `main` run 24 to 27 minutes behind a runner on 2026-09-05, and eleven
+commits went unanswered while a repaired tree still read as broken. So the
+script reports three states rather than two. `pending` names the commits whose run has not
+concluded, counts how many of the repository's 100 most recent runs are
+unfinished, exits 0, and closes no open `main-unverified` issue — a recovery
+is claimed off an answer, never off the absence of one.
+
+It is a separate job because it was the third step of the compile job, so an
+answer that costs seconds waited on a toolchain, a cache and
+`cargo check --workspace`, and a timeout there took it away entirely. Its
+checkout asks for thirty commits: the default shallow one gave `--limit 10`
+exactly one commit, so every CI run of this guard had reported on the tip
+alone. Hosted runners have no priority lane, so neither change makes the
+answer immune to a full queue — they stop it waiting on this repository's own
+slowest job, and the `pending` state is what keeps the wait from reading as
+green.
+
+**Both jobs file, under different labels.** The first job's `--announce`
+opened an issue; the second printed its finding into a step log and
+exited 1, and the composition job can pass on the same run — so the
 finding never reached anything a person reads. That happened twice, both
 times on a `chore(release): sync versions` commit whose run concluded
 `failure` with no `main-red` issue open either day.

--- a/scripts/check-main-verified.sh
+++ b/scripts/check-main-verified.sh
@@ -39,6 +39,26 @@
 #   queued too long  a run past --stuck-minutes with no runner
 #   startup_failure  the workflow never began, so no check ran
 #
+# ── Three states, because a run still going is not a verdict ─────────────────
+#
+# A run that has not ended is not an answer. Folding one into `verified` let
+# this script print "each of the last N commits on main has a completed ci
+# run" over commits with no completed run. A monitor must not say that.
+#
+# The window fills up under plain load. On 2026-09-05 fourteen open pull
+# requests fanned out across the workflows here. Every `main` run then sat 24
+# to 27 minutes behind a runner. Eight were queued at once, so the eleven
+# newest commits had no answer. The tree had been fixed eighteen minutes
+# earlier and nothing could see it.
+#
+#   verified   a terminal conclusion exists for the commit
+#   pending    a run exists, has not ended, and is inside the threshold
+#   unverified the absences listed above
+#
+# `pending` exits 0, like every other unknown here, and says what it is. It
+# closes no open `main-unverified` issue. A recovery is read off an answer,
+# never off the lack of one.
+#
 # ── It fails OPEN, at every unknown ──────────────────────────────────────────
 #
 # No `gh`, an unreachable API, an unparseable answer: report and exit 0. This
@@ -64,7 +84,7 @@
 # `main-red-hold.yml` reads only `main-red`, so an unverified-main issue never
 # arms it; blocking every open PR on an absence of information would fight the
 # fail-open discipline this whole file argues for. AGENTS.md's canary section
-# names which of `main-canary.yml`'s two steps files under which label.
+# names which of `main-canary.yml`'s two jobs files under which label.
 
 set -uo pipefail
 
@@ -75,6 +95,7 @@ limit=10
 stuck_minutes=45
 fixture_runs=""
 fixture_commits=""
+fixture_queue=""
 use_fixture=0
 announce=0
 dry_run=0
@@ -129,6 +150,16 @@ while [ $# -gt 0 ]; do
   --fixture-commits)
     fixture_commits="${2:-}"
     use_fixture=1
+    shift 2
+    ;;
+  # Test-only: stand in for the repository-wide queue census the pending
+  # report reads, so a case can pin the backlog line without an API.
+  --fixture-queue)
+    [ $# -ge 2 ] || {
+      echo "check-main-verified: --fixture-queue needs a number" >&2
+      exit 2
+    }
+    fixture_queue="$2"
     shift 2
     ;;
   -h | --help)
@@ -217,6 +248,7 @@ age_seconds() {
 }
 
 unverified=""
+still_running=""
 count=0
 
 while IFS= read -r commit; do
@@ -257,7 +289,7 @@ while IFS= read -r commit; do
         if [ "$age" -gt $((stuck_minutes * 60)) ]; then
           verdict="$status for $((age / 60))m — past the ${stuck_minutes}m threshold, so no runner is coming"
         else
-          verdict="verified"
+          verdict="pending: $status for $((age / 60))m, inside the ${stuck_minutes}m threshold"
         fi
       fi
       ;;
@@ -266,17 +298,58 @@ while IFS= read -r commit; do
 $runs
 EOF
 
-  if [ "$verdict" != "verified" ]; then
+  case "$verdict" in
+  verified) ;;
+  pending:*)
+    still_running="${still_running}  $short  ${verdict#pending: }
+      $subject
+"
+    ;;
+  *)
     unverified="${unverified}  $short  $verdict
       $subject
 "
-  fi
+    ;;
+  esac
 done <<EOF
 $commits
 EOF
 
+# Three states, and only the first one is green. `pending` and `unverified`
+# both mean no answer; they differ in whether an answer is still coming.
+state=verified
+[ -n "$still_running" ] && state=pending
+[ -n "$unverified" ] && state=unverified
+
 green=1
-[ -n "$unverified" ] && green=0
+[ "$state" = "verified" ] || green=0
+
+# How deep is the backlog these pending commits sit in? A commit list alone
+# cannot tell "the run is a minute old" from "this repo is a hundred runs
+# behind and nothing about `main` gets an answer for half an hour".
+queue_depth() {
+  if [ -n "$fixture_queue" ]; then
+    printf '%s' "$fixture_queue"
+    return
+  fi
+  [ "$use_fixture" -eq 1 ] && return
+  command -v gh >/dev/null 2>&1 || return
+  gh run list --limit 100 --json status \
+    --jq '[.[] | select(.status != "completed")] | length' 2>/dev/null || true
+}
+
+# Both reports below print this block, so it is written once.
+pending_report() {
+  printf 'These commits have a ci run that has not concluded yet:\n\n%s' "$still_running"
+  local depth
+  depth="$(queue_depth)"
+  case "$depth" in
+  '' | *[!0-9]*) ;;
+  *)
+    printf '\n%s of the 100 most recent runs in this repository have not finished.\n' "$depth"
+    ;;
+  esac
+}
 
 # ── Announcing ───────────────────────────────────────────────────────────────
 #
@@ -306,7 +379,16 @@ elif [ "$announce" -eq 1 ] && [ "$dry_run" -eq 0 ] && command -v gh >/dev/null 2
     --json number --jq '.[0].number // empty' 2>/dev/null || true)"
 fi
 
-if [ "$announce" -eq 1 ]; then
+if [ "$announce" -eq 1 ] && [ "$state" = "pending" ]; then
+  # An open issue stays open. Closing it here would report a recovery this run
+  # cannot see. That is the swap this script exists to refuse: no answer, read
+  # as green.
+  if [ -n "$open_issue" ]; then
+    printf 'check-main-verified: still pending — leaving issue %s open\n' "$open_issue" || true
+  else
+    printf 'check-main-verified: pending, nothing to file — an answer is still coming\n' || true
+  fi
+elif [ "$announce" -eq 1 ]; then
   if [ "$green" -eq 1 ]; then
     if [ -n "$open_issue" ]; then
       body="Every commit checked on this run has a completed \`ci\` run again.
@@ -392,14 +474,35 @@ ${unverified}\`\`\`"
   fi
 fi
 
-if [ "$green" -eq 1 ]; then
+if [ "$state" = "verified" ]; then
   echo "check-main-verified: OK — each of the last $count commit(s) on main has a completed ci run."
+  exit 0
+fi
+
+if [ "$state" = "pending" ]; then
+  echo "check-main-verified: PENDING — main carries commits with no answer yet."
+  echo
+  pending_report
+  cat <<'TXT'
+
+Exiting 0: an answer is still coming, so this is not a finding. It is also not
+green. Nothing here has checked these commits, and merging onto them is a bet
+on a run that has not reported.
+
+Watch for the answer rather than reading the silence:
+
+  gh run list --workflow ci.yml --branch main --limit 5
+TXT
   exit 0
 fi
 
 echo "check-main-verified: FAILED — main carries commits nothing verified."
 echo
 echo "$unverified"
+if [ -n "$still_running" ]; then
+  pending_report
+  echo
+fi
 cat <<'TXT'
 This is NOT "main is red". A failing run is a verified commit and the canary
 owns that. These commits have no answer at all, which every other mechanism

--- a/scripts/check-main-verified.sh
+++ b/scripts/check-main-verified.sh
@@ -335,17 +335,17 @@ queue_depth() {
     --jq '[.[] | select(.status != "completed")] | length' 2>/dev/null || true
 }
 
-# Both reports below print this block, so it is written once.
+# Read once, up front, so the three places that print the block below cost one
+# API call between them rather than one each.
+depth=""
+[ -n "$still_running" ] && depth="$(queue_depth)"
+case "$depth" in '' | *[!0-9]*) depth="" ;; esac
+
+# Every report that prints this block prints the same one.
 pending_report() {
   printf 'These commits have a ci run that has not concluded yet:\n\n%s' "$still_running"
-  local depth
-  depth="$(queue_depth)"
-  case "$depth" in
-  '' | *[!0-9]*) ;;
-  *)
+  [ -n "$depth" ] &&
     printf '\n%s of the 100 most recent runs in this repository have not finished.\n' "$depth"
-    ;;
-  esac
 }
 
 # ── Announcing ───────────────────────────────────────────────────────────────
@@ -405,13 +405,22 @@ Closing automatically — reopen if you disagree.
       printf 'check-main-verified: green, nothing open to close\n' || true
     fi
   else
-    body="\`main-canary.yml\`'s \`check-main-verified.sh\` step found commit(s) on
+    # A `main-unverified` issue filed during a forty-run backlog reads very
+    # differently once the reader can see the backlog, and nothing else on the
+    # issue says it.
+    pending_block=""
+    [ -n "$still_running" ] && pending_block="
+\`\`\`
+$(pending_report)
+\`\`\`
+"
+    body="\`main-canary.yml\`'s \`check-main-verified.sh\` job found commit(s) on
 \`main\` that **nothing has verified** — as distinct from a commit a check said
 no about, which \`main-canary.sh\`'s own issue already owns.
 
 \`\`\`
 ${unverified}\`\`\`
-
+${pending_block}
 This is NOT \"main is red\". A failing run is a verified commit and the canary
 owns that. These commits have no answer at all, which every other mechanism
 here reads as green: the canary files only when its job runs and fails, the

--- a/scripts/check-main-verified.sh
+++ b/scripts/check-main-verified.sh
@@ -321,9 +321,6 @@ state=verified
 [ -n "$still_running" ] && state=pending
 [ -n "$unverified" ] && state=unverified
 
-green=1
-[ "$state" = "verified" ] || green=0
-
 # How deep is the backlog these pending commits sit in? A commit list alone
 # cannot tell "the run is a minute old" from "this repo is a hundred runs
 # behind and nothing about `main` gets an answer for half an hour".
@@ -389,7 +386,7 @@ if [ "$announce" -eq 1 ] && [ "$state" = "pending" ]; then
     printf 'check-main-verified: pending, nothing to file — an answer is still coming\n' || true
   fi
 elif [ "$announce" -eq 1 ]; then
-  if [ "$green" -eq 1 ]; then
+  if [ "$state" = "verified" ]; then
     if [ -n "$open_issue" ]; then
       body="Every commit checked on this run has a completed \`ci\` run again.
 Closing automatically — reopen if you disagree.

--- a/scripts/test-main-verified.sh
+++ b/scripts/test-main-verified.sh
@@ -324,6 +324,19 @@ case "$out" in
   *) fail=$((fail + 1)); echo "FAIL a pending run did not say what it left open:"; echo "$out" ;;
 esac
 
+# A filed issue carries the backlog beside the absence. "Nothing verified
+# these commits" and "this repository is 46 runs deep" are one finding, and an
+# issue that reports the first without the second sends the reader hunting for
+# a cause that is on the same screen.
+out="$("$SCRIPT" --fixture-commits "$pending_and_missing" \
+  --fixture-runs "$B queued none $(now_iso)" \
+  --announce --dry-run --fixture-queue 46 2>&1)"
+case "$out" in
+  *"46 of the 100 most recent runs"*)
+    pass=$((pass + 1)); echo "ok   a filed issue names the backlog beside the absence" ;;
+  *) fail=$((fail + 1)); echo "FAIL the filed issue did not name the backlog:"; echo "$out" ;;
+esac
+
 # Nor does it file: an answer that has not arrived is not yet an absence, and
 # the stuck threshold above owns the point where it becomes one.
 out="$("$SCRIPT" --fixture-commits "$pending_commits" --fixture-runs "$pending_runs" \

--- a/scripts/test-main-verified.sh
+++ b/scripts/test-main-verified.sh
@@ -109,12 +109,64 @@ want "a run queued for hours with no runner is reported" expect-fail \
   "$A queued none $(long_ago)" \
   "no runner is coming"
 
-# ...and a run queued for a moment is NOT. Without this the guard fires on
-# every merge in the ninety seconds before a runner picks it up, which is how a
-# monitor earns a mute filter.
-want "a run queued a moment ago is not reported" expect-pass \
+# ── P: queued inside the threshold — the third state ─────────────────────────
+#
+# A run that has not concluded is not a verdict. Folding one into `verified`
+# for the whole 45-minute window let the script print "each of the last N
+# commits on main has a completed ci run" over commits that had no completed
+# run — a monitor asserting what it had not established.
+#
+# It still exits 0. Firing on every merge in the ninety seconds before a runner
+# picks it up is how a monitor earns a mute filter, and an unknown that blocks
+# a merge is the failure this whole file argues against. The state is reported,
+# not enforced.
+want "a run queued a moment ago does not fail the check" expect-pass \
   "$(commit $A 'a merge just now')" \
   "$A in_progress none $(now_iso)"
+
+want "...and is reported as pending rather than verified" expect-pass \
+  "$(commit $A 'a merge just now')" \
+  "$A in_progress none $(now_iso)" \
+  "PENDING"
+
+want "...naming the commit whose run has not concluded" expect-pass \
+  "$(commit $A 'a merge just now')" \
+  "$A in_progress none $(now_iso)" \
+  "${A:0:8}"
+
+# The false claim itself. This is the line a reader takes as green, and it must
+# not appear over a commit with no completed run.
+out="$("$SCRIPT" --fixture-commits "$(commit $A 'a merge just now')" \
+  --fixture-runs "$A queued none $(now_iso)" 2>&1)"
+case "$out" in
+  *"has a completed ci run"*)
+    fail=$((fail + 1)); echo "FAIL a queued run was described as completed:"; echo "$out" ;;
+  *) pass=$((pass + 1)); echo "ok   ...and never claims a completed run over a queued one" ;;
+esac
+
+# A pending commit beside an unverified one is still a failure, and the report
+# carries both: a reader who sees only the absence cannot tell how much of the
+# tree is unanswered.
+pending_and_missing="$(commit $A 'a merge nothing ran for')
+$(commit $B 'a merge still queued')"
+want "an unverified commit outranks a pending one" expect-fail \
+  "$pending_and_missing" \
+  "$B queued none $(now_iso)" \
+  "missing"
+want "...and the pending one is still listed" expect-fail \
+  "$pending_and_missing" \
+  "$B queued none $(now_iso)" \
+  "has not concluded yet"
+
+# The backlog census, which is what separates "a run is a minute old" from
+# "this repository is a hundred runs deep and cannot answer for half an hour".
+out="$("$SCRIPT" --fixture-commits "$(commit $A 'a merge just now')" \
+  --fixture-runs "$A queued none $(now_iso)" --fixture-queue 46 2>&1)"
+case "$out" in
+  *"46 of the 100 most recent runs"*)
+    pass=$((pass + 1)); echo "ok   the pending report names the queue depth" ;;
+  *) fail=$((fail + 1)); echo "FAIL the pending report did not name the queue depth:"; echo "$out" ;;
+esac
 
 # ── S: startup_failure — the canary's own blind spot ─────────────────────────
 want "a startup_failure is reported" expect-fail \
@@ -247,6 +299,39 @@ out="$("$SCRIPT" --fixture-commits "$verified_commits" --fixture-runs "$verified
 case "$out" in
   *"gh "*) fail=$((fail + 1)); echo "FAIL a green run with nothing open must never call gh:"; echo "$out" ;;
   *) pass=$((pass + 1)); echo "ok   ...and never calls gh" ;;
+esac
+
+# ── announcing: pending closes nothing ───────────────────────────────────────
+#
+# The recovery branch fires on a run with no unverified commit, and a tree
+# where every run is queued has none. So the backlog that hides an outage
+# would also close the issue tracking it, and the next reader would find a
+# tracker saying `main` recovered on the strength of nobody having looked.
+
+pending_commits="$(commit $A 'a merge still queued')"
+pending_runs="$A queued none $(now_iso)"
+
+out="$("$SCRIPT" --fixture-commits "$pending_commits" --fixture-runs "$pending_runs" \
+  --announce --dry-run --fixture-open-issue 42 2>&1)"
+case "$out" in
+  *"issue close"*)
+    fail=$((fail + 1)); echo "FAIL a pending run closed the open issue:"; echo "$out" ;;
+  *) pass=$((pass + 1)); echo "ok   a pending run does not close the open issue" ;;
+esac
+case "$out" in
+  *"leaving issue 42 open"*)
+    pass=$((pass + 1)); echo "ok   ...and says which issue it left open" ;;
+  *) fail=$((fail + 1)); echo "FAIL a pending run did not say what it left open:"; echo "$out" ;;
+esac
+
+# Nor does it file: an answer that has not arrived is not yet an absence, and
+# the stuck threshold above owns the point where it becomes one.
+out="$("$SCRIPT" --fixture-commits "$pending_commits" --fixture-runs "$pending_runs" \
+  --announce --dry-run 2>&1)"
+case "$out" in
+  *"gh issue"*)
+    fail=$((fail + 1)); echo "FAIL a pending run with nothing open touched the tracker:"; echo "$out" ;;
+  *) pass=$((pass + 1)); echo "ok   ...and a pending run with nothing open files nothing" ;;
 esac
 
 # ── the real repository ──────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Under a busy tree every mechanism that watches `main` queues behind PR
fan-out, so none of them can answer during the half hour they are most
needed. The issue measured it: on 2026-09-05 fourteen open pull requests put
every `main` run 24 to 27 minutes behind a runner, eight `main` runs were
queued at once, and the eleven newest commits had no answer of any kind while
a tree repaired 18 minutes earlier still read as broken.

`check-main-verified.sh` is the guard whose whole job is to say "nothing has
checked this commit", and it was the one turning that silence into a green.
A `ci` run that existed but had not concluded counted as `verified` for the
whole 45-minute stuck window, so the script printed

```
check-main-verified: OK — each of the last N commit(s) on main has a completed ci run.
```

over commits with no completed run.

It reports three states now — `verified`, `pending`, `unverified`:

- `pending` names the commits whose run has not concluded, and counts how many
  of the repository's 100 most recent runs are unfinished, which is the
  measurement that separates "the run is a minute old" from "this repository
  is a hundred runs deep".
- It exits 0, like every other unknown in this script. An unknown that blocks
  a merge is worse than the gap it watches, and the repair has to be able to
  land during an incident.
- Under `--announce` it closes no open `main-unverified` issue. Without that,
  the backlog hiding an outage would also close the issue tracking it, because
  a tree where every run is queued has no unverified commit to report.

Run against this repository while writing it, under a real backlog:

```
check-main-verified: FAILED — main carries commits nothing verified.

  c92a9e5b8  in_progress for 45m — past the 45m threshold, so no runner is coming
  9d0149545  in_progress for 66m — past the 45m threshold, so no runner is coming

These commits have a ci run that has not concluded yet:

  dd5382df6  queued for 32m, inside the 45m threshold

41 of the 100 most recent runs in this repository have not finished.
```

The two commits named as pending there are the ones the old script called
verified.

Closes #5964

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`scripts/test-main-verified.sh`, run with `scripts/check-main-verified.sh`
swapped back to its `main` copy: **29 passed, 8 failed**. With this branch's
copy: **34 passed, 0 failed**. The eight that flip:

```
FAIL ...and is reported as pending rather than verified — output did not say 'PENDING'
FAIL ...naming the commit whose run has not concluded — output did not say 'aaaaaaaa'
FAIL a queued run was described as completed
FAIL ...and the pending one is still listed — output did not say 'has not concluded yet'
FAIL the pending report did not name the queue depth
FAIL a pending run closed the open issue
FAIL a pending run did not say what it left open
FAIL the filed issue did not name the backlog
```

Every case is hermetic, through the script's existing fixture seams plus a new
`--fixture-queue` for the backlog census. The suite runs in
`guard-self-tests.yml`.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`, green)
- [ ] clippy over the workspace — no Rust in this diff; CI runs it
- [ ] the workspace test suite — no Rust in this diff; CI runs it
- [x] Docs updated where behavior changed — AGENTS.md's canary section
- [x] CLA signed
- [x] `Closes #5964` appears both here and as a commit trailer

Also run locally: `make guards-fast` (green), `python3 scripts/check-prose.py`
(green), `shellcheck` on both scripts, `check-gate-parity.sh`,
`check-action-pins.sh`, `check-line-citations.py`.

## Fix over file

- [x] Extra fixes in this PR:

  1. **The guard only ever read one commit in CI.** It runs `--limit 10`, and
     `main-canary.yml`'s default shallow checkout gives `git log -n 10
     origin/main` exactly one commit. Every CI run of this guard has reported
     on the tip alone — run 34107929950's step log says "each of the last **1**
     commit(s) on main has a completed ci run" — while the outage it was
     written for buried four commits in a row. Its checkout now asks for 30.

  2. **The answer queued behind the compile.** It was the third step of the
     canary job, so a report costing seconds waited on a toolchain install, a
     cache restore and a workspace `cargo check`, and the job's 15-minute
     timeout could take it away entirely. It is its own job now, with no
     toolchain and a 5-minute timeout, and with `permissions` scoped to the
     `contents: read` + `issues: write` it actually uses rather than inheriting
     the `actions: write` the compile job needs for its hold re-runs.

  3. **A filed issue named the absence and not its cause.** A
     `main-unverified` issue opened during a forty-run backlog listed the
     commits with no answer and said nothing about the queue. Its body now
     carries the pending commits and the unfinished-run count beside them.

- [x] Filed, with the reason a fix could not ride this PR: **#6401** — giving
      the main-health workflows a runner lane PR fan-out cannot consume. Hosted
      Actions has no priority mechanism, so the only real lane is a self-hosted
      runner or a larger allowance: spend, and a maintainer's call.

## Anything reviewers should know?

**What this does not do.** GitHub-hosted runners have no priority lane, so
nothing in this repository can stop a main-health run waiting for a runner
when the queue is full. Giving these workflows capacity that PR fan-out cannot
consume means self-hosted runners — spend, and a maintainer's call, not a
config change. What this PR does is stop the wait reading as green, and stop
the answer additionally queueing behind this repository's own slowest job.

That is why the report is a state and not a failure. Blocking merges on an
absence of information is the direction `check-main-verified.sh`'s header
argues against at length, and it would fight `main-red-hold.yml` during the
exact incident where the repair needs to land.

**Deleted tests:** none.

## Summary by Sourcery

Stop queued CI runs from being treated as verified main commits and make verification delays visible without blocking recovery work.

New Features:
- Add explicit verified, pending, and unverified states to main verification reporting, including unfinished-run backlog measurements.

Bug Fixes:
- Prevent queued or in-progress CI runs from being reported as completed verification.
- Keep main-unverified issues open while verification is still pending and include queue context in reported findings.

Enhancements:
- Run main verification independently from the compile job with a shorter timeout, appropriate permissions, and deeper checkout coverage.

Documentation:
- Update canary documentation to describe pending verification, backlog reporting, and the dedicated verification job.

Tests:
- Expand main verification witness tests to cover pending states, queue depth, issue handling, and combined pending/unverified results.