### PR TITLE
ci(auto-tag): name the version-sync branch once and hold the release verification wiring

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -94,6 +94,16 @@ permissions:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    # The version write-back branch, written once. Four steps need it: the
+    # one that pushes it, the one that approves its parked runs, the one
+    # that merges it, and the wait for an armed auto-merge to land. That
+    # last one is why one spelling now matters more than tidiness: a wait
+    # aimed at a branch with no pull request reads UNKNOWN and returns at
+    # once, so the dispatcher behind it asks about the tip from before the
+    # merge, finds a run there, and stops. The sync commit is then back
+    # where #5857 found it, with only the daily canary to ask.
+    env:
+      SYNC_BRANCH: bot/version-sync
     # Only cut a release for a *successful* CI run that this repository's own
     # main produced from a push. Guarding on the job (not just inside the step)
     # keeps a red build from ever reaching the tag push, and the repository
@@ -315,7 +325,7 @@ jobs:
         run: |
           set -euo pipefail
           version="${TAG#v}"
-          branch="bot/version-sync"
+          branch="${SYNC_BRANCH}"
 
           # Base on the current tip of main, not head_sha: if another merge
           # already landed, the bump must apply cleanly on top of it. Rapid
@@ -423,7 +433,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ADMIN_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
-          BRANCH: bot/version-sync
+          BRANCH: ${{ env.SYNC_BRANCH }}
         run: |
           set -euo pipefail
 
@@ -494,8 +504,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ADMIN_MERGE_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
-          # Fixed by convention — see "Open the version-sync PR" above.
-          BRANCH: bot/version-sync
+          BRANCH: ${{ env.SYNC_BRANCH }}
           VERSION: ${{ steps.ver.outputs.tag }}
         run: |
           set -euo pipefail
@@ -771,6 +780,6 @@ jobs:
         run: |
           set -uo pipefail
           if [ "${ARMED:-}" = "true" ]; then
-            ./scripts/wait-for-armed-merge.sh bot/version-sync
+            ./scripts/wait-for-armed-merge.sh "${SYNC_BRANCH}"
           fi
           ./scripts/dispatch-main-verification.sh

--- a/.github/workflows/guard-self-tests.yml
+++ b/.github/workflows/guard-self-tests.yml
@@ -141,6 +141,14 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 ./scripts/check-cargo-flags.py
 
+      # Here for the same reason: it reads `.github/workflows/auto-tag.yml`,
+      # and a diff confined to a workflow file answers `rust=false`, which
+      # skips ci.yml's `check` job. The lines it holds open are the release
+      # job's only ask for a run on the commit it merges (#5817, #5857).
+      - name: the release job still asks for a run on the commit it merges
+        if: ${{ !cancelled() }}
+        run: python3 ./scripts/check-release-wiring.py
+
       # The steps above run here because this trigger carries no `paths:`
       # filter at all -- that is what lets them fire on a scripts-only pull
       # request. Nothing enforced that absence except a comment, so this reads
@@ -274,6 +282,10 @@ jobs:
       - name: cargo-flags guard failure directions, variable expansion included
         if: ${{ !cancelled() }}
         run: python3 ./scripts/test-cargo-flags.py
