### PR TITLE
fix(scripts): --update carries a split's ceiling, so the canary can read it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,8 @@
 
     **`make prose-update` carries; `make prose-retighten` reclaims.** All
     three ratchets take that split. `--update` writes only the entries a move
-    or a split re-based and leaves every other number where it stands, so a
+    re-based — or, for the count and grade, a file split — and leaves every
+    other number where it stands, so a
     branch cannot lower the ceiling of a file it never opened. Reclaiming the slack
     a rewrite earns is a pass of its own, and a PR of its own — safe exactly
     when nothing is blocked on it. An unconditional reclaim wrote `AGENTS.md`
@@ -207,7 +208,11 @@
     mean lines, so a new one cannot arrive carrying essays. A move is the
     one exception. When a file changes crates, `--update` re-bases both
     units on the old lengths of the files they hold now, and writes those
-    entries. Both means shift, and no one wrote a word. The plain check reads
+    entries. Both means shift, and no one wrote a word. A **file split needs
+    no exception here**, unlike the count and grade: the mean is header lines
+    over file count, so a split that moves header text lowers it. It rises
+    only when a split adds lines, and a header written during a split is new
+    prose. The plain check reads
     the same way, over the files a crate holds now, so a move out of a crate
     sitting at its ceiling costs the next author nothing.
 - **AGENTS.md is the orientation document.** Commands, architectural

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,10 +181,17 @@
     during the split is still new prose: it sits in neither line set, so it
     lowers the share and is judged as new past the threshold.
 
+    **`--update` writes that carry down, and has to.** Forgiving it at check
+    time alone left the entry out of the baseline, and `--absolute` skips the
+    base tree by design — so the post-merge canary held the carried sentences
+    to the new-file ceiling and reddened `main` on prose nobody wrote
+    (`#6408`). Run `make prose-update` when you split a file. A source with no
+    entry of its own passes nothing on, because it has no allowance to give.
+
     **`make prose-update` carries; `make prose-retighten` reclaims.** All
     three ratchets take that split. `--update` writes only the entries a move
-    re-based and leaves every other number where it stands, so a branch
-    cannot lower the ceiling of a file it never opened. Reclaiming the slack
+    or a split re-based and leaves every other number where it stands, so a
+    branch cannot lower the ceiling of a file it never opened. Reclaiming the slack
     a rewrite earns is a pass of its own, and a PR of its own — safe exactly
     when nothing is blocked on it. An unconditional reclaim wrote `AGENTS.md`
     a lower grade ceiling from a branch whose diff did not contain that file,

--- a/scripts/check-prose.py
+++ b/scripts/check-prose.py
@@ -1192,6 +1192,10 @@ def main() -> int:
         # its own headers the first time anyone runs --update. A unit a move
         # touched is judged against the same files' lengths at HEAD instead --
         # see `base_tracked_paths` for why a set change is not a prose change.
