### PR TITLE
feat(stella-cli): let an operator run a sweep supply by hand

### DIFF
--- a/crates/stella-autonomy/src/surface.rs
+++ b/crates/stella-autonomy/src/surface.rs
@@ -202,6 +202,16 @@ pub const HOST_SURFACE: &[HostVerb] = &[
         summary: "the ranked defect queue this cycle draws its batch from",
     },
     HostVerb {
+        path: "sweep regress",
+        emits: Emits::QueryEnvelope,
+        summary: "re-check the fixes this loop has claimed, and file the ones that have left the base",
+    },
+    HostVerb {
+        path: "sweep meta",
+        emits: Emits::QueryEnvelope,
+        summary: "fold the loop's own ledger and file what the pathology signals say about it",
+    },
+    HostVerb {
         path: "file",
         emits: Emits::Text,
         summary: "file a finding as an issue — refused unless it matches this workspace's convention",

--- a/crates/stella-autonomy/src/tests.rs
+++ b/crates/stella-autonomy/src/tests.rs
@@ -1058,6 +1058,22 @@ fn the_emit_spelling_a_host_parses_is_the_one_a_person_reads() {
     }
 }
 
+/// **The witness.** The two hand-run sweep verbs are on the declared
+/// surface, so a host can discover them and the CLI's own parity test holds
+/// the clap tree to them. Before `#6184` the behaviour behind both was
+/// reachable only from inside the `drive` loop, and neither had a row here.
+#[test]
+fn the_hand_run_sweep_verbs_are_declared() {
+    for path in ["sweep regress", "sweep meta"] {
+        let verb = host_verb(path).unwrap_or_else(|| panic!("`{path}` has a HOST_SURFACE row"));
+        assert_eq!(
+            verb.emits,
+            Emits::QueryEnvelope,
+            "`{path}` prints a human report by default and the query envelope under --format json"
+        );
+    }
+}
+
 /// The declaration agrees with itself: feeding the surface its own paths must
 /// find nothing. The baseline the two drift cases below are read against.
 #[test]

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -46,16 +46,17 @@ mod query;
 pub(crate) mod ready;
 mod report;
 pub(crate) mod residue;
+mod runs;
 pub(crate) mod state;
 mod stats;
 mod stop;
 mod supply;
 mod surface;
+mod sweep;
 mod triage;
 pub(crate) mod turn_flags;
 pub(crate) mod work;
 
-use std::collections::BTreeMap;
 use std::process::Command;
 
 use clap::Subcommand;
@@ -195,6 +196,13 @@ pub(crate) enum SelfDrivingCmd {
         /// versioned query envelope (#1568).
         #[arg(long, value_enum, default_value = "text")]
         format: QueryFormat,
+    },
+
+    /// Draw from one supply that does not drain, by hand, and report what it
+    /// offers. `--dry-run` writes nothing to the tracker.
+    Sweep {
+        #[command(subcommand)]
+        cmd: sweep::SweepCmd,
     },
 
     /// File a finding as an issue, through the bound provider.
@@ -649,6 +657,7 @@ pub(crate) fn run(cmd: &SelfDrivingCmd, flags: &TurnFlags) -> Result<(), String>
             show,
         } => query::calibrate_cmd(&st, *ok, *resource_fail, *show),
         SelfDrivingCmd::Queue { limit, format } => query::queue(&st, *limit, *format),