+
+      - name: release-wiring guard failure directions
+        if: ${{ !cancelled() }}
+        run: python3 ./scripts/test-release-wiring.py
 
       - name: gate-parity guard failure directions
         if: ${{ !cancelled() }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,8 @@ make gate                # = no-scratch + no-secrets + design-refs
                          #     if: can skip)
                          #   + cargo-flags (no Makefile recipe hands cargo a
                          #     flag pair cargo refuses; #5992)
+                         #   + release-wiring (auto-tag.yml still asks
+                         #     for a run on the commit it merges; #5857)
                          #   + priority-scheme (the issue priority scheme is
                          #     stated once, in SCR-005, and the triage guard's
                          #     regex covers exactly the levels it names)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ python3 ./scripts/check-adr-numbering.py
 python3 ./scripts/check-guard-trigger-coverage.py
 python3 ./scripts/check-priority-scheme.py
 python3 ./scripts/check-cargo-flags.py
+python3 ./scripts/check-release-wiring.py
 ./scripts/check-left-behind.sh
 python3 ./scripts/check-retired-model-keys.py
 ./scripts/check-stat-portability.sh

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ GATE_GUARDS_FAST := no-scratch no-secrets design-refs action-pins cargo-install-
                     adr-numbering \
                     command-docs website-inputs brand-case file-size god-files gate-parity \
                     schema-tier-parity \
-                    guard-trigger-coverage priority-scheme cargo-flags left-behind \
+                    guard-trigger-coverage priority-scheme cargo-flags \
+                    release-wiring left-behind \
                     retired-model-keys \
                     stat-portability module-reachability core-reachability \
                     typed-errors \
@@ -854,6 +855,21 @@ cargo-flags: ## Assert no recipe hands cargo a flag pair cargo refuses (#5992)
 .PHONY: cargo-flags-test
 cargo-flags-test: ## Test the cargo-flags guard's failure directions (hermetic; not part of `gate`)
 	@python3 ./scripts/test-cargo-flags.py
+
+# The release job merges the version write-back with the token the run
+# holds, and a push made with that token starts no workflow. Two scripts
+# cover that: the dispatcher asks for the missing run (#5817), and the
+# wait holds the job open while an armed auto-merge lands, so the
+# dispatcher reads the merged tip rather than the one before it (#5857).
+# Four lines of `auto-tag.yml` wire them, and dropping any of them leaves
+# a green release with no run on the commit it landed.
+.PHONY: release-wiring
+release-wiring: ## Assert auto-tag.yml still asks for a run on the commit it merges (#5857)
+	@python3 ./scripts/check-release-wiring.py
+
+.PHONY: release-wiring-test
+release-wiring-test: ## Test the release-wiring guard's failure directions (hermetic; not part of `gate`)
+	@python3 ./scripts/test-release-wiring.py
 
 .PHONY: priority-scheme
 priority-scheme: ## Assert the issue priority scheme is stated once, in SCR-005 (#5216)

--- a/scripts/check-gate-parity.sh
+++ b/scripts/check-gate-parity.sh
@@ -167,6 +167,7 @@ step_command() {
   transcript-surfaces) echo 'check-transcript-surfaces' ;;
   guard-trigger-coverage) echo 'check-guard-trigger-coverage' ;;
   cargo-flags) echo 'check-cargo-flags' ;;
+  release-wiring) echo 'check-release-wiring' ;;
   priority-scheme) echo 'check-priority-scheme' ;;
   prose) echo 'check-prose' ;;
   line-citations) echo 'check-line-citations' ;;

--- a/scripts/check-guard-trigger-coverage.py
+++ b/scripts/check-guard-trigger-coverage.py
@@ -68,6 +68,9 @@ WATCHED_GUARDS = (
     # runs a Makefile recipe can be started by a Makefile edit. A `paths:`
     # filter here would put this guard back in the hole it closes.
     "check-cargo-flags.py",
+    # Watched for the same reason one file over. It reads a workflow, and a
+    # diff confined to workflow files skips ci.yml's Rust-gated `check` job.
+    "check-release-wiring.py",
 )
 
 WORKFLOWS_DIR = "workflows"