+        # Density takes a move and not a split, by arithmetic rather than
+        # omission: the mean is header lines over file count, so a split that
+        # moves header text lowers it. It rises only when a split ADDS lines,
+        # and a header written during a split is new prose.
         rebased = {
             unit: density_at_commit(
                 root,

--- a/scripts/check-prose.py
+++ b/scripts/check-prose.py
@@ -42,6 +42,13 @@ it, splitting a module means rewording prose nobody was editing — #5420 hit
 this and had to hand-edit the baseline, which is the one thing this file is
 supposed to make unnecessary.
 
+A split is the move git cannot name, and `--update` carries it too, through
+the `split_sources` pairing the plain check uses. Carrying it at check time
+alone was not enough: the entry never reached the baseline, so the post-merge
+`--absolute` run — which skips the base tree by design — charged the carried
+sentences to the new-file ceiling and reddened `main` (#6408). A source with
+no entry hands on nothing, having no allowance of its own to give.
+
 Adding a pattern is the one case a count legitimately goes up, and
 `--adopt=<name>` is the only door: it records that pattern's pre-existing
 hits and refuses to touch any other pattern's numbers, or to run twice for
@@ -73,10 +80,11 @@ and compose into a red `main`. Two doors close that, mirroring
   reading would forgive the thing it exists to catch. A file the base tree
   does not have inherits nothing, so a first-time offender still fails.
 - `--update` alone leaves every count, grade and unit ceiling where it
-  stands, except for an entry a file move re-based: a moved file's count and
-  grade follow it to its new path, and a unit a move took a header out of or
-  into is re-based against the same files' lengths, because a move changes a
-  number with nobody having written a word. Only `--update --retighten`
+  stands, except for an entry a file move or a split re-based: a moved file's
+  count and grade follow it to its new path, a split's new file takes the
+  ceiling of the file it came out of, and a unit a move took a header out of
+  or into is re-based against the same files' lengths, because a move changes
+  a number with nobody having written a word. Only `--update --retighten`
   lowers every ceiling to its current value, as a deliberate,
   separately-landed pass. Retightening on every `--update` run is what put
   every unit at exactly its ceiling with zero headroom, and it also let a
@@ -1116,12 +1124,37 @@ def main() -> int:
             )
             for old, new in carried:
                 print(f"check-prose: carried {old} -> {new}")
+        # The split half of that carry, and the reason the module header gives:
+        # forgiving it at check time alone kept the entry out of the baseline,
+        # and `--absolute` then charged the carried prose to the new-file
+        # ceiling (#6408). A rename remaps the key because the old path is
+        # gone; a split looks the source up, because the source is still there.
+        split_from = split_sources(root, resolve_base_commit(root, absolute=False))
+        for new, old in sorted(split_from.items()):
+            print(f"check-prose: {new} carries the ceiling of {old} (split)")
         # A pair absent from the baseline is held to zero, so `.get(pair, 0)`
         # is what makes --update refuse to grandfather a first-time offender.
+        # A split falls back to its source's allowance for that pattern, capped
+        # by the same `min`, so it can still only lower a count.
         retighten = "--retighten" in flagset
         moved_in = set(moved.values())
+        carried_in = moved_in | set(split_from)
+
+        def pair_ceiling(pair: tuple[str, str]) -> int:
+            if pair in baseline:
+                return baseline[pair]
+            source = split_from.get(pair[0])
+            return baseline.get((source, pair[1]), 0) if source else 0
+
+        def grade_ceiling(path: str) -> int:
+            if path in grade_baseline:
+                return grade_baseline[path]
+            source = split_from.get(path)
+            if source is not None and source in grade_baseline:
+                return grade_baseline[source]
+            return NEW_FILE_GRADE
         if retighten:
-            merged = {p: min(n, baseline.get(p, 0)) for p, n in per_pair.items()}
+            merged = {p: min(n, pair_ceiling(p)) for p, n in per_pair.items()}
         else:
             # Every entry stays where it stands, apart from one a move carried.
             # A global reclaim here lowers the ceiling of files the branch never
@@ -1130,12 +1163,12 @@ def main() -> int:
             # itself wrote (`#6274`). `--retighten` is the deliberate pass.
             merged = dict(baseline)
             for pair, n in per_pair.items():
-                if pair[0] in moved_in:
-                    merged[pair] = min(n, baseline.get(pair, 0))
+                if pair[0] in carried_in:
+                    merged[pair] = min(n, pair_ceiling(pair))
         raised = {
-            p: (baseline.get(p, 0), n)
+            p: (pair_ceiling(p), n)
             for p, n in per_pair.items()
-            if n > baseline.get(p, 0)
+            if n > pair_ceiling(p)
         }
         if raised:
             print(
@@ -1200,9 +1233,9 @@ def main() -> int:
                 moved.get(path, path): n for path, n in grade_baseline.items()
             }
         grade_raised = {
-            path: (grade_baseline.get(path, NEW_FILE_GRADE), grade)
+            path: (grade_ceiling(path), grade)
             for path, (grade, _) in per_grade.items()
-            if grade > grade_baseline.get(path, NEW_FILE_GRADE)
+            if grade > grade_ceiling(path)
         }
         if grade_raised:
             print(
@@ -1227,16 +1260,14 @@ def main() -> int:
         # failed the merge commit on three sentences its author never opened.
         if retighten:
             merged_grades = {
-                path: min(grade, grade_baseline.get(path, NEW_FILE_GRADE))
+                path: min(grade, grade_ceiling(path))
                 for path, (grade, _) in per_grade.items()
             }
         else:
             merged_grades = dict(grade_baseline)
             for path, (grade, _) in per_grade.items():
-                if path in moved_in:
-                    merged_grades[path] = min(
-                        grade, grade_baseline.get(path, NEW_FILE_GRADE)
-                    )
+                if path in carried_in:
+                    merged_grades[path] = min(grade, grade_ceiling(path))
         write_grade_baseline(grade_path, merged_grades)
         if retighten:
             # Pairs that reached zero drop out entirely; the ratchet retightens.

--- a/scripts/prose-grade-baseline.txt
+++ b/scripts/prose-grade-baseline.txt
@@ -1505,6 +1505,7 @@ crates/stella-tui/src/deck_ui/voice_inbound.rs 8.92
 crates/stella-tui/src/diff.rs 10.92
 crates/stella-tui/src/envelope.rs 8.73
 crates/stella-tui/src/envelope/engine_config.rs 10.20
+crates/stella-tui/src/envelope/inbound.rs 8.64
 crates/stella-tui/src/envelope/inspect.rs 10.57
 crates/stella-tui/src/envelope/issues.rs 7.08
 crates/stella-tui/src/envelope/mcp.rs 8.82
@@ -1512,6 +1513,7 @@ crates/stella-tui/src/envelope/roles.rs 11.52
 crates/stella-tui/src/envelope/skills.rs 7.89
 crates/stella-tui/src/envelope/steering.rs 11.88
 crates/stella-tui/src/envelope/tool_policy.rs 9.03
+crates/stella-tui/src/envelope/workspace_input.rs 8.55
 crates/stella-tui/src/fleet_dashboard.rs 7.68
 crates/stella-tui/src/graph.rs 8.45
 crates/stella-tui/src/input.rs 8.33

--- a/scripts/test-prose-guard.sh
+++ b/scripts/test-prose-guard.sh
@@ -1182,6 +1182,42 @@ expect_grade_at_most "X5 the split's entry is written, capped at its source" \
   "$r" docs/tail.md 50.00
 expect_absolute_pass "X5 the merged tree survives the post-merge canary" "$r"
 
+# X6: the density ratchet needs no split carry, and this pins the arithmetic
+# so nobody wires `split_from` into the rebase and breaks it. A review of #6412
+# read the count and grade carrying a split, saw density carrying only a move,
+# and called the difference an omission. It is not. The mean is header lines
+# over file count, so a split that MOVES header text leaves the total alone,
+# raises the count, and lowers the mean — it cannot fail. The mean rises only
+# when a split ADDS header lines, and a header written during a split is new
+# prose, which is the thing this ratchet exists to catch.
+#
+# `crates/alpha` sits exactly at its 20.00 ceiling: (30 + 10) / 2. The split
+# sheds 15 of `long`'s header lines into a new module in the same crate, so
+# the crate still holds 40 header lines, now over three files: 13.33.
+r="$(new_root x6)"
+baseline "$r"
+density_baseline "$r" crates/alpha 20.00
+rs_with_header "$r" alpha 30 long
+rs_with_header "$r" alpha 10 short
+commit_all "$r"
+rs_with_header "$r" alpha 15 long
+mkdir -p "$r/crates/alpha/src/long"
+rs_with_header "$r" alpha 15 long/part
+expect_pass "X6 a split that moves header text lowers the mean" "$r"
+expect_absolute_pass "X6 and passes the post-merge canary too" "$r"
+
+# X7: the direction that must not change — a split that ADDS header lines is
+# new prose and still fails, at the plain check, before the merge.
+r="$(new_root x7)"
+baseline "$r"
+density_baseline "$r" crates/alpha 20.00
+rs_with_header "$r" alpha 30 long
+rs_with_header "$r" alpha 10 short
+commit_all "$r"
+mkdir -p "$r/crates/alpha/src/long"
+rs_with_header "$r" alpha 30 long/part
+expect_fail "X7 a split that writes a new header is judged as new prose" "$r"
+
 # ── U1: an unmerged index counts each path once, not once per stage ─────────
 # `git ls-files --cached` prints a conflicted path once for each of stages 1,
 # 2 and 3, so a merge resolved on disk but not yet `git add`ed used to make

--- a/scripts/test-prose-guard.sh
+++ b/scripts/test-prose-guard.sh
@@ -564,6 +564,31 @@ expect_update_ok() {
   fi
 }
 
+# $1 = case name, $2 = root, $3 = path that must carry a grade entry, $4 = the
+# ceiling it may not exceed. A carry lowers a ceiling or leaves it; writing one
+# above the source's would be a raise wearing a move's clothes.
+expect_grade_at_most() {
+  line="$(grep "^$3 " "$2/scripts/prose-grade-baseline.txt" 2>/dev/null)"
+  if [ -z "$line" ]; then
+    no "$1" "the grade baseline has no entry for $3"
+  elif [ "$(printf '%s\n' "$line" | awk -v cap="$4" '{print ($2 <= cap) ? "y" : "n"}')" = y ]; then
+    ok "$1"
+  else
+    no "$1" "\"$line\" sits above the $4 it carried"
+  fi
+}
+
+# $1 = case name, $2 = root. `--absolute` -- what the post-merge canary runs --
+# must exit 0. It skips the base tree by design, so nothing but a recorded
+# entry can save a file there.
+expect_absolute_pass() {
+  if python3 "$SCRIPT" --absolute "$2" >/dev/null 2>&1; then
+    ok "$1"
+  else
+    no "$1" "--absolute exited non-zero"
+  fi
+}
+
 r="$(new_root r1)"
 doc "$r" docs/old.md <<'EOF'
 The cost is deliberate: the retention it buys is not worth the residue.
@@ -1133,6 +1158,29 @@ commit_all "$r"
 split_tail "$r" docs/big.md docs/moved.md 30
 hard_doc_varied "$r" docs/unrelated.md 40
 PROSE_BASE_REF=HEAD expect_fail "X4 an unrelated new file inherits nothing" "$r"
+
+# X5: the carry has to be written down, not only granted. X1 forgives a split's
+# prose at check time and records nothing, and those were the only two doors --
+# `--update` paired renames alone. So the entry never reached the baseline, the
+# plain check forgave the new file on every later run, and the post-merge
+# `--absolute` run, which has no base tree to pair against, held the carried
+# sentences to the new-file ceiling. That is #6408: `envelope.rs` split into
+# `envelope/inbound.rs` and `envelope/workspace_input.rs`, passed every
+# pre-merge check, and reddened `main` on prose nobody had written.
+#
+# The source needs a real ceiling here, because a carry hands on what the
+# source is allowed rather than what it happens to read. A source with no entry
+# is over the ceiling itself and has no allowance to give.
+r="$(new_root x5)"
+hard_doc_varied "$r" docs/big.md 60
+baseline "$r"
+grade_baseline "$r" docs/big.md 50.00
+commit_all "$r"
+split_tail "$r" docs/big.md docs/tail.md 30
+PROSE_BASE_REF=HEAD expect_update_ok "X5 --update accepts a split" "$r"
+expect_grade_at_most "X5 the split's entry is written, capped at its source" \
+  "$r" docs/tail.md 50.00
+expect_absolute_pass "X5 the merged tree survives the post-merge canary" "$r"
 
 # ── U1: an unmerged index counts each path once, not once per stage ─────────
 # `git ls-files --cached` prints a conflicted path once for each of stages 1,


### PR DESCRIPTION
## What & why

**`main` is red on `prose`, and this repairs it.** Landing on its own from a fresh `main` (`876deab01`), per AGENTS.md's rule about a ratchet's shared cell.

`check-prose.py`'s plain check pairs a **split**: a new file whose prose lines mostly came out of a file the same change shrank is judged against that file's numbers in the base tree, not against the new-file ceiling. That is what makes the `mod` hierarchy AGENTS.md prescribes for a crowded file cost no rewrite of the comments it carries.

`--update` did not pair splits. It asked `renamed_paths` alone, so the carried entry was never written down.

That gap is invisible until after the merge, which is the whole of the bug:

- Every **pre-merge** run is the plain check, which pairs the split and forgives the carried prose. Green.
- The **post-merge canary** runs `--absolute`, which skips the base tree by design — a canary asking whether drift reached `main` must not be given the base-relative mercy. With no baseline entry to read, it holds the carried sentences to the 6.00 new-file ceiling.

So #6399 split `crates/stella-tui/src/envelope.rs` into `envelope/inbound.rs` and `envelope/workspace_input.rs`, passed every check it was shown, and reddened `main` on prose nobody had written (#6408).

### The evidence that the prose is carried, not new

```
$ PROSE_BASE_REF=9a49e2b python3 scripts/check-prose.py     # on main, before this fix
check-prose: drift inherited from the base tree, which this change did not cause
             and does not fail on:
  crates/stella-tui/src/envelope/inbound.rs:        grade 8.64, 6.00 allowed, 8.72 in the base tree
  crates/stella-tui/src/envelope/workspace_input.rs: grade 8.55, 6.00 allowed, 8.72 in the base tree
```

`split_sources` pairs both files to `envelope.rs`, and both read **below** the 8.72 their source read. There is no new prose debt here. Rewriting ~7,000 words of carried doc comments down to grade 6.00 would have been paying for a guard defect — and would have charged a pure split exactly the rewrite the split-carry mechanism exists to prevent.

### The fix

`--update` now asks `split_sources` — the same function, against the same resolved base commit — for the grade and count ceilings, and writes the carried entry through the same `min`.

- A **rename** remaps the baseline key, because the old path is gone.
- A **split** looks its source up, because the source is still there with its own entry and its own prose.
- A source with **no entry** hands on nothing: it has no allowance of its own to give, so its split is held to the new-file ceiling like any other new file.

The count ratchet had the identical gap and takes the identical fix. It writes nothing here (both split files carry zero flagged constructions), so the baseline diff is the grade half alone.

### The two baseline lines

```
+crates/stella-tui/src/envelope/inbound.rs 8.64
+crates/stella-tui/src/envelope/workspace_input.rs 8.55
```

These are the carry applied to the split already on `main`, each recorded at **its own** grade, both under the 8.73 `envelope.rs` carries. **No ceiling is raised** — this is the entry following the sentences, which is what `--update` is for, not a grandfathering of new debt. `--update` still refuses to raise a number or grandfather a first-time offender; X3 and X4 in the suite pin that direction and are unchanged.

Closes #6408

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`X5` in `scripts/test-prose-guard.sh`, the split analogue of `S7` (which covers `--update`'s rename carry). Three assertions: `--update` accepts a split, the entry is written capped at its source, and the tree then survives `--absolute` — the last one being the canary's exact question.

**Demonstrated, not asserted.** Restoring `scripts/check-prose.py` from this commit's parent and re-running the current test file against it:

| module under test | result |
|---|---|
| `main`'s copy (`876deab01`) | **86 passed, 3 failed** — all three X5 rows |
| this branch | **89 passed, 0 failed** |

The failure text on `main` is the bug verbatim: `--update exited non-zero`, `the grade baseline has no entry for docs/tail.md`, `--absolute exited non-zero`.

## The gate

Run here (toolchain-free guards only — CLAUDE.md, "CI builds and tests; this laptop does not"; no crate is touched, so nothing to compile):

- [x] `check-prose.py` **plain** — OK, judged against `9a49e2b8323f`
- [x] `check-prose.py --absolute` — **OK**, the canary's check, which is `main`'s repair
- [x] `scripts/test-prose-guard.sh` — 89 passed, 0 failed
- [x] `check-line-citations.py`, `check-left-behind.sh`, `check-file-size.sh` — all clean
- [x] `python3 -m py_compile scripts/check-prose.py` — clean
- [ ] `shellcheck scripts/test-prose-guard.sh` — **UNAVAILABLE, THIS CHECK DID NOT RUN.** The agent container ships no `shellcheck` (#3830). CI's guards job is the gate for it.
- [x] Docs updated — the module header, and `CLAUDE.md`'s split paragraph, which stated the check-time half as if it were the whole mechanism
- [x] `Closes #6408` appears above **and** as a commit trailer

## Fix over file

- [x] Extra fixes in this PR:
  - **`CLAUDE.md`'s account of the carry was wrong in the direction that matters.** It said "The plain check pairs them itself" and "`--update` writes only the entries a move re-based" — true separately, and together they described a mechanism with no way to record a split. Both now say what the code does, with the failure named.
- [x] Filed, with the reason a fix could not ride this PR: **#6413** — `scripts/check-prose.py` is at 1493 of the 1500-line ceiling and wants a `mod`-style split. It cannot ride this PR because AGENTS.md holds a red-`main` repair to landing on its own from a fresh `main`, and a ~1500-line restructure folded in would hold every open PR behind it. See below.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] N/A — no cross-boundary types

## Anything reviewers should know?

**`scripts/check-prose.py` is now crowded: 1493 / 1500 lines**, up from 1462. It is not grandfathered, so the next author to touch it meets the ceiling inside a change about something else — the exact scenario AGENTS.md's "God files" section describes, and the one #6399 was splitting `envelope.rs` to avoid. I tightened my own added comments twice to buy the headroom back rather than growing the file further, which is design pressure landing on the wrong thing: the comment explaining this carry rule got shorter so the file would fit. Filed as **#6413** with a proposed seam; happy for it to ride a different change if you would rather.

**On the `PROSE_BASE_REF` in the evidence above.** The split is already on `main`, so `--update` run from a branch cut after it cannot see the split in its own diff. I pointed the documented override at the pre-split commit (`9a49e2b`) to write the two carried entries. Going forward no override is needed: an author running `make prose-update` while making the split has it in `git diff <base>`, which is the case X5 covers.

**What this does not establish.** The guards above are the ones that can run without a toolchain. `fmt`, `clippy`, `doc-warnings` and the workspace suite are untouched by this diff — no Rust changed — but I have not run them, and CI is the gate of record. I also could not run `shellcheck`, named above rather than left silent.

**Blast radius.** `--update` is a writer, and a writer that carries too eagerly would grandfather debt. The two directions that must not change are pinned by existing tests I did not touch: `X3` (prose added during a split is new prose, at zero allowance) and `X4` (a new file that merely appeared beside a shrinking one inherits nothing). Both still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCEFEPtRwpJCg66w1sqMzi

## Summary by Sourcery

Record split-derived prose and count allowances during baseline updates so carried content remains valid after merge without grandfathering new debt.

Bug Fixes:
- Ensure prose and count baselines persist allowances for files created by splits, preventing post-merge absolute checks from treating carried content as new debt.

Enhancements:
- Align split handling in --update with the plain check while preserving new-content protections and excluding density ratchet carry where splits lower the mean.
- Clarify split carry behavior and its limitations in the project guidance and prose checker documentation.

Documentation:
- Document how --update records split carries and why density does not require split carry handling.

Tests:
- Add witness coverage for split baseline persistence, source-ceiling caps, absolute canary checks, and density behavior for moved versus newly added headers.