### PR TITLE
feat(stella-plugin): disclose the stages and roles a package adds to a turn

### DIFF
--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -63,6 +63,7 @@ use std::path::{Path, PathBuf};
 use crate::self_driving_cmd::turn_flags::TurnFlags;
 use crate::settings::{Settings, Toggle};
 
+pub(crate) mod composition;
 pub(crate) mod configure;
 pub(crate) mod doctor;
 pub(crate) mod package;
@@ -826,6 +827,7 @@ fn list(workspace_root: &Path, settings: &Settings) -> Result<(), String> {
     if roster.plugins().is_empty() {
         println!("no plugins installed — add one with `stella plugin install <dir>`");
     }
+    let seat_models = composition::seat_assignments(settings);
     for (plugin, inventory) in package::inventories(&roster) {
         let grant = &plugin.manifest.loop_grant;
         println!(
@@ -858,6 +860,14 @@ fn list(workspace_root: &Path, settings: &Settings) -> Result<(), String> {
         // `stella.toml` that signs their commits in someone else's name has no
         // way to learn from stella that a package put it there.
         for line in configure_lines(workspace_root, plugin) {
+            println!("{line}");
+        }
+        // What it adds to every turn: the stages, their bands, and the seat
+        // each declared role spends under. The `ships …` lines answer what a
+        // package brought with it, and this answers what it does with a turn —
+        // which nothing here rendered while a manifest's stages already
+        // decided a turn's composition (`doc:roleless-core` §6).
+        for line in composition::composition_lines(plugin, &seat_models) {
             println!("{line}");
         }
         match &plugin.manifest.runtime {

--- a/crates/stella-cli/src/plugin_cmd/composition.rs
+++ b/crates/stella-cli/src/plugin_cmd/composition.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The `composes:` and `roles:` lines `stella plugin list` prints.
+//!
+//! The install prompt draws the same facts from the same value,
+//! [`stella_plugin::TurnComposition`]. The two differ in one thing. Consent
+//! is asked before a package is on disk. So it can only say what a seat with
+//! no model costs. This report can read the `[seats]` table. It names the
+//! model each seat holds.
+//!
+//! Pure over the strings, so the words can be checked with no terminal.
+//! `plugin_cmd`'s `driver_lines` and `configure_lines` set that shape.
+//! `plugin_cmd.rs` is near its size ceiling, so this report gets a file.
+
+use std::collections::BTreeMap;
+
+use stella_plugin::TurnComposition;
+
+use super::roster::InstalledPlugin;
+
+/// What one installed package adds to a turn, one line per fact.
+///
+/// Empty for a package with no `[wrapper]` stages and no `[roles]`. It adds
+/// nothing to merge, and a heading over an empty list reads as a report.
+///
+/// `assignments` is the merged `[seats]` table. A role missing from it is
+/// still printed, as one running on the session's model. The quiet version
+/// of that is the defect: the seat spends, and no surface says so.
+#[must_use]
+pub(crate) fn composition_lines(
+    plugin: &InstalledPlugin,
+    assignments: &BTreeMap<String, String>,
+) -> Vec<String> {
+    let Some(composed) = TurnComposition::of(&plugin.manifest) else {
+        return Vec::new();
+    };
+    let mut lines = Vec::new();
+
+    if !composed.stages.is_empty() {
+        lines.push(match &composed.pipeline {
+            Some(pipeline) => format!("  composes: pipeline `{pipeline}`"),
+            None => "  composes:".to_string(),
+        });
+        for stage in &composed.stages {
+            let own = if stage.contributed {
+                " (this package's own stage)"
+            } else {
+                ""
+            };
+            let when = match &stage.condition {
+                Some(condition) => format!("when: {condition}"),
+                None => "on every turn".to_string(),
+            };
+            lines.push(format!(
+                "    {:<6} {}{own} — {when}",
+                stage.band.as_str(),
+                stage.name
+            ));
+        }
+    }
+
+    if !composed.roles.is_empty() {
+        lines.push("  roles:".to_string());
+        for role in &composed.roles {
+            let runs_on = match assignments.get(&role.seat) {
+                Some(model) => model.clone(),
+                None => "your session's model (no `[seats]` line)".to_string(),
+            };
+            lines.push(format!(
+                "    {} — tier `{}`, seat `{}` -> {runs_on}",
+                role.role, role.tier, role.seat
+            ));
+        }
+    }
+
+    lines
+}
+
+/// The merged `[seats]` table. Empty when nothing assigns a seat.
+#[must_use]
+pub(crate) fn seat_assignments(settings: &crate::settings::Settings) -> BTreeMap<String, String> {
+    settings
+        .agent_engine_config
+        .as_ref()
+        .and_then(|config| config.seat_models.clone())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin_cmd::panel_grant::PanelGrantState;
+    use crate::plugin_cmd::receipt::ConsentState;
+    use crate::plugin_cmd::roster::PluginScope;
+    use stella_plugin::PluginManifest;
+
+    fn installed(toml: &str) -> InstalledPlugin {
+        InstalledPlugin {
+            manifest: PluginManifest::from_toml_str(toml).expect("fixture manifest parses"),
+            scope: PluginScope::Project,
+            dir: std::path::PathBuf::from("/tmp/pkg"),
+            consent: ConsentState::Receipted,
+            panel_grant: PanelGrantState::Undecided,
+        }
+    }
+
+    #[test]
+    fn a_package_that_adds_nothing_prints_nothing() {
+        let lines = composition_lines(&installed("name = \"p\"\n"), &BTreeMap::new());
+        assert!(lines.is_empty(), "{lines:?}");
+    }
+
+    /// The witness. The listing named the tools, skills, records and MCP
+    /// servers a package ships. It said nothing about the stages the package
+    /// puts in every turn. So "why did my turn gain a triage step" could only
+    /// be answered by reading `plugin.toml`.
+    #[test]
+    fn the_listing_names_each_stage_its_band_and_its_condition() {
+        let lines = composition_lines(
+            &installed(
+                "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n\
+                 [wrapper]\nid = \"v\"\n\
+                 [[wrapper.stages]]\nname = \"triage-lite\"\nband = \"early\"\n\
+                 [[wrapper.stages]]\nname = \"plan\"\n",
+            ),
+            &BTreeMap::new(),
+        );
+        assert_eq!(lines[0], "  composes: pipeline `v`");
+        assert!(
+            lines[1].contains("early  triage-lite (this package's own stage) — on every turn"),
+            "{lines:?}"
+        );
+        assert!(
+            lines[2].contains("normal plan — on every turn"),
+            "{lines:?}"
+        );
+    }
+
+    /// A seat with no model is printed as one running on the session model.
+    /// An assigned seat names the model it was given.
+    #[test]
+    fn a_role_reports_the_model_its_seat_resolves_to() {
+        let package = installed(
+            "name = \"acme\"\n[loop]\nparticipation = \"steering\"\n\n\
+             [subloop]\nstages = [\"triage\", \"plan\"]\n\n\
+             [roles.triage]\ntier = \"cheap\"\n\n\
+             [roles.plan]\ntier = \"pro\"\n",
+        );
+        let unassigned = composition_lines(&package, &BTreeMap::new());
+        assert!(
+            unassigned.iter().any(|line| line.contains(
+                "triage — tier `cheap`, seat `acme/triage` -> your session's model \
+                 (no `[seats]` line)"
+            )),
+            "{unassigned:?}"
+        );
+
+        let assignments = BTreeMap::from([(
+            "acme/plan".to_string(),
+            "anthropic/claude-opus-5".to_string(),
+        )]);
+        let assigned = composition_lines(&package, &assignments);
+        assert!(
+            assigned.iter().any(|line| line
+                .contains("plan — tier `pro`, seat `acme/plan` -> anthropic/claude-opus-5")),
+            "{assigned:?}"
+        );
+        assert!(
+            assigned
+                .iter()
+                .any(|line| line.contains("seat `acme/triage` -> your session's model")),
+            "the seat with no model is still printed: {assigned:?}"
+        );
+    }
+}

--- a/crates/stella-plugin/README.md
+++ b/crates/stella-plugin/README.md
@@ -256,6 +256,11 @@ before it crosses.
 - `src/consent.rs` — the install-consent surface: `Capability` (the
   `[[capabilities]]` entry and its validation), `highest_risk`, and
   `consent_text`, the pure renderer of the whole consent document.
+- `src/composition.rs` — `TurnComposition`: what a package adds to a turn,
+  as data. Each stage with its band and its condition, and each role with
+  its tier and its seat key. `consent_text` renders it before an install,
+  and `stella plugin list` renders it for a package on disk. It derives
+  `Serialize`, so a listing a script can read emits the value itself.
 - `src/wire.rs` — the wrapper socket's wire contract (#3380, `doc:wrapper-socket`
   §2): `BeforeTurnRequest`/`Response`, `AfterTurnRequest`/`Response`,
   `WrapperPoint`, `CandidateGrant`, `EvidenceSet`, and `VerdictRule` — the

--- a/crates/stella-plugin/src/composition.rs
+++ b/crates/stella-plugin/src/composition.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! What a package adds to a turn, as data.
+//!
+//! A manifest's `[[wrapper.stages]]` entries decide what a turn does. They
+//! say which stages run, what each is named, and when each runs. A person
+//! must be told all of that before they say yes. Two surfaces owe the
+//! answer. One is the install prompt. The other is `stella plugin list`.
+//!
+//! # Why a struct, and not words in each surface
+//!
+//! The two surfaces want different shapes. Consent is read once, before
+//! anything runs. The listing reports on a package on disk, whose seats may
+//! each hold a model. Writing the words twice leaves two copies. One of them
+//! goes stale.
+//!
+//! It also settles the order of the work. A listing that a script can read
+//! is asked for elsewhere. Words added first would be encoded again later.
+//! [`TurnComposition`] is that encoding. It derives `Serialize`, so a JSON
+//! report emits it, and the words stay a view of it.
+//!
+//! # This describes; it decides nothing
+//!
+//! Merging many packages into one order is `stella_runtime`'s job. It reads
+//! bands across the whole active set. This module reads one manifest. A band
+//! here is what the package asked for, not where it lands.
+
+use serde::Serialize;
+
+use crate::manifest::PluginManifest;
+use crate::seat::seat_key;
+use crate::wrapper::StageBand;
+
+/// The stages and roles one package adds to a turn.
+///
+/// `None` when a manifest asks for neither. Such a package adds nothing to
+/// merge. An empty block would read as a report about something.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TurnComposition {
+    /// The `[wrapper] id` this package runs under.
+    ///
+    /// Absent when the manifest has no `[wrapper]` block. It is what
+    /// `--pipeline` matches, and what the store writes down for a run. A
+    /// reader hunting the runs a package joined needs it here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipeline: Option<String>,
+    /// The stages the `[wrapper]` block names, in the order it wrote them.
+    pub stages: Vec<StageDisclosure>,
+    /// The `[roles.<name>]` entries, ordered by role name.
+    pub roles: Vec<RoleDisclosure>,
+}
+
+/// One `[[wrapper.stages]]` entry, as a reader needs it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StageDisclosure {
+    /// The stage's name.
+    pub name: String,
+    /// Whether the package made this name up.
+    ///
+    /// The word list is open. So the name alone cannot tell a reader which
+    /// kind of stage this is. That is the part a name does not carry.
+    pub contributed: bool,
+    /// Which band the stage asks to run in.
+    pub band: StageBand,
+    /// When the stage runs, as the author wrote it. Absent means every turn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+}
+
+/// One `[roles.<name>]` entry, joined to the seat a user assigns against.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RoleDisclosure {
+    /// The bare role name the package chose.
+    pub role: String,
+    /// The tier it asks to be routed at.
+    pub tier: String,
+    /// The seat key a `[seats]` line uses.
+    ///
+    /// It is the package name and the role, joined by the host. Carried here
+    /// because the package never writes that first half. A reader who guesses
+    /// the bare role name writes a line nothing looks up.
+    pub seat: String,
+}
+
+impl TurnComposition {
+    /// What `manifest` adds to a turn. `None` when it adds nothing.
+    #[must_use]
+    pub fn of(manifest: &PluginManifest) -> Option<Self> {
+        let stages: Vec<StageDisclosure> = manifest
+            .wrapper
+            .iter()
+            .flat_map(|wrapper| &wrapper.stages)
+            .map(|stage| StageDisclosure {
+                name: stage.name.as_str().to_owned(),
+                contributed: stage.name.is_contributed(),
+                band: stage.band,
+                condition: stage.condition.clone(),
+            })
+            .collect();
+        let roles: Vec<RoleDisclosure> = manifest
+            .roles
+            .iter()
+            .flatten()
+            .map(|(role, declared)| RoleDisclosure {
+                role: role.clone(),
+                tier: declared.tier.clone(),
+                seat: seat_key(&manifest.name, role),
+            })
+            .collect();
+        if stages.is_empty() && roles.is_empty() {
+            return None;
+        }
+        Some(Self {
+            pipeline: manifest.wrapper.as_ref().map(|wrapper| wrapper.id.clone()),
+            stages,
+            roles,
+        })
+    }
+}
+
+/// The sentence every surface says about a seat with no model.
+///
+/// Such a seat runs on the session's own model. Both surfaces have to say
+/// so. Leaving the role out is the defect: the seat spends, and nothing
+/// tells the user.
+pub const UNASSIGNED_SEAT_SENTENCE: &str = "A seat with no `[seats]` line runs on your session's own model, so this package costs what a \
+     single-model session costs until you assign one.";
+
+/// The sentence every surface says about a tier.
+///
+/// A tier is a name the package asks for. What it maps to is the reader's
+/// own setup. Naming a model here would be a claim this crate cannot keep.
+pub const TIER_IS_AN_ASK_SENTENCE: &str = "A tier is the name this plugin asks for, never a model: your own provider configuration \
+     decides what each one resolves to, and your key pays for it.";
+
+/// The sentence every surface says about band order.
+pub const BAND_ORDER_SENTENCE: &str = "Bands run in that order across every active plugin, not just this one: every `early` stage, \
+     then every `normal` one, then every `late` one.";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(toml: &str) -> PluginManifest {
+        PluginManifest::from_toml_str(toml).expect("fixture manifest parses")
+    }
+
+    #[test]
+    fn a_manifest_that_adds_nothing_composes_nothing() {
+        assert!(TurnComposition::of(&parse("name = \"p\"\n")).is_none());
+    }
+
+    #[test]
+    fn a_stage_carries_its_band_and_its_condition() {
+        let composed = TurnComposition::of(&parse(
+            "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n\
+             [wrapper]\nid = \"v\"\n\
+             [[wrapper.stages]]\nname = \"triage-lite\"\nband = \"early\"\n\
+             [[wrapper.stages]]\nname = \"plan\"\n",
+        ))
+        .expect("a wrapper composes something");
+        assert_eq!(composed.pipeline.as_deref(), Some("v"));
+        assert_eq!(composed.stages.len(), 2);
+        assert_eq!(composed.stages[0].band, StageBand::Early);
+        assert!(composed.stages[0].contributed);
+        assert_eq!(composed.stages[1].band, StageBand::Normal);
+        assert!(!composed.stages[1].contributed);
+    }
+
+    #[test]
+    fn a_role_carries_the_seat_key_the_host_writes() {
+        let composed = TurnComposition::of(&parse(
+            "name = \"acme\"\n[loop]\nparticipation = \"steering\"\n\n\
+             [subloop]\nstages = [\"triage\"]\n\n\
+             [roles.triage]\ntier = \"cheap\"\n",
+        ))
+        .expect("a role composes something");
+        assert_eq!(composed.roles.len(), 1);
+        assert_eq!(composed.roles[0].seat, "acme/triage");
+        assert_eq!(composed.roles[0].tier, "cheap");
+    }
+}

--- a/crates/stella-plugin/src/consent.rs
+++ b/crates/stella-plugin/src/consent.rs
@@ -43,6 +43,9 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::composition::{
+    BAND_ORDER_SENTENCE, TIER_IS_AN_ASK_SENTENCE, TurnComposition, UNASSIGNED_SEAT_SENTENCE,
+};
 use crate::error::ManifestError;
 use crate::host_call::HostCall;
 use crate::manifest::{Participation, PluginManifest};
@@ -489,31 +492,57 @@ fn loop_say(manifest: &PluginManifest) -> Vec<String> {
     }
     lines.extend(role_spend(manifest));
 
-    if let Some(wrapper) = &manifest.wrapper {
-        // A contributed stage is named as the plugin's own rather than listed
-        // beside the host's twelve as though Stella had always had it (#3963).
-        // Consent is a claim about what installing this changes, and "it runs
-        // a stage of its own invention" is exactly the part a reader cannot
-        // recover from the name alone once the vocabulary is open.
-        let stages: Vec<String> = wrapper
-            .stages
-            .iter()
-            .map(|stage| {
-                let name = one_line(stage.name.as_str());
-                if stage.name.is_contributed() {
-                    format!("{name} (this plugin's own stage)")
-                } else {
-                    name
-                }
-            })
-            .collect();
-        lines.push(format!(
-            "  - wraps every turn as variant `{}`, running: {}",
-            one_line(&wrapper.id),
-            stages.join(", ")
-        ));
-    }
+    lines.extend(stage_say(manifest));
 
+    lines
+}
+
+/// The stages a `[wrapper]` block adds to every turn, each with the band it
+/// runs in and the condition it runs under.
+///
+/// Empty for a manifest with no `[wrapper]` block, on
+/// `the_scope_disclaimer_appears_only_when_a_scope_was_declared`'s reasoning.
+///
+/// # Why the band belongs here
+///
+/// A stage's band decides when it runs against every other active plugin's
+/// stages, so two manifests naming the same stages in different bands compose
+/// into two different turns. The list of names alone rendered those two
+/// declarations identically, which left a reader agreeing to an order they
+/// were never shown (`doc:roleless-core` §6). A contributed name is marked as
+/// the plugin's own for the same reason: once the vocabulary is open, the name
+/// cannot tell a reader whether Stella has always had that stage.
+///
+/// One line per stage rather than a comma-joined list, because a band and a
+/// condition are two more facts per entry and a single line stops being
+/// readable at the second one.
+fn stage_say(manifest: &PluginManifest) -> Vec<String> {
+    let Some(wrapper) = &manifest.wrapper else {
+        return Vec::new();
+    };
+    let Some(composed) = TurnComposition::of(manifest) else {
+        return Vec::new();
+    };
+    if composed.stages.is_empty() {
+        return Vec::new();
+    }
+    let mut lines = vec![format!(
+        "  - wraps every turn as pipeline `{}`, adding these stages to it:",
+        one_line(&wrapper.id)
+    )];
+    for stage in &composed.stages {
+        let mut line = format!("      {}", one_line(&stage.name));
+        if stage.contributed {
+            line.push_str(" (this plugin's own stage)");
+        }
+        line.push_str(&format!(" — band: {}", stage.band.as_str()));
+        match &stage.condition {
+            Some(condition) => line.push_str(&format!(", when: {}", one_line(condition))),
+            None => line.push_str(", on every turn"),
+        }
+        lines.push(line);
+    }
+    lines.push(format!("      {BAND_ORDER_SENTENCE}"));
     lines
 }
 
