### PR TITLE
fix(ci): the canary sweeps the holds on the break path, not just the recovery

### DIFF
--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -109,7 +109,18 @@ jobs:
       #
       # It runs after the step above either way, because that step is what
       # files or closes the issue this one reads.
+      #
+      # `if: always()` is what makes "either way" true. A step with no
+      # condition defaults to `success()`, and the step above exits non-zero
+      # precisely when `main` is broken — so the break path, the only one that
+      # can strand a green hold on a red tree, was the one path that never
+      # swept. #6408 was filed at 14:56:59Z by a run whose sweep step is
+      # recorded as `skipped` at the same second, and #6371's hold still read
+      # the answer it was given at 04:22Z through the whole 84-minute outage.
+      # That is `#5949` again, with the sweep built and wired and never
+      # reached.
       - name: Refresh the hold on every open pull request
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/refresh-main-red-holds.sh

--- a/scripts/test-main-red-hold.sh
+++ b/scripts/test-main-red-hold.sh
@@ -430,6 +430,31 @@ else
   bad "the canary sweeps before it writes the issue the sweep reads"
 fi
 
+# Ordering alone was the whole of that check, and ordering is not the hazard.
+# A step with no `if:` defaults to `success()`, and the announce step exits
+# non-zero exactly when `main` is broken — so the sweep was skipped on the one
+# transition it exists for. Read the sweep step's own block: from its `- name:`
+# line to the next step at the same indent, it has to carry a condition that
+# survives a failed predecessor.
+sweep_name_line="$(grep -n 'name: Refresh the hold on every open pull request' \
+  "$canary" | head -1 | cut -d: -f1)"
+if [ -z "$sweep_name_line" ]; then
+  bad "the canary has no step named for the sweep, so its condition cannot be read"
+else
+  sweep_block="$(awk -v start="$sweep_name_line" '
+    NR < start { next }
+    NR > start && /^      - / { exit }
+    { print }' "$canary")"
+  case "$sweep_block" in
+  *"if: always()"*)
+    ok "the sweep still runs when the announce step fails, which is the break path"
+    ;;
+  *)
+    bad "the sweep step has no \`if: always()\`, so a failed announce skips it and a red main sweeps nothing"
+    ;;
+  esac
+fi
+
 printf '\n\033[1mdrilling — the re-run call is rehearsed without an outage\033[0m\n'
 
 # The drill asks the tracker nothing, and it sweeps no second pull request.


### PR DESCRIPTION
## What & why

`main-canary.yml`'s "Refresh the hold on every open pull request" step carried no `if:`, so it defaulted to `success()`. The step before it — `main-canary.sh --announce`, which files or closes the `main-red` issue — exits non-zero **exactly when `main` is broken**. So the sweep was skipped on the one transition it exists for.

Run [34135528510](https://github.com/macanderson/stella/actions/runs/34135528510) records both halves at the same second:

| step | conclusion | at |
|---|---|---|
| Reconcile main against the composition checks | **failure** (filed #6408) | 14:56:59Z |
| Refresh the hold on every open pull request | **skipped** | 14:56:59Z |

Across the whole 84-minute outage (#6408 filed 14:56:59Z, closed 16:20:03Z) #6371's `main is not known-broken` still read the answer it was given at **04:22:24Z** — a green required check on a red tree. That is the stale-green hazard `refresh-main-red-holds.sh` was built to close, and AGENTS.md describes it under `main-red-hold.yml`: *"`#5928`'s hold ran at 09:41, the `main-red` issue was filed at 10:07, and it merged onto the broken tree during the red window."* Same shape, larger gap, with the remedy built, wired, and never reached.

**The recovery direction always worked**, because a clean announce exits 0 and the sweep runs. That asymmetry is why the machinery looked live: the direction that merely blocks good work (`#5913`) swept, and the direction that admits a merge onto a broken tree (`#5949`) did not.

`if: always()` is the fix. The step's own comment already claimed it ran "either way"; the YAML did not implement that, and now does.

No issue is linked, so this needs the `no-issue` label to clear `dod` — I could not apply it from this session. Per AGENTS.md § "Fix over file" this was fixed in the PR rather than filed: it is a one-line CI repair with a witness, which is what the escape hatch is for. Say the word and I will file one instead.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)
- [ ] No witness needed (pure refactor / docs / CI)

In `scripts/test-main-red-hold.sh`, beside the wiring assertions that already read this workflow. Those checked that the sweep is *called*, that the job holds `actions: write`, and that the sweep is *ordered* after the announce. Ordering was never the hazard, and no assertion asked whether the step runs at all when its predecessor fails.

The new case reads the sweep step's own block out of the workflow — from its `- name:` line to the next step at the same indent — and requires a condition that survives a failed predecessor.

**Demonstrated, not asserted.** Restoring `.github/workflows/main-canary.yml` from `origin/main` and re-running the current test file against it:

| workflow under test | result |
|---|---|
| `main`'s copy (`db19af3`) | **52 passed, 1 failed** |
| this branch | **53 passed, 0 failed** |

The failing line on `main` reads verbatim:

```
  ✗ the sweep step has no `if: always()`, so a failed announce skips it and a red main sweeps nothing
main-red-hold-test: FAILED — 52 passed, 1 failed
```

## The gate

Nothing in this diff compiles — one YAML key plus a shell assertion — so the cargo rungs are CI's.

- [x] `bash scripts/test-main-red-hold.sh` — 53 passed (and the witness above)
- [x] `check-prose.py`, `check-line-citations.py`, `check-left-behind.sh`, `check-file-size.sh` — all clean
- [x] `bash -n scripts/test-main-red-hold.sh`, and the workflow parses with the sweep step's `if` resolving to `always()`
- [ ] `shellcheck scripts/test-main-red-hold.sh` — **UNAVAILABLE, THIS CHECK DID NOT RUN.** The agent container ships no `shellcheck` (#3830). CI's guards job is the gate for it.
- [ ] `cargo fmt --check` / `clippy` / `test --workspace` — not run; no Rust changed, CI owns them
- [x] Docs updated where behavior changed — the step's comment now says what the YAML does
- [x] CLA signed

## Fix over file

- [x] Extra fixes in this PR: none
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] N/A — no cross-boundary types

## Anything reviewers should know?

**Where it came from.** A scheduled PR-management sweep across the org. #6371 read as `mergeable_state: clean` with 28 green check runs while `main` was red — a previous session had already flagged the stale hold on that PR as an observation; this is its cause.

**What this does not establish.** The fix is verified by the workflow's parsed `if` and by the witness. It is **not** verified against a live break — that needs `main` to go red again, which is not something to arrange. The next outage is the real test, and the failure mode if I am wrong is the status quo: the sweep skips, exactly as it does today.

**Blast radius is one direction only.** `if: always()` can make the sweep run in cases it previously skipped; it cannot make it skip one it previously ran. The sweep itself fails open at every unknown and re-runs nothing already answering today's question, so an extra invocation costs nothing. The announce step keeps its own non-zero exit, so the job still concludes `failure` on a red `main` and the canary's signal is unchanged.

https://claude.ai/code/session_01ShSLxJeLg7QqPR1txNrwtM