--- a/scripts/check-release-wiring.py
+++ b/scripts/check-release-wiring.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Guard: the release job still asks for a run on the commit it merges.
+
+`auto-tag.yml` merges the version write-back with the token the run holds.
+A push made with that token starts no workflow. So the
+`chore(release): sync versions` commit lands on `main` with nothing to
+check it. `scripts/dispatch-main-verification.sh` asks for the missing run.
+
+The last resort merges later. When the plain merge and the admin merge both
+fail, the job arms auto-merge and GitHub lands the pull request on its own,
+after the step ends. Asking about the tip of `main` right then asks about
+the wrong commit. `scripts/wait-for-armed-merge.sh` is the wait in between.
+
+Four lines hold that path open, and nothing read them back:
+
+1. The merge step records `armed=true` when it arms auto-merge.
+2. A later step reads that output.
+3. That step runs the wait, under the flag.
+4. It runs the dispatcher after the wait, outside the flag.
+
+Drop any one of them and the release still passes. The gap comes back, and
+only a release that takes the last-resort path would show it — which is
+rare, and which is why the first one took two weeks to find.
+
+The branch name is the fifth line. Four steps name it: the push, the run
+approval, the merge, and the wait. They agree by convention until somebody
+edits one. A wait aimed at a branch with no pull request reads UNKNOWN and
+returns at once, so the dispatcher behind it asks about the tip from before
+the merge, finds a run, and stops. This guard reads the name out of the
+job's `env:` block and fails on a second copy anywhere the shell can see.
+
+Text, not YAML. The rules above are about the shape of a shell block inside
+a `run:` key, which a parsed document flattens into one string anyway, and
+this has to run on a bare runner with no PyYAML.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/auto-tag.yml")
+
+WAIT_SCRIPT = "scripts/wait-for-armed-merge.sh"
+DISPATCH_SCRIPT = "scripts/dispatch-main-verification.sh"
+
+BRANCH_KEY = "SYNC_BRANCH"
+
+
+def is_comment(line: str) -> bool:
+    return line.lstrip().startswith("#")
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def main() -> int:
+    if not WORKFLOW.exists():
+        print(f"check-release-wiring: FAIL — {WORKFLOW} does not exist.")
+        return 1
+
+    lines = WORKFLOW.read_text(encoding="utf-8").splitlines()
+    code = [(n, text) for n, text in enumerate(lines, 1) if not is_comment(text)]
+
+    problems: list[str] = []
+
+    # ── The branch, named once ────────────────────────────────────────────
+    declarations = [
+        (n, m.group(1))
+        for n, text in code
+        if (m := re.fullmatch(rf"\s+{BRANCH_KEY}:\s*(\S+)", text))
+    ]
+    if len(declarations) != 1:
+        problems.append(
+            f"the job declares {BRANCH_KEY} {len(declarations)} times; it takes "
+            "exactly one, in the job's `env:` block."
+        )
+    else:
+        _, branch = declarations[0]
+        strays = [
+            n for n, text in code if branch in text and not text.strip().startswith(BRANCH_KEY)
+        ]
+        for n in strays:
+            problems.append(
+                f"line {n} writes `{branch}` again. Every step reads "
+                f"${BRANCH_KEY} instead, so the wait cannot end up aimed at a "
+                "branch the merge step never touched."
+            )
+
+    # ── The four lines of the last-resort path ────────────────────────────
+    armed = [n for n, text in code if "armed=true" in text and "GITHUB_OUTPUT" in text]
+    if not armed:
+        problems.append(
+            "no step records `armed=true` into $GITHUB_OUTPUT. That output is "
+            "how the step after the merge learns a merge is still coming."
+        )
+
+    reads_armed = [n for n, text in code if re.search(r"steps\.\w+\.outputs\.armed", text)]
+    if not reads_armed:
+        problems.append(
+            "nothing reads `steps.<merge step>.outputs.armed`, so the wait "
+            "below can never fire."
+        )
+
+    waits = [(n, text) for n, text in code if WAIT_SCRIPT in text]
+    dispatches = [(n, text) for n, text in code if DISPATCH_SCRIPT in text]
+
+    if not waits:
+        problems.append(
+            f"nothing runs {WAIT_SCRIPT}. An armed auto-merge lands after the "
+            "job ends, and the dispatcher would read the tip from before it."
+        )
+    if not dispatches:
+        problems.append(
+            f"nothing runs {DISPATCH_SCRIPT}. The merged commit gets no run at "
+            "all until the daily canary asks."
+        )
+
+    if waits and dispatches:
+        wait_line, wait_text = waits[-1]
+        dispatch_line, dispatch_text = dispatches[-1]
+        if dispatch_line < wait_line:
+            problems.append(
+                f"line {dispatch_line} runs the dispatcher before line "
+                f"{wait_line} waits. It would ask about the tip from before "
+                "the merge."
+            )
+        elif indent_of(dispatch_text) >= indent_of(wait_text):
+            problems.append(
+                f"line {dispatch_line} runs the dispatcher at or below the "
+                f"wait's own indent. The wait is conditional and the "
+                "dispatcher must not be: every other merge path in this job "
+                "needs it too."
+            )
+
+    for script in (WAIT_SCRIPT, DISPATCH_SCRIPT):
+        path = Path(script)
+        if not path.exists():
+            problems.append(f"{script} does not exist.")
+        elif not path.stat().st_mode & 0o111:
+            problems.append(f"{script} is not executable, so the step would fail.")
+
+    if problems:
+        print("check-release-wiring: FAIL — the release job's verification path is broken.")
+        for problem in problems:
+            print(f"       {problem}")
+        print("       Each script's own header says what its line holds open.")
+        return 1
+
+    print(
+        "check-release-wiring: OK — the sync branch is named once, and the "
+        "armed-merge wait still runs before the dispatcher."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-release-wiring.py
+++ b/scripts/test-release-wiring.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Self-test for `check-release-wiring.py`.
+
+A guard nobody can watch fail is a guard nobody knows works. Each case
+below builds a small tree in a temporary directory, breaks one line of the
+release job's verification path, and asserts the guard says so. The last
+case runs it over this repository, where it has to pass.
+
+Hermetic: no network, no `gh`, nothing outside the temporary directory but
+the guard itself.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GUARD = REPO / "scripts" / "check-release-wiring.py"
+
+WORKFLOW = """\
+name: auto-tag
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    env:
+      SYNC_BRANCH: bot/version-sync
+    steps:
+      - name: Wait for the required checks, then merge the version-sync PR
+        id: merge
+        env:
+          BRANCH: ${{ env.SYNC_BRANCH }}
+        run: |
+          if gh pr merge "${BRANCH}" --squash --auto; then
+            echo "armed=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for an armed auto-merge to land, then check the merged tip
+        env:
+          ARMED: ${{ steps.merge.outputs.armed }}
+        run: |
+          if [ "${ARMED:-}" = "true" ]; then
+            ./scripts/wait-for-armed-merge.sh "${SYNC_BRANCH}"
+          fi
+          ./scripts/dispatch-main-verification.sh
+"""
+
+failures: list[str] = []
+
+
+def build(workflow: str, executable: bool = True) -> Path:
+    """A tree with one workflow and the two scripts it calls."""
+    root = Path(tempfile.mkdtemp(prefix="release-wiring-"))
+    target = root / ".github" / "workflows"
+    target.mkdir(parents=True)
+    (target / "auto-tag.yml").write_text(workflow, encoding="utf-8")
+
+    scripts = root / "scripts"
+    scripts.mkdir()
+    for name in ("wait-for-armed-merge.sh", "dispatch-main-verification.sh"):
+        path = scripts / name
+        path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        path.chmod(0o755 if executable else 0o644)
+    return root
+
+
+def run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GUARD)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def case(name: str, workflow: str, expect_pass: bool, executable: bool = True) -> None:
+    result = run(build(workflow, executable))
+    passed = result.returncode == 0
+    if passed != expect_pass:
+        want = "pass" if expect_pass else "fail"
+        failures.append(f"{name}: expected the guard to {want}, got exit {result.returncode}\n{result.stdout}")
+
+
+case("the wiring as it stands", WORKFLOW, expect_pass=True)
+
+case(
+    "a second copy of the branch name",
+    WORKFLOW.replace('"${SYNC_BRANCH}"\n          fi', '"bot/version-sync"\n          fi'),
+    expect_pass=False,
+)
+
+case(
+    "no branch declared",
+    WORKFLOW.replace("      SYNC_BRANCH: bot/version-sync\n", ""),
+    expect_pass=False,
+)
+
+case(
+    "the armed output dropped",
+    WORKFLOW.replace('            echo "armed=true" >>"$GITHUB_OUTPUT"\n', ""),
+    expect_pass=False,
+)
+
+case(
+    "nothing reads the armed output",
+    WORKFLOW.replace("${{ steps.merge.outputs.armed }}", "false"),
+    expect_pass=False,
+)
+
+case(
+    "the wait dropped",
+    WORKFLOW.replace('            ./scripts/wait-for-armed-merge.sh "${SYNC_BRANCH}"\n', ""),
+    expect_pass=False,
+)
+
+case(
+    "the dispatcher dropped",
+    WORKFLOW.replace("          ./scripts/dispatch-main-verification.sh\n", ""),
+    expect_pass=False,
+)
+
+case(
+    "the dispatcher inside the armed branch",
+    WORKFLOW.replace(
+        "          fi\n          ./scripts/dispatch-main-verification.sh\n",
+        "            ./scripts/dispatch-main-verification.sh\n          fi\n",
+    ),
+    expect_pass=False,
+)
+
+case("the wait script not executable", WORKFLOW, expect_pass=False, executable=False)
+
+missing = Path(tempfile.mkdtemp(prefix="release-wiring-"))
+if run(missing).returncode == 0:
+    failures.append("a tree with no workflow: expected the guard to fail")
+
+live = run(REPO)
+if live.returncode != 0:
+    failures.append(f"this repository: expected the guard to pass\n{live.stdout}")
+
+if failures:
+    print("test-release-wiring: FAIL")
+    for failure in failures:
+        print(f"  {failure}")
+    sys.exit(1)
+
+print("test-release-wiring: OK — 11 cases")