@@ -540,26 +569,24 @@ fn loop_say(manifest: &PluginManifest) -> Vec<String> {
 /// default. Rendering it as a model would be `capability_grant`'s claimed-limit
 /// error in the other direction — a promise this crate cannot keep.
 fn role_spend(manifest: &PluginManifest) -> Vec<String> {
-    let Some(roles) = &manifest.roles else {
+    let Some(composed) = TurnComposition::of(manifest) else {
         return Vec::new();
     };
-    if roles.is_empty() {
+    if composed.roles.is_empty() {
         return Vec::new();
     }
     let mut lines = vec!["  - spends each stage's model calls at a tier it names:".into()];
     // A `BTreeMap`, so the order is the manifest's own and is stable.
-    for (name, role) in roles {
+    for role in &composed.roles {
         lines.push(format!(
-            "      {}: the `{}` tier",
-            one_line(name),
-            one_line(&role.tier)
+            "      {}: the `{}` tier, assigned through the seat `{}`",
+            one_line(&role.role),
+            one_line(&role.tier),
+            one_line(&role.seat)
         ));
     }
-    lines.push(
-        "      A tier is the name this plugin asks for, never a model: your own provider \
-         configuration decides what each one resolves to, and your key pays for it."
-            .into(),
-    );
+    lines.push(format!("      {TIER_IS_AN_ASK_SENTENCE}"));
+    lines.push(format!("      {UNASSIGNED_SEAT_SENTENCE}"));
     lines
 }
 

--- a/crates/stella-plugin/src/consent/tests.rs
+++ b/crates/stella-plugin/src/consent/tests.rs
@@ -684,3 +684,91 @@ fn the_handshake_is_deterministic() {
         panel_handshake_text(&manifest, "sha256:c0ffee")
     );
 }
+
+/// **The witness for `doc:roleless-core` §6's consent gap.** A manifest's
+/// `[[wrapper.stages]]` entries decide a turn's composition — which stages
+/// exist, and through `band`, when each runs against every other active
+/// plugin's stages. The prompt listed the names and nothing else, so two
+/// manifests composing two different turns rendered the same sentence and a
+/// reader agreed to an order they were never shown.
+///
+/// Anti-vacuity is the second half, on
+/// [`the_scope_disclaimer_appears_only_when_a_scope_was_declared`]'s
+/// reasoning: a manifest with no `[wrapper]` renders none of it.
+#[test]
+fn the_consent_prompt_names_each_stages_band() {
+    let text = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n\
+         [wrapper]\nid = \"v\"\n\
+         [[wrapper.stages]]\nname = \"triage-lite\"\nband = \"early\"\n\
+         [[wrapper.stages]]\nname = \"plan\"\n",
+    ));
+    assert!(
+        text.contains("wraps every turn as pipeline `v`, adding these stages to it:"),
+        "{text}"
+    );
+    assert!(
+        text.contains("triage-lite (this plugin's own stage) — band: early, on every turn"),
+        "a contributed stage renders its band and that it is the plugin's own: {text}"
+    );
+    assert!(
+        text.contains("plan — band: normal, on every turn"),
+        "a stage that names no band renders the one it gets: {text}"
+    );
+    assert!(
+        text.contains("every `early` stage, then every `normal` one"),
+        "{text}"
+    );
+
+    let wrapperless = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"steering\"\n",
+    ));
+    assert!(
+        !wrapperless.contains("adding these stages to it"),
+        "a manifest with no [wrapper] renders no stage block: {wrapperless}"
+    );
+}
+
+/// The same manifest gaining one stage changes the document a person reads,
+/// which is what makes the disclosure worth reading at all.
+#[test]
+fn adding_a_stage_changes_the_rendered_consent_text() {
+    let one = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n\
+         [wrapper]\nid = \"v\"\n\
+         [[wrapper.stages]]\nname = \"plan\"\n",
+    ));
+    let two = consent_text(&parse(
+        "name = \"p\"\n[loop]\nparticipation = \"steering\"\n\n\
+         [wrapper]\nid = \"v\"\n\
+         [[wrapper.stages]]\nname = \"plan\"\n\
+         [[wrapper.stages]]\nname = \"review\"\nband = \"late\"\n",
+    ));
+    assert_ne!(one, two);
+    assert!(!one.contains("review"), "{one}");
+    assert!(
+        two.contains("review (this plugin's own stage) — band: late"),
+        "{two}"
+    );
+}
+
+/// A role with no `[seats]` line spends on the session model, and the prompt
+/// named the tier without ever naming the seat a person would write to change
+/// that — so the key they need was recoverable only by
+/// knowing that the host, not the plugin, writes the `<plugin>/<role>` prefix.
+#[test]
+fn the_consent_prompt_names_the_seat_and_what_an_unassigned_one_costs() {
+    let text = consent_text(&parse(
+        "name = \"acme\"\n[loop]\nparticipation = \"steering\"\n\n\
+         [subloop]\nstages = [\"triage\"]\n\n\
+         [roles.triage]\ntier = \"premium\"\n",
+    ));
+    assert!(
+        text.contains("triage: the `premium` tier, assigned through the seat `acme/triage`"),
+        "{text}"
+    );
+    assert!(
+        text.contains("A seat with no `[seats]` line runs on your session's own model"),
+        "an unassigned seat is disclosed rather than omitted: {text}"
+    );
+}