+        SelfDrivingCmd::Sweep { cmd } => sweep::run(&st, cmd),
         SelfDrivingCmd::File {
             title,
             body,
@@ -702,14 +711,14 @@ pub(crate) fn run(cmd: &SelfDrivingCmd, flags: &TurnFlags) -> Result<(), String>
             remaining,
         }),
         SelfDrivingCmd::Run { cmd } => match cmd {
-            RunCmd::Start => run_start(&st),
-            RunCmd::End { status, reason } => run_end(&st, status, reason),
-            RunCmd::Cancel { reason } => run_end_as(
+            RunCmd::Start => runs::start(&st),
+            RunCmd::End { status, reason } => runs::end(&st, status, reason),
+            RunCmd::Cancel { reason } => runs::end(
                 &st,
                 "cancelled",
                 reason.as_deref().unwrap_or("stopped by hand"),
             ),
-            RunCmd::List => runs_report(&st),
+            RunCmd::List => runs::report(&st),
             RunCmd::StampCyclePid { pid } => {
                 st.update_run_doc(|doc| match pid {
                     Some(p) => {
@@ -723,7 +732,7 @@ pub(crate) fn run(cmd: &SelfDrivingCmd, flags: &TurnFlags) -> Result<(), String>
             }
         },
         SelfDrivingCmd::Stop { root } => stop::request(root.as_deref().unwrap_or(&st.dir)),
-        SelfDrivingCmd::Runs => runs_report(&st),
+        SelfDrivingCmd::Runs => runs::report(&st),
         SelfDrivingCmd::Phase { name } => {
             st.run_write(name, None, None);
             println!("phase: {name}");
@@ -936,7 +945,7 @@ fn cycle_begin(st: &LoopState) -> Result<(), String> {
         &st.repo_root,
         &hooks::settings_for(&st.repo_root),
         hooks::HookEvent::DriveCycleStart,
-        run_info(st).in_cycle(n),
+        runs::info(st).in_cycle(n),
         None,
     );
 
@@ -1030,7 +1039,7 @@ fn cycle_end(
     st.run_write("idle", None, Some(tier));
 
     let settings = hooks::settings_for(&st.repo_root);
-    let run = run_info(st).in_cycle(cycle);
+    let run = runs::info(st).in_cycle(cycle);
     hooks::drive(
         &st.repo_root,
         &settings,
@@ -1381,114 +1390,4 @@ fn file_finding(
     }
 
     backlog::render_not_filed(&outcome, &bound, format)
-}
-
-// ---------------------------------------------------------------------------
-// run lifecycle
-// ---------------------------------------------------------------------------
-
-fn run_start(st: &LoopState) -> Result<(), String> {
-    let rid = state::new_run_id();
-    let driver = std::env::var("SELF_DRIVING_DRIVER").unwrap_or_else(|_| "interactive".to_string());
-    let mut fields = BTreeMap::new();
-    fields.insert("run_id".to_string(), Value::String(rid.clone()));
-    fields.insert("status".to_string(), Value::String("running".to_string()));
-    fields.insert("driver".to_string(), Value::String(driver));
-    fields.insert(
-        "slug".to_string(),
-        Value::String(state::repo_slug(&st.repo_root)),
-    );
-    fields.insert(
-        "workspace_root".to_string(),
-        Value::String(st.repo_root.to_string_lossy().into_owned()),
-    );
-    fields.insert("pid".to_string(), u64::from(std::process::id()).into());
-    st.append_run_record(fields)?;
-
-    let started = rfc3339_utc_now();
-    st.update_run_doc(|doc| {
-        doc.insert("run_id".into(), rid.clone().into());
-        doc.entry("started_at".to_string())
-            .or_insert_with(|| Value::String(started));
-    });
-    // Stamp the first heartbeat through the SAME writer every other phase
-    // uses — the record must be complete from its first byte, not completed
-    // by whatever happens next.
-    st.run_write("idle", None, None);
-
-    hooks::drive(
-        &st.repo_root,
-        &hooks::settings_for(&st.repo_root),
-        hooks::HookEvent::DriveRunStart,
-        hooks::HookRunInfo::new(&rid),
-        None,
-    );
-
-    say(&format!("run {rid} started"));
-    println!("SELF_DRIVING_RUN_ID={rid}");
-    Ok(())
-}
-
-fn run_end(st: &LoopState, status: &str, reason: &str) -> Result<(), String> {
-    run_end_as(st, status, reason)
-}
-
-fn run_end_as(st: &LoopState, status: &str, reason: &str) -> Result<(), String> {
-    let rid = st
-        .current_run_id()
-        .ok_or_else(|| "run end: no run in progress".to_string())?;
-    let mut fields = BTreeMap::new();
-    fields.insert("run_id".to_string(), Value::String(rid.clone()));
-    fields.insert("status".to_string(), Value::String(status.to_string()));
-    fields.insert("reason".to_string(), Value::String(reason.to_string()));
-    st.append_run_record(fields)?;
-    st.clear_run_doc();
-    // After the record is banked and before the line is printed, so a
-    // subscriber that reads the ledger on being woken finds this run's ending
-    // already in it.
-    hooks::drive(
-        &st.repo_root,
-        &hooks::settings_for(&st.repo_root),
-        hooks::HookEvent::DriveRunEnd,
-        hooks::HookRunInfo::new(&rid),
-        Some(format!("{status}: {reason}")),
-    );
-    say(&format!("run {rid} -> {status}"));
-    Ok(())
-}
-
-/// The run a lifecycle event belongs to.
-///
-/// A run that was never opened still has events worth reporting — `cycle
-/// begin` outside `run start` is an ordinary way to drive the loop by hand —
-/// so the identifier degrades to `-` rather than the event being withheld.
-/// That is `state::LoopState`'s own convention for the same absence, which is
-/// what a `CycleRecord` written outside a run already carries.
-fn run_info(st: &LoopState) -> hooks::HookRunInfo {
-    hooks::HookRunInfo::new(st.current_run_id().unwrap_or_else(|| "-".to_string()))
-}
-
-fn runs_report(st: &LoopState) -> Result<(), String> {
-    let rows = stella_autonomy::fold_runs(
-        &st.run_records(),
-        &st.cycles().rows,
-        st.run_doc().as_ref(),
-        now_unix(),
-        state::stale_after_secs(),
-    );
-    if rows.is_empty() {
-        println!("no self-driving runs recorded yet");
-        return Ok(());
-    }
-    println!(
-        "{:<28} {:<10} {:>3} {:>5} {:>5} {:>4}  phase",
-        "run", "status", "cyc", "fixed", "filed", "new"
-    );
-    for r in rows {
-        println!(
-            "{:<28} {:<10} {:>3} {:>5} {:>5} {:>4}  {}",
-            r.run_id, r.status, r.cycles, r.fixed, r.filed, r.new_findings, r.phase
-        );
-    }
-    Ok(())
 }

--- a/crates/stella-cli/src/self_driving_cmd/runs.rs
+++ b/crates/stella-cli/src/self_driving_cmd/runs.rs
@@ -1,0 +1,123 @@
+//! Starting, ending and listing a **run**.
+//!
+//! A run spans many cycles. A person starts one and stops it.
+//!
+//! Each run is a row in `runs.jsonl` plus a live doc the phase stamps write
+//! to. `stella_autonomy::fold_runs` turns both into the table [`report`]
+//! prints. Nothing here folds anything.
+//!
+//! Split from `self_driving_cmd.rs` at the gate's line ceiling. The seam is
+//! the banner that file drew around these verbs.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use super::state::LoopState;
+use super::{hooks, say, state};
+use crate::timefmt::{now_unix, rfc3339_utc_now};
+
+/// Open a run. Bank its first record, stamp a heartbeat, and print the id
+/// every later verb writes under.
+pub(super) fn start(st: &LoopState) -> Result<(), String> {
+    let rid = state::new_run_id();
+    let driver = std::env::var("SELF_DRIVING_DRIVER").unwrap_or_else(|_| "interactive".to_string());
+    let mut fields = BTreeMap::new();
+    fields.insert("run_id".to_string(), Value::String(rid.clone()));
+    fields.insert("status".to_string(), Value::String("running".to_string()));
+    fields.insert("driver".to_string(), Value::String(driver));
+    fields.insert(
+        "slug".to_string(),
+        Value::String(state::repo_slug(&st.repo_root)),
+    );
+    fields.insert(
+        "workspace_root".to_string(),
+        Value::String(st.repo_root.to_string_lossy().into_owned()),
+    );
+    fields.insert("pid".to_string(), u64::from(std::process::id()).into());
+    st.append_run_record(fields)?;
+
+    let started = rfc3339_utc_now();
+    st.update_run_doc(|doc| {
+        doc.insert("run_id".into(), rid.clone().into());
+        doc.entry("started_at".to_string())
+            .or_insert_with(|| Value::String(started));
+    });
+    // Stamp the first heartbeat through the SAME writer every other phase
+    // uses — the record must be complete from its first byte, not completed
+    // by whatever happens next.
+    st.run_write("idle", None, None);
+
+    hooks::drive(
+        &st.repo_root,
+        &hooks::settings_for(&st.repo_root),
+        hooks::HookEvent::DriveRunStart,
+        hooks::HookRunInfo::new(&rid),
+        None,
+    );
+
+    say(&format!("run {rid} started"));
+    println!("SELF_DRIVING_RUN_ID={rid}");
+    Ok(())
+}
+
+/// Close the live run with a status and a reason.
+pub(super) fn end(st: &LoopState, status: &str, reason: &str) -> Result<(), String> {
+    let rid = st
+        .current_run_id()
+        .ok_or_else(|| "run end: no run in progress".to_string())?;
+    let mut fields = BTreeMap::new();
+    fields.insert("run_id".to_string(), Value::String(rid.clone()));
+    fields.insert("status".to_string(), Value::String(status.to_string()));
+    fields.insert("reason".to_string(), Value::String(reason.to_string()));
+    st.append_run_record(fields)?;
+    st.clear_run_doc();
+    // After the record is banked and before the line is printed, so a
+    // subscriber that reads the ledger on being woken finds this run's ending
+    // already in it.
+    hooks::drive(
+        &st.repo_root,
+        &hooks::settings_for(&st.repo_root),
+        hooks::HookEvent::DriveRunEnd,
+        hooks::HookRunInfo::new(&rid),
+        Some(format!("{status}: {reason}")),
+    );
+    say(&format!("run {rid} -> {status}"));
+    Ok(())
+}
+
+/// The run a lifecycle event belongs to.
+///
+/// A run that was never opened still has events worth reporting. `cycle
+/// begin` outside `run start` is a normal way to drive the loop by hand. So
+/// the id falls back to `-` and the event is still reported. A `CycleRecord`
+/// written outside a run carries the same mark.
+pub(super) fn info(st: &LoopState) -> hooks::HookRunInfo {
+    hooks::HookRunInfo::new(st.current_run_id().unwrap_or_else(|| "-".to_string()))
+}
+
+/// Every run, folded: status, cycles, yield, live phase.
+pub(super) fn report(st: &LoopState) -> Result<(), String> {
+    let rows = stella_autonomy::fold_runs(
+        &st.run_records(),
+        &st.cycles().rows,
+        st.run_doc().as_ref(),
+        now_unix(),
+        state::stale_after_secs(),
+    );
+    if rows.is_empty() {
+        println!("no self-driving runs recorded yet");
+        return Ok(());
+    }
+    println!(
+        "{:<28} {:<10} {:>3} {:>5} {:>5} {:>4}  phase",
+        "run", "status", "cyc", "fixed", "filed", "new"
+    );
+    for r in rows {
+        println!(
+            "{:<28} {:<10} {:>3} {:>5} {:>5} {:>4}  {}",
+            r.run_id, r.status, r.cycles, r.fixed, r.filed, r.new_findings, r.phase
+        );
+    }
+    Ok(())
+}

--- a/crates/stella-cli/src/self_driving_cmd/supply.rs
+++ b/crates/stella-cli/src/self_driving_cmd/supply.rs
@@ -263,37 +263,15 @@ fn pass_with(
     }
 
     if cfg.supply.regress {
-        let receipts = durable.receipts();
-        let report = stella_autonomy::regress::sweep(&receipts, |cite| present_on_base(root, cite));
-        audit::record(
-            durable,
-            Audit::Swept,
-            None,
-            &format!(
-                "regress: {} of {} receipt(s) re-checked, {} could not be, {} fix(es) gone",
-                report.checked,
-                receipts.len(),
-                report.skipped.len(),
-                report.findings.len()
-            ),
-        );
-        findings.extend(report.findings);
+        let drawn = draw_regress(durable, root);
+        audit::record(durable, Audit::Swept, None, &drawn.summary);
+        findings.extend(drawn.findings);
     }
 
     if cfg.supply.meta {
-        let rows = durable.cycles().rows;
-        let found = stella_autonomy::meta::sweep(&rows, &durable.calibration());
-        audit::record(
-            durable,
-            Audit::Swept,
-            None,
-            &format!(
-                "meta: {} finding(s) over {} cycle(s)",
-                found.len(),
-                rows.len()
-            ),
-        );
-        findings.extend(found);
+        let drawn = draw_meta(durable);
+        audit::record(durable, Audit::Swept, None, &drawn.summary);
+        findings.extend(drawn.findings);
     }
 
     let seen = durable.live_seen();
@@ -318,8 +296,8 @@ fn pass_with(
     let mut filed = 0_u32;
     for finding in &fresh {
         match file(durable, provider, cfg, root, finding) {
-            Ok(true) => filed += 1,
-            Ok(false) => {}
+            Ok(Some(_)) => filed += 1,
+            Ok(None) => {}
             Err(error) => audit::record(
                 durable,
                 Audit::Transient,
@@ -329,6 +307,67 @@ fn pass_with(
         }
     }
     filed > 0
+}
+
+/// What one supply offered when it was drawn from.
+///
+/// The loop reads this to decide what to file; `sweep.rs` renders it for an
+/// operator running the same supply by hand. One draw, two readers, so a
+/// hand-run report cannot describe a different sweep from the one the loop
+/// does.
+pub(super) struct Drawn {
+    /// What the supply offers, before the seen set is consulted.
+    pub findings: Vec<Finding>,
+    /// One line naming what was read and what came back.
+    pub summary: String,
+    /// The receipt ledger this draw read, for the supply that reads one.
+    pub receipts: Option<Receipts>,
+}
+
+/// How much of the closure ledger one `regress` draw could re-ask.
+pub(super) struct Receipts {
+    /// Receipts on file.
+    pub total: usize,
+    /// Those whose cited change could be looked for on the base.
+    pub checked: u64,
+    /// Those that could not be — no change cited, or none visible at close.
+    pub skipped: usize,
+}
+
+/// Re-check every fix this loop has claimed, and offer the ones that are gone.
+pub(super) fn draw_regress(durable: &Durable, root: &Path) -> Drawn {
+    let receipts = durable.receipts();
+    let report = stella_autonomy::regress::sweep(&receipts, |cite| present_on_base(root, cite));
+    Drawn {
+        summary: format!(
+            "regress: {} of {} receipt(s) re-checked, {} could not be, {} fix(es) gone",
+            report.checked,
+            receipts.len(),
+            report.skipped.len(),
+            report.findings.len()
+        ),
+        receipts: Some(Receipts {
+            total: receipts.len(),
+            checked: report.checked,
+            skipped: report.skipped.len(),
+        }),
+        findings: report.findings,
+    }
+}
+
+/// Fold the loop's own ledger and offer what its pathology signals say.
+pub(super) fn draw_meta(durable: &Durable) -> Drawn {
+    let rows = durable.cycles().rows;
+    let findings = stella_autonomy::meta::sweep(&rows, &durable.calibration());
+    Drawn {
+        summary: format!(
+            "meta: {} finding(s) over {} cycle(s)",
+            findings.len(),
+            rows.len()
+        ),
+        findings,
+        receipts: None,
+    }
 }
 
 /// Write down what a closure cited, and whether that change was on the base.
@@ -371,7 +410,7 @@ pub(super) fn record_receipt(durable: &Durable, key: &str, closure: &Closure) {
 /// A commit is asked about by sha. A pull request is looked for by the `(#N)`
 /// a squash merge leaves in the subject line. Anything else answers `false`.
 /// A document names a choice, and a choice cannot leave a branch.
-fn present_on_base(root: &Path, cite: &Citation) -> bool {
+pub(super) fn present_on_base(root: &Path, cite: &Citation) -> bool {
     match cite {
         Citation::Commit { sha } => {
             let sha = sha.trim();
@@ -449,15 +488,16 @@ fn noisy(durable: &Durable) -> bool {
 
 /// File one finding through the door every filing goes through.
 ///
-/// `Ok(true)` means the tracker took it. A repeat and a refusal are both
-/// `Ok(false)`. Neither is an error, and both are counted already.
-fn file(
+/// The tracker hands back a key when it takes the finding. A repeat and a
+/// refusal are both `Ok(None)`. Neither is an error, and both are counted
+/// already.
+pub(super) fn file(
     durable: &Durable,
     provider: &dyn IssueProvider,
     cfg: &LoopConfig,
     root: &Path,
     finding: &Finding,
-) -> Result<bool, String> {
+) -> Result<Option<String>, String> {
     let bound = convention::load(root);
     let draft = IssueDraft {
         title: finding.title.clone(),
@@ -488,17 +528,10 @@ fn file(
     durable.update_stats(|stats| stats.record_filing(outcome.canonical()));
 
     if let backlog::Filed::New(key) = &outcome {
-        durable.record_filing(
-            &stella_autonomy::finding_digest(&finding.title),
-            &key.to_string(),
-        )?;
-        audit::record(
-            durable,
-            Audit::IssueFiled,
-            Some(&key.to_string()),
-            &finding.title,
-        );
-        return Ok(true);
+        let key = key.to_string();
+        durable.record_filing(&stella_autonomy::finding_digest(&finding.title), &key)?;
+        audit::record(durable, Audit::IssueFiled, Some(&key), &finding.title);
+        return Ok(Some(key));
     }
 
     audit::record(
@@ -507,7 +540,7 @@ fn file(
         None,
         &format!("not filed ({}): {}", outcome.canonical(), finding.title),
     );
-    Ok(false)
+    Ok(None)
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/self_driving_cmd/sweep.rs
+++ b/crates/stella-cli/src/self_driving_cmd/sweep.rs
@@ -110,6 +110,10 @@ pub(super) fn run(st: &LoopState, cmd: &SweepCmd) -> Result<(), String> {
 ///
 /// A dry run builds no issue provider. The tracker is not reached at all,
 /// not even to be asked a question.
+///
+/// The seen set is read as it stands. `pass` refreshes it from the tracker
+/// first; this does not. A digest whose issue has closed since may still be
+/// held, so the sweep offers less rather than filing a repeat.
 fn collect(
     st: &LoopState,
     supply_name: &'static str,

--- a/crates/stella-cli/src/self_driving_cmd/sweep.rs
+++ b/crates/stella-cli/src/self_driving_cmd/sweep.rs
@@ -102,8 +102,7 @@ pub(super) fn run(st: &LoopState, cmd: &SweepCmd) -> Result<(), String> {
         ),
         SweepCmd::Meta { dry_run, format } => ("meta", supply::draw_meta(st), *dry_run, *format),
     };
-    let report = collect(st, name, drawn, dry_run)?;
-    render(&report, format)
+    render(&collect(st, name, drawn, dry_run), format)
 }
 
 /// Drop what the seen set holds, file what is left, and count both.
@@ -119,7 +118,7 @@ fn collect(
     supply_name: &'static str,
     drawn: supply::Drawn,
     dry_run: bool,
-) -> Result<Report, String> {
+) -> Report {
     let seen = st.live_seen();
     let novel: Vec<Finding> = stella_autonomy::supply::novel(&drawn.findings, &seen)
         .into_iter()
@@ -129,10 +128,10 @@ fn collect(
     let keys = if dry_run {
         vec![None; novel.len()]
     } else {
-        file_each(st, &novel)?
+        file_each(st, &novel)
     };
 
-    Ok(Report {
+    Report {
         supply: supply_name,
         dry_run,
         offered: drawn.findings.len(),
@@ -152,14 +151,14 @@ fn collect(
                 key,
             })
             .collect(),
-    })
+    }
 }
 
 /// File each finding through the one door, and say what the tracker did.
 ///
 /// A refusal is printed, never raised. The rest of the sweep still has
 /// findings worth filing.
-fn file_each(st: &LoopState, novel: &[Finding]) -> Result<Vec<Option<String>>, String> {
+fn file_each(st: &LoopState, novel: &[Finding]) -> Vec<Option<String>> {
     let cfg = config::load(&st.repo_root);
     let provider = crate::issue_provider::GhIssueProvider::from_manifest(&cfg.manifest);
     let mut keys = Vec::with_capacity(novel.len());
@@ -172,7 +171,7 @@ fn file_each(st: &LoopState, novel: &[Finding]) -> Result<Vec<Option<String>>, S
             }
         }
     }
-    Ok(keys)
+    keys
 }
 
 fn render(report: &Report, format: QueryFormat) -> Result<(), String> {
@@ -252,7 +251,7 @@ mod tests {
         );
 
         let drawn = supply::draw_regress(&st, &st.repo_root);
-        let report = collect(&st, "regress", drawn, true).expect("a dry run reaches no tracker");
+        let report = collect(&st, "regress", drawn, true);
 
         assert_eq!(report.supply, "regress");
         assert!(report.dry_run);
@@ -281,7 +280,7 @@ mod tests {
         let st = workspace(tmp.path());
 
         let drawn = supply::draw_regress(&st, &st.repo_root);
-        let report = collect(&st, "regress", drawn, true).expect("a dry run reaches no tracker");
+        let report = collect(&st, "regress", drawn, true);
 
         assert_eq!(report.offered, 0);
         assert_eq!(report.filed, 0);
@@ -305,7 +304,7 @@ mod tests {
         .expect("calibration");
 
         let drawn = supply::draw_meta(&st);
-        let report = collect(&st, "meta", drawn, true).expect("a dry run reaches no tracker");
+        let report = collect(&st, "meta", drawn, true);
 
         assert_eq!(report.supply, "meta");
         assert!(

--- a/crates/stella-cli/src/self_driving_cmd/sweep.rs
+++ b/crates/stella-cli/src/self_driving_cmd/sweep.rs
@@ -1,0 +1,340 @@
+//! `stella self-driving sweep` — draw from one supply by hand.
+//!
+//! `doc:backlog-self-driving` §5 lists these as verbs a person or a host can
+//! run. The code behind them shipped inside the loop, where only the `drive`
+//! verb could reach it. So a supply that ships shut had no way to be tried
+//! once (`#6184`).
+//!
+//! Both verbs draw through [`super::supply`]'s `draw_regress` and
+//! `draw_meta`. Those are the same calls the loop's `pass` makes. A hand-run
+//! report cannot show a different sweep from the one the loop does.
+//!
+//! Neither verb reads the `[supply]` switches. Those say what the loop may
+//! draw from on its own. A person who types the verb has already chosen.
+//!
+//! `--dry-run` says what would be filed and reaches no tracker. A supply you
+//! can only try by letting it write to the tracker is one nobody tries.
+
+use clap::Subcommand;
+use serde::Serialize;
+use stella_autonomy::supply::Finding;
+
+use super::state::LoopState;
+use super::{config, supply};
+use crate::query_format::{QueryFormat, Versioned};
+
+/// Which supply to draw from.
+///
+/// `sweep audit` is left out on purpose. Running a lens's own tooling by
+/// hand waits on the driver learning to run it (`#6182`).
+#[derive(Subcommand)]
+pub(crate) enum SweepCmd {
+    /// Re-check every fix this loop has closed, and file the ones whose
+    /// change has left the base branch.
+    Regress {
+        /// Report what would be filed and write nothing to the tracker.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Output format: the human report, or the versioned query envelope.
+        #[arg(long, value_enum, default_value = "text")]
+        format: QueryFormat,
+    },
+
+    /// Fold the loop's own cycle ledger and file what its pathology signals
+    /// say about the loop.
+    Meta {
+        /// Report what would be filed and write nothing to the tracker.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Output format: the human report, or the versioned query envelope.
+        #[arg(long, value_enum, default_value = "text")]
+        format: QueryFormat,
+    },
+}
+
+/// One hand-run sweep, as a host parses it and as a person reads it.
+#[derive(Serialize)]
+struct Report {
+    /// Which supply was drawn from.
+    supply: &'static str,
+    /// Whether the tracker was left alone.
+    dry_run: bool,
+    /// What the supply offered, before the seen set was consulted.
+    offered: usize,
+    /// Those the seen set does not already hold.
+    novel: usize,
+    /// Those the tracker took. Zero under `--dry-run`.
+    filed: usize,
+    /// What the closure ledger could answer, for the supply that reads one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    receipts: Option<Receipts>,
+    /// The novel findings, in the order the supply offered them.
+    findings: Vec<Row>,
+}
+
+/// The receipt counts a `regress` sweep read, in the wire shape.
+#[derive(Serialize)]
+struct Receipts {
+    total: usize,
+    checked: u64,
+    skipped: usize,
+}
+
+/// One finding the sweep would file, or did.
+#[derive(Serialize)]
+struct Row {
+    title: String,
+    labels: Vec<String>,
+    /// The issue key the tracker gave it, when it took it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    key: Option<String>,
+}
+
+pub(super) fn run(st: &LoopState, cmd: &SweepCmd) -> Result<(), String> {
+    let (name, drawn, dry_run, format) = match cmd {
+        SweepCmd::Regress { dry_run, format } => (
+            "regress",
+            supply::draw_regress(st, &st.repo_root),
+            *dry_run,
+            *format,
+        ),
+        SweepCmd::Meta { dry_run, format } => ("meta", supply::draw_meta(st), *dry_run, *format),
+    };
+    let report = collect(st, name, drawn, dry_run)?;
+    render(&report, format)
+}
+
+/// Drop what the seen set holds, file what is left, and count both.
+///
+/// A dry run builds no issue provider. The tracker is not reached at all,
+/// not even to be asked a question.
+fn collect(
+    st: &LoopState,
+    supply_name: &'static str,
+    drawn: supply::Drawn,
+    dry_run: bool,
+) -> Result<Report, String> {
+    let seen = st.live_seen();
+    let novel: Vec<Finding> = stella_autonomy::supply::novel(&drawn.findings, &seen)
+        .into_iter()
+        .cloned()
+        .collect();
+
+    let keys = if dry_run {
+        vec![None; novel.len()]
+    } else {
+        file_each(st, &novel)?
+    };
+
+    Ok(Report {
+        supply: supply_name,
+        dry_run,
+        offered: drawn.findings.len(),
+        novel: novel.len(),
+        filed: keys.iter().filter(|key| key.is_some()).count(),
+        receipts: drawn.receipts.map(|counts| Receipts {
+            total: counts.total,
+            checked: counts.checked,
+            skipped: counts.skipped,
+        }),
+        findings: novel
+            .into_iter()
+            .zip(keys)
+            .map(|(finding, key)| Row {
+                title: finding.title,
+                labels: finding.labels,
+                key,
+            })
+            .collect(),
+    })
+}
+
+/// File each finding through the one door, and say what the tracker did.
+///
+/// A refusal is printed, never raised. The rest of the sweep still has
+/// findings worth filing.
+fn file_each(st: &LoopState, novel: &[Finding]) -> Result<Vec<Option<String>>, String> {
+    let cfg = config::load(&st.repo_root);
+    let provider = crate::issue_provider::GhIssueProvider::from_manifest(&cfg.manifest);
+    let mut keys = Vec::with_capacity(novel.len());
+    for finding in novel {
+        match supply::file(st, &provider, &cfg, &st.repo_root, finding) {
+            Ok(key) => keys.push(key),
+            Err(error) => {
+                eprintln!("could not file `{}`: {error}", finding.title);
+                keys.push(None);
+            }
+        }
+    }
+    Ok(keys)
+}
+
+fn render(report: &Report, format: QueryFormat) -> Result<(), String> {
+    if format == QueryFormat::Json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&Versioned::new(report)).map_err(|e| e.to_string())?
+        );
+        return Ok(());
+    }
+
+    let mode = if report.dry_run {
+        " (dry run — nothing was filed)"
+    } else {
+        ""
+    };
+    println!("sweep {}{mode}", report.supply);
+    if let Some(counts) = &report.receipts {
+        println!(
+            "  {} receipt(s) on file, {} re-checked, {} could not be",
+            counts.total, counts.checked, counts.skipped
+        );
+    }
+    println!(
+        "  {} offered, {} the seen set does not hold, {} filed",
+        report.offered, report.novel, report.filed
+    );
+    for row in &report.findings {
+        let key = row.key.as_deref().unwrap_or("-");
+        println!("  {key}  {}  [{}]", row.title, row.labels.join(", "));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use stella_autonomy::Citation;
+    use stella_autonomy::regress::ClosureReceipt;
+
+    use super::*;
+
+    /// A loop state in an empty directory. A sweep here reads only what the
+    /// test wrote.
+    fn workspace(tmp: &std::path::Path) -> LoopState {
+        let dir = tmp.join("state");
+        std::fs::create_dir_all(&dir).expect("state dir");
+        LoopState {
+            dir,
+            repo_root: tmp.to_path_buf(),
+        }
+    }
+
+    fn write_receipt(st: &LoopState, receipt: &ClosureReceipt) {
+        let line = serde_json::to_string(receipt).expect("receipt serializes");
+        std::fs::write(st.dir.join("receipts.jsonl"), format!("{line}\n")).expect("receipts");
+    }
+
+    /// **The witness.** `sweep regress --dry-run` draws the supply by hand.
+    /// A receipt whose cited fix is gone from the base comes back as a
+    /// finding. The counts are reported and the tracker is not reached.
+    /// Before this change no verb could draw it. The `drive` loop was the
+    /// only caller.
+    #[test]
+    fn a_hand_run_regress_sweep_reports_a_lost_fix_and_files_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let st = workspace(tmp.path());
+        write_receipt(
+            &st,
+            &ClosureReceipt {
+                key: "4100".to_owned(),
+                closed_at: "2026-09-01T00:00:00Z".to_owned(),
+                by: Some(Citation::PullRequest {
+                    key: "4101".to_owned(),
+                }),
+                present_at_close: Some(true),
+            },
+        );
+
+        let drawn = supply::draw_regress(&st, &st.repo_root);
+        let report = collect(&st, "regress", drawn, true).expect("a dry run reaches no tracker");
+
+        assert_eq!(report.supply, "regress");
+        assert!(report.dry_run);
+        assert_eq!(report.offered, 1);
+        assert_eq!(report.novel, 1);
+        assert_eq!(report.filed, 0, "a dry run writes nothing to the tracker");
+        let counts = report.receipts.expect("the regress sweep reads receipts");
+        assert_eq!(counts.total, 1);
+        assert_eq!(counts.checked, 1);
+        assert_eq!(counts.skipped, 0);
+        assert!(
+            report.findings[0]
+                .title
+                .contains("has left the base branch"),
+            "{}",
+            report.findings[0].title
+        );
+        assert!(report.findings[0].key.is_none());
+    }
+
+    /// A workspace with no receipts reports zero rather than failing. That
+    /// is the state every workspace starts in.
+    #[test]
+    fn a_regress_sweep_over_no_receipts_reports_zero_checked() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let st = workspace(tmp.path());
+
+        let drawn = supply::draw_regress(&st, &st.repo_root);
+        let report = collect(&st, "regress", drawn, true).expect("a dry run reaches no tracker");
+
+        assert_eq!(report.offered, 0);
+        assert_eq!(report.filed, 0);
+        let counts = report.receipts.expect("the regress sweep reads receipts");
+        assert_eq!(counts.total, 0);
+        assert_eq!(counts.checked, 0);
+        assert!(report.findings.is_empty());
+    }
+
+    /// **The witness.** `sweep meta --dry-run` folds the loop's own
+    /// calibration by hand. A ceiling that stayed low through five clean runs
+    /// raises `STARVED`. The finding is reported and not filed.
+    #[test]
+    fn a_hand_run_meta_sweep_reports_a_starved_controller_and_files_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let st = workspace(tmp.path());
+        std::fs::write(
+            st.dir.join("calibration.json"),
+            r#"{"batch_ceiling":3,"parallel_ceiling":2,"clean_run":6,"note":"test"}"#,
+        )
+        .expect("calibration");
+
+        let drawn = supply::draw_meta(&st);
+        let report = collect(&st, "meta", drawn, true).expect("a dry run reaches no tracker");
+
+        assert_eq!(report.supply, "meta");
+        assert!(
+            report.receipts.is_none(),
+            "the meta supply reads the cycle ledger, not receipts"
+        );
+        assert_eq!(report.novel, 1);
+        assert_eq!(report.filed, 0, "a dry run writes nothing to the tracker");
+        assert!(
+            report.findings[0].title.contains("STARVED"),
+            "{}",
+            report.findings[0].title
+        );
+    }
+
+    /// The JSON leads with the envelope version. A host can branch on it
+    /// before it reads anything else.
+    #[test]
+    fn the_json_payload_leads_with_the_envelope_version() {
+        let report = Report {
+            supply: "meta",
+            dry_run: true,
+            offered: 0,
+            novel: 0,
+            filed: 0,
+            receipts: None,
+            findings: Vec::new(),
+        };
+
+        let rendered = serde_json::to_string(&Versioned::new(&report)).expect("serializes");
+        assert!(
+            rendered.starts_with(r#"{"schema_version":1,"supply":"meta","dry_run":true"#),
+            "{rendered}"
+        );
+    }
+}

--- a/website/content/docs/commands/self-driving.mdx
+++ b/website/content/docs/commands/self-driving.mdx
@@ -19,6 +19,7 @@ stella self-driving aperture (--current | --advance | --reset | --list)
 stella self-driving seen (--digest TEXT… | --new DIGEST… | --add DIGEST… | --count)
 stella self-driving calibrate (--ok | --resource-fail | --show)
 stella self-driving queue [--limit N] [--format <text|json>]
+stella self-driving sweep (regress | meta) [--dry-run] [--format <text|json>]
 stella self-driving file --title TEXT [--body TEXT] [--label L…] [--format <text|json>]
 stella self-driving work --issue KEY [--spend-limit USD] [--format <text|json>]
 stella self-driving drive [--max-issues N] [--no-review] [--poll-secs N] [--backlog] [--dry-run] [--parallel N]
@@ -95,6 +96,34 @@ A run covers many cycles: one `/loop` session, or one daemon's whole lifetime. I
 ### metrics, state, queue
 
 `metrics` turns the ledger into evidence about how the loop itself is doing, flagging specific problems: `STUCK`, `STARVED`, `NOISY`, and `FRAGILE`. `state` shows the current counters and the last five cycles. `queue` ranks open problems by priority — P0, then P1, then P2, then untriaged, oldest first within each rank. Feature requests are left out, because this loop only closes defects. Ranking reads up to 1,000 open issues, which has to be more than your repository has: your tracker hands back the newest issues first, and the priority order is applied afterwards to whatever arrived. If the read stops before the end of your backlog, an old P0 never reaches the ranker at all.
+
+### sweep
+
+```bash
+stella self-driving sweep regress --dry-run
+stella self-driving sweep meta --format json
+```
+
+The ranked queue runs dry. Two other sources of work do not, and `sweep` draws
+from one of them by hand.
+
+`sweep regress` re-checks every fix the loop has closed. The loop writes down
+what each closure cited and whether that change was on the base branch at the
+time. This asks the same question again. A change that was there and is gone
+was taken back out — by a revert, a force push, or a rebase that dropped it —
+and the defect it fixed is back. That is a fact rather than a guess, so it is
+filed as a fresh defect.
+
+`sweep meta` folds the loop's own cycle ledger and reports what its signals say
+about the loop: a ceiling stuck low, a lens that keeps finding nothing, a run
+that files far more than it fixes.
+
+`--dry-run` prints what would be filed and writes nothing to your tracker. Run
+it that way first. Both sources ship switched off in `stella.toml`, and this is
+how you see what one would do before you switch it on.
+
+Neither verb reads those switches. They say what the unattended loop may draw
+from on its own; you typing the verb have already chosen.
 
 ### file
 


### PR DESCRIPTION
## What & why

`doc:backlog-self-driving` §5 lists `sweep regress` and `sweep meta` as verbs an
operator or a host can run and read. The behaviour behind both shipped inside
the loop, where only `drive` could reach it. So the first thing anybody wants to
do with a supply that ships shut — try it once and read what it would file — had
no command at all, and `surface_drift` could not hold the document and the
binary together over a verb neither the clap tree nor `HOST_SURFACE` carried.

`stella self-driving sweep regress|meta` draws the supply, reports what it
offers as text or under the versioned query envelope, and files what the seen
set does not already hold.

- `--dry-run` builds no issue provider, so the tracker is not reached even to be
  asked a question.
- Neither verb reads the `[supply]` switches. Those say what the unattended loop
  may draw from on its own; an operator typing the verb has already chosen.
- Both verbs draw through `supply::draw_regress` and `supply::draw_meta`, which
  `pass` now calls too, so a hand-run report cannot describe a different sweep
  from the one the loop performs.
- `supply::file` hands its issue key back rather than a bool, which is what lets
  the report name what the tracker took.

`sweep audit` is left out on purpose: running a lens's own tooling by hand waits
on `#6182`.

Run against an empty workspace:

```
$ stella self-driving sweep regress --dry-run --format json
{
  "schema_version": 1,
  "supply": "regress",
  "dry_run": true,
  "offered": 0,
  "novel": 0,
  "filed": 0,
  "receipts": { "total": 0, "checked": 0, "skipped": 0 },
  "findings": []
}
$ stella self-driving surface | grep sweep
  sweep regress        query-envelope     re-check the fixes this loop has claimed, and file the ones that have left the base
  sweep meta           query-envelope     fold the loop's own ledger and file what the pathology signals say about it
```

Closes #6184

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

Three, one per half of the gap:

- `the_hand_run_sweep_verbs_are_declared` (`crates/stella-autonomy/src/tests.rs`)
  — `host_verb("sweep regress")` and `host_verb("sweep meta")` are `None` on
  `main`, so the test panics there.
- `a_hand_run_regress_sweep_reports_a_lost_fix_and_files_nothing`
  (`crates/stella-cli/src/self_driving_cmd/sweep.rs`) — a receipt whose cited
  fix is gone from the base comes back as one finding, the receipt counts are
  reported, `filed` is 0. The module it lives in does not exist on `main`.
- `a_hand_run_meta_sweep_reports_a_starved_controller_and_files_nothing` — a
  ceiling that stayed low through five clean runs raises `STARVED`, reported and
  not filed.

Plus `a_regress_sweep_over_no_receipts_reports_zero_checked` (the empty-workspace
case the issue names) and `the_json_payload_leads_with_the_envelope_version`.

`surface_matches_the_argument_tree` (`stella-cli`) is the two-way gate that now
holds the new clap leaves and the new `HOST_SURFACE` rows together; it passes on
`main` and here, and fails on either half of this change alone.

## The gate

Run scoped, per CLAUDE.md's "CI builds and tests; this laptop does not" — CI is
the evidence for the workspace.

- [x] `cargo fmt --check` (via `make guards-fast`, exit 0)
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` (exit 0) and
      `-p stella-autonomy` (exit 0)
- [x] `cargo test -p stella-cli self_driving_cmd` — 267 passed, 0 failed;
      `cargo test -p stella-autonomy` — 232 + 4 passed, 0 failed
- [x] `make doc-warnings CARGO_SCOPE="-p stella-cli -p stella-autonomy"` (exit 0)
- [x] `make guards-fast` (exit 0), `python3 scripts/check-prose.py` and
      `--absolute` both OK, `check-line-citations` OK
- [x] Docs updated: `website/content/docs/commands/self-driving.mdx` gained a
      `sweep` section and a synopsis line
- [x] CLA signed
- [x] `Closes #6184` appears both above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR:
  1. **`self_driving_cmd.rs` had six lines of headroom under the 1500-line
     ceiling and no baseline entry**, so no verb could land in it. The
     run-lifecycle block the file already banners moves to
     `self_driving_cmd/runs.rs` (1494 → 1393 lines, no new baseline entry).
  2. **`run_end` was a wrapper whose whole body called `run_end_as`** with the
     same arguments. Gone; callers use `runs::end`.
  3. **The docs page listed every self-driving verb except the ones this PR
     adds** — it now lists them.
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls — `--dry-run` reaches no tracker at all, and
      the filing path is the same `backlog::file_finding` door the loop uses
- [x] The report's JSON rides the existing versioned query envelope
      (`Versioned`, `QUERY_SCHEMA_VERSION`); `HOST_SURFACE_VERSION` is not
      bumped, because two added verbs are purely additive

## Anything reviewers should know?

No test was deleted. `runs.rs` is a move of five functions out of
`self_driving_cmd.rs`, with two doc comments added and one redundant wrapper
dropped; the bodies are unchanged.

## Summary by Sourcery

Enable operators to manually draw, inspect, and optionally file regress and meta self-driving findings.

New Features:
- Add operator-run `self-driving sweep regress` and `sweep meta` commands with text and versioned JSON reports.
- Support dry-run sweeps that report novel findings without contacting or writing to the issue tracker.
- Expose the new sweep verbs through the autonomy host surface for discovery and parity validation.

Bug Fixes:
- Reuse the same regress and meta supply-drawing paths for manual sweeps and unattended drive cycles, keeping their findings consistent.
- Return filed issue keys so sweep reports identify findings accepted by the tracker.

Enhancements:
- Move run lifecycle functionality into a dedicated module while preserving existing run behavior.

Documentation:
- Document the sweep commands, options, output formats, and supply behavior in the self-driving command guide.

Tests:
- Add witness coverage for host-surface declarations, empty and populated regress sweeps, starved meta sweeps, dry-run filing behavior, and JSON envelope ordering.