### PR DESCRIPTION
## What & why

The release job asks for a run on the commit it merges through two scripts.
`scripts/dispatch-main-verification.sh` starts the `ci` run a push made with
the run's own token never raised. `scripts/wait-for-armed-merge.sh` holds the
job open while an armed auto-merge lands, so the dispatcher reads the merged
tip rather than the one before it.

Two things hold that path open, and nothing read either of them back.

**The branch name was written four times.** `bot/version-sync` was a literal
in the step that pushes it, the step that approves its parked runs, the step
that merges it, and — since the armed-merge wait landed — the wait as well.
They agreed by convention; one of the four carried a comment saying so. A wait
aimed at a branch with no pull request reads `UNKNOWN` and returns at once, so
the dispatcher behind it asks about the tip from before the merge, finds a run
there, and stops. That is the state this issue describes, reached by an edit
nothing would have reported. The name now lives in the job's `env:` block as
`SYNC_BRANCH`, and every step reads it from there.

**The four lines of the last-resort path were held by a comment.** The merge
step records `armed=true`, the step after it reads that output, runs the wait
under the flag, and runs the dispatcher after the wait outside the flag. Drop
any one and the release still reports success; only a release that actually
takes the last-resort path would show it, which is rare.
`scripts/check-release-wiring.py` reads all four back, plus the single branch
name, and joins `GATE_GUARDS_FAST` as `release-wiring`. It needs no toolchain,
and it runs in `guard-self-tests.yml`'s `gate steps no other workflow runs`
job — no `paths:` filter and no `needs`-gated `if:`, so a workflow-only pull
request reaches it. It is on `check-guard-trigger-coverage.py`'s watch list so
a later filter cannot reopen that quietly.

