### PR TITLE
test(stella-cli): hold a driver session's refusals to the durable record

### DIFF
--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -1200,8 +1200,13 @@ fn driving_manifest_text(name: &str) -> String {
 ///
 /// `sleep_secs` is a parameter because a run of sessions waits between them:
 /// a test that opens several passes zero, so it costs no wall clock.
+///
+/// `ask` names one capability the driver requests before it answers, and
+/// `None` is a driver that asks for nothing. The script reads the host's reply
+/// and ignores what it says: the answer is the gate's business, and what this
+/// fixture is here to produce is the ask.
 #[cfg(unix)]
-fn driving_package(dir: &Path, name: &str, sleep_secs: u32) -> PathBuf {
+fn driving_package(dir: &Path, name: &str, sleep_secs: u32, ask: Option<&str>) -> PathBuf {
     use std::os::unix::fs::PermissionsExt;
 
     let source = dir.join(format!("src-{name}"));
@@ -1211,12 +1216,19 @@ fn driving_package(dir: &Path, name: &str, sleep_secs: u32) -> PathBuf {
         driving_manifest_text(name),
     )
     .expect("fixture manifest");
+    let asking = match ask {
+        Some(call) => {
+            format!("printf '{{\"call\":\"{call}\",\"id\":1}}\\n'\nread -r _answer\n")
+        }
+        None => String::new(),
+    };
     let script = source.join("drive.sh");
     std::fs::write(
         &script,
         format!(
             "#!/bin/sh\n\
              read -r _line\n\
+             {asking}\
              printf '{{\"point\":\"drive\",\"body\":{{\"next\":{{\"sleep\":{{\"secs\":{sleep_secs}}}}}}}}}\\n'\n"
         ),
     )
@@ -1242,7 +1254,7 @@ fn a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended() 
     unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
 
     let root = temp_root("drive-record");
-    let source = driving_package(&root, "watcher", 9);
+    let source = driving_package(&root, "watcher", 9, None);
     let settings = Settings::default();
     install(&root, &source, PluginScope::Project, true, &settings).expect("install must succeed");
 
@@ -1264,13 +1276,67 @@ fn a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended() 
     assert_eq!(entry.plugin, "watcher");
     assert!(!entry.session_id.is_empty(), "{entry:?}");
     assert!(entry.program.ends_with("drive.sh"), "{entry:?}");
+    // The session that asks for nothing records nothing, which is what makes
+    // the sibling below's non-empty list mean something. Its `None` is the
+    // choice this test makes, not a shape the fixture is stuck with.
     assert!(
         entry.refusals.is_empty(),
-        "the fixture never asks for a capability: {entry:?}"
+        "this fixture asks for no capability: {entry:?}"
     );
     assert_eq!(
         entry.outcome,
         crate::driver_plugin::session_log::DriverSessionOutcome::Sleep { secs: 9 }
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// **The witness.** A refusal a session actually produced reaches the file,
+/// naming the ask and the plugin that made it.
+///
+/// The sibling above only ever asserted the recorded list was *empty*, against
+/// a fixture that could not ask for anything — so `drive` could stop reading
+/// the gate, or read it before the session rather than after, and every test
+/// here would still pass. `DriverCallGate` fills that list while the session
+/// runs, so reading it early gives an empty vector that looks exactly like a
+/// well-behaved driver.
+///
+/// The ask is `deliver_merge`, which `driving_manifest_text` does not declare.
+/// The gate refuses it on the grant alone, before any capability is consulted,
+/// so this test reaches no tracker and starts no `gh`.
+#[cfg(unix)]
+#[test]
+fn a_refusal_a_driver_session_produced_is_named_in_the_durable_record() {
+    let _env = crate::test_env::lock();
+    let _restore = crate::test_env::EnvRestore::capture(&["STELLA_TRUST_PROJECT"]);
+    // SAFETY: the env lock above is held for the whole mutate-read-restore
+    // window, and `EnvRestore` puts the prior value back on drop.
+    unsafe { std::env::set_var("STELLA_TRUST_PROJECT", "1") };
+
+    let root = temp_root("drive-refusal");
+    // Zero seconds, so the run's one wait costs the test nothing.
+    let source = driving_package(&root, "asker", 0, Some("deliver_merge"));
+    let settings = Settings::default();
+    install(&root, &source, PluginScope::Project, true, &settings).expect("install must succeed");
+
+    drive(&root, "asker", Some(1), TurnFlags::default())
+        .expect("a refused ask is a value the driver reads, never a failed run");
+
+    let sessions = crate::driver_plugin::session_log::read_sessions(&root);
+    assert_eq!(sessions.len(), 1, "{sessions:?}");
+    let entry = &sessions[0];
+    assert_eq!(entry.refusals.len(), 1, "one ask, one refusal: {entry:?}");
+    let refusal = &entry.refusals[0];
+    assert!(refusal.contains("deliver_merge"), "{refusal}");
+    assert!(refusal.contains("undeclared"), "{refusal}");
+    assert!(
+        refusal.contains("asker"),
+        "the record says which plugin asked: {refusal}"
+    );
+    assert_eq!(
+        entry.outcome,
+        crate::driver_plugin::session_log::DriverSessionOutcome::Sleep { secs: 0 },
+        "the session went on to answer after the refusal: {entry:?}"
     );
 
     let _ = std::fs::remove_dir_all(&root);
@@ -1296,7 +1362,7 @@ fn one_invocation_opens_a_session_for_each_sleep_the_driver_asks_for() {
 
     let root = temp_root("drive-sequence");
     // Zero seconds, so the run's waits cost the test nothing.
-    let source = driving_package(&root, "sleeper", 0);
+    let source = driving_package(&root, "sleeper", 0, None);
     let settings = Settings::default();
     install(&root, &source, PluginScope::Project, true, &settings).expect("install must succeed");
 


### PR DESCRIPTION
## What & why

`a_driver_session_leaves_a_durable_record_of_what_it_asked_and_how_it_ended`
(`crates/stella-cli/src/plugin_cmd/tests.rs`) asserted the recorded `refusals`
was **empty**, against a fixture that could not ask for a capability at all.
That assertion holds whatever the host does with the gate. It would go on
passing if the record stopped carrying the field, and it would go on passing if
`PluginDriveHost::open` read `BoundDriver::refusals()` before opening the
session rather than after — `DriverCallGate` fills its list while the session
runs, so an early read gives back the same empty vector a well-behaved driver
produces. Every capability the CLI serves is refused for the plugins that ask
for something they did not declare, so the refusal list is the field carrying
the most information about what a driver tried to do, and it was the one field
nothing checked end to end.

`driving_package` now takes the capability its `drive.sh` asks for before it
answers its `next`, and a sibling test drives a fixture that asks. The existing
test keeps the "a session that refuses nothing records nothing" case, now with
a fixture that *could* have asked.

**The ask is `deliver_merge`, not `backlog_next` as the issue proposed.** The
issue's plan rested on "every capability answers `unsupported`
(`NoDriverCapabilities`)", which the shipping host has outgrown:
`HostDriverCapabilities` serves `backlog_next` through `GhIssueProvider`
(#6063), so a fixture asking for it would shell out to `gh` and reach the real
tracker from a unit test. `deliver_merge` is not in `driving_manifest_text`'s
grant, so `DriverSession::call` refuses it on the grant alone, before anything
is spent and before any capability is consulted. Same one refusal, no new
host-side machinery, and the test stays hermetic.

Closes #5962
Refs #5109
Refs #5946

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)

`a_refusal_a_driver_session_produced_is_named_in_the_durable_record` runs the
real `drive` entrypoint against an installed fixture, then reads
`.stella/private/driver-sessions.jsonl` back off disk and asserts the one
recorded refusal names the call, the refusal code and the plugin that asked.

**Both flips were run, not asserted** (`cargo test -p stella-cli --bins
a_refusal_a_driver_session_produced`):

| Change to `crates/stella-cli/src/driver_plugin/sequence.rs` | Result |
| --- | --- |
| `refusals: end.refusals.clone()` → `refusals: Vec::new()` in `record` | FAILED — `left: 0, right: 1` |
| `bound.refusals()` moved above `bound.open(session)` in `PluginDriveHost::open` | FAILED — `left: 0, right: 1` |
| unmodified | ok |

Both failures print the whole record, which is otherwise complete — so the test
fails because a real refusal stopped reaching the file, not because the record
went missing. That is the issue's "Done when", verified rather than claimed.
`sequence.rs` is unchanged in this diff; the flips were made and reverted in
the working tree.

## The gate

- [x] `cargo fmt --check` — via `make guards-fast`, clean
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean.
      Scoped per SCR-001 and CLAUDE.md's "CI builds and tests; this laptop does
      not"; the workspace run is this PR's CI.
- [x] `cargo test -p stella-cli --bins plugin_cmd::tests` — 41 passed, 0 failed.
      Scoped for the same reason; the workspace suite is CI's.
- [x] Docs updated where behavior/flags changed — no behavior or flag changed.
      This is a test-only diff, and the ledger's shape matches what
      `doc:backlog-self-driving` already describes.
- [x] CLA signed
- [x] `Closes #5962` appears both above and as a commit trailer

Also run: `make guards-fast` (green) and `python3 scripts/check-prose.py`
(green — no construction added, every header and reading grade within its
ceiling).

## Fix over file

- [x] Extra fixes in this PR: none
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls — and the fixture is chosen so the test
      starts no `gh` either
- [x] No new cross-boundary types

## Anything reviewers should know?

The issue names `plugin_cmd.rs`'s `drive` as the place that reads
`bound.refusals()`. That read has since moved to
`driver_plugin::sequence::PluginDriveHost::open`, with the record built by
`sequence::record`. The claim behind the issue is unchanged — those are the two
lines the flips above cut — but the file paths in the issue body are stale.

## Summary by Sourcery

Verify that driver-session records retain refusals produced during a session, while preserving the no-refusal case.

Enhancements:
- Strengthen driver-session durability coverage by exercising a real undeclared capability request and verifying its refusal is persisted with the call and requesting plugin.
- Allow test driver fixtures to optionally issue a capability request before responding while preserving coverage for sessions that make no requests.

Tests:
- Add an end-to-end CLI test confirming refused driver requests are recorded in the durable session log and do not prevent the session from completing.