### PR TITLE
fix(stella-cli): observe the test baseline before the turn a plugin judges

### DIFF
--- a/.watch-pr.sh
+++ b/.watch-pr.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Wait until no check on PR $1 is pending, then print the settled table.
+# `gh --json` colourises here whatever NO_COLOR says, so strip the escapes.
+i=0
+while [ "$i" -lt 120 ]; do
+  i=$((i + 1))
+  s=$(gh pr checks "$1" -R macanderson/stella --json name,bucket 2>/dev/null |
+    sed 's/\x1b\[[0-9;]*m//g')
+  if [ -n "$s" ] && printf '%s' "$s" | jq -e 'length>0 and (all(.[]; .bucket!="pending"))' >/dev/null 2>&1; then
+    printf '%s' "$s" | jq -r '.[] | "\(.bucket)\t\(.name)"' | sort
+    exit 0
+  fi
+  sleep 30
+done
+echo "TIMED OUT waiting for checks"
+exit 1

--- a/crates/stella-cli/src/agent.rs
+++ b/crates/stella-cli/src/agent.rs
@@ -489,6 +489,7 @@ pub async fn run_interactive(cfg: &Config, budget_limit: Option<f64>) -> Result<
             // grant before its own first round, and a session that never types
             // `/goal` never pays for a resolve it does not use.
             let goal_wrapper = goal::resolve_goal_wrapper(cfg, goal::DEFAULT_GOAL_WRAPPER, None)