The shape is `check-cargo-flags.py`'s, landed this morning for the same class
of defect: a guard whose subject is a file the workflows that run it cannot be
started by.

Refs #5857

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`scripts/check-release-wiring.py` is the witness. Against `main`'s
`auto-tag.yml`:

```
$ git stash push .github/workflows/auto-tag.yml && python3 scripts/check-release-wiring.py
check-release-wiring: FAIL — the release job's verification path is broken.
       the job declares SYNC_BRANCH 0 times; it takes exactly one, in the job's `env:` block.
exit=1
```

and with this branch's workflow:

```
$ python3 scripts/check-release-wiring.py
check-release-wiring: OK — the sync branch is named once, and the armed-merge wait still runs before the dispatcher.
exit=0
```

`scripts/test-release-wiring.py` holds that in eleven hermetic cases against
fixture trees in a temporary directory: the wiring as it stands, a second copy
of the branch name, no branch declared, the `armed=true` output dropped,
nothing reading it, the wait dropped, the dispatcher dropped, the dispatcher
moved inside the armed branch, the wait script left non-executable, a tree with
no workflow at all, and this repository. `python3 scripts/test-release-wiring.py`
→ `OK — 11 cases`.

## The gate

- [x] `cargo fmt --check` (via `make guards-fast`, green — 59 gate steps,
      `gate-parity` included)
- [ ] clippy over the workspace — no Rust changed; CI runs it
- [ ] the workspace suite — no Rust changed; CI runs it
- [x] Docs updated: AGENTS.md's gate block and CONTRIBUTING.md's gate fence —
      `gate-parity` enforces the trio and passes
- [x] CLA signed
- [x] `Refs #5857` appears above and as a commit trailer. This PR does not
      close the issue: its remaining checklist item is an observation of the
      first real release that takes the last-resort path, which no pull
      request can produce. No such release has happened since PR #6359 merged
      at 03:58Z today — the three successful `auto-tag` runs after it
      (34086753617, 34103503174, 34107062639) all merged inside the run, and
      each one's wait step took under twenty seconds.

## Fix over file

- [x] Extra fixes in this PR: the four copies of the branch name are the
      second fix, beside the guard. Both are in the release job's verification
      path, which is why they ride together.
- [x] Filed, with the reason a fix could not ride this PR: nothing was
      deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

`${{ env.SYNC_BRANCH }}` in a step's `env:` block is the one expression form
this change relies on; GitHub makes the `env` context available there, and the
two steps that already declared `BRANCH` keep that name so their shell bodies
are untouched.

The indentation rule in the guard is a proxy, and the header says so: the
dispatcher must sit at a shallower indent than the wait, which is how a shell
block spells "outside the `if`". A parsed YAML document flattens the whole
`run:` value into one string, so nothing is lost by reading the file as text —
and reading it as text is what lets this run on a bare runner with no PyYAML.

## Summary by Sourcery

Protect the release verification path by centralizing the sync branch and continuously validating the armed-merge wait and dispatcher wiring.

Bug Fixes:
- Prevent release verification from targeting the pre-merge commit when the version-sync branch is auto-merged asynchronously.

Enhancements:
- Centralize the version-sync branch name in the auto-tag job and enforce the release verification wiring with a dedicated guard.
- Add hermetic coverage for missing or reordered release verification steps and ensure workflow-only changes trigger the guard.

Build:
- Register the release-wiring guard in the fast gate, Makefile targets, gate parity checks, and contributor gate documentation.

CI:
- Run release-wiring validation and its self-tests in the guard self-test workflow, and monitor the guard for trigger coverage.

Documentation:
- Document the release-wiring guard in AGENTS.md and CONTRIBUTING.md.

Tests:
- Add eleven hermetic cases covering valid wiring and failure modes for the release verification path.