### PR TITLE
docs(codeql): triage the 52 cleartext-logging alerts and record why the rule is wrong here

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -79,12 +79,15 @@
 #
 # ── What `rust/cleartext-logging` gets wrong here (#6388) ────────────────────
 #
-# That rule had 52 open alerts, all high severity, none dismissed — a signal
-# firing often enough that nobody read it, so the next real one would land in
-# the pile and look the same. #6388 read every site against the code. Fifty
-# were still open by then and every one was wrong, in three shapes. They are
-# written down here so the next author dismisses by citing this and does not
-# read the same fifty sites again.
+# That rule had 52 open alerts when #6388 was filed, all high severity, none
+# dismissed — a signal firing often enough that nobody read it, so the next
+# real one would land in the pile and look the same. Fifty were open by the
+# time the sweep ran, because the set moves: three had been answered on
+# #6384, a few had closed themselves when the code they pointed at moved, and
+# a moved line mints a new alert. Every one of the fifty was read against the
+# code, and every one was wrong, in three shapes. They are written down here
+# so the next author dismisses by citing this and does not read the same
+# fifty sites again.
 #
 # The rule keys on the NAME of the taint source, not on what the value is, so
 # it is wrong three ways:
@@ -92,8 +95,10 @@
 #   1. A correlation id read as a session token. `ZaiProvider::session_id`,
 #      `lane_journal_key`, the self-driving loop's `sd-<secs>-<pid>` and the
 #      driver's `drive-<secs>-<hex>` all read as credentials. None grants
-#      access. z.ai's is on the wire in every request body on purpose, so
-#      hiding it from a log protects nothing.
+#      access. `ZaiProvider`'s goes on the wire in the request body under the
+#      `openrouter` identity, where it is the sticky-routing key
+#      (`build_body`'s `self.serves_openrouter().then_some(...)`), so hiding
+#      it from a log protects nothing.
 #   2. A guard read as a leak. `validate_project_secrets`,
 #      `refuse_unless_trusted`, `no_api_key_error` and `api_key_refusal` are
 #      the functions that turn a credential DOWN. What they return is a

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,6 +76,51 @@
 # — `scripts/codeql-canary.sh`, modeled on `main-canary.yml`'s pattern but
 # scoped to the one fact this workflow already knows: did the analyze job
 # conclude success or failure.
+#
+# ── What `rust/cleartext-logging` gets wrong here (#6388) ────────────────────
+#
+# That rule had 52 open alerts, all high severity, none dismissed — a signal
+# firing often enough that nobody read it, so the next real one would land in
+# the pile and look the same. #6388 read every site against the code. Fifty
+# were still open by then and every one was wrong, in three shapes. They are
+# written down here so the next author dismisses by citing this and does not
+# read the same fifty sites again.
+#
+# The rule keys on the NAME of the taint source, not on what the value is, so
+# it is wrong three ways:
+#
+#   1. A correlation id read as a session token. `ZaiProvider::session_id`,
+#      `lane_journal_key`, the self-driving loop's `sd-<secs>-<pid>` and the
+#      driver's `drive-<secs>-<hex>` all read as credentials. None grants
+#      access. z.ai's is on the wire in every request body on purpose, so
+#      hiding it from a log protects nothing.
+#   2. A guard read as a leak. `validate_project_secrets`,
+#      `refuse_unless_trusted`, `no_api_key_error` and `api_key_refusal` are
+#      the functions that turn a credential DOWN. What they return is a
+#      refusal naming a flag, a path or an environment variable's name. The
+#      tests that pin those refusals assert the key is absent, and the string
+#      CodeQL flags is the assertion message that prints only when the assert
+#      fails.
+#   3. A keyboard key read as a cryptographic one. Every `stella-tui` alert
+#      traces to `handle_deck_key`, `handle_session_key` or
+#      `handle_mcp_auth_key`, whose `key: KeyEvent` is a keystroke. The one
+#      credential those handlers carry — what a user types into the MCP auth
+#      prompt — is wrapped in `Secret`, whose `Debug` prints `<redacted>`
+#      (`crates/stella-tui/src/envelope/workspace_input.rs`) and whose `Drop`
+#      zeroizes (`AuthPrompt` in `crates/stella-tui/src/views/mcp_tab.rs`).
+#      `deck_ui/tests/queue.rs` asserts a typed key never appears under
+#      `Debug`, and CodeQL flagged the panic arm of that very test.
+#
+# No query filter was added. CodeQL filters by query id, not by path, so the
+# only filter that clears these is `exclude: id: rust/cleartext-logging`,
+# which would hide the first true one too. A dismissal is per-alert and
+# carries a written reason, which is what a later reader needs.
+#
+# The advisory posture above is unchanged, for a reason #3260 did not have.
+# The backlog is empty now, so a required check would cost nothing today.
+# What argues against it is the hit rate: this query fired 52 times and was
+# right none of them. Make CodeQL required once a run produces an alert
+# somebody agrees with.
 name: CodeQL
 
 on:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -118,9 +118,10 @@
 #
 # The advisory posture above is unchanged, for a reason #3260 did not have.
 # The backlog is empty now, so a required check would cost nothing today.