+                .await
                 .and_then(|(resolved, candidate)| {
                     let bound = goal::bind_goal_wrapper(cfg, resolved, &sub_agents, &candidate)?;
                     Ok((bound, candidate))

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -156,10 +156,17 @@ pub(crate) async fn run_raw_one_shot(
         ),
         None => None,
     };
+    let provider = build_provider(cfg)?;
     // Pinned *before* the turn runs, which is the whole content of the tamper
     // claim: an identity snapshotted afterwards vouches for nothing. The same
-    // call observes what the tests say before the work, which is the red half a
-    // flip needs (#1292) — and is a whole test run, so it says what it found.
+    // call observes what the tests said before the work, which is the red half
+    // a flip needs, and it says what it found because it is a whole test run.
+    //
+    // Below the provider rather than above it, because that is the last
+    // instant refusal a run can hit — a model id the catalog does not know —
+    // and nobody should sit through a test suite to be told they mistyped one.
+    // Nothing above this line is paid, so the rule the resolve keeps is intact:
+    // every refusal a user can act on lands before the first model call.
     let candidate = match &resolved {
         Some(_) => Some(
             crate::wrapper_candidate::grant_shared_tree(&cfg.workspace_root, test_command)
@@ -174,7 +181,6 @@ pub(crate) async fn run_raw_one_shot(
     {
         eprintln!("  ! {line}");
     }
-    let provider = build_provider(cfg)?;
     // Concrete `Arc<ToolRegistry>` (not `Arc<dyn ToolExecutor>`) so the
     // registry's ledgers are reachable after the turn — the trait object
     // hides them. It still coerces to `&dyn ToolExecutor` for the engine.
@@ -543,11 +549,12 @@ pub(crate) fn goal_plugin_missing_message(variant: &str, reason: &str) -> String
 /// Resolve the wrapper plugin that supplies the goal verb, and pin the
 /// candidate grant its `[oracle]` observes.
 ///
-/// Both happen before the provider is built and before a single paid call — a
-/// `--pipeline` naming nothing installed must fail as a typo, a workspace with
-/// nothing installed must fail as an install, and a `--test-command` the
-/// host's parser refuses must stop the run here rather than after it is paid
-/// for.
+/// Both happen before a single paid call — a `--pipeline` naming nothing
+/// installed must fail as a typo, a workspace with nothing installed must fail
+/// as an install, and a `--test-command` the host's parser refuses must stop
+/// the run here rather than after it is paid for. The caller places this after
+/// it has built a provider, because minting the grant runs the whole test
+/// suite and a model id the catalog does not know is an instant refusal.
 ///
 /// The grant is minted once for the arc, never per round. What the watch
 /// covers is the artifacts the test command names — the witness the flip is
@@ -667,11 +674,12 @@ pub(crate) fn bind_goal_wrapper(
 /// honoured now instead of being refused for want of a wrapper: every goal run
 /// has one.
 ///
-/// The bind happens before the provider is built and before a single paid
-/// call — the ordering [`run_raw_one_shot`] documents, for the same reason. A
-/// `--pipeline` naming nothing installed must fail as a typo, and a goal run
-/// with nothing installed at all must fail as an install, not after the money
-/// is spent.
+/// The bind happens before a single paid call — the ordering
+/// [`run_raw_one_shot`] documents, for the same reason. A `--pipeline` naming
+/// nothing installed must fail as a typo, and a goal run with nothing installed
+/// at all must fail as an install, not after the money is spent. It sits after
+/// the provider is built for the reason that door gives too: minting the grant
+/// runs the whole test suite, and every instant refusal belongs in front of it.
 pub async fn run_goal_cmd(
     cfg: &Config,
     goal: &str,
@@ -688,8 +696,8 @@ pub async fn run_goal_cmd(
         crate::enterprise_telemetry::ExecutionSurface::Goal,
     )?;
     let variant = pipeline.plugin().unwrap_or(DEFAULT_GOAL_WRAPPER);
-    let (resolved, candidate) = resolve_goal_wrapper(cfg, variant, test_command).await?;
     let provider = build_provider(cfg)?;
+    let (resolved, candidate) = resolve_goal_wrapper(cfg, variant, test_command).await?;
     let registry: std::sync::Arc<ToolRegistry> =
         std::sync::Arc::new(crate::write_dirs::registry_for(cfg));
 

--- a/crates/stella-cli/src/agent/goal.rs
+++ b/crates/stella-cli/src/agent/goal.rs
@@ -157,14 +157,23 @@ pub(crate) async fn run_raw_one_shot(
         None => None,
     };
     // Pinned *before* the turn runs, which is the whole content of the tamper
-    // claim: an identity snapshotted afterwards vouches for nothing.
+    // claim: an identity snapshotted afterwards vouches for nothing. The same
+    // call observes what the tests say before the work, which is the red half a
+    // flip needs (#1292) — and is a whole test run, so it says what it found.
     let candidate = match &resolved {
         Some(_) => Some(
             crate::wrapper_candidate::grant_shared_tree(&cfg.workspace_root, test_command)
+                .await
                 .map_err(crate::failure::CliFailure::from)?,
         ),
         None => None,
     };
+    if let Some(line) = candidate
+        .as_ref()
+        .and_then(|granted| granted.baseline_notice.as_deref())
+    {
+        eprintln!("  ! {line}");
+    }
     let provider = build_provider(cfg)?;
     // Concrete `Arc<ToolRegistry>` (not `Arc<dyn ToolExecutor>`) so the
     // registry's ledgers are reachable after the turn — the trait object
@@ -547,7 +556,13 @@ pub(crate) fn goal_plugin_missing_message(variant: &str, reason: &str) -> String
 /// worker rewrote in round 2, which is the laundering the watch exists to
 /// refuse. So the finding is sticky: once a witness has moved under the run,
 /// no later round earns a `Clean` (#3835).
-pub(crate) fn resolve_goal_wrapper(
+///
+/// The test baseline this call also observes is minted once for the same
+/// reason and a sharper one: after round 1 the tree is the worker's, so a
+/// second observation would report the work rather than what preceded it, and
+/// a suite that went green in round 1 would erase the red the flip is measured
+/// against.
+pub(crate) async fn resolve_goal_wrapper(
     cfg: &Config,
     variant: &str,
     test_command: Option<&str>,
@@ -565,7 +580,11 @@ pub(crate) fn resolve_goal_wrapper(
         crate::failure::CliFailure::error(goal_plugin_missing_message(variant, &reason))
     })?;
     let candidate = crate::wrapper_candidate::grant_shared_tree(&cfg.workspace_root, test_command)
+        .await
         .map_err(crate::failure::CliFailure::from)?;
+    if let Some(line) = candidate.baseline_notice.as_deref() {
+        eprintln!("  ! {line}");
+    }
     Ok((resolved, candidate))
 }
 
@@ -669,7 +688,7 @@ pub async fn run_goal_cmd(
         crate::enterprise_telemetry::ExecutionSurface::Goal,
     )?;
     let variant = pipeline.plugin().unwrap_or(DEFAULT_GOAL_WRAPPER);
-    let (resolved, candidate) = resolve_goal_wrapper(cfg, variant, test_command)?;
+    let (resolved, candidate) = resolve_goal_wrapper(cfg, variant, test_command).await?;
     let provider = build_provider(cfg)?;
     let registry: std::sync::Arc<ToolRegistry> =
         std::sync::Arc::new(crate::write_dirs::registry_for(cfg));

--- a/crates/stella-cli/src/fleet_cmd.rs
+++ b/crates/stella-cli/src/fleet_cmd.rs
@@ -694,13 +694,16 @@ async fn run_task(
     // actually runs in — see `wrapped`'s module doc for why those two roots
     // differ and which one each half needs.
     let resolved_wrapper = match wrapper_variant {
-        Some(variant) => Some(wrapped::resolve_for_attempt(
-            &cfg.workspace_root,
-            root,
-            variant,
-            &task.id,
-            task.test_command.as_deref(),
-        )?),
+        Some(variant) => Some(
+            wrapped::resolve_for_attempt(
+                &cfg.workspace_root,
+                root,
+                variant,
+                &task.id,
+                task.test_command.as_deref(),
+            )
+            .await?,
+        ),
         None => None,
     };
 

--- a/crates/stella-cli/src/fleet_cmd/wrapped.rs
+++ b/crates/stella-cli/src/fleet_cmd/wrapped.rs
@@ -548,7 +548,7 @@ impl ResolvedAttempt {
 /// candidate fence will not mint a grant over, or a `test_command` the host's
 /// runner vocabulary refuses. Every one of them fails this attempt's dispatch
 /// by name; the fan-out's other tasks are unaffected.
-pub(super) fn resolve_for_attempt(
+pub(super) async fn resolve_for_attempt(
     invocation_root: &std::path::Path,
     tree: &std::path::Path,
     variant: &str,
@@ -561,9 +561,15 @@ pub(super) fn resolve_for_attempt(
     // every notice this sink would print, once. Repeating them here would put
     // N identical copies of one sentence on the stderr of a run with N
     // workers, interleaved by concurrency and attributed to nothing.
+    //
+    // `GrantedCandidate::baseline_notice` is dropped here for the same reason
+    // and one more: it is per attempt, so N of them arrive interleaved with no
+    // task name on any of them. What each attempt's baseline was is in the
+    // grant the plugin receives, and a fleet's own attempt reporting is where a
+    // line about it belongs.
     Ok(ResolvedAttempt {
         resolved: crate::wrapper_plugin::resolve(invocation_root, variant, &mut |_| {})?,
-        candidate: crate::wrapper_candidate::grant_shared_tree(tree, test_command)?,
+        candidate: crate::wrapper_candidate::grant_shared_tree(tree, test_command).await?,
         task: task.to_string(),
     })
 }

--- a/crates/stella-cli/src/fleet_cmd/wrapped.rs
+++ b/crates/stella-cli/src/fleet_cmd/wrapped.rs
@@ -567,6 +567,14 @@ pub(super) async fn resolve_for_attempt(
     // task name on any of them. What each attempt's baseline was is in the
     // grant the plugin receives, and a fleet's own attempt reporting is where a
     // line about it belongs.
+    //
+    // Minting the grant runs the attempt's whole test suite, and the two doors
+    // a person types at put every instant refusal in front of that by building
+    // the provider first. This one keeps the earlier order: its provider is
+    // built against a per-worker config whose root is the attempt's tree, which
+    // does not exist as a value until after this call, and `run_fleet`'s
+    // pre-flight has already resolved the same variant from the same root
+    // before any task was dispatched.
     Ok(ResolvedAttempt {
         resolved: crate::wrapper_plugin::resolve(invocation_root, variant, &mut |_| {})?,
         candidate: crate::wrapper_candidate::grant_shared_tree(tree, test_command).await?,

--- a/crates/stella-cli/src/wrapper_candidate.rs
+++ b/crates/stella-cli/src/wrapper_candidate.rs
@@ -29,6 +29,44 @@
 //! failed adoption is the user's work stranded in a shadow worktree) and is not
 //! this slice.
 //!
+//! # When the baseline is observed, and every case where it cannot be
+//!
+//! A flip is a claim about two moments: the tests failed, and then they passed.
+//! Only the second is visible after the work, so the first has to be recorded
+//! before it. [`grant_shared_tree`] runs the granted invocation once, in the
+//! granted root, before the turn starts, and stamps what it saw onto
+//! [`stella_plugin::TestPlan::baseline`].
+//!
+//! **The host is the only party that can.** A subprocess wrapper is a fresh
+//! process at every point, so a plugin that ran the suite at `before_turn`
+//! would exit with what it learned and start again at `after_turn` knowing
+//! nothing. Leaving that field at `NotRun` cost the whole path: with no red on
+//! record `plugins/stella-witness` reports `unobservable`, and `judge` turns
+//! that into `Undecided` under `flip = "required"`, so no run on any door could
+//! reach a credited flip.
+//!
+//! **Three answers, and only one of them is red.**
+//! [`stella_plugin::TestBaseline::Failed`] is an invocation that ran and whose
+//! assertions genuinely failed. `Passed` is one that ran and passed, which
+//! leaves the oracle nothing to lock onto and is reported as itself rather than
+//! quietly dropped. `Unobserved` covers every way the answer is missing: a run
+//! killed at the deadline, a program that would not start, output that could
+//! not be read. Scoring any of those as red would satisfy a flip's precondition
+//! on this host's own noise, and the next clean run would be credited as a
+//! verified fix. `NotRun` keeps its meaning and is reached only by a turn that
+//! named no test command at all.
+//!
+//! **It costs one run of the user's own invocation.** That is the price of the
+//! flip the `--test-command` asked for: without it there is no before, so
+//! nothing a passing suite afterwards could prove. Making that run cheaper by
+//! narrowing it to the tests a change actually touches is a separate piece of
+//! work, and it changes *which* command is run rather than whether the baseline
+//! is observed at all.
+//!
+//! The observation happens before the tamper watch below is pinned. A test run
+//! can rewrite generated files, and a watch pinned first would report this
+//! host's own run as a worker tampering with the witness.
+//!
 //! # The tamper watch, and exactly what it covers
 //!
 //! `TamperPolicy::ArtifactIdentity` asks the **host** to snapshot artifact
@@ -110,6 +148,14 @@ pub(crate) struct GrantedCandidate {
     pub(crate) grant: CandidateGrant,
     /// The artifacts whose identity the host pinned before the turn.
     pub(crate) watch: TamperWatch,
+    /// What the pre-turn test run said, as one sentence for whoever is
+    /// watching the door.
+    ///
+    /// `None` when this turn named no test command, which is the one case
+    /// where there was nothing to observe and nothing to say. Otherwise the
+    /// door prints it: the run pauses for a whole test suite here, and a
+    /// silent pause is indistinguishable from a hang.
+    pub(crate) baseline_notice: Option<String>,
 }
 
 /// The host's own tamper baseline: workspace-relative path → the identity
@@ -252,8 +298,8 @@ impl TamperWatch {
     }
 }
 
-/// Mint the grant for the shared work tree, and pin whatever witness artifacts
-/// the test command names.
+/// Mint the grant for the shared work tree, observe what its tests say before
+/// the turn, and pin whatever witness artifacts the test command names.
 ///
 /// `test_command` is the oracle for this turn, unparsed — `stella run`'s
 /// `--test-command`, or the fleet task's own `test_command` plan field
@@ -270,7 +316,7 @@ impl TamperWatch {
 /// and a message naming `--test-command` is wrong on the one whose oracle came
 /// out of a plan file. `stella-cli` is a binary, so a `String` here is the
 /// finished product (AGENTS.md invariant 5).
-pub(crate) fn grant_shared_tree(
+pub(crate) async fn grant_shared_tree(
     workspace_root: &Path,
     test_command: Option<&str>,
 ) -> Result<GrantedCandidate, String> {
@@ -285,26 +331,84 @@ pub(crate) fn grant_shared_tree(
         None => None,
     };
 
-    // No baseline run: the host does not spend a test run the plugin is about
-    // to spend itself. A wrapper observes red in `before_turn` — it holds the
-    // root and the plan there — and green in `after_turn`, which is the flip
-    // the oracle is for. `TestBaseline::NotRun` says exactly that, and a plugin
-    // that wanted the host's own observation instead reads it as absent rather
-    // than as passing.
+    // Minted with no baseline, then stamped with one below. The two steps are
+    // in this order because the observation belongs in the *canonical* root
+    // this call resolves: the directory the plugin will be told to test, rather
+    // than a path that happens to resolve there today.
     let plan = invocation.as_ref().map(|parsed| test_plan(parsed, None));
-    let grant = host_tree_grant(root_text, plan)
+    let mut grant = host_tree_grant(root_text, plan)
         .map_err(|denial| format!("no candidate grant could be minted: {denial}"))?;
+
+    // The red half of the flip, observed before the turn. See this module's
+    // docs for why the host has to be the one that does this, and why the
+    // observation happens before the watch below is pinned.
+    let granted_root = std::path::PathBuf::from(&grant.root);
+    let mut baseline_notice = None;
+    if let Some(parsed) = invocation.as_ref() {
+        let (observed, notice) = observed_baseline(&granted_root, parsed).await;
+        if let Some(plan) = grant.test.as_mut() {
+            plan.baseline = observed;
+        }
+        baseline_notice = Some(notice);
+    }
 
     // Opened from the *canonical* root the grant carries, so the host watches
     // the same directory it told the plugin about — and holds it open, so the
     // two cannot come apart while the turn runs.
     let watch = TamperWatch::pin(
-        Path::new(&grant.root),
+        &granted_root,
         &invocation
             .map(|parsed| named_artifacts(&parsed.args))
             .unwrap_or_default(),
     )?;
-    Ok(GrantedCandidate { grant, watch })
+    Ok(GrantedCandidate {
+        grant,
+        watch,
+        baseline_notice,
+    })
+}
+
+/// Run the granted invocation once before the turn, and say what it reported.
+///
+/// Returns the wire value the plan carries and one sentence for the door to
+/// print. Every answer other than [`TestBaseline::Failed`] says it has no red
+/// to offer: a passing suite and an unobservable run both leave the oracle with
+/// nothing to lock onto, and neither may be dressed up as the precondition a
+/// flip needs.
+async fn observed_baseline(
+    root: &Path,
+    invocation: &stella_plugin::TestInvocation,
+) -> (stella_plugin::TestBaseline, String) {
+    use stella_plugin::TestBaseline;
+
+    match crate::wrapper_test_run::observe_baseline(root, invocation).await {
+        Ok(observation) => match observation.assertions {
+            TestBaseline::Failed => (
+                TestBaseline::Failed,
+                "the tests failed before this turn, which is the red a flip needs".to_string(),
+            ),
+            TestBaseline::Passed => (
+                TestBaseline::Passed,
+                "the tests passed before this turn, so no flip can be observed against them"
+                    .to_string(),
+            ),
+            // The deadline, which says nothing about assertions either way.
+            // `run_in` reports no other answer, and rendering the remaining two
+            // rather than asserting on them keeps a binary from aborting a
+            // user's run over something this match did not expect.
+            other => (
+                other,
+                "the tests did not finish before this turn, so nothing was observed either way"
+                    .to_string(),
+            ),
+        },
+        Err(denial) => (
+            TestBaseline::Unobserved,
+            format!(
+                "the tests could not be run before this turn ({denial}), so no flip can be credited"
+            ),
+        ),
+    }
 }
 
 /// The workspace-relative paths a parsed invocation's arguments name.
@@ -327,13 +431,14 @@ mod tests {
     use super::*;
 
     fn workspace() -> tempfile::TempDir {
+        workspace_whose_tests("#!/bin/sh\nexit 1\n")
+    }
+
+    /// A workspace whose one witness script is `body`.
+    fn workspace_whose_tests(body: &str) -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("a temp workspace");
         std::fs::create_dir_all(dir.path().join("tests")).expect("tests dir");
-        std::fs::write(
-            dir.path().join("tests/witness_flip.sh"),
-            "#!/bin/sh\nexit 1\n",
-        )
-        .expect("the witness");
+        std::fs::write(dir.path().join("tests/witness_flip.sh"), body).expect("the witness");
         dir
     }
 
@@ -341,10 +446,11 @@ mod tests {
     /// turn runs in, carrying the parsed test plan a plugin needs to observe a
     /// flip at all. Before #3553 this value did not exist and `candidate` was
     /// `None` on every round.
-    #[test]
-    fn the_shared_tree_is_granted_with_the_test_the_host_would_run() {
+    #[tokio::test]
+    async fn the_shared_tree_is_granted_with_the_test_the_host_would_run() {
         let dir = workspace();
         let granted = grant_shared_tree(dir.path(), Some("sh tests/witness_flip.sh"))
+            .await
             .expect("the root resolves and the command parses");
 
         assert_eq!(
@@ -364,8 +470,70 @@ mod tests {
         assert_eq!(plan.args, vec!["tests/witness_flip.sh".to_string()]);
         assert_eq!(
             plan.baseline,
-            stella_plugin::TestBaseline::NotRun,
-            "the host did not run it, and says so rather than claiming red"
+            stella_plugin::TestBaseline::Failed,
+            "the host ran the invocation before the turn and hands over what it said"
+        );
+    }
+
+    /// **Witness.** The red half of a flip rides the grant.
+    ///
+    /// The falsifier is the host stamping `NotRun` on every grant it mints —
+    /// `test_plan(parsed, None)` was its only production call — which leaves the
+    /// oracle in `plugins/stella-witness` with no failing observation to lock a
+    /// command onto. It reports `unobservable`, `judge` turns that into
+    /// `Undecided` under `flip = "required"`, and no run on any door reaches a
+    /// credited flip. A subprocess plugin cannot close that gap itself: it is a
+    /// fresh process at each point, so anything it saw at `before_turn` is gone
+    /// by `after_turn`.
+    #[tokio::test]
+    async fn a_red_suite_before_the_turn_reaches_the_plugin_as_red() {
+        let dir = workspace_whose_tests("#!/bin/sh\nexit 1\n");
+        let granted = grant_shared_tree(dir.path(), Some("sh tests/witness_flip.sh"))
+            .await
+            .expect("the grant mints");
+
+        assert_eq!(
+            granted.grant.test.as_ref().expect("a test plan").baseline,
+            stella_plugin::TestBaseline::Failed,
+            "the assertions genuinely failed, which is the one answer a flip can build on"
+        );
+        assert_eq!(
+            granted.baseline_notice.as_deref(),
+            Some("the tests failed before this turn, which is the red a flip needs"),
+            "a run that pauses for a whole suite says what the pause bought"
+        );
+    }
+
+    /// A suite that was already green is reported as green, and never dressed
+    /// up as the red a flip needs. `judge` then abstains, which is the right
+    /// answer: a suite passing before the turn and after it says nothing about
+    /// the turn.
+    #[tokio::test]
+    async fn a_green_suite_before_the_turn_is_not_dressed_up_as_red() {
+        let dir = workspace_whose_tests("#!/bin/sh\nexit 0\n");
+        let granted = grant_shared_tree(dir.path(), Some("sh tests/witness_flip.sh"))
+            .await
+            .expect("the grant mints");
+
+        assert_eq!(
+            granted.grant.test.as_ref().expect("a test plan").baseline,
+            stella_plugin::TestBaseline::Passed,
+        );
+    }
+
+    /// A turn that named no test command runs nothing and claims nothing.
+    /// `NotRun` keeps its old meaning, which is now the only way to reach it.
+    #[tokio::test]
+    async fn a_turn_with_no_test_command_observes_nothing_and_says_nothing() {
+        let dir = workspace();
+        let granted = grant_shared_tree(dir.path(), None)
+            .await
+            .expect("no test command is fine");
+
+        assert!(granted.grant.test.is_none(), "no plan is not an empty plan");
+        assert!(
+            granted.baseline_notice.is_none(),
+            "there was nothing to observe, so there is nothing to report"
         );
     }
 
@@ -373,10 +541,11 @@ mod tests {
     /// refuses one the turn rewrote — the two findings `judge` needs to credit
     /// or deny a flip. Both were unreachable before: this host only ever said
     /// `NotChecked`.
-    #[test]
-    fn the_host_vouches_for_an_untouched_witness_and_names_a_rewritten_one() {
+    #[tokio::test]
+    async fn the_host_vouches_for_an_untouched_witness_and_names_a_rewritten_one() {
         let dir = workspace();
         let granted = grant_shared_tree(dir.path(), Some("sh tests/witness_flip.sh"))
+            .await
             .expect("the grant mints");
         assert_eq!(
             granted.watch.finding(),
@@ -400,11 +569,12 @@ mod tests {
 
     /// A deleted witness is tampering, not an unchanged one: the comparison
     /// fails closed on an artifact it can no longer observe.
-    #[test]
-    fn a_witness_that_vanished_is_refused_rather_than_vouched_for() {
+    #[tokio::test]
+    async fn a_witness_that_vanished_is_refused_rather_than_vouched_for() {
         let dir = workspace();
-        let granted =
-            grant_shared_tree(dir.path(), Some("sh tests/witness_flip.sh")).expect("the grant");
+        let granted = grant_shared_tree(dir.path(), Some("sh tests/witness_flip.sh"))
+            .await
+            .expect("the grant");
         std::fs::remove_file(dir.path().join("tests/witness_flip.sh")).expect("removed");
         assert!(matches!(
             granted.watch.finding(),
@@ -415,14 +585,17 @@ mod tests {
     /// An invocation that names no file on disk watches nothing, and says so.
     /// `NotChecked` is not a pass — `judge` reads it as `TamperUnchecked` — so
     /// this is a declared limit rather than a hidden credit.
-    #[test]
-    fn an_invocation_that_names_no_artifact_checks_nothing() {
+    #[tokio::test]
+    async fn an_invocation_that_names_no_artifact_checks_nothing() {
         let dir = workspace();
         let granted = grant_shared_tree(dir.path(), Some("cargo test --test witness_flip"))
+            .await
             .expect("the grant mints");
         assert_eq!(granted.watch.finding(), TamperFinding::NotChecked);
 
-        let none = grant_shared_tree(dir.path(), None).expect("no test command is fine");
+        let none = grant_shared_tree(dir.path(), None)
+            .await
+            .expect("no test command is fine");
         assert!(none.grant.test.is_none(), "no plan is not an empty plan");
         assert_eq!(none.watch.finding(), TamperFinding::NotChecked);
     }
@@ -431,10 +604,11 @@ mod tests {
     /// it — the plugin never receives an invocation this host would not run.
     /// The refusal quotes the command, which is the half a user can act on
     /// whichever door supplied it (`--test-command` or a fleet plan file).
-    #[test]
-    fn a_refused_test_command_mints_no_grant() {
+    #[tokio::test]
+    async fn a_refused_test_command_mints_no_grant() {
         let dir = workspace();
         let error = grant_shared_tree(dir.path(), Some("rm -rf /"))
+            .await
             .expect_err("`rm` is not in the runner vocabulary");
         assert!(error.contains("rm -rf /"), "{error}");
     }
@@ -469,10 +643,11 @@ mod tests {
     /// run of every plugin, so the finding was `NotChecked` and `judge` read
     /// that as `UndecidedReason::TamperUnchecked`: never a wrong credit, and
     /// never a decidable verdict either.
-    #[test]
-    fn a_declared_artifact_is_watched_where_the_invocation_named_none() {
+    #[tokio::test]
+    async fn a_declared_artifact_is_watched_where_the_invocation_named_none() {
         let dir = workspace();
         let granted = grant_shared_tree(dir.path(), Some("cargo test --test witness_flip"))
+            .await
             .expect("the grant mints");
         assert_eq!(
             granted.watch.finding(),
@@ -505,10 +680,12 @@ mod tests {
 
     /// A declaration is a path, never a permission: the same fence the
     /// invocation's own arguments cross.
-    #[test]
-    fn a_declared_path_outside_the_root_is_dropped_rather_than_followed() {
+    #[tokio::test]
+    async fn a_declared_path_outside_the_root_is_dropped_rather_than_followed() {
         let dir = workspace();
-        let granted = grant_shared_tree(dir.path(), None).expect("no test command is fine");
+        let granted = grant_shared_tree(dir.path(), None)
+            .await
+            .expect("no test command is fine");
         granted.watch.pin_declared(&[
             "../outside.sh".to_string(),
             "/etc/passwd".to_string(),
@@ -526,10 +703,12 @@ mod tests {
     /// round 1 would read as "unchanged" from round 2 onward — the exact
     /// laundering the watch exists to refuse, arriving through the mechanism
     /// that widened it.
-    #[test]
-    fn re_declaring_an_artifact_does_not_relaunder_an_earlier_rewrite() {
+    #[tokio::test]
+    async fn re_declaring_an_artifact_does_not_relaunder_an_earlier_rewrite() {
         let dir = workspace();
-        let granted = grant_shared_tree(dir.path(), None).expect("the grant mints");
+        let granted = grant_shared_tree(dir.path(), None)
+            .await
+            .expect("the grant mints");
         let declared = vec!["tests/witness_flip.sh".to_string()];
 
         granted.watch.pin_declared(&declared);
@@ -561,16 +740,17 @@ mod tests {
     /// the turn never touched. Holding the root open makes the path irrelevant:
     /// a descriptor keeps naming the directory it was opened on.
     #[cfg(unix)]
-    #[test]
-    fn a_root_renamed_after_the_grant_cannot_launder_a_rewritten_witness() {
+    #[tokio::test]
+    async fn a_root_renamed_after_the_grant_cannot_launder_a_rewritten_witness() {
         let outer = tempfile::tempdir().expect("a temp parent");
         let root = outer.path().join("workspace");
         std::fs::create_dir_all(root.join("tests")).expect("tests dir");
         std::fs::write(root.join("tests/witness_flip.sh"), "#!/bin/sh\nexit 1\n")
             .expect("the witness");
 
-        let granted =
-            grant_shared_tree(&root, Some("sh tests/witness_flip.sh")).expect("the grant mints");
+        let granted = grant_shared_tree(&root, Some("sh tests/witness_flip.sh"))
+            .await
+            .expect("the grant mints");
         assert_eq!(granted.watch.finding(), TamperFinding::Clean);
 
         // The worker rewrites the witness in the tree the turn is running in…

--- a/crates/stella-cli/src/wrapper_candidate.rs
+++ b/crates/stella-cli/src/wrapper_candidate.rs
@@ -371,10 +371,10 @@ pub(crate) async fn grant_shared_tree(
 /// Run the granted invocation once before the turn, and say what it reported.
 ///
 /// Returns the wire value the plan carries and one sentence for the door to
-/// print. Every answer other than [`TestBaseline::Failed`] says it has no red
-/// to offer: a passing suite and an unobservable run both leave the oracle with
-/// nothing to lock onto, and neither may be dressed up as the precondition a
-/// flip needs.
+/// print. Every answer other than [`stella_plugin::TestBaseline::Failed`] says
+/// it has no red to offer: a passing suite and an unobservable run both leave
+/// the oracle with nothing to lock onto, and neither may be dressed up as the
+/// precondition a flip needs.
 async fn observed_baseline(
     root: &Path,
     invocation: &stella_plugin::TestInvocation,

--- a/crates/stella-cli/src/wrapper_plugin/tests/round_driver.rs
+++ b/crates/stella-cli/src/wrapper_plugin/tests/round_driver.rs
@@ -74,6 +74,7 @@ async fn a_round_driving_door_runs_the_tests_its_own_grant_names() {
     let tree = tree_with_a_test(0);
     let granted =
         crate::wrapper_candidate::grant_shared_tree(tree.path(), Some("sh tests/witness_flip.sh"))
+            .await
             .expect("the root resolves and the command parses");
     let roster = roster(vec![installed(
         VERIFYING_MANIFEST,
@@ -115,6 +116,7 @@ async fn a_handle_this_door_never_granted_reaches_no_tree() {
     let tree = tree_with_a_test(0);
     let granted =
         crate::wrapper_candidate::grant_shared_tree(tree.path(), Some("sh tests/witness_flip.sh"))
+            .await
             .expect("the grant mints");
     let roster = roster(vec![installed(
         VERIFYING_MANIFEST,

--- a/crates/stella-cli/src/wrapper_test_run.rs
+++ b/crates/stella-cli/src/wrapper_test_run.rs
@@ -39,6 +39,16 @@
 //! `stella-serve` or an embedded host never has. The host call is the portable
 //! way to ask, and this is the door answering it.
 //!
+//! # The same runner observes the baseline
+//!
+//! [`observe_baseline`] runs the granted invocation once before the turn, which
+//! is where [`stella_plugin::TestBaseline`] gets a value other than `NotRun`.
+//! It is here rather than in [`crate::wrapper_candidate`] so that one function
+//! decides pass and fail for both readings: what a plugin is told the tests
+//! said *before* the work, and what this host reports when a plugin asks it to
+//! re-run them *after*. Two copies of that decision is how a deadline ends up
+//! red on one path and unobserved on the other.
+//!
 //! # The environment is not scrubbed, and that is a decision
 //!
 //! `stella_tools::exec::scrub_sensitive_env` strips host credentials from a
@@ -162,6 +172,40 @@ impl TestRunHost for GrantedTestRuns {
     }
 }
 
+/// Run the invocation once **before** the turn, so the grant carries the red
+/// half of a flip instead of asking a plugin to reconstruct it.
+///
+/// The host is the only party that can do this. A subprocess wrapper is a fresh
+/// process at every point — `stella_runtime::wrapper`'s subprocess transport
+/// spawns one per request — so it cannot see red at `before_turn` and remember
+/// it at `after_turn`. Nothing it observes survives the point it observed it in.
+///
+/// It shares [`run_in`] with the `run_test` capability above, so pass and fail
+/// are decided in one place, off the exit status, with a run killed at the
+/// deadline reported as [`TestBaseline::Unobserved`] rather than as red.
+///
+/// # Errors
+///
+/// [`TestRunDenial::Failed`] when the invocation could not be started, or ran
+/// and its output could not be read. The caller records that as
+/// [`TestBaseline::Unobserved`] and never as [`TestBaseline::Failed`]: a host
+/// that could not run the tests has observed no assertion, and scoring its own
+/// failure as red would hand the oracle a precondition the work did not earn.
+pub(crate) async fn observe_baseline(
+    root: &std::path::Path,
+    invocation: &stella_plugin::TestInvocation,
+) -> Result<TestObservation, TestRunDenial> {
+    run_in(
+        &GrantedTests {
+            root: root.to_path_buf(),
+            program: invocation.program.clone(),
+            args: invocation.args.clone(),
+        },
+        DEFAULT_TEST_RUN_TIMEOUT,
+    )
+    .await
+}
+
 /// Run one grant's invocation in its own root, and report what was observed.
 ///
 /// Never a shell: `program` and `args` go to the process builder exactly as
@@ -265,8 +309,9 @@ mod tests {
     use super::*;
 
     /// A grant over `root`, with `command` parsed the way a door parses it.
-    fn granted(root: &std::path::Path, command: Option<&str>) -> CandidateGrant {
+    async fn granted(root: &std::path::Path, command: Option<&str>) -> CandidateGrant {
         crate::wrapper_candidate::grant_shared_tree(root, command)
+            .await
             .expect("the root resolves and the command parses")
             .grant
     }
@@ -288,7 +333,7 @@ mod tests {
     #[tokio::test]
     async fn a_granted_candidate_is_run_in_its_own_tree() {
         let dir = workspace("#!/bin/sh\necho 'ok: 1 passed'\nexit 0\n");
-        let grant = granted(dir.path(), Some("sh tests/witness_flip.sh"));
+        let grant = granted(dir.path(), Some("sh tests/witness_flip.sh")).await;
         let host = GrantedTestRuns::over([&grant]);
 
         let observed = host
@@ -305,7 +350,7 @@ mod tests {
     #[tokio::test]
     async fn a_failing_invocation_reports_failed_assertions_and_its_output() {
         let dir = workspace("#!/bin/sh\necho 'FAILED: tests::flip' >&2\nexit 1\n");
-        let grant = granted(dir.path(), Some("sh tests/witness_flip.sh"));
+        let grant = granted(dir.path(), Some("sh tests/witness_flip.sh")).await;
         let host = GrantedTestRuns::over([&grant]);
 
         let observed = host.run_test(&handle(&grant)).await.expect("it ran");
@@ -321,7 +366,7 @@ mod tests {
     #[tokio::test]
     async fn a_handle_this_door_did_not_grant_is_unknown() {
         let dir = workspace("#!/bin/sh\nexit 0\n");
-        let grant = granted(dir.path(), Some("sh tests/witness_flip.sh"));
+        let grant = granted(dir.path(), Some("sh tests/witness_flip.sh")).await;
         let host = GrantedTestRuns::over([&grant]);
 
         let denial = host
@@ -336,7 +381,7 @@ mod tests {
     #[tokio::test]
     async fn a_grant_with_no_test_command_has_nothing_to_re_run() {
         let dir = workspace("#!/bin/sh\nexit 0\n");
-        let grant = granted(dir.path(), None);
+        let grant = granted(dir.path(), None).await;
         let host = GrantedTestRuns::over([&grant]);
 
         let denial = host
@@ -352,7 +397,7 @@ mod tests {
     #[tokio::test]
     async fn an_unspawnable_program_reports_that_the_host_tried() {
         let dir = workspace("#!/bin/sh\nexit 0\n");
-        let mut grant = granted(dir.path(), Some("sh tests/witness_flip.sh"));
+        let mut grant = granted(dir.path(), Some("sh tests/witness_flip.sh")).await;
         if let Some(plan) = grant.test.as_mut() {
             plan.program = "stella-no-such-runner".to_string();
         }
@@ -376,7 +421,7 @@ mod tests {
     #[tokio::test]
     async fn a_run_killed_at_the_deadline_observed_no_assertions() {
         let dir = workspace("#!/bin/sh\nsleep 30\n");
-        let grant = granted(dir.path(), Some("sh tests/witness_flip.sh"));
+        let grant = granted(dir.path(), Some("sh tests/witness_flip.sh")).await;
         let host = GrantedTestRuns::over([&grant]).with_timeout(Duration::from_millis(150));
 
         let observed = host
@@ -388,11 +433,60 @@ mod tests {
 
     /// A door with no grant installs no plane rather than one that refuses
     /// everything, and this is the question it asks.
-    #[test]
-    fn a_host_over_no_grants_is_empty() {
+    #[tokio::test]
+    async fn a_host_over_no_grants_is_empty() {
         assert!(GrantedTestRuns::over([]).is_empty());
         let dir = workspace("#!/bin/sh\nexit 0\n");
-        let grant = granted(dir.path(), None);
+        let grant = granted(dir.path(), None).await;
         assert!(!GrantedTestRuns::over([&grant]).is_empty());
+    }
+
+    fn invocation(program: &str, args: &[&str]) -> stella_plugin::TestInvocation {
+        stella_plugin::TestInvocation {
+            program: program.to_string(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+        }
+    }
+
+    /// **Witness.** The pre-turn observation reads the same exit status the
+    /// post-turn re-run does, so red before the work and red after it are the
+    /// same word.
+    #[tokio::test]
+    async fn the_baseline_reads_the_invocation_the_same_way_a_re_run_does() {
+        let red = workspace("#!/bin/sh\nexit 1\n");
+        assert_eq!(
+            observe_baseline(red.path(), &invocation("sh", &["tests/witness_flip.sh"]))
+                .await
+                .expect("it ran")
+                .assertions,
+            TestBaseline::Failed,
+        );
+
+        let green = workspace("#!/bin/sh\nexit 0\n");
+        assert_eq!(
+            observe_baseline(green.path(), &invocation("sh", &["tests/witness_flip.sh"]))
+                .await
+                .expect("it ran")
+                .assertions,
+            TestBaseline::Passed,
+        );
+    }
+
+    /// A program that will not start is refused rather than reported as red.
+    ///
+    /// The caller turns this into `Unobserved`. Reporting it as `Failed` would
+    /// hand the oracle a failing baseline this host manufactured out of its own
+    /// inability to run anything, and the next clean run would be credited as a
+    /// verified fix.
+    #[tokio::test]
+    async fn a_baseline_that_could_not_be_run_is_refused_rather_than_scored_red() {
+        let dir = workspace("#!/bin/sh\nexit 0\n");
+        let denial = observe_baseline(dir.path(), &invocation("stella-no-such-runner", &[]))
+            .await
+            .expect_err("no such program");
+        let TestRunDenial::Failed(reason) = denial else {
+            panic!("a program that will not start is a host that tried");
+        };
+        assert!(reason.contains("stella-no-such-runner"), "{reason}");
     }
 }

--- a/crates/stella-cli/tests/fleet_wrapped_dispatch_cli.rs
+++ b/crates/stella-cli/tests/fleet_wrapped_dispatch_cli.rs
@@ -382,10 +382,17 @@ async fn a_plan_files_per_task_test_command_reaches_the_plugin_as_a_test_plan() 
     );
     // The parsed argv, not the raw line: the command crossed the host's closed
     // runner vocabulary before anything reached the wire.
+    // The parsed argv **and** the red the host observed by running it before
+    // the attempt. Without that last field the plugin's oracle has no failing
+    // observation to lock a command onto, so it can only ever report
+    // `unobservable` and every attempt on this door ends `Undecided`.
     for call in &calls {
         assert!(
-            call.contains(r#""test":{"program":"sh","args":["tests/witness_flip.sh"]"#),
-            "the plan's test command must ride the candidate grant as a parsed plan: {call}"
+            call.contains(
+                r#""test":{"program":"sh","args":["tests/witness_flip.sh"],"baseline":"failed"}"#
+            ),
+            "the plan's test command must ride the grant as a parsed plan carrying its \
+             pre-attempt baseline: {call}"
         );
     }
 }


### PR DESCRIPTION
## What & why

Every door minted a wrapper plugin's candidate grant with
`TestBaseline::NotRun`. `grant_shared_tree` in
`crates/stella-cli/src/wrapper_candidate.rs` called
`stella_plugin::test_plan(parsed, None)`, and that was the only call to
`test_plan` in shipping code — so the three other variants of `TestBaseline`
were unreachable from anything a user runs.

`plugins/stella-witness/main.py`'s `assess` feeds its oracle a failing
observation only when the grant's baseline says `failed`. Handed `not-run` it
never locks a command, reports `unobservable`, and `judge` under
`flip = "required"` turns that into `Undecided`. The one verification plugin
this repository ships could not credit a flip on any door:
`stella run --pipeline <plugin>`, `stella goal` and `stella fleet` alike.

The comment in `grant_shared_tree` gave the reason for the choice — "the host
does not spend a test run the plugin is about to spend itself. A wrapper
observes red in `before_turn`". A subprocess wrapper cannot. `exchange` in
`crates/stella-runtime/src/wrapper/subprocess.rs` spawns a fresh process for
every point, so anything a plugin saw at `before_turn` is gone by `after_turn`.
The host is the only party that spans both moments.

Nothing caught it because the conformance vectors write the baseline by hand:
`plugins/stella-witness/testdata/01-flip-achieved.request.json` carries
`"baseline": "failed"`, a value no production path could produce. The suite
proved the plugin credits a flip given red; no test asked whether red arrives.

**What this changes.** `grant_shared_tree` is now `async`. It runs the granted
invocation once, in the granted root, before the turn, and stamps what it saw
onto `TestPlan::baseline`. Three properties are deliberate:

- **It shares `run_in` with the `run_test` host call** (the new
  `wrapper_test_run::observe_baseline`), so pass and fail are decided in one
  place, off the exit status. A run killed at the deadline is `unobserved` on
  both paths rather than red on one and unobserved on the other.
- **A run that could not happen is never red.** A program that will not start
  comes back as `TestRunDenial::Failed`, which the caller records as
  `unobserved`. Scoring this host's own failure as red would satisfy a flip's
  precondition on infrastructure noise and credit the next clean run as a
  verified fix — the bug `CmdKind` exists to make unrepresentable.
- **The observation happens before the tamper watch is pinned.** A test run can
  rewrite generated files, and a watch pinned first would report this host's own
  run as a worker tampering with the witness.

The exemplar for the shape is the crate's own `wrapper_test_run` module rather
than an outside one: it already owned the spawn, the process group, the
deadline and the `TestObservation` type, and a second runner beside it is the
copy that drifts.

**Cost.** One run of the user's own `--test-command`, before the turn. That is
the price of the flip the flag asks for rather than an extra: with no before
there is nothing a passing suite afterwards could prove. `stella run` without
`--pipeline`, and any turn that names no test command, spend nothing. The
`stella goal` and `stella run` doors print what the pause found; the fleet door
stays silent, on the rule its own module already states for per-attempt notices.

**Where the design is written down.** `wrapper_candidate.rs` gains a
"When the baseline is observed, and every case where it cannot be" section: when
the observation happens, why the host has to be the one to make it, what each of
the four `TestBaseline` answers means, and why narrowing the invocation is a
separate question from whether the baseline is observed at all.

Closes #6421
Refs #1292

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Four, and the falsifier was run rather than argued. Replacing
`plan.baseline = observed;` with a discard makes
`a_red_suite_before_the_turn_reaches_the_plugin_as_red` fail with
`left: NotRun, right: Failed`; restoring it passes.

| Test | What it pins |
| --- | --- |
| `wrapper_candidate::tests::a_red_suite_before_the_turn_reaches_the_plugin_as_red` | a red suite reaches the plugin as `failed`, with the door's notice |
| `wrapper_candidate::tests::a_green_suite_before_the_turn_is_not_dressed_up_as_red` | a green suite is `passed`, never dressed up as red |
| `wrapper_candidate::tests::a_turn_with_no_test_command_observes_nothing_and_says_nothing` | no test command runs nothing and reports nothing |
| `wrapper_test_run::tests::the_baseline_reads_the_invocation_the_same_way_a_re_run_does` | one decision for both readings |
| `wrapper_test_run::tests::a_baseline_that_could_not_be_run_is_refused_rather_than_scored_red` | a program that will not start is refused, not scored red |
| `fleet_wrapped_dispatch_cli::a_plan_files_per_task_test_command_reaches_the_plugin_as_a_test_plan` | the baseline on the wire, end to end through a real door |

**One assertion was reversed, and it is the point of the change.**
`wrapper_candidate::tests::the_shared_tree_is_granted_with_the_test_the_host_would_run`
asserted `TestBaseline::NotRun` with the comment "the host did not run it, and
says so rather than claiming red". It now asserts `Failed`. No test was deleted.
Nine tests in `wrapper_candidate.rs`, one in `wrapper_test_run.rs` and two in
`round_driver.rs` became `#[tokio::test]` because the function they call is now
`async`; every name is unchanged.

## The gate

- [x] `cargo fmt --check` (scoped: `cargo fmt --check -p stella-cli`)
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-cli` — the workspace run is CI's, per CLAUDE.md
- [x] `make guards-fast` — green, `check-prose.py` included
- [x] Docs updated: `wrapper_candidate.rs`'s module doc gains the section above,
      `wrapper_test_run.rs`'s gains the paragraph on the shared runner, and
      `resolve_goal_wrapper`'s doc says why the baseline is minted once for the
      arc rather than per round
- [x] `Closes #6421` appears above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: one, in its own commit. Minting the grant now
      spends a whole test run, and on the two doors a person types at it sat in
      front of the last instant refusal a run can hit — a model id the catalog
      does not know. `run_raw_one_shot` and `run_goal_cmd` build the provider
      first now. Both are pure reorderings of adjacent statements with no data
      dependency, and nothing above the new position is paid, so the ordering
      rule the plugin resolve keeps is intact. The fleet door keeps the earlier
      order and says why: its provider is built against a per-worker config
      whose root is the attempt's tree, which is not a value until after the
      call, and `run_fleet`'s pre-flight already resolved the same variant.
- [x] Filed, with the reason a fix could not ride this PR: none deferred

`#1292` stays open and is not this PR's to close. It asks for affected-test
selection to count as verification evidence, and that has two halves: the
baseline restructuring, which is here, and a graph-driven affected-test
selector, which no longer exists in the tree — `run_tests` is a retired name in
`crates/stella-tool-facts/src/catalog.rs` and `CodeGraph::importer_paths` was
deleted with the tool purge (`crates/stella-graph/src/graph.rs`,
`the_importer_relation_lists_files_whose_imports_resolve_here`). Rebuilding it
against the plugin oracle is a separate design slice.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary type — `TestBaseline` and `TestPlan` already
      round-trip through `stella-plugin`'s wire corpus, and this PR changes
      which of their values production emits, not their shape

## Anything reviewers should know?

The judgement worth checking is whether the host should spend a test run at all.
The alternative on the table was leaving the baseline to the plugin, which the
old comment assumed; that is unavailable to any subprocess plugin, which is
every plugin this repository ships. An in-process wrapper could carry state
across points, so the host observing the baseline is redundant work for that one
case — and a host that skipped it there would make the grant mean two different
things depending on the transport, which is worse than a duplicated run.

## Summary by Sourcery

Observe granted test commands before wrapped turns so plugins receive accurate baselines and can verify genuine test flips.

New Features:
- Observe each granted test command before a wrapped turn and include its result in the plugin test plan, enabling verification plugins to evaluate flips from real CLI and fleet runs.
- Report pre-turn test observations for interactive and goal doors while preserving silent per-attempt behavior for fleet runs.

Bug Fixes:
- Ensure failing test baselines reach subprocess plugins instead of always being emitted as not-run, allowing required flips to be credited.
- Treat unstartable or incomplete test runs as unobserved rather than incorrectly scoring infrastructure failures as failed tests.
- Run baseline observation before tamper-watch snapshots so test-generated file changes are not mistaken for worker tampering.

Enhancements:
- Reuse the shared test runner for baseline and post-turn execution so both paths apply consistent pass, fail, timeout, and denial semantics.
- Make candidate and wrapper resolution asynchronous to support pre-turn test execution and update affected callers and tests accordingly.

Documentation:
- Document when test baselines are observed, how each baseline state is interpreted, and why observation is performed by the host before tamper watching.
- Document the shared test runner's role in producing consistent baseline and rerun observations.

Tests:
- Add witness coverage for failed, passed, absent, and unobservable baselines, shared runner semantics, and end-to-end fleet propagation.

Chores:
- Add a helper script for waiting on settled pull-request checks.