--- a/crates/stella-plugin/src/lib.rs
+++ b/crates/stella-plugin/src/lib.rs
@@ -102,6 +102,7 @@
 //! would answer or ask for one.
 
 mod candidate_grant;
+mod composition;
 mod configure;
 mod consent;
 mod drawable;
@@ -152,6 +153,10 @@ pub use candidate_grant::{
     ArtifactIdentity, ArtifactKind, CmdKind, CmdOutcome, HOST_TREE_HANDLE, TestInvocation,
     TestInvocationError, canonical_root, fence_lexical, host_tree_grant, parse_test_invocation,
     test_plan, witness_identity_matches,
+};
+pub use composition::{
+    BAND_ORDER_SENTENCE, RoleDisclosure, StageDisclosure, TIER_IS_AN_ASK_SENTENCE, TurnComposition,
+    UNASSIGNED_SEAT_SENTENCE,
 };
 pub use configure::{ConfigureEntry, REFUSED_SECTIONS};
 pub use consent::{

--- a/docs/spec/roleless-core.md
+++ b/docs/spec/roleless-core.md
@@ -315,10 +315,19 @@ no stage at the **end** of the order built so far for exactly this reason —
 starting it at the front, which is right for a member read against a stage
 already placed, answered with the reverse of what somebody wrote.
 
+**Landed with it — the disclosure.** `stella_plugin::TurnComposition` is what
+a manifest adds to a turn, as data: each stage with its band and its
+condition, and each role with its tier and the seat key the host writes.
+`consent_text` renders it before anything executes, and `stella plugin list`
+renders it for a package on disk, adding the model each seat resolves to. A
+role with no `[seats]` line is reported as running on the session's own model
+rather than omitted, so an unassigned seat is visible instead of silent. The
+value derives `Serialize`, so a machine-readable `stella plugin list` emits it
+rather than re-encoding a paragraph.
+
 Still ahead: `stella plugin enable`/`disable`, which would write the list for
 you and pick the insertion point from the band with a lexicographic tie-break
-on plugin id; consent text and `stella plugin list` rendering the stages and
-roles a package adds; and interactive mode, which offers no `--pipeline` and so
+on plugin id; and interactive mode, which offers no `--pipeline` and so
 runs no wrapper at all. A contributed stage also publishes no signal — the
 signal vocabulary stays closed, because a plugin minting a fact for another
 plugin's condition to read is a decision nothing here has made.

--- a/website/content/docs/commands/plugin.mdx
+++ b/website/content/docs/commands/plugin.mdx
@@ -123,6 +123,12 @@ vera                     project  arbiter
   Holds a turn open until the tests pass.
   /ws/.stella/plugins/vera
   runs: python3 ${plugin_dir}/main.py (30s, env: PATH)
+  composes: pipeline `vera-v1`
+    early  triage-lite (this package's own stage) — on every turn
+    late   verify — when: tests_ran
+  roles:
+    verifier — tier `pro`, seat `vera/verifier` -> anthropic/claude-opus-5
+    triage — tier `cheap`, seat `vera/triage` -> your session's model (no `[seats]` line)
   panel: ! `vera` declares a panel and is not drawing one — nobody has been asked yet. Run `stella plugin panel vera` to read the handshake and decide.
 
 hook dispatches:
@@ -131,6 +137,10 @@ hook dispatches:
 ```
 
 The output has two parts, and they answer different questions. The first part shows what each plugin asked for. The second part, "hook dispatches," shows what stella will actually run. If a plugin lists a hook but has no `[runtime]` block, it shows up in the first part but not the second. That's why a plugin can declare `Stop` and still never run anything.
+
+The `composes:` lines say what the plugin puts in your turn. Each line names a stage, the band it runs in, and when it runs. Bands run in one order across every plugin you switched on: every `early` stage, then every `normal` one, then every `late` one. A stage marked as the package's own is a name the plugin invented rather than one stella ships.
+
+The `roles:` lines say what each stage costs. A role names a tier, and the seat key you write in `[seats]` to give it a model of its own. A seat with no `[seats]` line runs on your session's model, and the list says so rather than leaving the role out. The install screen shows the same stages and roles before you say yes.
 
 If a plugin asks for an environment variable that stella recognizes as a model API key, stella blocks it and tells you here, in the list output. You won't have to discover a missing variable later when the plugin runs. A plugin never gets the API key that pays for model usage directly. Instead, a plugin that needs model access should use a `[roles]` block, so stella makes the model call itself and tracks the cost properly.
 


### PR DESCRIPTION
## What & why

A manifest's `[[wrapper.stages]]` entries decide a turn's composition — which
stages exist, what each is named, and through `band`, when each runs against
every other active plugin's stages. Neither `stella_plugin::consent_text` nor
`stella plugin list` rendered any of it, so a person approving an install was
told a program would run but not **what it adds to their turn**.

`stella_plugin::TurnComposition` (new, `crates/stella-plugin/src/composition.rs`)
is that answer as data: each stage with its band, whether the package invented
the name, and its condition; each role with its tier and the seat key the host
writes. Two renderers read one value:

- **`consent_text`** now prints one line per stage with its band and condition,
  the band-order sentence, and — for each declared role — the seat key a
  `[seats]` line uses plus what an unassigned seat costs.
- **`stella plugin list`** prints the same and adds the model each seat holds,
  read from the merged `[seats]` table
  (`crates/stella-cli/src/plugin_cmd/composition.rs`).

A role with no `[seats]` line is printed as running on the session's own model
rather than left out, so an unassigned seat is visible instead of silent.

**Settled against #5294 rather than in front of it.** `TurnComposition` derives
`Serialize`, so the machine-readable `stella plugin list` that #5294 asks for
emits this value instead of re-encoding a prose paragraph added now. That is
the whole reason the content lives in a struct rather than in each renderer's
`format!`.

`doc:roleless-core` §6 moves this out of "still ahead" and records what landed.

Closes #5975

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Three consent witnesses, checked by stashing `crates/stella-plugin/src/consent.rs`
alone and re-running `cargo test -p stella-plugin --lib consent::tests` — the
three FAILED against the old renderer and pass with the new one:

- `the_consent_prompt_names_each_stages_band` — a stage renders its band and,
  for a contributed name, that the package invented it; a manifest with no
  `[wrapper]` renders none of it.
- `adding_a_stage_changes_the_rendered_consent_text` — the DoD's own witness.
- `the_consent_prompt_names_the_seat_and_what_an_unassigned_one_costs`.

Three more cover the listing, in a module that did not exist before:
`plugin_cmd::composition::{a_package_that_adds_nothing_prints_nothing,
the_listing_names_each_stage_its_band_and_its_condition,
a_role_reports_the_model_its_seat_resolves_to}`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-plugin -p stella-cli --all-targets -- -D warnings`
- [x] `cargo test -p stella-plugin --lib` / `cargo test -p stella-cli --bins plugin_cmd`
      (workspace build is CI's job — CLAUDE.md, "CI builds and tests; this laptop does not")
- [x] `make guards-fast` and `python3 scripts/check-prose.py` green;
      `make doc-warnings CARGO_SCOPE=…` green for both crates
- [x] Docs updated: `doc:roleless-core` §6 and `crates/stella-plugin/README.md`
- [x] CLA signed
- [x] `Closes #5975` appears both here and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: two. `consent_text` says "pipeline" where it said
      "variant", so the one Rust word a non-Rust reader had to decode leaves
      the install prompt. And `website/content/docs/commands/plugin.mdx`'s
      sample output and prose predated the disclosure, so a reader learning the
      listing there would not have seen the new lines.
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies at all
- [x] No new outbound network calls
- [x] `TurnComposition` is `Serialize`-only and does not cross a crate boundary
      on the wire, so no round-trip test is owed; it is built from a manifest
      that already round-trips.

## Anything reviewers should know?

`crates/stella-cli/src/plugin_cmd.rs` is near its 1500-line ceiling, so the
listing renderer is a sibling module rather than more lines there — the shape
`driver_lines` and `configure_lines` already set, and what #5294's own
constraints section asks for.

## Summary by Sourcery

Disclose the turn stages and role seats each plugin contributes across install consent and plugin listings.

New Features:
- Expose each plugin’s turn stages, bands, conditions, roles, tiers, and seat keys through a shared serializable composition model.
- Show turn composition and resolved seat models in `stella plugin list`, including visibility for roles using the session model by default.

Bug Fixes:
- Make install consent disclose the stages and role seats a package adds to a turn, including the cost of unassigned seats.
- Replace the Rust-specific “variant” wording with the user-facing “pipeline” terminology in consent output.

Enhancements:
- Centralize turn-composition data for reuse by consent and listing renderers.
- Document the landed composition disclosure behavior in the plugin README and roleless-core specification.

Documentation:
- Document `TurnComposition` and the completed turn-composition disclosure work.

Tests:
- Add witness coverage for consent stage, band, condition, seat, and unassigned-seat disclosures.
- Add listing coverage for empty composition, stage details, and assigned or unassigned seat models.