-# What argues against it is the hit rate: this query fired 52 times and was
-# right none of them. Make CodeQL required once a run produces an alert
-# somebody agrees with.
+# What argues against it is the hit rate: of the alerts this query has ever
+# produced here, the fifty a person read were wrong, and the rest closed on
+# their own when the code they pointed at moved. Make CodeQL required once a
+# run produces an alert somebody agrees with.
 name: CodeQL
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -902,6 +902,15 @@ breaks both AGPL redistribution and the commercial track. **If `cargo deny`
 rejects a new dependency, drop the dependency — do not widen the allow-list in
 `deny.toml` without a licensing decision.**
 
+**CodeQL reads the code, and it stays advisory.** `.github/workflows/codeql.yml`
+runs it over rust, python, javascript-typescript and the workflow files. Its
+header carries the two things a later session needs: why it is not a required
+check, and the three shapes `rust/cleartext-logging` gets wrong here — a
+correlation id read as a session token, a guard read as a leak, and a keyboard
+key read as a cryptographic one. All 52 of that rule's alerts were read against
+the code and dismissed one by one, in `#6388`. Read that header before you
+dismiss a new alert, and before you assume a new one is noise.
+
 ---
 
 ## Architecture: ports, not direct dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -907,9 +907,10 @@ runs it over rust, python, javascript-typescript and the workflow files. Its
 header carries the two things a later session needs: why it is not a required
 check, and the three shapes `rust/cleartext-logging` gets wrong here — a
 correlation id read as a session token, a guard read as a leak, and a keyboard
-key read as a cryptographic one. All 52 of that rule's alerts were read against
-the code and dismissed one by one, in `#6388`. Read that header before you
-dismiss a new alert, and before you assume a new one is noise.
+key read as a cryptographic one. Every alert that rule had open was read
+against the code and dismissed with its own written reason, in `#6388`. Read
+that header before you dismiss a new alert, and before you assume a new one is
+noise.
 
 ---
 


### PR DESCRIPTION
## What & why

`rust/cleartext-logging` had 52 open alerts, all graded high, none dismissed. A check that fires that often and is never answered cannot report the one that matters — the next real finding lands in the pile and looks like the other 51.

Every site was read against the code before any verdict. All of them were false positives, and each alert is dismissed on GitHub with its own written reason naming what the value actually is. Fifty were still open when the sweep ran (135–138, 141–148, 150–176, 179–186, 188, 189, 194); three (190–192) had been answered on #6384 and five (139, 140, 149, 177, 178) had already closed as fixed when the code moved. That rule now returns zero open alerts.

**Nothing was a real leak.** The one place a typed credential genuinely flows through a flagged function — the MCP auth prompt in the deck — was already safe: `Secret`'s `Debug` prints `<redacted>` (`crates/stella-tui/src/envelope/workspace_input.rs`), `AuthPrompt`'s `Drop` zeroizes (`crates/stella-tui/src/views/mcp_tab.rs`), and `crates/stella-tui/src/deck_ui/tests/queue.rs` asserts a typed `sk-secret` never appears under `Debug`. CodeQL flagged the panic arm of that very test.

The rule keys on the **name** of the taint source, not on what the value is, so it is wrong three ways here:

1. **A correlation id read as a session token.** `ZaiProvider::session_id` (which this adapter puts in every request body on the wire on purpose), `lane_journal_key`'s `ses-1__req-3`, the self-driving loop's `sd-<secs>-<pid>`, the driver's `drive-<secs>-<hex>`. None grants access.
2. **A guard read as a leak.** `validate_project_secrets`, `refuse_unless_trusted`, `no_api_key_error` and `api_key_refusal` are the functions that turn a credential *down*. What they return is a refusal naming a flag, a path, or an environment variable's name. The tests that pin those refusals assert the key is absent, and the string CodeQL flags is the assertion message that prints only when the assert fails.
3. **A keyboard key read as a cryptographic one.** Every `stella-tui` alert traces to `handle_deck_key`, `handle_session_key` or `handle_mcp_auth_key`, whose `key: KeyEvent` is a keystroke.

Two other readings worth recording: `crates/stella-graph/src/storage/ts.rs`'s `user_id` is a local binding for the parsed DynamoDB *field* named `userId` in a TypeScript CDK fixture, and the value printed is its constraints list; `crates/stella-cli/src/main.rs`'s `advisory.line()` is `CredentialAdvisory::LoosePermissions`, whose only fields are a path and a `u32` mode.

The diff writes those three shapes into `.github/workflows/codeql.yml`'s header, beside the reasoning that file already carries, and points `AGENTS.md`'s supply-chain paragraph at it, so the next author dismisses by citation instead of reading fifty sites again.

**No query filter.** CodeQL filters by query id and not by path, so the only filter that clears these is `exclude: id: rust/cleartext-logging` — it would hide the first true one as well.

**CodeQL stays advisory.** The backlog is empty, so a required check would cost nothing today; what argues against it is the hit rate — of the 58 alerts this query has ever produced here, the 50 a person read were wrong, and the other 8 closed as fixed or were answered on #6384. Make it required once a run produces an alert somebody agrees with.

Closes #6388

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: the diff is comments in `.github/workflows/codeql.yml` and one paragraph in `AGENTS.md`. No Rust changed, so there is no behaviour for a test to flip. The work itself is the 50 per-alert dismissals, and its evidence is the alert state: `gh api "repos/macanderson/stella/code-scanning/alerts?state=open&per_page=100"` returned 50 rows for this rule before and returns 0 after, with 53 now dismissed and each carrying a reason naming its value.

## The gate

- [x] `cargo fmt --check` — via `make guards-fast`, green
- [x] `make prose` and `make line-citations` — green (`AGENTS.md` was edited)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not run locally; no Rust changed, CI owns it
- [ ] `cargo test --workspace` — not run locally; no Rust changed, CI owns it
- [x] Docs updated where behavior/flags changed
- [x] CLA signed
- [x] `Closes #6388` appears **both** above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: none
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

The alert numbers and their dispositions are on the issue, so the audit trail survives if a future CodeQL run re-mints any of them under new numbers. A dismissal follows an alert's fingerprint, so a flagged line moving into a new file mints a new alert — which is exactly how #6384 surfaced this backlog in the first place.

## Summary by Sourcery

Document and triage the repository’s cleartext-logging CodeQL alerts while preserving CodeQL’s advisory status.

Enhancements:
- Document why the local `rust/cleartext-logging` CodeQL findings are false positives and preserve the rationale for future triage.
- Keep CodeQL advisory rather than required until it produces an agreed true positive.

Documentation:
- Update the CodeQL workflow and contributor guidance with the documented false-positive patterns and alert-dismissal process.

Chores:
- Record the completed triage and dismissals for the cleartext-logging alert backlog.