### PR TITLE
feat(stella-cli): put the delivery loop's pull requests behind a provider port

### DIFF
--- a/crates/stella-cli/src/driver_plugin/deliver.rs
+++ b/crates/stella-cli/src/driver_plugin/deliver.rs
@@ -146,11 +146,14 @@ impl DeliverForge for GhDeliverForge {
 
     async fn ready(&self, pr: &str) -> Result<(), String> {
         let pr = pr.to_owned();
-        tokio::task::spawn_blocking(move || crate::self_driving_cmd::deliver::mark_ready(&pr))
-            .await
-            .map_err(|error| {
-                format!("taking the pull request out of draft did not finish: {error}")
-            })?
+        tokio::task::spawn_blocking(move || {
+            crate::self_driving_cmd::deliver::mark_ready(
+                &crate::pull_request_provider::GhPullRequests::new(),
+                &pr,
+            )
+        })
+        .await
+        .map_err(|error| format!("taking the pull request out of draft did not finish: {error}"))?
     }
 
     async fn merge(&self, pr: &str) -> Result<(), String> {

--- a/crates/stella-cli/src/driver_plugin/deliver.rs
+++ b/crates/stella-cli/src/driver_plugin/deliver.rs
@@ -117,7 +117,14 @@ impl DeliverForge for GhDeliverForge {
         let signature = self.config.attribution.pull_request.clone();
         let (branch, issue, title) = (branch.to_owned(), issue.to_owned(), title.to_owned());
         tokio::task::spawn_blocking(move || {
-            crate::self_driving_cmd::deliver::open(&root, &branch, &issue, &title, &signature)
+            crate::self_driving_cmd::deliver::open(
+                &crate::pull_request_provider::GhPullRequests::new(),
+                &root,
+                &branch,
+                &issue,
+                &title,
+                &signature,
+            )
         })
         .await
         .map_err(|error| format!("the pull request did not finish opening: {error}"))?
@@ -126,9 +133,15 @@ impl DeliverForge for GhDeliverForge {
     async fn observe(&self, pr: &str) -> Result<Reading, String> {
         let policy = self.config.merge.clone();
         let pr = pr.to_owned();
-        tokio::task::spawn_blocking(move || crate::self_driving_cmd::deliver::observe(&pr, &policy))
-            .await
-            .map_err(|error| format!("the forge read did not finish: {error}"))?
+        tokio::task::spawn_blocking(move || {
+            crate::self_driving_cmd::deliver::observe(
+                &crate::pull_request_provider::GhPullRequests::new(),
+                &pr,
+                &policy,
+            )
+        })
+        .await
+        .map_err(|error| format!("the forge read did not finish: {error}"))?
     }
 
     async fn ready(&self, pr: &str) -> Result<(), String> {
@@ -142,9 +155,14 @@ impl DeliverForge for GhDeliverForge {
 
     async fn merge(&self, pr: &str) -> Result<(), String> {
         let pr = pr.to_owned();
-        tokio::task::spawn_blocking(move || crate::self_driving_cmd::deliver::merge(&pr))
-            .await
-            .map_err(|error| format!("the merge did not finish: {error}"))?
+        tokio::task::spawn_blocking(move || {
+            crate::self_driving_cmd::deliver::merge(
+                &crate::pull_request_provider::GhPullRequests::new(),
+                &pr,
+            )
+        })
+        .await
+        .map_err(|error| format!("the merge did not finish: {error}"))?
     }
 }
 

--- a/crates/stella-cli/src/driver_plugin/work.rs
+++ b/crates/stella-cli/src/driver_plugin/work.rs
@@ -137,6 +137,7 @@ impl WorkRunner for SpawnedWorkRunner {
 
         let (outcome, budget) = tokio::task::spawn_blocking(move || {
             let outcome = crate::self_driving_cmd::work::start(
+                &crate::pull_request_provider::GhPullRequests::new(),
                 &root,
                 &issue,
                 &mut budget,

--- a/crates/stella-cli/src/main.rs
+++ b/crates/stella-cli/src/main.rs
@@ -113,6 +113,9 @@ mod promotion_gate;
 // Phase 3 (#714): the adaptive-context proposal review surface.
 mod prompt_source;
 mod proposals_cmd;
+// The GitHub adapter behind `stella_protocol::pull_request::PullRequestProvider`
+// — the delivery loop's sibling of `issue_provider`.
+mod pull_request_provider;
 mod query_format;
 mod question;
 mod resume_frame;

--- a/crates/stella-cli/src/pull_request_provider.rs
+++ b/crates/stella-cli/src/pull_request_provider.rs
@@ -429,8 +429,12 @@ impl PullRequestProvider for GhPullRequests {
         let raw = gh(&args)?;
         let rows: Vec<GhPullRequest> =
             serde_json::from_str(&raw).map_err(|error| malformed("gh pr list", &error))?;
+        // A row with no `number` is skipped rather than failing the whole
+        // read. It decodes as 0, which is no pull request, and passing that on
+        // would hand a caller a key that addresses nothing.
         Ok(rows
             .into_iter()
+            .filter(|row| row.number != 0)
             .map(|row| PullRequestSummary {
                 key: PullRequestKey(row.number.to_string()),
                 title: row.title,
@@ -734,6 +738,26 @@ mod tests {
                 },
             ]
         );
+    }
+
+    /// A listing row with no number is skipped, not passed on as zero.
+    ///
+    /// `number` defaults, so a payload that dropped it decodes as pull request
+    /// 0. That key addresses nothing. Handing it to a caller would turn a
+    /// dropped field into a pull request the loop then tries to read.
+    #[test]
+    fn a_listing_row_with_no_number_is_skipped() {
+        let raw = r#"[
+            {"title": "no number here", "body": "Closes #43"},
+            {"number": 9, "title": "t", "body": "Closes #43", "headRefName": "fix/43"}
+        ]"#;
+        let rows: Vec<GhPullRequest> = serde_json::from_str(raw).expect("decode");
+        let kept: Vec<String> = rows
+            .into_iter()
+            .filter(|row| row.number != 0)
+            .map(|row| row.number.to_string())
+            .collect();
+        assert_eq!(kept, vec!["9".to_owned()]);
     }
 
     /// An unknown state keeps the caller asking. It never calls a pull

--- a/crates/stella-cli/src/pull_request_provider.rs
+++ b/crates/stella-cli/src/pull_request_provider.rs
@@ -1,0 +1,756 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The GitHub adapter behind [`PullRequestProvider`].
+//!
+//! This is the one place a pull request `gh` command is spelled. It is the
+//! sibling of [`crate::issue_provider`], which does the same for issues.
+//! Before it, the loop ran `gh pr view` and `gh pr merge` in its own
+//! `deliver` module. It read two REST endpoints there too, and both of
+//! GitHub's check dialects. So "which forge" was not a choice. It was
+//! spelled into the reader.
+//!
+//! The I/O and the dialect moved here. The port is
+//! [`stella_protocol::pull_request`]. The policy stays above it, in
+//! `self_driving_cmd::deliver`.
+//!
+//! # `gh`, not the REST API
+//!
+//! Shelling out keeps one property. **Stella never holds a GitHub
+//! credential.** `gh` owns the auth. The token never enters this process, and
+//! `stella auth` stores nothing new. `doc:agent-native-delivery` §4.4's
+//! `kind = "exec"` is the general form.
+
+use std::process::Command;
+
+use stella_protocol::pull_request::{
+    Check, CheckOutcome, MergeStatus, PullRequest, PullRequestDraft, PullRequestError,
+    PullRequestKey, PullRequestProvider, PullRequestState, PullRequestSummary, ReviewDecision,
+};
+
+/// The provider id this adapter answers to, and the one an error names.
+pub(crate) const GITHUB: &str = "github";
+
+/// Reads and drives GitHub pull requests through the `gh` CLI.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct GhPullRequests;
+
+impl GhPullRequests {
+    /// The adapter. It holds nothing: `gh` carries the repository and the
+    /// credential.
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+/// What `gh pr view --json …` and `gh pr list --json …` write.
+///
+/// This and [`GhCheck`] are the **only** types here that carry GitHub's field
+/// names. Both are private to this module. `issue_provider.rs` confines the
+/// issue names the same way.
+#[derive(Debug, Default, serde::Deserialize)]
+struct GhPullRequest {
+    #[serde(default)]
+    number: u64,
+    #[serde(default, rename = "isDraft")]
+    is_draft: bool,
+    #[serde(default)]
+    mergeable: String,
+    #[serde(default, rename = "reviewDecision")]
+    review_decision: String,
+    #[serde(default, rename = "statusCheckRollup")]
+    status_check_rollup: Vec<GhCheck>,
+    #[serde(default, rename = "baseRefName")]
+    base_ref_name: String,
+    #[serde(default, rename = "headRefName")]
+    head_ref_name: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    state: String,
+    #[serde(default)]
+    labels: Vec<GhLabel>,
+}
+
+/// A label, which GitHub reports as an object rather than a string.
+#[derive(Debug, Default, serde::Deserialize)]
+struct GhLabel {
+    #[serde(default)]
+    name: String,
+}
+
+/// One check as GitHub reports it.
+///
+/// # Two kinds of check, two spellings
+///
+/// A rollup mixes **check runs** with **commit statuses**. A check run carries
+/// `name`, `status` and `conclusion`. A commit status carries `context` and
+/// `state`, and no `status` at all. Third-party services post those.
+///
+/// Reading only the first shape does not fail. Every field is
+/// `#[serde(default)]`, so it yields a check with no name and no outcome.
+///
+/// Such a check reads as *pending forever*. Its `status` is never
+/// `COMPLETED`. This repository carries a Vercel commit status that fails on
+/// every pull request. The loop re-read `ci=Pending` for twenty-five minutes
+/// after all three required checks went green.
+///
+/// The empty name is the same bug's other half. A base read joins by name, so
+/// every commit status would join against every other.
+#[derive(Debug, Default, Clone, serde::Deserialize)]
+struct GhCheck {
+    /// A check run's name.
+    #[serde(default)]
+    name: String,
+    /// A commit status's name. GitHub calls the same thing `context` here.
+    #[serde(default)]
+    context: String,
+    /// A check run's outcome: `SUCCESS`, `FAILURE`, `SKIPPED`, `""` while
+    /// running.
+    #[serde(default)]
+    conclusion: String,
+    /// A commit status's outcome: `SUCCESS`, `FAILURE`, `ERROR`, `PENDING`,
+    /// `EXPECTED`.
+    #[serde(default)]
+    state: String,
+    /// A check run's progress: `COMPLETED`, `IN_PROGRESS`, `QUEUED`. **Absent
+    /// on a commit status**, which is how the two are told apart.
+    #[serde(default)]
+    status: String,
+}
+
+impl GhCheck {
+    /// The join key, whichever shape reported it.
+    fn name(&self) -> &str {
+        if self.name.is_empty() {
+            &self.context
+        } else {
+            &self.name
+        }
+    }
+
+    /// The outcome, whichever shape reported it.
+    fn raw_outcome(&self) -> String {
+        let raw = if self.conclusion.is_empty() {
+            &self.state
+        } else {
+            &self.conclusion
+        };
+        raw.trim().to_ascii_uppercase()
+    }
+
+    /// Where this check got to, in the port's vocabulary.
+    ///
+    /// Inert wins over failed, and failed wins over running. That is the order
+    /// a rollup verdict reads. A skipped job is not a failure. A build that
+    /// already failed stays failed while other jobs run.
+    fn outcome(&self) -> CheckOutcome {
+        let raw = self.raw_outcome();
+        if matches!(raw.as_str(), "SKIPPED" | "NEUTRAL" | "CANCELLED") {
+            return CheckOutcome::Inert;
+        }
+        if matches!(
+            raw.as_str(),
+            "FAILURE" | "ERROR" | "TIMED_OUT" | "STARTUP_FAILURE" | "ACTION_REQUIRED"
+        ) {
+            return CheckOutcome::Failed;
+        }
+        // A commit status has no progress field. Its outcome is the whole
+        // story. A check run has one. A completed run with no conclusion is a
+        // forge quirk. Read it as unknown, not as green.
+        let running = if self.status.trim().is_empty() {
+            matches!(raw.as_str(), "PENDING" | "EXPECTED" | "")
+        } else {
+            !self.status.eq_ignore_ascii_case("COMPLETED") || raw.is_empty()
+        };
+        if running {
+            CheckOutcome::Running
+        } else {
+            CheckOutcome::Passed
+        }
+    }
+
+    /// The port's shape.
+    fn into_check(self) -> Check {
+        Check {
+            name: self.name().to_owned(),
+            outcome: self.outcome(),
+        }
+    }
+}
+
+/// Map GitHub's mergeability string.
+///
+/// `UNKNOWN` and anything else read as [`MergeStatus::Unknown`], never
+/// `Clean`. GitHub reports the field before it has worked it out. Reading
+/// that as clean is how a merge is tried into a conflict.
+fn merge_status_from(raw: &str) -> MergeStatus {
+    match raw.to_ascii_uppercase().as_str() {
+        "MERGEABLE" => MergeStatus::Clean,
+        "CONFLICTING" => MergeStatus::Conflicted,
+        _ => MergeStatus::Unknown,
+    }
+}
+
+/// Map GitHub's review decision.
+///
+/// An empty string means nobody has reviewed. GitHub returns it when a
+/// repository asks for no review.
+fn review_from(raw: &str) -> ReviewDecision {
+    match raw.to_ascii_uppercase().as_str() {
+        "APPROVED" => ReviewDecision::Approved,
+        "CHANGES_REQUESTED" => ReviewDecision::ChangesRequested,
+        _ => ReviewDecision::None,
+    }
+}
+
+/// Map GitHub's pull request state.
+///
+/// Anything else reads as [`PullRequestState::Open`], which keeps a caller
+/// asking. Guessing `Merged` from an unknown word would strand a live pull
+/// request.
+fn state_from(raw: &str) -> PullRequestState {
+    match raw.to_ascii_uppercase().as_str() {
+        "MERGED" => PullRequestState::Merged,
+        "CLOSED" => PullRequestState::Closed,
+        _ => PullRequestState::Open,
+    }
+}
+
+impl From<GhPullRequest> for PullRequest {
+    fn from(row: GhPullRequest) -> Self {
+        Self {
+            key: PullRequestKey(row.number.to_string()),
+            state: state_from(&row.state),
+            draft: row.is_draft,
+            base_ref: row.base_ref_name,
+            head_ref: row.head_ref_name,
+            title: row.title,
+            body: row.body,
+            merge_status: merge_status_from(&row.mergeable),
+            review: review_from(&row.review_decision),
+            checks: row
+                .status_check_rollup
+                .into_iter()
+                .map(GhCheck::into_check)
+                .collect(),
+            labels: row.labels.into_iter().map(|label| label.name).collect(),
+        }
+    }
+}
+
+/// The workflow-run id inside a check's link, if it has one.
+///
+/// A check link looks like `…/actions/runs/<run>/job/<job>`. Anything else
+/// yields `None` rather than a guess. A third-party check points at its own
+/// dashboard. Re-running the wrong id is worse than re-running nothing.
+#[must_use]
+fn run_id_from_link(link: &str) -> Option<String> {
+    let after = link.split("/actions/runs/").nth(1)?;
+    let id = after.split('/').next()?;
+    if !id.is_empty() && id.chars().all(|c| c.is_ascii_digit()) {
+        Some(id.to_owned())
+    } else {
+        None
+    }
+}
+
+/// Run `gh` and return stdout, with colour forced off.
+fn gh(args: &[&str]) -> Result<String, PullRequestError> {
+    let out = Command::new("gh")
+        .args(args)
+        .env("NO_COLOR", "1")
+        .env("CLICOLOR_FORCE", "0")
+        .output()
+        .map_err(|error| PullRequestError::Unavailable {
+            provider: GITHUB.into(),
+            reason: format!("could not run `gh`: {error} — is the GitHub CLI installed?"),
+        })?;
+    if out.status.success() {
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_owned())
+    } else {
+        Err(PullRequestError::Failed {
+            provider: GITHUB.into(),
+            reason: String::from_utf8_lossy(&out.stderr).trim().to_owned(),
+        })
+    }
+}
+
+/// Run `gh` and return stdout even when the command exits non-zero.
+///
+/// Some `gh` subcommands report through the exit code and still write the
+/// payload. `gh pr checks` exits 1 on a failing check and 8 on a pending one.
+/// It writes its `--json` output either way. There a non-zero exit is a
+/// verdict about the checks, not a failed command, so the payload has to
+/// survive it. stderr is surfaced only when stdout came back empty. That is
+/// the one case where the command itself could not run.
+fn gh_stdout(args: &[&str]) -> Result<String, PullRequestError> {
+    let out = Command::new("gh")
+        .args(args)
+        .env("NO_COLOR", "1")
+        .env("CLICOLOR_FORCE", "0")
+        .output()
+        .map_err(|error| PullRequestError::Unavailable {
+            provider: GITHUB.into(),
+            reason: format!("could not run `gh`: {error} — is the GitHub CLI installed?"),
+        })?;
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    if stdout.is_empty() && !out.status.success() {
+        return Err(PullRequestError::Failed {
+            provider: GITHUB.into(),
+            reason: String::from_utf8_lossy(&out.stderr).trim().to_owned(),
+        });
+    }
+    Ok(stdout)
+}
+
+/// What a payload this build cannot read is called.
+fn malformed(what: &str, error: &impl std::fmt::Display) -> PullRequestError {
+    PullRequestError::Malformed {
+        provider: GITHUB.into(),
+        reason: format!("`{what}`: {error}"),
+    }
+}
+
+/// Run one `gh api` read and decode a [`GhCheck`] per line.
+///
+/// **The exit status is the read's verdict.** An empty stdout is not. A 404,
+/// an expired token and a rate limit all run `gh`, exit non-zero, and print
+/// little or nothing. `--paginate` widens it. A run whose third page fails
+/// still has the first two on stdout, so a part of the list would come back
+/// as the whole of it.
+///
+/// It matters because a base read that came back empty reads as "the base
+/// does not excuse this failure". That answer costs a fix turn on somebody
+/// else's breakage.
+fn read_checks(endpoint: &str, jq: &str) -> Result<Vec<GhCheck>, PullRequestError> {
+    let out = Command::new("gh")
+        .args(["api", endpoint, "--paginate", "--jq", jq])
+        .env("NO_COLOR", "1")
+        .output()
+        .map_err(|error| PullRequestError::Unavailable {
+            provider: GITHUB.into(),
+            reason: format!("could not run `gh`: {error} — is the GitHub CLI installed?"),
+        })?;
+    if !out.status.success() {
+        return Err(PullRequestError::Failed {
+            provider: GITHUB.into(),
+            reason: String::from_utf8_lossy(&out.stderr).trim().to_owned(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| serde_json::from_str::<GhCheck>(line).ok())
+        .collect())
+}
+
+/// The endpoint carrying a ref's check runs.
+///
+/// Split out so a test can see the one thing that can be wrong here: *which
+/// commit gets asked about*.
+#[must_use]
+fn check_runs_endpoint(git_ref: &str) -> String {
+    format!("repos/{{owner}}/{{repo}}/commits/{git_ref}/check-runs")
+}
+
+/// The endpoint carrying a ref's commit statuses.
+///
+/// A second endpoint, not a second field. GitHub never merged the two APIs,
+/// and `check-runs` holds no commit status.
+#[must_use]
+fn statuses_endpoint(git_ref: &str) -> String {
+    format!("repos/{{owner}}/{{repo}}/commits/{git_ref}/status")
+}
+
+impl PullRequestProvider for GhPullRequests {
+    fn id(&self) -> &str {
+        GITHUB
+    }
+
+    fn open(&self, draft: &PullRequestDraft) -> Result<PullRequestKey, PullRequestError> {
+        let mut args = vec![
+            "pr",
+            "create",
+            "--head",
+            &draft.head_ref,
+            "--title",
+            &draft.title,
+            "--body",
+            &draft.body,
+        ];
+        if draft.draft {
+            args.push("--draft");
+        }
+        let url = gh(&args)?;
+        url.rsplit('/')
+            .next()
+            .filter(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()))
+            .map(|s| PullRequestKey(s.to_owned()))
+            .ok_or_else(|| PullRequestError::Malformed {
+                provider: GITHUB.into(),
+                reason: format!("`gh pr create` printed no pull request number: {url:?}"),
+            })
+    }
+
+    fn get(&self, key: &PullRequestKey) -> Result<PullRequest, PullRequestError> {
+        let raw = gh(&[
+            "pr",
+            "view",
+            key.as_str(),
+            "--json",
+            "number,isDraft,mergeable,reviewDecision,statusCheckRollup,baseRefName,headRefName,\
+             title,body,state,labels",
+        ])?;
+        let row: GhPullRequest =
+            serde_json::from_str(&raw).map_err(|error| malformed("gh pr view", &error))?;
+        // `gh pr view` echoes the number it was asked about. A payload that
+        // dropped the field would decode as pull request 0, and every later
+        // call would address the wrong one.
+        let mut pr = PullRequest::from(row);
+        pr.key = key.clone();
+        Ok(pr)
+    }
+
+    fn list_open(&self, search: Option<&str>) -> Result<Vec<PullRequestSummary>, PullRequestError> {
+        let mut args = vec![
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,body,headRefName",
+        ];
+        if let Some(search) = search {
+            args.extend_from_slice(&["--search", search]);
+        }
+        let raw = gh(&args)?;
+        let rows: Vec<GhPullRequest> =
+            serde_json::from_str(&raw).map_err(|error| malformed("gh pr list", &error))?;
+        Ok(rows
+            .into_iter()
+            .map(|row| PullRequestSummary {
+                key: PullRequestKey(row.number.to_string()),
+                title: row.title,
+                body: row.body,
+                head_ref: row.head_ref_name,
+            })
+            .collect())
+    }
+
+    fn checks_for_ref(&self, git_ref: &str) -> Result<Vec<Check>, PullRequestError> {
+        let mut checks = read_checks(
+            &check_runs_endpoint(git_ref),
+            ".check_runs[] | {name: .name, conclusion: (.conclusion // \"\"), status: .status}",
+        )?;
+
+        // Commit statuses sit behind a second endpoint and speak a second
+        // dialect. They are read apart and appended, because a rollup holds
+        // both. A base showing only half of it would fail to excuse the very
+        // checks most likely to be broken repository-wide: a third-party
+        // service is what posts a commit status. A failed second read leaves
+        // that half, so its failure fails the pair.
+        checks.extend(read_checks(
+            &statuses_endpoint(git_ref),
+            ".statuses[] | {context: .context, state: .state}",
+        )?);
+        Ok(checks.into_iter().map(GhCheck::into_check).collect())
+    }
+
+    fn required_checks(&self, branch: &str) -> Result<Vec<String>, PullRequestError> {
+        let raw = gh(&[
+            "api",
+            &format!("repos/{{owner}}/{{repo}}/branches/{branch}/protection"),
+            "--jq",
+            ".required_status_checks.contexts[]?",
+        ])?;
+        Ok(raw
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(str::to_owned)
+            .collect())
+    }
+
+    fn recent_commits(&self, branch: &str, depth: usize) -> Result<Vec<String>, PullRequestError> {
+        let raw = gh(&[
+            "api",
+            &format!("repos/{{owner}}/{{repo}}/commits?sha={branch}&per_page={depth}"),
+            "--jq",
+            ".[].sha",
+        ])?;
+        Ok(raw
+            .lines()
+            .map(str::trim)
+            .filter(|sha| !sha.is_empty())
+            .take(depth)
+            .map(str::to_owned)
+            .collect())
+    }
+
+    fn mark_ready(&self, key: &PullRequestKey) -> Result<(), PullRequestError> {
+        gh(&["pr", "ready", key.as_str()]).map(|_| ())
+    }
+
+    fn add_label(&self, key: &PullRequestKey, label: &str) -> Result<(), PullRequestError> {
+        gh(&["pr", "edit", key.as_str(), "--add-label", label]).map(|_| ())
+    }
+
+    fn merge(&self, key: &PullRequestKey) -> Result<(), PullRequestError> {
+        // No `--delete-branch`. It deletes the *local* branch too, and this
+        // loop works inside worktrees that hold those branches. So the delete
+        // fails, `gh` exits non-zero, and a merge that already worked is
+        // reported as a failure. That is what it did. A pull request merged,
+        // and the loop went on re-reading it, because the branch cleanup after
+        // the merge had failed.
+        //
+        // Cleanup is not delivery. The forge's own "automatically delete head
+        // branches" setting does it with no local side effect. Losing a branch
+        // can be undone. Losing the record of a merge strands the pull request
+        // for good.
+        let outcome = gh(&["pr", "merge", key.as_str(), "--squash"]).map(|_| ());
+
+        // A pull request that is already merged is the state this asked for.
+        // So it is a success. Racing a human who merged it by hand must not
+        // read as an error. Nor must a re-read after a part-done merge.
+        match outcome {
+            Err(error)
+                if error
+                    .to_string()
+                    .to_ascii_lowercase()
+                    .contains("already merged") =>
+            {
+                Ok(())
+            }
+            other => other,
+        }
+    }
+
+    fn sync_with_base(&self, key: &PullRequestKey) -> Result<(), PullRequestError> {
+        gh(&["pr", "update-branch", key.as_str()]).map(|_| ())
+    }
+
+    fn rerun_failed_checks(&self, key: &PullRequestKey) -> Result<(), PullRequestError> {
+        // `gh pr checks --json` names each check's run only in its URL, so
+        // the run id is read from there.
+        //
+        // `gh pr checks` exits non-zero whenever the checks are not all green.
+        // It exits 1 on a failure and 8 while any are still pending, and it
+        // writes the JSON either way. The plain helper reads that as an error
+        // and throws the payload away. So it cannot be used here. This only
+        // ever runs on a red pull request, which is exactly when the exit code
+        // is non-zero.
+        let raw = gh_stdout(&["pr", "checks", key.as_str(), "--json", "state,link"])?;
+
+        #[derive(serde::Deserialize)]
+        struct Row {
+            #[serde(default)]
+            state: String,
+            #[serde(default)]
+            link: String,
+        }
+
+        let rows: Vec<Row> =
+            serde_json::from_str(&raw).map_err(|error| malformed("gh pr checks", &error))?;
+
+        let mut runs: Vec<String> = rows
+            .iter()
+            .filter(|row| row.state.eq_ignore_ascii_case("FAILURE"))
+            .filter_map(|row| run_id_from_link(&row.link))
+            .collect();
+        runs.sort();
+        runs.dedup();
+
+        if runs.is_empty() {
+            return Err(PullRequestError::Failed {
+                provider: GITHUB.into(),
+                reason: "no failed check named a workflow run to re-run".to_owned(),
+            });
+        }
+
+        for run in &runs {
+            gh(&["run", "rerun", run, "--failed"])?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check_run(name: &str, conclusion: &str) -> GhCheck {
+        GhCheck {
+            name: name.into(),
+            conclusion: conclusion.into(),
+            status: "COMPLETED".into(),
+            ..GhCheck::default()
+        }
+    }
+
+    /// A commit status is a concluded check, not a pending one.
+    ///
+    /// **The witness for the bug that stalled the loop.** A rollup mixes two
+    /// dialects. A check run carries `name`, `status` and `conclusion`. A
+    /// commit status carries `context` and `state`, and no `status`. Reading
+    /// only the first shape does not fail. Every field defaults, so it yields
+    /// a nameless check with no outcome. That check reads as unfinished on
+    /// every poll, for ever.
+    ///
+    /// That is what happened. This repository's Vercel commit status had
+    /// already concluded `FAILURE`. The loop re-read `ci=Pending` for
+    /// twenty-five minutes after all three required checks went green.
+    #[test]
+    fn a_commit_status_is_read_as_concluded_not_as_pending() {
+        let vercel = GhCheck {
+            context: "Vercel".into(),
+            state: "FAILURE".into(),
+            ..GhCheck::default()
+        };
+        assert_eq!(vercel.name(), "Vercel", "it must join by its context");
+        assert_eq!(vercel.outcome(), CheckOutcome::Failed);
+    }
+
+    /// A commit status that really is pending still reads as pending.
+    ///
+    /// The other way round, so the fix above cannot be "call every commit
+    /// status finished".
+    #[test]
+    fn a_pending_commit_status_still_reads_as_pending() {
+        let waiting = GhCheck {
+            context: "Vercel".into(),
+            state: "PENDING".into(),
+            ..GhCheck::default()
+        };
+        assert_eq!(waiting.outcome(), CheckOutcome::Running);
+    }
+
+    /// A completed check run with no conclusion is unknown, not green.
+    #[test]
+    fn a_completed_check_with_no_conclusion_is_still_running() {
+        assert_eq!(check_run("ci", "").outcome(), CheckOutcome::Running);
+        assert_eq!(check_run("ci", "SUCCESS").outcome(), CheckOutcome::Passed);
+    }
+
+    /// A skipped job did not run, so it is neither a pass nor a failure.
+    ///
+    /// Counting it as pending would stall the loop on a job that is skipped
+    /// by design. This repository skips several on a docs-only diff.
+    #[test]
+    fn a_skipped_check_is_inert() {
+        assert_eq!(check_run("docs", "SKIPPED").outcome(), CheckOutcome::Inert);
+        assert_eq!(
+            check_run("docs", "CANCELLED").outcome(),
+            CheckOutcome::Inert
+        );
+    }
+
+    /// A service that broke while running its own check is a failure.
+    #[test]
+    fn a_check_that_errored_counts_as_failed() {
+        for raw in ["FAILURE", "ERROR", "TIMED_OUT", "STARTUP_FAILURE"] {
+            assert_eq!(
+                check_run("ci", raw).outcome(),
+                CheckOutcome::Failed,
+                "{raw} is a failure"
+            );
+        }
+    }
+
+    /// The base is asked about by branch name, so no local ref can go stale.
+    ///
+    /// A remote-tracking name resolves against the last fetch, and this loop
+    /// never fetches. A base that broke while the process was up would still
+    /// resolve to the older commit. Then a failure the base handed down gets
+    /// scored as the pull request's own. One pull request was escalated for a
+    /// `cargo fmt` diff in a file it never touched.
+    ///
+    /// So the check is on the *absence* of `origin/`. That name is what brings
+    /// the staleness back.
+    #[test]
+    fn the_base_is_named_to_the_forge_not_a_remote_tracking_ref() {
+        let endpoint = check_runs_endpoint("main");
+        assert_eq!(endpoint, "repos/{owner}/{repo}/commits/main/check-runs");
+        assert!(
+            !endpoint.contains("origin/"),
+            "a remote-tracking ref resolves against the last fetch, not the forge: {endpoint}"
+        );
+    }
+
+    /// A check link naming a workflow run yields its id, and anything else
+    /// yields nothing.
+    #[test]
+    fn only_an_actions_link_names_a_run_to_rerun() {
+        assert_eq!(
+            run_id_from_link("https://github.com/o/r/actions/runs/12345/job/9"),
+            Some("12345".to_owned())
+        );
+        assert_eq!(run_id_from_link("https://vercel.com/dashboard"), None);
+        assert_eq!(run_id_from_link(""), None);
+    }
+
+    /// The whole payload decodes into the port's shape.
+    #[test]
+    fn a_gh_pr_view_payload_maps_onto_a_pull_request() {
+        let raw = r#"{
+            "number": 4022,
+            "isDraft": true,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "",
+            "baseRefName": "main",
+            "headRefName": "fix/4022-x",
+            "title": "a title",
+            "body": "Closes #4022",
+            "state": "OPEN",
+            "labels": [{"name": "stella-verified-locally"}],
+            "statusCheckRollup": [
+                {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"context": "Vercel", "state": "FAILURE"}
+            ]
+        }"#;
+        let row: GhPullRequest = serde_json::from_str(raw).expect("decode");
+        let pr = PullRequest::from(row);
+
+        assert_eq!(pr.key, PullRequestKey::from("4022"));
+        assert_eq!(pr.state, PullRequestState::Open);
+        assert!(pr.draft);
+        assert_eq!(pr.base_ref, "main");
+        assert_eq!(pr.head_ref, "fix/4022-x");
+        assert_eq!(pr.merge_status, MergeStatus::Clean);
+        assert_eq!(pr.review, ReviewDecision::None);
+        assert_eq!(pr.labels, vec!["stella-verified-locally".to_owned()]);
+        assert_eq!(
+            pr.checks,
+            vec![
+                Check {
+                    name: "ci".to_owned(),
+                    outcome: CheckOutcome::Passed
+                },
+                Check {
+                    name: "Vercel".to_owned(),
+                    outcome: CheckOutcome::Failed
+                },
+            ]
+        );
+    }
+
+    /// An unknown state keeps the caller asking. It never calls a pull
+    /// request finished.
+    #[test]
+    fn an_unknown_state_reads_as_open() {
+        assert_eq!(state_from("MERGED"), PullRequestState::Merged);
+        assert_eq!(state_from("CLOSED"), PullRequestState::Closed);
+        assert_eq!(state_from("DRAFTING"), PullRequestState::Open);
+    }
+
+    /// Mergeability the forge has not computed is unknown, never clean.
+    #[test]
+    fn unknown_mergeability_is_not_clean() {
+        assert_eq!(merge_status_from("MERGEABLE"), MergeStatus::Clean);
+        assert_eq!(merge_status_from("CONFLICTING"), MergeStatus::Conflicted);
+        assert_eq!(merge_status_from("UNKNOWN"), MergeStatus::Unknown);
+        assert_eq!(merge_status_from(""), MergeStatus::Unknown);
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd.rs
+++ b/crates/stella-cli/src/self_driving_cmd.rs
@@ -34,6 +34,9 @@ pub(crate) mod contention;
 mod convention;
 mod curate;
 pub(crate) mod deliver;
+// `stella self-driving deliver` — the one-shot pull request verbs, split out
+// of this file so it stays under the size ceiling.
+mod deliver_verb;
 mod drive;
 pub(crate) mod governor;
 mod graph_seed;
@@ -665,7 +668,7 @@ pub(crate) fn run(cmd: &SelfDrivingCmd, flags: &TurnFlags) -> Result<(), String>
             format,
         } => file_finding(&st, title, body, labels, *format),
         SelfDrivingCmd::Work { issue, format } => work_issue(&st, issue, flags, *format),
-        SelfDrivingCmd::Deliver { cmd } => deliver_cmd(cmd),
+        SelfDrivingCmd::Deliver { cmd } => deliver_verb::run(cmd),
         SelfDrivingCmd::Drive {
             max_issues,
             no_review,
@@ -1097,116 +1100,6 @@ fn advance_aperture(st: &LoopState, current: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// `stella self-driving deliver` — the pull-request rhythm.
-///
-/// Every arm that acts re-derives the decision from a fresh observation rather
-/// than trusting a verdict handed to it. `merge` in particular does **not**
-/// take "the caller already ran `next`" as evidence: the forge moves between
-/// calls, and a merge authorised by a stale read is exactly the failure the
-/// machine's `Mergeability::Unknown` arm exists to prevent one layer down.
-fn deliver_cmd(cmd: &DeliverCmd) -> Result<(), String> {
-    let root = state::repo_root();
-
-    match cmd {
-        DeliverCmd::Open {
-            issue,
-            branch,
-            title,
-        } => {
-            let attribution = config::load(&root).attribution;
-            let pr = deliver::open(&root, branch, issue, title, &attribution.pull_request)?;
-            println!("opened #{pr} for #{issue} from {branch}");
-            Ok(())
-        }
-
-        DeliverCmd::Observe { pr, format } => {
-            let obs = deliver::observe(pr, &config::load(&state::repo_root()).merge)?.observation;
-            if *format == QueryFormat::Json {
-                println!(
-                    "{}",
-                    serde_json::to_string(&obs).map_err(|e| e.to_string())?
-                );
-            } else {
-                println!(
-                    "pr #{pr}: ci={:?} base_ci={:?} mergeable={:?} review={:?} draft={}",
-                    obs.ci, obs.base_ci, obs.mergeable, obs.review, obs.draft
-                );
-            }
-            Ok(())
-        }
-
-        DeliverCmd::Next {
-            pr,
-            fixes,
-            rebases,
-            no_review,
-            format,
-        } => {
-            let transition = decide(pr, *fixes, *rebases, *no_review)?;
-            if *format == QueryFormat::Json {
-                println!(
-                    "{}",
-                    serde_json::to_string(&transition).map_err(|e| e.to_string())?
-                );
-            } else {
-                println!(
-                    "pr #{pr}: {:?} -> {:?}",
-                    transition.state, transition.action
-                );
-            }
-            Ok(())
-        }
-
-        DeliverCmd::Merge {
-            pr,
-            fixes,
-            rebases,
-            no_review,
-        } => {
-            let transition = decide(pr, *fixes, *rebases, *no_review)?;
-            if transition.action != stella_autonomy::Action::Merge {
-                // Refused, not silently skipped: a caller that asked to merge
-                // and got nothing must be able to tell "already merged" from
-                // "not allowed yet".
-                return Err(format!(
-                    "pr #{pr} is not mergeable yet — the machine says {:?} ({:?})",
-                    transition.action, transition.state
-                ));
-            }
-            deliver::merge(pr)?;
-            println!("merged #{pr}");
-            Ok(())
-        }
-    }
-}
-
-/// Observe the forge and run the pure machine over what it said.
-fn decide(
-    pr: &str,
-    fixes: u32,
-    rebases: u32,
-    no_review: bool,
-) -> Result<stella_autonomy::Transition, String> {
-    let obs = deliver::observe(pr, &config::load(&state::repo_root()).merge)?.observation;
-    let policy = stella_autonomy::DeliverPolicy {
-        require_approval: !no_review,
-        ..stella_autonomy::DeliverPolicy::default()
-    };
-    let attempts = stella_autonomy::Attempts { fixes, rebases };
-
-    // The state is re-derived from the observation each call rather than
-    // persisted: the forge is the source of truth about a pull request, and a
-    // remembered state that disagreed with it would be the stale-read defect
-    // this design is trying to avoid. `CiPending` is the neutral entry point —
-    // every arm of the machine is reachable from it.
-    Ok(stella_autonomy::deliver_next(
-        stella_autonomy::PrState::CiPending,
-        &obs,
-        attempts,
-        &policy,
-    ))
-}
-
 /// `stella self-driving work` — run one issue to a diff.
 ///
 /// The issue is resolved through the port **before** anything touches git, so
@@ -1262,7 +1155,15 @@ fn work_issue(
     // child turn's ceiling is decided and one place its cost is folded back in
     // (#4353).
     let mut budget = budget::RunBudget::new(flags.clone());
-    let outcome = work::start(&root, &issue, &mut budget, attribution, &loop_config.worker)?;
+    let forge = crate::pull_request_provider::GhPullRequests::new();
+    let outcome = work::start(
+        &forge,
+        &root,
+        &issue,
+        &mut budget,
+        attribution,
+        &loop_config.worker,
+    )?;
     let learned = learning::tally(&root).since(learned_before);
     hooks::after_issue_work(&root, &settings, &hook_issue, hook_outcome(&outcome));
 

--- a/crates/stella-cli/src/self_driving_cmd/contention.rs
+++ b/crates/stella-cli/src/self_driving_cmd/contention.rs
@@ -67,6 +67,7 @@
 use std::path::Path;
 
 use stella_autonomy::Contention;
+use stella_protocol::pull_request::{PullRequestProvider, PullRequestSummary};
 
 use super::state::git;
 
@@ -77,8 +78,8 @@ use super::state::git;
 /// is what repairs it — one step further on than a deferral ever reaches
 /// (#4300).
 #[must_use]
-pub(super) fn for_issue(root: &Path, key: &str) -> Contention {
-    gather(root, key, Some(&super::work::worktrees_root(root)))
+pub(super) fn for_issue(forge: &dyn PullRequestProvider, root: &Path, key: &str) -> Contention {
+    gather(forge, root, key, Some(&super::work::worktrees_root(root)))
 }
 
 /// Every contention signal for one issue key, **before adopting a broken
@@ -89,8 +90,8 @@ pub(super) fn for_issue(root: &Path, key: &str) -> Contention {
 /// adopt the same breakage and race to fix it, and unlike the claim site there
 /// is no recovery downstream that repairs a leftover of the loop's own.
 #[must_use]
-pub(super) fn for_base_fix(root: &Path, key: &str) -> Contention {
-    gather(root, key, None)
+pub(super) fn for_base_fix(forge: &dyn PullRequestProvider, root: &Path, key: &str) -> Contention {
+    gather(forge, root, key, None)
 }
 
 /// The four reads, with the one policy difference as an argument.
@@ -101,15 +102,20 @@ pub(super) fn for_base_fix(root: &Path, key: &str) -> Contention {
 /// is unreachable" is not a peer and a loop meant to run for days cannot treat
 /// a network blip as somebody else's work.
 #[must_use]
-fn gather(root: &Path, key: &str, own_root: Option<&Path>) -> Contention {
+fn gather(
+    forge: &dyn PullRequestProvider,
+    root: &Path,
+    key: &str,
+    own_root: Option<&Path>,
+) -> Contention {
     let mut contention = Contention::default();
 
     if let Some(out) = git(root, &["ls-remote", "--heads", "origin"]) {
         contention.remote_branches = branches_naming(&out, key);
     }
 
-    if let Ok(raw) = super::deliver::prs_matching(key) {
-        contention.open_prs = raw;
+    if let Ok(numbers) = super::deliver::prs_matching(forge, key) {
+        contention.open_prs = numbers;
     }
 
     if let Some(out) = git(root, &["worktree", "list", "--porcelain"]) {
@@ -211,46 +217,37 @@ pub(super) fn worktrees_naming(porcelain: &str, key: &str, own_root: Option<&Pat
         .collect()
 }
 
-/// Pull request numbers from a `gh pr list --json number,title,body` payload,
-/// keeping the ones whose text names `key` as an issue.
+/// Pull request numbers from a forge listing, keeping the ones whose text
+/// names `key` as an issue.
 ///
-/// The search that produced this payload is a full-text one on the bare
-/// number, so the forge answers with every open pull request that mentions it
-/// for any reason — "43 files changed", "cuts latency by 43%". Each of those
-/// deferred issue #43, and a deferral writes no `spent` entry, so it deferred
-/// again on the next pass. `deliver::open_prs_for_issue`, in the same file,
-/// already searched the precise form; this one did not.
+/// The search that produced these rows is a full-text one on the bare number,
+/// so the forge answers with every open pull request that mentions it for any
+/// reason — "43 files changed", "cuts latency by 43%". Each of those deferred
+/// issue #43, and a deferral writes no `spent` entry, so it deferred again on
+/// the next pass. `deliver::open_prs_for_issue` searches the precise form;
+/// this one did not.
 ///
 /// A mention is `#<key>` with no digit after it, so `#43` names issue 43 and
 /// `#4300` does not. The loop writes `Closes #<key>` into every pull request it
 /// opens, so its own always match.
 ///
-/// Two tolerances, both in the direction that keeps a signal rather than losing
-/// one: a row missing `number` is skipped rather than failing the whole read,
-/// and a row carrying **neither** `title` nor `body` counts as contention. This
+/// A row carrying **neither** a title nor a body counts as contention. This
 /// build cannot tell whether such a row names the issue, and silently dropping
 /// a contention signal it could not read is what ends with two loops on one
 /// issue.
 #[must_use]
-pub(super) fn prs_naming(raw: &str, key: &str) -> Vec<String> {
-    let Ok(rows) = serde_json::from_str::<Vec<serde_json::Value>>(raw) else {
-        return Vec::new();
-    };
+pub(super) fn prs_naming(rows: &[PullRequestSummary], key: &str) -> Vec<String> {
     let reference = format!("#{key}");
     rows.iter()
         .filter(|row| {
-            let title = row.get("title").and_then(serde_json::Value::as_str);
-            let body = row.get("body").and_then(serde_json::Value::as_str);
-            match (title, body) {
-                (None, None) => true,
-                _ => [title, body]
-                    .into_iter()
-                    .flatten()
-                    .any(|text| names_issue(text, &reference)),
+            if row.title.is_empty() && row.body.is_empty() {
+                return true;
             }
+            [row.title.as_str(), row.body.as_str()]
+                .into_iter()
+                .any(|text| names_issue(text, &reference))
         })
-        .filter_map(|row| row.get("number").and_then(serde_json::Value::as_u64))
-        .map(|n| n.to_string())
+        .map(|row| row.key.0.clone())
         .collect()
 }
 
@@ -658,22 +655,32 @@ mod tests {
         );
     }
 
+    /// One row of a forge listing.
+    fn summary(number: &str, title: &str, body: &str) -> PullRequestSummary {
+        PullRequestSummary {
+            key: stella_protocol::pull_request::PullRequestKey::from(number),
+            title: title.to_owned(),
+            body: body.to_owned(),
+            head_ref: String::new(),
+        }
+    }
+
     /// A pull request that merely contains the number is not about the issue.
     ///
-    /// The search behind this payload is full-text on the bare number, so the
+    /// The search behind this listing is full-text on the bare number, so the
     /// forge returns everything mentioning it. Counting all of them deferred
     /// the issue, and a deferral writes no `spent` entry, so it deferred again
     /// every pass.
     #[test]
     fn a_pull_request_that_only_mentions_the_number_is_not_contention() {
-        let raw = r#"[
-            {"number":11,"title":"perf: cuts latency by 43%","body":"no issue here"},
-            {"number":12,"title":"43 files changed","body":"a sweep"},
-            {"number":13,"title":"fix: the thing","body":"Closes #43"}
-        ]"#;
+        let rows = [
+            summary("11", "perf: cuts latency by 43%", "no issue here"),
+            summary("12", "43 files changed", "a sweep"),
+            summary("13", "fix: the thing", "Closes #43"),
+        ];
 
         assert_eq!(
-            prs_naming(raw, "43"),
+            prs_naming(&rows, "43"),
             vec!["13".to_string()],
             "only the one that names the issue"
         );
@@ -682,38 +689,29 @@ mod tests {
     /// `#43` is not `#4300`.
     #[test]
     fn a_longer_issue_reference_is_not_a_mention_of_its_prefix() {
-        let raw = r#"[
-            {"number":11,"title":"fix","body":"Closes #4300"},
-            {"number":12,"title":"fix","body":"Refs #43, and more"}
-        ]"#;
+        let rows = [
+            summary("11", "fix", "Closes #4300"),
+            summary("12", "fix", "Refs #43, and more"),
+        ];
 
-        assert_eq!(prs_naming(raw, "43"), vec!["12".to_string()]);
+        assert_eq!(prs_naming(&rows, "43"), vec!["12".to_string()]);
     }
 
     /// A row this build cannot read counts as contention rather than vanishing.
     ///
     /// The two errors are not symmetric: keeping a row the build cannot
     /// classify costs a deferral, and dropping it costs two loops working one
-    /// issue. A forge that stops returning `title` and `body` must not silently
+    /// issue. A forge that stops returning a title and a body must not silently
     /// switch this signal off.
     #[test]
     fn a_row_with_no_text_at_all_is_kept() {
         assert_eq!(
-            prs_naming(r#"[{"number":7}]"#, "43"),
+            prs_naming(&[summary("7", "", "")], "43"),
             vec!["7".to_string()],
             "neither field present: this build cannot tell, so it does not drop it"
         );
         // A row with text that simply does not name the issue is still dropped.
-        assert!(prs_naming(r#"[{"number":7,"title":"unrelated"}]"#, "43").is_empty());
-        // And a row with no number is skipped rather than failing the read.
-        assert_eq!(
-            prs_naming(
-                r#"[{"title":"Closes #43"},{"number":9,"body":"Closes #43"}]"#,
-                "43"
-            ),
-            vec!["9".to_string()]
-        );
-        assert!(prs_naming("not json at all", "43").is_empty());
+        assert!(prs_naming(&[summary("7", "unrelated", "")], "43").is_empty());
     }
 
     /// One claim, as the ledger would hand it back.

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -12,7 +12,7 @@
 //! # The forge is a port
 //!
 //! Every function here takes a
-//! [`PullRequestProvider`](stella_protocol::pull_request::PullRequestProvider).
+//! [`stella_protocol::pull_request::PullRequestProvider`].
 //! Nothing in this module spells `gh`: the shipping adapter is
 //! `crate::pull_request_provider`, GitHub's two check dialects are its
 //! business, and a test hands over a fixture forge and runs the same code that

--- a/crates/stella-cli/src/self_driving_cmd/deliver.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver.rs
@@ -9,6 +9,20 @@
 //! machine where a test can pin it, and everything here is reading a forge and
 //! running `git`.
 //!
+//! # The forge is a port
+//!
+//! Every function here takes a
+//! [`PullRequestProvider`](stella_protocol::pull_request::PullRequestProvider).
+//! Nothing in this module spells `gh`: the shipping adapter is
+//! `crate::pull_request_provider`, GitHub's two check dialects are its
+//! business, and a test hands over a fixture forge and runs the same code that
+//! ships. It is the pull request half of what `crate::issue_provider` already
+//! did for the backlog.
+//!
+//! What stays above the port is policy — which checks may block a merge,
+//! whether a red base excuses a red pull request, and what to try when a
+//! verdict is stale.
+//!
 //! # `base_ci` is a second read, and it is the point
 //!
 //! The machine separates [`CiRed`](stella_autonomy::PrState::CiRed) from
@@ -29,121 +43,30 @@
 //! # Closing the issue takes both spellings
 //!
 //! `deliver open` writes `Closes #N` into the pull request body **and** as a
-//! commit trailer. Both are required and AGENTS.md § *Closing the issue on
-//! merge* says why: a squash merge composes the commit message from
-//! `COMMIT_MESSAGES` and never from the PR body, so a `Closes` that exists only
-//! in the description never reaches the commit — and a rebase merge replays the
-//! commits verbatim, so the PR body is likewise never consulted. Either alone is
-//! a silent single point of failure whose failure mode is invisible until
-//! someone audits the backlog.
+//! commit trailer. Both are required, and AGENTS.md § *Closing the issue on
+//! merge* says why. A squash merge builds the commit message from
+//! `COMMIT_MESSAGES`, never from the PR body. So a `Closes` that lives only in
+//! the description never reaches the commit. A rebase merge replays the
+//! commits as they are, so it never reads the PR body either. Either spelling
+//! alone can fail on its own, and nothing shows it until someone audits the
+//! backlog.
 
 use stella_autonomy::{CiConclusion, Mergeability, Observation, ReviewState};
+use stella_protocol::pull_request::{
+    Check, CheckOutcome, MergeStatus, PullRequest, PullRequestDraft, PullRequestKey,
+    PullRequestProvider, ReviewDecision,
+};
+
+#[cfg(test)]
+pub(super) mod fixture;
+#[cfg(test)]
+mod witness;
 
 use super::state::git;
 
-/// One check as the forge reports it, reduced to what the mapping reads.
-///
-/// # There are two kinds of check and they do not share a spelling
-///
-/// A pull request's rollup mixes **check runs** (GitHub Actions: `name`,
-/// `status`, `conclusion`) with **commit statuses** (the older API that
-/// third-party services still post to: `context`, `state`, and no `status`
-/// field at all). Deserializing only the first shape does not fail — every
-/// field is `#[serde(default)]` — it silently produces a check with no name
-/// and no conclusion.
-///
-/// Which reads as *pending forever*: `status` is not `COMPLETED`, so
-/// [`Self::pending`] is true on every poll, for a check that concluded before
-/// the loop ever looked. That is what it did. This repository carries a Vercel
-/// commit status that has been failing on every pull request, and the loop sat
-/// on #4022 re-reading `ci=Pending` for twenty-five minutes after all three
-/// required checks had gone green.
-///
-/// The empty `name` is the same bug's other half: [`base_conclusion`] joins by
-/// name, and every commit status would have joined against every other.
-#[derive(Debug, Clone, Default, serde::Deserialize)]
-pub(super) struct Check {
-    /// A check run's name.
-    #[serde(default)]
-    pub name: String,
-    /// A commit status's name. GitHub calls the same thing `context` here.
-    #[serde(default)]
-    pub context: String,
-    /// A check run's outcome: `SUCCESS`, `FAILURE`, `SKIPPED`, `""` while
-    /// running.
-    #[serde(default)]
-    pub conclusion: String,
-    /// A commit status's outcome: `SUCCESS`, `FAILURE`, `ERROR`, `PENDING`,
-    /// `EXPECTED`.
-    #[serde(default)]
-    pub state: String,
-    /// A check run's progress: `COMPLETED`, `IN_PROGRESS`, `QUEUED`. **Absent
-    /// on a commit status**, which is how the two are told apart.
-    #[serde(default)]
-    pub status: String,
-}
-
-impl Check {
-    /// The join key, whichever shape reported it.
-    pub(super) fn name(&self) -> &str {
-        if self.name.is_empty() {
-            &self.context
-        } else {
-            &self.name
-        }
-    }
-
-    /// The outcome, whichever shape reported it.
-    fn outcome(&self) -> String {
-        let raw = if self.conclusion.is_empty() {
-            &self.state
-        } else {
-            &self.conclusion
-        };
-        raw.trim().to_ascii_uppercase()
-    }
-
-    /// Whether this is a commit status rather than a check run.
-    ///
-    /// The absence of `status` is the discriminator, because it is the one
-    /// field the older API has no equivalent for.
-    fn is_commit_status(&self) -> bool {
-        self.status.trim().is_empty()
-    }
-
-    /// Whether this check has concluded and concluded badly.
-    ///
-    /// `ERROR` is a commit status's way of saying the service itself broke,
-    /// which is a failure for every purpose this loop has.
-    fn failed(&self) -> bool {
-        matches!(
-            self.outcome().as_str(),
-            "FAILURE" | "ERROR" | "TIMED_OUT" | "STARTUP_FAILURE" | "ACTION_REQUIRED"
-        )
-    }
-
-    /// Whether it has not finished.
-    fn pending(&self) -> bool {
-        if self.is_commit_status() {
-            // No progress field exists, so the outcome is the whole story.
-            return matches!(self.outcome().as_str(), "PENDING" | "EXPECTED" | "");
-        }
-        !self.status.eq_ignore_ascii_case("COMPLETED")
-            // A completed check with no conclusion is a forge quirk, not a
-            // pass: treated as still-unknown rather than green, on the same
-            // reasoning as `Mergeability::Unknown`.
-            || self.outcome().is_empty()
-    }
-
-    /// Whether it should be ignored entirely.
-    ///
-    /// A skipped or neutral check is not a failure and not a pass — it did not
-    /// run. Counting it as pending would stall the loop forever on a job that
-    /// is skipped by design (this repository skips several on a docs-only
-    /// diff).
-    fn inert(&self) -> bool {
-        matches!(self.outcome().as_str(), "SKIPPED" | "NEUTRAL" | "CANCELLED")
-    }
+/// Whether a check has concluded badly.
+fn failed(check: &Check) -> bool {
+    check.outcome == CheckOutcome::Failed
 }
 
 /// Reduce a rollup to the one conclusion the machine branches on.
@@ -151,16 +74,24 @@ impl Check {
 /// Red wins over pending: a build that has already failed does not become
 /// undecided because something else is still running, and waiting for the rest
 /// before saying so only delays the fix.
+///
+/// A check the forge reported as [`Inert`](CheckOutcome::Inert) is dropped
+/// first. It did not run, so it is neither a pass nor a failure, and counting
+/// it as pending would stall the loop forever on a job that is skipped by
+/// design — this repository skips several on a docs-only diff.
 #[must_use]
 pub(super) fn ci_from(checks: &[Check]) -> CiConclusion {
-    let live: Vec<&Check> = checks.iter().filter(|c| !c.inert()).collect();
+    let live: Vec<&Check> = checks
+        .iter()
+        .filter(|c| c.outcome != CheckOutcome::Inert)
+        .collect();
     if live.is_empty() {
         return CiConclusion::Pending;
     }
-    if live.iter().any(|c| c.failed()) {
+    if live.iter().copied().any(failed) {
         return CiConclusion::Red;
     }
-    if live.iter().any(|c| c.pending()) {
+    if live.iter().any(|c| c.outcome == CheckOutcome::Running) {
         return CiConclusion::Pending;
     }
     CiConclusion::Green
@@ -182,7 +113,11 @@ pub(super) fn ci_from(checks: &[Check]) -> CiConclusion {
 /// forbids spending on somebody else's breakage.
 #[must_use]
 pub(super) fn base_conclusion(pr: &[Check], base: Option<&[Check]>) -> CiConclusion {
-    let failing_here: Vec<&str> = pr.iter().filter(|c| c.failed()).map(Check::name).collect();
+    let failing_here: Vec<&str> = pr
+        .iter()
+        .filter(|c| failed(c))
+        .map(|c| c.name.as_str())
+        .collect();
 
     if failing_here.is_empty() {
         // Nothing failed here, so there is nothing for the base to excuse, and
@@ -194,7 +129,7 @@ pub(super) fn base_conclusion(pr: &[Check], base: Option<&[Check]>) -> CiConclus
         return CiConclusion::Red;
     };
 
-    let failing_there = |name: &str| base.iter().any(|c| c.name() == name && c.failed());
+    let failing_there = |name: &str| base.iter().any(|c| c.name == name && failed(c));
 
     if failing_here.iter().all(|name| failing_there(name)) {
         CiConclusion::Red
@@ -203,75 +138,39 @@ pub(super) fn base_conclusion(pr: &[Check], base: Option<&[Check]>) -> CiConclus
     }
 }
 
-/// Map the forge's mergeability string.
+/// Map the forge's mergeability onto the machine's.
 ///
-/// `UNKNOWN` and anything unrecognised become [`Mergeability::Unknown`] rather
-/// than `Clean`: GitHub reports the field before it has computed it, and
-/// reading that as clean is how a merge is attempted into a conflict.
+/// [`MergeStatus::Unknown`] becomes [`Mergeability::Unknown`] rather than
+/// `Clean`: a forge reports the field before it has computed it, and reading
+/// that as clean is how a merge is attempted into a conflict.
 #[must_use]
-pub(super) fn mergeable_from(raw: &str) -> Mergeability {
-    match raw.to_ascii_uppercase().as_str() {
-        "MERGEABLE" => Mergeability::Clean,
-        "CONFLICTING" => Mergeability::Conflicted,
-        _ => Mergeability::Unknown,
+pub(super) fn mergeable_from(raw: MergeStatus) -> Mergeability {
+    match raw {
+        MergeStatus::Clean => Mergeability::Clean,
+        MergeStatus::Conflicted => Mergeability::Conflicted,
+        MergeStatus::Unknown => Mergeability::Unknown,
     }
 }
 
-/// Map the forge's review decision.
-///
-/// An empty string is "nobody has reviewed", which is what GitHub returns when
-/// a repository does not require review at all.
+/// Map the forge's review decision onto the machine's.
 #[must_use]
-pub(super) fn review_from(raw: &str) -> ReviewState {
-    match raw.to_ascii_uppercase().as_str() {
-        "APPROVED" => ReviewState::Approved,
-        "CHANGES_REQUESTED" => ReviewState::ChangesRequested,
-        _ => ReviewState::None,
+pub(super) fn review_from(raw: ReviewDecision) -> ReviewState {
+    match raw {
+        ReviewDecision::Approved => ReviewState::Approved,
+        ReviewDecision::ChangesRequested => ReviewState::ChangesRequested,
+        ReviewDecision::None => ReviewState::None,
     }
-}
-
-/// The payload `gh pr view` returns, in the shape this module reads.
-///
-/// The forge's camelCase spellings are confined here by `rename`, the same way
-/// `issue_provider.rs` confines GitHub's issue field names: this struct is the
-/// only place in the tree that has to know how one forge spells things.
-#[derive(Debug, Clone, serde::Deserialize)]
-pub(super) struct PrView {
-    #[serde(default, rename = "isDraft")]
-    pub is_draft: bool,
-    #[serde(default)]
-    pub mergeable: String,
-    #[serde(default, rename = "reviewDecision")]
-    pub review_decision: String,
-    #[serde(default, rename = "statusCheckRollup")]
-    pub status_check_rollup: Vec<Check>,
-    /// The branch this pull request targets, so the base is read from the
-    /// branch it actually merges into rather than an assumed `main`.
-    #[serde(default, rename = "baseRefName")]
-    pub base_ref_name: String,
-    /// The pull request's labels, which is where local verification is
-    /// recorded so it survives a restart.
-    #[serde(default)]
-    pub labels: Vec<stella_protocol::IssueLabel>,
-    /// `OPEN`, `MERGED`, `CLOSED`.
-    ///
-    /// Read because a pull request that has already reached its destination
-    /// needs no further transition, and the observation the pure machine
-    /// decides over cannot express that: a merged pull request reports
-    /// `mergeable: UNKNOWN`, which is `Wait` — forever.
-    #[serde(default)]
-    pub state: String,
 }
 
 /// Assemble the observation the pure machine decides over.
 #[must_use]
-pub(super) fn observation_from(view: &PrView, base_checks: Option<&[Check]>) -> Observation {
+pub(super) fn observation_from(pr: &PullRequest, base_checks: Option<&[Check]>) -> Observation {
     Observation {
-        ci: ci_from(&view.status_check_rollup),
-        base_ci: base_conclusion(&view.status_check_rollup, base_checks),
-        mergeable: mergeable_from(&view.mergeable),
-        review: review_from(&view.review_decision),
-        draft: view.is_draft,
+        ci: ci_from(&pr.checks),
+        base_ci: base_conclusion(&pr.checks, base_checks),
+        mergeable: mergeable_from(pr.merge_status),
+        review: review_from(pr.review),
+        draft: pr.draft,
     }
 }
 
@@ -301,101 +200,57 @@ pub(super) fn commit_trailer(issue_key: &str) -> String {
 /// Re-decide a red verdict against the base as it stands now.
 ///
 /// The one remedy the loop has for a red it did not cause and cannot see. A
-/// check that ran against a base which has since been repaired keeps its
-/// failing verdict forever, and `base_conclusion` compares what is failing
-/// *now* — so once the base goes green the pull request is left holding a
-/// failure that reproduces nowhere.
+/// check that ran against a base somebody has since repaired keeps its failing
+/// verdict for ever. `base_conclusion` compares what is failing *now*. So once
+/// the base goes green, the pull request holds a failure that happens
+/// nowhere.
 ///
 /// # Re-running alone does not do it, and that is the whole subtlety
 ///
-/// A `pull_request` run is anchored to the merge commit computed when the run
-/// was **created**. `gh run rerun` replays that same commit, stale base and
-/// all. Measured here rather than assumed: #4022's failed job was re-run at
-/// 23:28, twelve minutes after #4015 repaired `main`, and reproduced the
-/// identical `cargo fmt` diff at `stella-autonomy/src/lib.rs:824` that only
-/// ever existed on the old base.
+/// A `pull_request` run is pinned to the merge commit worked out when the run
+/// was **created**. Re-running replays that same commit, stale base and all.
+/// This was measured, not assumed. One failed job was re-run twelve minutes
+/// after a repair landed on `main`. It produced the same `cargo fmt` diff at
+/// `stella-autonomy/src/lib.rs`'s `sign` that only ever existed on the old
+/// base.
 ///
 /// So the base is merged in first — a new head commit, and a fresh run that
-/// sees the repair. Re-running is kept as the fallback for the case
-/// `update-branch` declines, which is a branch that is *already* current: then
-/// there is no staleness to clear and a red that re-runs green was a flake.
+/// sees the repair. Re-running is kept as the fallback for the case the forge
+/// declines the sync, which is a branch that is *already* current: then there
+/// is no staleness to clear and a red that re-runs green was a flake.
 ///
 /// Either way the caller bounds this to once per pull request, so a genuine
 /// failure reaches the fix path on the next poll.
-pub(super) fn refresh_against_base(pr: &str) -> Result<(), String> {
+pub(super) fn refresh_against_base(
+    forge: &dyn PullRequestProvider,
+    pr: &str,
+) -> Result<(), String> {
+    let key = PullRequestKey::from(pr);
     // Ahead of the fallback because it is the one that can actually change the
     // answer. A branch already level with the base refuses here, which is
     // exactly when re-running is the right move instead.
-    if gh(&["pr", "update-branch", pr]).is_ok() {
+    if forge.sync_with_base(&key).is_ok() {
         return Ok(());
     }
-    rerun_failed(pr)
+    forge
+        .rerun_failed_checks(&key)
+        .map_err(|error| error.to_string())
 }
 
-/// Ask the forge to run this pull request's failed checks again.
+/// Keep only the checks that can block a merge.
 ///
-/// The fallback half of [`refresh_against_base`] — correct for a flake, and
-/// unable to clear a stale base. See that function for why the distinction
-/// matters.
-fn rerun_failed(pr: &str) -> Result<(), String> {
-    // `gh pr checks --json` names the run each check belongs to only through
-    // its URL, so the run id is recovered from there. A pull request whose
-    // checks all pass yields nothing to re-run, which is not an error.
-    //
-    // `gh pr checks` exits non-zero whenever the checks are not all green —
-    // exit 1 on a failure, exit 8 while any are still pending — and does so
-    // *while still writing the requested JSON to stdout*. The plain `gh`
-    // helper reads that as an error and throws the payload away, so it cannot
-    // be used here: this fallback only ever runs on a red pull request, i.e.
-    // exactly when the exit code is non-zero. Read stdout regardless of exit
-    // status and let the JSON parse below be the arbiter instead.
-    let raw = gh_stdout(&["pr", "checks", pr, "--json", "state,link"])?;
-
-    #[derive(serde::Deserialize)]
-    struct Row {
-        #[serde(default)]
-        state: String,
-        #[serde(default)]
-        link: String,
-    }
-
-    let rows: Vec<Row> = serde_json::from_str(&raw).map_err(|error| {
-        format!("`gh pr checks` returned a payload this build cannot read: {error}")
-    })?;
-
-    let mut runs: Vec<String> = rows
-        .iter()
-        .filter(|row| row.state.eq_ignore_ascii_case("FAILURE"))
-        .filter_map(|row| run_id_from_link(&row.link))
-        .collect();
-    runs.sort();
-    runs.dedup();
-
-    if runs.is_empty() {
-        return Err("no failed check named a workflow run to re-run".to_owned());
-    }
-
-    for run in &runs {
-        gh(&["run", "rerun", run, "--failed"])?;
-    }
-    Ok(())
-}
-
-/// The workflow-run id inside a check's link, if it has one.
-///
-/// A check link looks like `…/actions/runs/<run>/job/<job>`. Anything else —
-/// a third-party check pointing at its own dashboard, an empty link — yields
-/// `None` rather than a guess, because re-running the wrong id is worse than
-/// re-running nothing.
+/// An empty `required` list leaves the rollup untouched — see
+/// [`required_contexts`] for why that is the safe reading rather than "nothing
+/// is required".
 #[must_use]
-fn run_id_from_link(link: &str) -> Option<String> {
-    let after = link.split("/actions/runs/").nth(1)?;
-    let id = after.split('/').next()?;
-    if !id.is_empty() && id.chars().all(|c| c.is_ascii_digit()) {
-        Some(id.to_owned())
-    } else {
-        None
+fn only_required(checks: Vec<Check>, required: &[String]) -> Vec<Check> {
+    if required.is_empty() {
+        return checks;
     }
+    checks
+        .into_iter()
+        .filter(|check| required.iter().any(|name| name == &check.name))
+        .collect()
 }
 
 /// The checks this repository actually requires to merge into `branch`.
@@ -419,182 +274,43 @@ fn run_id_from_link(link: &str) -> Option<String> {
 /// every check counts, which is what the loop did before it could ask. That is
 /// the conservative direction — it can refuse to merge something mergeable,
 /// but it can never merge something the repository would have blocked.
-fn required_contexts(branch: &str) -> Vec<String> {
-    let out = std::process::Command::new("gh")
-        .args([
-            "api",
-            &format!("repos/{{owner}}/{{repo}}/branches/{branch}/protection"),
-            "--jq",
-            ".required_status_checks.contexts[]?",
-        ])
-        .env("NO_COLOR", "1")
-        .output();
-    let Ok(out) = out else {
-        return Vec::new();
-    };
-    if !out.status.success() {
-        return Vec::new();
-    }
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(str::to_owned)
-        .collect()
-}
-
-/// Keep only the checks that can block a merge.
-///
-/// An empty `required` list leaves the rollup untouched — see
-/// [`required_contexts`] for why that is the safe reading rather than "nothing
-/// is required".
-#[must_use]
-fn only_required(checks: Vec<Check>, required: &[String]) -> Vec<Check> {
-    if required.is_empty() {
-        return checks;
-    }
-    checks
-        .into_iter()
-        .filter(|check| required.iter().any(|name| name == check.name()))
-        .collect()
-}
-
-/// The forge endpoint carrying a ref's check runs.
-///
-/// Split out so the one thing that can be wrong here — *which commit gets
-/// asked about* — is visible to a test. See [`checks_for_branch`].
-#[must_use]
-fn check_runs_endpoint(branch: &str) -> String {
-    format!("repos/{{owner}}/{{repo}}/commits/{branch}/check-runs")
+fn required_contexts(forge: &dyn PullRequestProvider, branch: &str) -> Vec<String> {
+    forge.required_checks(branch).unwrap_or_default()
 }
 
 /// Read a branch's checks from the forge.
 ///
 /// # The branch is named to the forge, never resolved locally first
 ///
-/// This used to run `git rev-parse origin/<branch>` and ask about the commit
-/// that came back. A remote-tracking ref is only as fresh as the last fetch,
-/// and this loop does not fetch between polls — so once the process had been
-/// up for a while, `origin/main` still pointed at whatever main was when it
-/// started.
+/// A remote-tracking ref is only as fresh as the last fetch, and this loop
+/// does not fetch between polls. Ask about `origin/main` after the process has
+/// been up a while and you get whatever main was when it started.
 ///
-/// That is not a stale-data annoyance; it is a loss of work, and in the one
-/// direction that costs. [`base_conclusion`] excuses a pull request only when
-/// **every** check failing on it also fails on the base. Reading a
-/// pre-breakage base makes the base look green, so an inherited failure is
-/// scored as the pull request's own and a change that was never wrong gets a
-/// fix attempt or an escalation. It happened on the first pull request this
-/// loop ever opened: #4014 failed on a `cargo fmt` diff in a file its own diff
-/// never touched, and was escalated for it.
+/// That is a loss of work, not a stale-data annoyance. [`base_conclusion`]
+/// excuses a pull request only when **every** check failing on it fails on the
+/// base too. An old base looks green, so a failure the base handed down gets
+/// scored as the pull request's own. A change that was never wrong then draws
+/// a fix attempt or an escalation. It happened on the first pull request this
+/// loop ever opened, over a `cargo fmt` diff in a file it never touched.
 ///
-/// Naming the branch to the forge has no local state left to be stale. It is
-/// the same rule [`open_prs_for_prefix`] follows: for a question about the
+/// Naming the branch to the forge leaves no local state to go stale.
+/// [`open_prs_for_prefix`] follows the same rule. For a question about the
 /// forge, ask the forge.
-pub(super) fn checks_for_branch(branch: &str) -> Option<Vec<Check>> {
-    // `gh pr view` is not available for a branch with no pull request, so the
-    // base is read through the ref's check-runs instead. `Some(empty)` means
-    // "the base really has no checks", which `base_conclusion` may read as
-    // "does not excuse anything"; `None` means nobody could say, which it may
-    // not. An unnamed base is the second of those — `baseRefName` is
-    // `#[serde(default)]`, so an empty string is a field the payload did not
-    // carry, not a branch with no checks.
+pub(super) fn checks_for_branch(
+    forge: &dyn PullRequestProvider,
+    branch: &str,
+) -> Option<Vec<Check>> {
+    // A pull request read is not available for a branch that has none, so the
+    // base is read through the ref's checks instead. `Some(empty)` means "the
+    // base really has no checks", which `base_conclusion` may read as "does
+    // not excuse anything"; `None` means nobody could say, which it may not.
+    // An unnamed base is the second of those — a payload that carried no base
+    // name decodes to an empty string, which is a field that was absent rather
+    // than a branch with no checks.
     if branch.is_empty() {
         return None;
     }
-    let mut checks = read_jq(
-        &check_runs_endpoint(branch),
-        ".check_runs[] | {name: .name, conclusion: (.conclusion // \"\"), status: .status}",
-    )?;
-
-    // Commit statuses live behind a different endpoint and speak a different
-    // dialect. Read separately and appended, because a pull request's rollup
-    // contains both — and a base showing only half of it would fail to excuse
-    // exactly the checks most likely to be broken repository-wide, since a
-    // third-party service is what posts a commit status. Half of it is what a
-    // failed second read would leave, so that read's failure fails the pair.
-    checks.extend(read_jq(
-        &statuses_endpoint(branch),
-        ".statuses[] | {context: .context, state: .state}",
-    )?);
-    Some(checks)
-}
-
-/// The forge endpoint carrying a ref's commit statuses.
-///
-/// A second endpoint rather than a second field: GitHub never merged the two
-/// APIs, and `check-runs` genuinely does not contain a commit status.
-#[must_use]
-fn statuses_endpoint(branch: &str) -> String {
-    format!("repos/{{owner}}/{{repo}}/commits/{branch}/status")
-}
-
-/// Run one `gh api` read and parse a [`Check`] per line, or `None` if the read
-/// did not succeed.
-///
-/// **The exit status is the read's verdict, not the emptiness of stdout.** This
-/// used to return a bare `Vec` and never look at the status, and its own doc
-/// said the empty result "is reached only when `gh` itself cannot run". That
-/// was false: a 404, an expired token and a rate limit all *run* `gh`, exit
-/// non-zero, and print little or nothing to stdout. `--paginate` widens it
-/// further — a run whose third page fails still has the first two on stdout, so
-/// a partial list came back as a complete one.
-///
-/// It matters because an empty base is what [`base_conclusion`] reads as "the
-/// base does not excuse this failure", and that answer costs a `PushFix` turn
-/// spent on somebody else's breakage.
-fn read_jq(endpoint: &str, jq: &str) -> Option<Vec<Check>> {
-    let out = std::process::Command::new("gh")
-        .args(["api", endpoint, "--paginate", "--jq", jq])
-        .env("NO_COLOR", "1")
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    Some(
-        String::from_utf8_lossy(&out.stdout)
-            .lines()
-            .filter_map(|line| serde_json::from_str::<Check>(line).ok())
-            .collect(),
-    )
-}
-
-/// Run `gh` and return stdout, with colour forced off.
-fn gh(args: &[&str]) -> Result<String, String> {
-    let out = std::process::Command::new("gh")
-        .args(args)
-        .env("NO_COLOR", "1")
-        .env("CLICOLOR_FORCE", "0")
-        .output()
-        .map_err(|error| format!("could not run `gh`: {error} — is the GitHub CLI installed?"))?;
-    if out.status.success() {
-        Ok(String::from_utf8_lossy(&out.stdout).trim().to_owned())
-    } else {
-        Err(String::from_utf8_lossy(&out.stderr).trim().to_owned())
-    }
-}
-
-/// Run `gh` and return stdout even when the command exits non-zero.
-///
-/// Some `gh` subcommands report their result through the exit code while still
-/// emitting the requested payload on stdout — `gh pr checks` exits 1 on a
-/// failing check and 8 on a pending one, yet writes its `--json` output either
-/// way. For those, a non-zero exit is a verdict about the checks, not a
-/// failure of the command, so the payload must survive it. stderr is only
-/// surfaced when stdout came back empty, which is the one case that signals
-/// the command itself could not run.
-fn gh_stdout(args: &[&str]) -> Result<String, String> {
-    let out = std::process::Command::new("gh")
-        .args(args)
-        .env("NO_COLOR", "1")
-        .env("CLICOLOR_FORCE", "0")
-        .output()
-        .map_err(|error| format!("could not run `gh`: {error} — is the GitHub CLI installed?"))?;
-    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_owned();
-    if stdout.is_empty() && !out.status.success() {
-        return Err(String::from_utf8_lossy(&out.stderr).trim().to_owned());
-    }
-    Ok(stdout)
+    forge.checks_for_ref(branch).ok()
 }
 
 /// Push `branch` and open a draft pull request that closes `issue_key`.
@@ -602,7 +318,11 @@ fn gh_stdout(args: &[&str]) -> Result<String, String> {
 /// Draft on purpose: the machine takes it out of draft itself once CI is green
 /// ([`stella_autonomy::Action::MarkReady`]), so a pull request that never goes
 /// green never asks a human to look at it.
+///
+/// The push is `git`, on this machine, so it stays here rather than behind the
+/// forge port: a provider is asked about a branch the forge can already see.
 pub(crate) fn open(
+    forge: &dyn PullRequestProvider,
     root: &std::path::Path,
     branch: &str,
     issue_key: &str,
@@ -612,20 +332,20 @@ pub(crate) fn open(
     git(root, &["push", "-u", "origin", branch])
         .ok_or_else(|| format!("could not push `{branch}` — is the remote reachable?"))?;
 
-    let body = pr_body(
-        issue_key,
-        &format!("Autonomous fix for #{issue_key}."),
-        signature,
-    );
-    let url = gh(&[
-        "pr", "create", "--head", branch, "--title", title, "--body", &body, "--draft",
-    ])?;
-
-    url.rsplit('/')
-        .next()
-        .filter(|s| s.chars().all(|c| c.is_ascii_digit()) && !s.is_empty())
-        .map(str::to_owned)
-        .ok_or_else(|| format!("`gh pr create` printed no pull request number: {url:?}"))
+    let draft = PullRequestDraft {
+        head_ref: branch.to_owned(),
+        title: title.to_owned(),
+        body: pr_body(
+            issue_key,
+            &format!("Autonomous fix for #{issue_key}."),
+            signature,
+        ),
+        draft: true,
+    };
+    forge
+        .open(&draft)
+        .map(|key| key.0)
+        .map_err(|error| error.to_string())
 }
 
 /// What one read of the forge said about a pull request.
@@ -655,24 +375,18 @@ pub(crate) struct Reading {
 /// One read of the forge, plus the second read of the base its
 /// [`Observation::base_ci`] needs.
 pub(crate) fn observe(
+    forge: &dyn PullRequestProvider,
     pr: &str,
     policy: &stella_autonomy::BlockingPolicy,
 ) -> Result<Reading, String> {
-    let raw = gh(&[
-        "pr",
-        "view",
-        pr,
-        "--json",
-        "isDraft,mergeable,reviewDecision,statusCheckRollup,baseRefName,state,labels",
-    ])?;
-    let view: PrView = serde_json::from_str(&raw).map_err(|error| {
-        format!("`gh pr view` returned a payload this build cannot read: {error}")
-    })?;
+    let mut view = forge
+        .get(&PullRequestKey::from(pr))
+        .map_err(|error| error.to_string())?;
 
     // The forge's own name for the base, passed through untouched. Prefixing
     // it with `origin/` would name a remote-tracking ref this process no
     // longer resolves — see `checks_for_branch`.
-    let required = required_contexts(&view.base_ref_name);
+    let required = required_contexts(forge, &view.base_ref);
 
     // Required is necessary and not sufficient. A check that has been red on
     // the base for every recent commit is not something this pull request can
@@ -681,7 +395,7 @@ pub(crate) fn observe(
         std::collections::BTreeSet::new()
     } else {
         stella_autonomy::stuck_on_base(
-            &base_failure_history(&view.base_ref_name, policy.stuck_after.max(1)),
+            &base_failure_history(forge, &view.base_ref, policy.stuck_after.max(1)),
             policy.stuck_after,
         )
     };
@@ -689,21 +403,17 @@ pub(crate) fn observe(
     let waived = stella_autonomy::waived(&required, &stuck, policy);
 
     let base_checks =
-        checks_for_branch(&view.base_ref_name).map(|checks| only_required(checks, &blocking));
+        checks_for_branch(forge, &view.base_ref).map(|checks| only_required(checks, &blocking));
 
     // Both sides filtered by the same list, so the base can still excuse a
     // blocking check — and a waived one can no longer condemn.
-    let mut view = view;
     let verified_locally = view
         .labels
         .iter()
-        .any(|label| label.name == VERIFIED_LOCALLY_LABEL);
-    view.status_check_rollup = only_required(view.status_check_rollup, &blocking);
+        .any(|label| label == VERIFIED_LOCALLY_LABEL);
+    view.checks = only_required(std::mem::take(&mut view.checks), &blocking);
 
-    let settled = matches!(
-        view.state.to_ascii_uppercase().as_str(),
-        "MERGED" | "CLOSED"
-    );
+    let settled = view.state.settled();
     let mut observation = observation_from(&view, base_checks.as_deref());
 
     // Nothing is left that can gate this pull request remotely, for one of two
@@ -712,8 +422,8 @@ pub(crate) fn observe(
     // - every check the repository *requires* has been waived as unwinnable; or
     // - the repository declares no required checks at all. A private repository
     //   on a free plan cannot even expose branch protection — the API answers
-    //   403 — and `gh pr merge` will merge such a pull request whatever its
-    //   checks say. A gate the forge does not enforce is not a gate.
+    //   403 — and a merge will go through whatever its checks say. A gate the
+    //   forge does not enforce is not a gate.
     //
     // Either way the forge has no opinion to offer, so `ci_from` sees an empty
     // rollup and says `Pending`, parking the loop forever on a verdict that is
@@ -748,8 +458,13 @@ pub(crate) fn observe(
 pub(super) const VERIFIED_LOCALLY_LABEL: &str = "stella-verified-locally";
 
 /// Record that a pull request was proved on this machine.
-pub(super) fn mark_verified_locally(pr: &str) -> Result<(), String> {
-    gh(&["pr", "edit", pr, "--add-label", VERIFIED_LOCALLY_LABEL]).map(|_| ())
+pub(super) fn mark_verified_locally(
+    forge: &dyn PullRequestProvider,
+    pr: &str,
+) -> Result<(), String> {
+    forge
+        .add_label(&PullRequestKey::from(pr), VERIFIED_LOCALLY_LABEL)
+        .map_err(|error| error.to_string())
 }
 
 /// Which checks failed on each of the last `depth` commits of `branch`.
@@ -761,25 +476,23 @@ pub(super) fn mark_verified_locally(pr: &str) -> Result<(), String> {
 /// a stuck streak. That is the conservative direction: an unreadable history
 /// must not manufacture evidence that a check is unwinnable.
 #[must_use]
-pub(super) fn base_failure_history(branch: &str, depth: usize) -> Vec<Vec<String>> {
-    let raw = gh(&[
-        "api",
-        &format!("repos/{{owner}}/{{repo}}/commits?sha={branch}&per_page={depth}"),
-        "--jq",
-        ".[].sha",
-    ])
-    .unwrap_or_default();
-
-    raw.lines()
-        .map(str::trim)
-        .filter(|sha| !sha.is_empty())
+pub(super) fn base_failure_history(
+    forge: &dyn PullRequestProvider,
+    branch: &str,
+    depth: usize,
+) -> Vec<Vec<String>> {
+    forge
+        .recent_commits(branch, depth)
+        .unwrap_or_default()
+        .into_iter()
         .take(depth)
         .map(|sha| {
-            checks_for_branch(sha)
+            forge
+                .checks_for_ref(&sha)
                 .unwrap_or_default()
                 .into_iter()
-                .filter(Check::failed)
-                .map(|check| check.name().to_owned())
+                .filter(failed)
+                .map(|check| check.name)
                 .collect()
         })
         .collect()
@@ -794,7 +507,7 @@ pub(super) fn base_failure_history(branch: &str, depth: usize) -> Vec<Vec<String
 /// everybody, and the loop is supposed to go and fix it rather than open work
 /// that will fail for a reason nobody's diff caused.
 ///
-/// Only **required** checks count, on exactly the reasoning `only_required`
+/// Only **required** checks count, on exactly the reasoning [`only_required`]
 /// documents: an advisory check that fails forever would otherwise convince
 /// the loop the repository is permanently on fire.
 ///
@@ -803,12 +516,15 @@ pub(super) fn base_failure_history(branch: &str, depth: usize) -> Vec<Vec<String
 /// deliberately: an unreadable forge would otherwise make the loop file a
 /// breakage report about nothing and adopt an imaginary emergency.
 #[must_use]
-pub(super) fn base_is_broken(branch: &str) -> bool {
-    let required = required_contexts(branch);
+pub(super) fn base_is_broken(forge: &dyn PullRequestProvider, branch: &str) -> bool {
+    let required = required_contexts(forge, branch);
     // `unwrap_or_default` here says the same thing the `is_empty` below
     // already said: an unreadable forge must not make the loop file a
     // breakage report about nothing.
-    let checks = only_required(checks_for_branch(branch).unwrap_or_default(), &required);
+    let checks = only_required(
+        checks_for_branch(forge, branch).unwrap_or_default(),
+        &required,
+    );
     if checks.is_empty() {
         return false;
     }
@@ -817,35 +533,29 @@ pub(super) fn base_is_broken(branch: &str) -> bool {
 
 /// Open pull request numbers the forge's own search associates with `key`.
 ///
-/// Broader than [`open_prs_for_issue`] on purpose, and the two are not
-/// interchangeable: that one asks "did *this loop* deliver an attempt", so it
-/// searches the `Closes #key` trailer it writes itself, and a false positive
-/// there would refuse to clean up a dead branch. This one asks "is *anybody*
-/// on this", where a pull request that merely names the issue is exactly the
-/// actor worth deferring to.
+/// Broader than [`open_prs_for_issue`] on purpose, and the two do not swap.
+/// That one asks whether *this loop* delivered an attempt, so it searches the
+/// `Closes #key` trailer it writes itself. A false hit there would refuse to
+/// clean up a dead branch. This one asks whether *anybody* is on it, and a
+/// pull request that merely names the issue is the actor worth waiting for.
 ///
-/// The gathering that consumes it lives in [`super::contention`], along with
-/// the other three signals. It moved there when the claim site and the
-/// base-fix site stopped being able to share one probe unchanged: the claim
-/// site must drop worktrees under the loop's own root and the base-fix site
-/// must keep them, and that difference is an argument to one gatherer rather
-/// than a second copy of four reads (#4300).
-pub(super) fn prs_matching(key: &str) -> Result<Vec<String>, String> {
-    // `title,body` as well as `number`: the search is a full-text one on the
-    // bare number, so the forge answers with every open pull request that
-    // mentions it for any reason. The text is what says whether the mention is
-    // this issue — see `contention::prs_naming`.
-    let raw = gh(&[
-        "pr",
-        "list",
-        "--state",
-        "open",
-        "--search",
-        key,
-        "--json",
-        "number,title,body",
-    ])?;
-    Ok(super::contention::prs_naming(&raw, key))
+/// The gathering that reads it lives in [`super::contention`], with the other
+/// three signals. It moved there once the claim site and the base-fix site
+/// stopped sharing one probe. The claim site drops worktrees under the loop's
+/// own root; the base-fix site keeps them. That difference is an argument to
+/// one gatherer, not a second copy of four reads.
+pub(super) fn prs_matching(
+    forge: &dyn PullRequestProvider,
+    key: &str,
+) -> Result<Vec<String>, String> {
+    // The search is a full-text one on the bare number, so the forge answers
+    // with every open pull request that mentions it for any reason. The text
+    // is what says whether the mention is this issue — see
+    // `contention::prs_naming`.
+    let rows = forge
+        .list_open(Some(key))
+        .map_err(|error| error.to_string())?;
+    Ok(super::contention::prs_naming(&rows, key))
 }
 
 /// Open pull requests that say they close `key`.
@@ -854,58 +564,32 @@ pub(super) fn prs_matching(key: &str) -> Result<Vec<String>, String> {
 /// a pull request, and one that does not has nothing worth keeping. Searched
 /// rather than listed-and-filtered because the forge already indexes the body
 /// text, and the loop writes `Closes #key` into every one it opens.
-pub(super) fn open_prs_for_issue(key: &str) -> Result<Vec<String>, String> {
-    let raw = gh(&[
-        "pr",
-        "list",
-        "--state",
-        "open",
-        "--search",
-        &format!("Closes #{key}"),
-        "--json",
-        "number",
-    ])?;
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&raw).map_err(|error| {
-        format!("`gh pr list` returned a payload this build cannot read: {error}")
-    })?;
-    Ok(rows
-        .iter()
-        .filter_map(|row| row.get("number").and_then(serde_json::Value::as_u64))
-        .map(|n| n.to_string())
-        .collect())
+pub(super) fn open_prs_for_issue(
+    forge: &dyn PullRequestProvider,
+    key: &str,
+) -> Result<Vec<String>, String> {
+    let rows = forge
+        .list_open(Some(&format!("Closes #{key}")))
+        .map_err(|error| error.to_string())?;
+    Ok(rows.into_iter().map(|row| row.key.0).collect())
 }
 
 /// Every open pull request on a branch with this workspace's prefix.
 ///
 /// How a restarted loop finds what it was carrying. It **asks the forge**
-/// rather than reading a list it wrote down, because the forge is the source
-/// of truth about a pull request and a remembered list can only be wrong —
-/// stale after a human merges one by hand, or after a run died between opening
-/// a pull request and recording it.
-pub(super) fn open_prs_for_prefix(prefix: &str) -> Result<Vec<String>, String> {
-    #[derive(serde::Deserialize)]
-    struct Row {
-        number: u64,
-        #[serde(rename = "headRefName", default)]
-        head_ref_name: String,
-    }
-
-    let raw = gh(&[
-        "pr",
-        "list",
-        "--state",
-        "open",
-        "--json",
-        "number,headRefName",
-    ])?;
-    let rows: Vec<Row> = serde_json::from_str(&raw).map_err(|error| {
-        format!("`gh pr list` returned a payload this build cannot read: {error}")
-    })?;
-
+/// rather than reading a list it wrote down. The forge is the truth about a
+/// pull request, and a remembered list can only be wrong. It goes stale when
+/// a human merges one by hand, or when a run dies between opening a pull
+/// request and writing it down.
+pub(super) fn open_prs_for_prefix(
+    forge: &dyn PullRequestProvider,
+    prefix: &str,
+) -> Result<Vec<String>, String> {
+    let rows = forge.list_open(None).map_err(|error| error.to_string())?;
     Ok(rows
         .into_iter()
-        .filter(|row| row.head_ref_name.starts_with(prefix))
-        .map(|row| row.number.to_string())
+        .filter(|row| row.head_ref.starts_with(prefix))
+        .map(|row| row.key.0)
         .collect())
 }
 
@@ -914,8 +598,10 @@ pub(super) fn open_prs_for_prefix(prefix: &str) -> Result<Vec<String>, String> {
 /// Called only when the machine returned `MarkReady`, which it does once CI is
 /// green — so a pull request that never goes green never asks a human to look
 /// at it.
-pub(crate) fn mark_ready(pr: &str) -> Result<(), String> {
-    gh(&["pr", "ready", pr]).map(|_| ())
+pub(crate) fn mark_ready(forge: &dyn PullRequestProvider, pr: &str) -> Result<(), String> {
+    forge
+        .mark_ready(&PullRequestKey::from(pr))
+        .map_err(|error| error.to_string())
 }
 
 /// Merge the pull request.
@@ -923,54 +609,15 @@ pub(crate) fn mark_ready(pr: &str) -> Result<(), String> {
 /// Called **only** when [`stella_autonomy::deliver_next`] returned
 /// [`stella_autonomy::Action::Merge`]; the caller enforces that, and the
 /// machine emits it from exactly one state.
-pub(crate) fn merge(pr: &str) -> Result<(), String> {
-    // No `--delete-branch`. It deletes the *local* branch too, and this loop
-    // works inside git worktrees that hold exactly those branches — so the
-    // delete fails, `gh` exits non-zero, and a merge that already succeeded is
-    // reported as a failure. That is what it did: #4022 merged at 00:32:54 and
-    // the loop went on re-observing a merged pull request because the branch
-    // cleanup after it had failed.
-    //
-    // Cleanup is a separate concern from delivery, and the forge's own
-    // "automatically delete head branches" setting does it without a local
-    // side effect. Losing a branch is recoverable; losing the record of a
-    // merge strands the pull request forever.
-    let outcome = gh(&["pr", "merge", pr, "--squash"]).map(|_| ());
-
-    // A pull request that is already merged is the state this asked for, so it
-    // is a success. Racing a human who merged it by hand, or re-observing
-    // after a partial failure, must not read as an error.
-    match outcome {
-        Err(error) if error.to_ascii_lowercase().contains("already merged") => Ok(()),
-        other => other,
-    }
+pub(crate) fn merge(forge: &dyn PullRequestProvider, pr: &str) -> Result<(), String> {
+    forge
+        .merge(&PullRequestKey::from(pr))
+        .map_err(|error| error.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// The base is asked about by branch name, so no local ref can go stale.
-    ///
-    /// The endpoint used to carry a commit resolved by `git rev-parse
-    /// origin/<branch>`, which is only as fresh as the last fetch — and this
-    /// loop never fetches. A base that broke while the process was up still
-    /// resolved to the pre-breakage commit, so [`base_conclusion`] saw a green
-    /// base and scored an inherited failure as the pull request's own. #4014
-    /// was escalated for a `cargo fmt` diff in a file it never touched.
-    ///
-    /// Asserting the *absence* of `origin/` is the half that matters: a
-    /// remote-tracking spelling would resolve locally again and re-introduce
-    /// exactly the staleness this replaced.
-    #[test]
-    fn the_base_is_named_to_the_forge_not_a_remote_tracking_ref() {
-        let endpoint = check_runs_endpoint("main");
-        assert_eq!(endpoint, "repos/{owner}/{repo}/commits/main/check-runs");
-        assert!(
-            !endpoint.contains("origin/"),
-            "a remote-tracking ref resolves against the last fetch, not the forge: {endpoint}"
-        );
-    }
 
     /// An advisory check that fails forever must not block forever.
     ///
@@ -987,12 +634,8 @@ mod tests {
     fn an_advisory_check_does_not_block_a_merge() {
         let required = vec!["fmt + clippy + test".to_owned()];
         let rollup = vec![
-            check("fmt + clippy + test", "SUCCESS"),
-            Check {
-                context: "Vercel".into(),
-                state: "FAILURE".into(),
-                ..Check::default()
-            },
+            check("fmt + clippy + test", CheckOutcome::Passed),
+            check("Vercel", CheckOutcome::Failed),
         ];
 
         assert_eq!(
@@ -1014,7 +657,10 @@ mod tests {
     /// something the repository would have blocked.
     #[test]
     fn no_declared_requirements_filters_nothing() {
-        let rollup = vec![check("a", "FAILURE"), check("b", "SUCCESS")];
+        let rollup = vec![
+            check("a", CheckOutcome::Failed),
+            check("b", CheckOutcome::Passed),
+        ];
         assert_eq!(only_required(rollup, &[]).len(), 2);
     }
 
@@ -1025,15 +671,15 @@ mod tests {
         let required = vec!["fmt + clippy + test".to_owned()];
         let pr = only_required(
             vec![
-                check("fmt + clippy + test", "FAILURE"),
-                check("noise", "FAILURE"),
+                check("fmt + clippy + test", CheckOutcome::Failed),
+                check("noise", CheckOutcome::Failed),
             ],
             &required,
         );
         let base = only_required(
             vec![
-                check("fmt + clippy + test", "FAILURE"),
-                check("other noise", "SUCCESS"),
+                check("fmt + clippy + test", CheckOutcome::Failed),
+                check("other noise", CheckOutcome::Passed),
             ],
             &required,
         );
@@ -1044,122 +690,6 @@ mod tests {
         );
     }
 
-    /// A commit status is a concluded check, not a pending one.
-    ///
-    /// **The witness for the bug that stalled the loop.** GitHub's rollup
-    /// mixes two dialects: a check run carries `name`/`status`/`conclusion`,
-    /// a commit status carries `context`/`state` and no `status` at all.
-    /// Reading only the first shape does not fail — every field defaults — it
-    /// yields a nameless check with no conclusion, which `pending()` reports
-    /// as unfinished on every poll forever.
-    ///
-    /// That is what happened: this repository's Vercel commit status had
-    /// already concluded `FAILURE`, and the loop re-read `ci=Pending` on #4022
-    /// for twenty-five minutes after all three required checks went green.
-    #[test]
-    fn a_commit_status_is_read_as_concluded_not_as_pending() {
-        let vercel = Check {
-            context: "Vercel".into(),
-            state: "FAILURE".into(),
-            ..Check::default()
-        };
-
-        assert!(
-            !vercel.pending(),
-            "it concluded — before the loop ever looked"
-        );
-        assert!(vercel.failed());
-        assert_eq!(vercel.name(), "Vercel", "and it must join by its context");
-        assert_eq!(ci_from(&[vercel]), CiConclusion::Red);
-    }
-
-    /// A commit status that really is pending still reads as pending.
-    ///
-    /// The other direction, so the fix above cannot be "call every commit
-    /// status finished".
-    #[test]
-    fn a_pending_commit_status_still_reads_as_pending() {
-        let waiting = Check {
-            context: "Vercel".into(),
-            state: "PENDING".into(),
-            ..Check::default()
-        };
-        assert!(waiting.pending());
-        assert!(!waiting.failed());
-        assert_eq!(ci_from(&[waiting]), CiConclusion::Pending);
-    }
-
-    /// A commit status failing on both sides is the base's fault, not ours.
-    ///
-    /// This only works because the base is read from *two* endpoints. A base
-    /// read that saw check runs alone would show no `Vercel` row, the join
-    /// would find nothing, and a service broken account-wide would be charged
-    /// to every pull request the loop opened.
-    #[test]
-    fn a_commit_status_broken_on_the_base_excuses_the_pull_request() {
-        let failing = |context: &str| Check {
-            context: context.into(),
-            state: "FAILURE".into(),
-            ..Check::default()
-        };
-
-        assert_eq!(
-            base_conclusion(&[failing("Vercel")], Some(&[failing("Vercel")])),
-            CiConclusion::Red,
-            "the base is broken in the same way, so this is not ours to fix"
-        );
-        assert_eq!(
-            base_conclusion(&[failing("Vercel")], Some(&[])),
-            CiConclusion::Green,
-            "and a base that does not share the failure excuses nothing"
-        );
-    }
-
-    /// A check run and a commit status of the same name are one check.
-    ///
-    /// Neither dialect is privileged: the join key is whichever field carried
-    /// the name.
-    #[test]
-    fn the_two_dialects_join_on_one_name() {
-        let run = Check {
-            name: "build".into(),
-            status: "COMPLETED".into(),
-            conclusion: "FAILURE".into(),
-            ..Check::default()
-        };
-        let status = Check {
-            context: "build".into(),
-            state: "FAILURE".into(),
-            ..Check::default()
-        };
-        assert_eq!(base_conclusion(&[run], Some(&[status])), CiConclusion::Red);
-    }
-
-    /// A check link yields a run id, or nothing — never a guess.
-    ///
-    /// The re-run is the loop's one remedy for a red the base already
-    /// explains, and it is aimed by parsing a URL. Re-running the wrong id is
-    /// worse than re-running nothing, so every shape that is not a GitHub
-    /// Actions run must decline: this repository's checks include third-party
-    /// ones (Vercel) whose links point somewhere else entirely, and one of
-    /// them is failing on every pull request right now.
-    #[test]
-    fn only_an_actions_run_link_names_a_run_to_rerun() {
-        assert_eq!(
-            run_id_from_link(
-                "https://github.com/macanderson/stella/actions/runs/32311670564/job/96255819957"
-            )
-            .as_deref(),
-            Some("32311670564")
-        );
-        assert_eq!(run_id_from_link("https://vercel.com/github"), None);
-        assert_eq!(run_id_from_link(""), None);
-        assert_eq!(
-            run_id_from_link("https://github.com/o/r/actions/runs/not-a-number/job/1"),
-            None
-        );
-    }
-
     /// A base with no name is not a base with no failures.
     ///
     /// Reading an empty list here means "the base excuses nothing", which
@@ -1167,24 +697,23 @@ mod tests {
     /// no checks — so the empty-name path returns early rather than asking the
     /// forge about a ref spelled `""` and reading its 404 as the same thing.
     ///
-    /// It now returns `None` rather than an empty list, which is the same
-    /// argument carried in the type: an unnamed base is one nobody read.
-    /// `baseRefName` is `#[serde(default)]`, so an empty string is a field the
-    /// payload did not carry.
+    /// It returns `None` rather than an empty list, which is the same argument
+    /// carried in the type: an unnamed base is one nobody read.
     #[test]
     fn an_unnamed_base_asks_the_forge_nothing() {
-        assert!(checks_for_branch("").is_none());
+        let forge = super::fixture::FixtureForge::new();
+        assert!(checks_for_branch(&forge, "").is_none());
+        assert!(
+            forge.journal().is_empty(),
+            "an unnamed base is never asked about: {:?}",
+            forge.journal()
+        );
     }
 
     /// A base nobody could read does not become a base that excuses nothing.
     ///
-    /// **The witness.** The test above guarded one route to the empty list;
-    /// `read_jq` left three others open, because it never looked at the exit
-    /// status. A `gh` that runs and exits non-zero — a 404, an expired token, a
-    /// rate limit — printed little or nothing to stdout and was read as a base
-    /// with no checks; `--paginate` adds a fourth, where a failed later page
-    /// still leaves the earlier ones on stdout and a partial list comes back as
-    /// a complete one.
+    /// **The witness.** A forge read that runs and fails — a 404, an expired
+    /// token, a rate limit — must not come back as a base with no checks.
     ///
     /// `base_conclusion` returning `Green` means "this failure is yours", and
     /// the machine answers it with `CiRed` / `PushFix` — a turn spent fixing a
@@ -1193,7 +722,7 @@ mod tests {
     /// else's breakage on this PR's budget."* #4014 is the incident.
     #[test]
     fn an_unread_base_does_not_blame_the_pull_request() {
-        let pr = [check("build", "FAILURE")];
+        let pr = [check("build", CheckOutcome::Failed)];
 
         assert_eq!(
             base_conclusion(&pr, None),
@@ -1213,21 +742,10 @@ mod tests {
         assert_eq!(base_conclusion(&[], None), CiConclusion::Green);
     }
 
-    fn check(name: &str, conclusion: &str) -> Check {
+    fn check(name: &str, outcome: CheckOutcome) -> Check {
         Check {
-            name: name.into(),
-            conclusion: conclusion.into(),
-            status: "COMPLETED".into(),
-            ..Check::default()
-        }
-    }
-
-    fn running(name: &str) -> Check {
-        Check {
-            name: name.into(),
-            conclusion: String::new(),
-            status: "IN_PROGRESS".into(),
-            ..Check::default()
+            name: name.to_owned(),
+            outcome,
         }
     }
 
@@ -1237,12 +755,12 @@ mod tests {
     #[test]
     fn a_base_failing_a_different_check_does_not_excuse_this_one() {
         let pr = vec![
-            check("fmt + clippy + test", "FAILURE"),
-            check("docs", "SUCCESS"),
+            check("fmt + clippy + test", CheckOutcome::Failed),
+            check("docs", CheckOutcome::Passed),
         ];
         let base = vec![
-            check("deck-fit", "FAILURE"),
-            check("fmt + clippy + test", "SUCCESS"),
+            check("deck-fit", CheckOutcome::Failed),
+            check("fmt + clippy + test", CheckOutcome::Passed),
         ];
 
         assert_eq!(
@@ -1256,8 +774,8 @@ mod tests {
     /// `BaseBroken` is for, and the loop must not spend a fix on it.
     #[test]
     fn the_same_check_failing_on_the_base_is_inherited() {
-        let pr = vec![check("fmt + clippy + test", "FAILURE")];
-        let base = vec![check("fmt + clippy + test", "FAILURE")];
+        let pr = vec![check("fmt + clippy + test", CheckOutcome::Failed)];
+        let base = vec![check("fmt + clippy + test", CheckOutcome::Failed)];
 
         assert_eq!(base_conclusion(&pr, Some(&base)), CiConclusion::Red);
     }
@@ -1266,8 +784,14 @@ mod tests {
     /// PR's problem: it introduced the second.
     #[test]
     fn a_partial_overlap_is_still_this_prs_fault() {
-        let pr = vec![check("a", "FAILURE"), check("b", "FAILURE")];
-        let base = vec![check("a", "FAILURE"), check("b", "SUCCESS")];
+        let pr = vec![
+            check("a", CheckOutcome::Failed),
+            check("b", CheckOutcome::Failed),
+        ];
+        let base = vec![
+            check("a", CheckOutcome::Failed),
+            check("b", CheckOutcome::Passed),
+        ];
 
         assert_eq!(base_conclusion(&pr, Some(&base)), CiConclusion::Green);
     }
@@ -1276,8 +800,8 @@ mod tests {
     /// state it is in.
     #[test]
     fn a_green_pr_is_never_inherited_from_a_red_base() {
-        let pr = vec![check("a", "SUCCESS")];
-        let base = vec![check("a", "FAILURE")];
+        let pr = vec![check("a", CheckOutcome::Passed)];
+        let base = vec![check("a", CheckOutcome::Failed)];
 
         assert_eq!(base_conclusion(&pr, Some(&base)), CiConclusion::Green);
     }
@@ -1287,7 +811,10 @@ mod tests {
     #[test]
     fn a_failure_beats_a_check_still_running() {
         assert_eq!(
-            ci_from(&[check("a", "FAILURE"), running("b")]),
+            ci_from(&[
+                check("a", CheckOutcome::Failed),
+                check("b", CheckOutcome::Running)
+            ]),
             CiConclusion::Red
         );
     }
@@ -1297,21 +824,12 @@ mod tests {
     #[test]
     fn a_skipped_check_neither_blocks_nor_fails() {
         assert_eq!(
-            ci_from(&[check("a", "SUCCESS"), check("cla", "SKIPPED")]),
+            ci_from(&[
+                check("a", CheckOutcome::Passed),
+                check("cla", CheckOutcome::Inert)
+            ]),
             CiConclusion::Green
         );
-    }
-
-    /// A completed check with an empty conclusion is a forge quirk, not a pass.
-    #[test]
-    fn a_completed_check_with_no_conclusion_is_not_green() {
-        let odd = Check {
-            name: "a".into(),
-            conclusion: String::new(),
-            status: "COMPLETED".into(),
-            ..Check::default()
-        };
-        assert_eq!(ci_from(&[odd]), CiConclusion::Pending);
     }
 
     #[test]
@@ -1323,21 +841,22 @@ mod tests {
     /// into a conflict.
     #[test]
     fn an_unrecognised_mergeability_is_unknown_never_clean() {
-        assert_eq!(mergeable_from("MERGEABLE"), Mergeability::Clean);
-        assert_eq!(mergeable_from("CONFLICTING"), Mergeability::Conflicted);
-        assert_eq!(mergeable_from("UNKNOWN"), Mergeability::Unknown);
-        assert_eq!(mergeable_from(""), Mergeability::Unknown);
-        assert_eq!(mergeable_from("something new"), Mergeability::Unknown);
+        assert_eq!(mergeable_from(MergeStatus::Clean), Mergeability::Clean);
+        assert_eq!(
+            mergeable_from(MergeStatus::Conflicted),
+            Mergeability::Conflicted
+        );
+        assert_eq!(mergeable_from(MergeStatus::Unknown), Mergeability::Unknown);
     }
 
     #[test]
     fn review_maps_the_three_states_and_defaults_to_none() {
-        assert_eq!(review_from("APPROVED"), ReviewState::Approved);
+        assert_eq!(review_from(ReviewDecision::Approved), ReviewState::Approved);
         assert_eq!(
-            review_from("CHANGES_REQUESTED"),
+            review_from(ReviewDecision::ChangesRequested),
             ReviewState::ChangesRequested
         );
-        assert_eq!(review_from(""), ReviewState::None);
+        assert_eq!(review_from(ReviewDecision::None), ReviewState::None);
     }
 
     /// **The closing witness.** Both spellings, because the two merge paths read
@@ -1355,22 +874,28 @@ mod tests {
         );
     }
 
-    /// The real payload shape, parsed from what `gh pr view` actually returned
-    /// for PR #3985 — abridged, but with its field names and its empty
-    /// `reviewDecision` untouched.
+    /// A pull request still running one check is pending, whatever else passed.
+    ///
+    /// The shape `gh pr view` returned for #3985, in the port's vocabulary.
     #[test]
-    fn the_real_gh_payload_maps_onto_an_observation() {
-        let raw = r#"{
-            "isDraft": false,
-            "mergeable": "MERGEABLE",
-            "reviewDecision": "",
-            "statusCheckRollup": [
-                {"name": "typecheck + build", "conclusion": "", "status": "IN_PROGRESS"},
-                {"name": "docs guards", "conclusion": "SUCCESS", "status": "COMPLETED"}
-            ]
-        }"#;
-        let view: PrView = serde_json::from_str(raw).expect("the recorded payload parses");
-        let obs = observation_from(&view, Some(&[]));
+    fn a_running_check_leaves_the_observation_pending() {
+        let pr = PullRequest {
+            key: PullRequestKey::from("3985"),
+            state: stella_protocol::pull_request::PullRequestState::Open,
+            draft: false,
+            base_ref: "main".to_owned(),
+            head_ref: "fix/3985".to_owned(),
+            title: String::new(),
+            body: String::new(),
+            merge_status: MergeStatus::Clean,
+            review: ReviewDecision::None,
+            checks: vec![
+                check("typecheck + build", CheckOutcome::Running),
+                check("docs guards", CheckOutcome::Passed),
+            ],
+            labels: Vec::new(),
+        };
+        let obs = observation_from(&pr, Some(&[]));
 
         assert_eq!(obs.ci, CiConclusion::Pending);
         assert_eq!(obs.mergeable, Mergeability::Clean);

--- a/crates/stella-cli/src/self_driving_cmd/deliver/fixture.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver/fixture.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! A forge that lives in memory, for the tests of everything above the port.
+//!
+//! It spawns no process and opens no socket. So a test that drives the
+//! delivery loop's pull request steps through it needs neither `gh` nor a
+//! network. [`witness`](super::witness) rests on that.
+//!
+//! It records every call in order. The journal lets a test assert the steps
+//! that ran, not just the state they left. Without it, a merge that never
+//! asked the forge to merge would pass on a fixture that merges by itself.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use stella_protocol::pull_request::{
+    Check, MergeStatus, PullRequest, PullRequestDraft, PullRequestError, PullRequestKey,
+    PullRequestProvider, PullRequestState, PullRequestSummary, ReviewDecision,
+};
+
+/// What the forge holds, behind one lock.
+///
+/// One lock rather than one per field. Every method here is short. A test
+/// that has to work out which halves of the forge moved together is a test
+/// somebody will read wrong.
+#[derive(Default)]
+struct Inner {
+    /// Pull requests by key.
+    prs: HashMap<String, PullRequest>,
+    /// Checks by ref — a branch name or a commit id.
+    checks: HashMap<String, Vec<Check>>,
+    /// The check names the repository requires, if it declares any.
+    required: Vec<String>,
+    /// Commit ids on the base, newest first.
+    commits: Vec<String>,
+    /// The number the next opened pull request gets.
+    next: u64,
+    /// Every call, in order.
+    journal: Vec<String>,
+    /// Whether syncing a branch with its base succeeds.
+    ///
+    /// A forge declines when the branch is already level with its base. That
+    /// refusal sends the loop to its re-run fallback.
+    sync_succeeds: bool,
+}
+
+/// A forge in memory.
+pub(crate) struct FixtureForge {
+    inner: Mutex<Inner>,
+}
+
+impl FixtureForge {
+    /// An empty forge that numbers its first pull request `1`.
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                next: 1,
+                sync_succeeds: true,
+                ..Inner::default()
+            }),
+        }
+    }
+
+    /// Borrow the state, recovering a lock a panicking test poisoned.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Record a call.
+    fn note(&self, call: impl Into<String>) {
+        self.lock().journal.push(call.into());
+    }
+
+    /// Say what `git_ref` reports.
+    pub(crate) fn set_checks(&self, git_ref: &str, checks: Vec<Check>) {
+        self.lock().checks.insert(git_ref.to_owned(), checks);
+    }
+
+    /// Say what the repository requires.
+    pub(crate) fn set_required(&self, required: &[&str]) {
+        self.lock().required = required.iter().map(|name| (*name).to_owned()).collect();
+    }
+
+    /// Say which commits the base carries, newest first.
+    pub(crate) fn set_commits(&self, commits: &[&str]) {
+        self.lock().commits = commits.iter().map(|sha| (*sha).to_owned()).collect();
+    }
+
+    /// Say whether a base sync succeeds.
+    pub(crate) fn set_sync_succeeds(&self, succeeds: bool) {
+        self.lock().sync_succeeds = succeeds;
+    }
+
+    /// Read one pull request back.
+    pub(crate) fn pr(&self, key: &str) -> Option<PullRequest> {
+        self.lock().prs.get(key).cloned()
+    }
+
+    /// Every call so far, in order.
+    pub(crate) fn journal(&self) -> Vec<String> {
+        self.lock().journal.clone()
+    }
+
+    /// The failure a forge reports when it has no such pull request.
+    fn missing(key: &PullRequestKey) -> PullRequestError {
+        PullRequestError::NotFound { key: key.clone() }
+    }
+
+    /// The failure a forge reports when it declines.
+    fn refused(reason: &str) -> PullRequestError {
+        PullRequestError::Failed {
+            provider: "fixture".to_owned(),
+            reason: reason.to_owned(),
+        }
+    }
+}
+
+impl PullRequestProvider for FixtureForge {
+    fn id(&self) -> &str {
+        "fixture"
+    }
+
+    fn open(&self, draft: &PullRequestDraft) -> Result<PullRequestKey, PullRequestError> {
+        self.note(format!("open {}", draft.head_ref));
+        let mut inner = self.lock();
+        let number = inner.next;
+        inner.next += 1;
+        let key = PullRequestKey(number.to_string());
+        inner.prs.insert(
+            key.0.clone(),
+            PullRequest {
+                key: key.clone(),
+                state: PullRequestState::Open,
+                draft: draft.draft,
+                base_ref: "main".to_owned(),
+                head_ref: draft.head_ref.clone(),
+                title: draft.title.clone(),
+                body: draft.body.clone(),
+                merge_status: MergeStatus::Clean,
+                review: ReviewDecision::None,
+                checks: Vec::new(),
+                labels: Vec::new(),
+            },
+        );
+        Ok(key)
+    }
+
+    fn get(&self, key: &PullRequestKey) -> Result<PullRequest, PullRequestError> {
+        self.note(format!("get {key}"));
+        let inner = self.lock();
+        let mut pr = inner
+            .prs
+            .get(key.as_str())
+            .cloned()
+            .ok_or_else(|| Self::missing(key))?;
+        // A pull request's rollup is whatever its head reports. So a test
+        // sets the checks once, and both reads answer from one table.
+        if let Some(checks) = inner.checks.get(&pr.head_ref) {
+            pr.checks = checks.clone();
+        }
+        Ok(pr)
+    }
+
+    fn list_open(&self, search: Option<&str>) -> Result<Vec<PullRequestSummary>, PullRequestError> {
+        self.note(format!("list {}", search.unwrap_or("*")));
+        let inner = self.lock();
+        let mut rows: Vec<PullRequestSummary> = inner
+            .prs
+            .values()
+            .filter(|pr| pr.state == PullRequestState::Open)
+            .filter(|pr| {
+                // The forge's own search is full text over the title and the
+                // body. That is why the caller filters again, more narrowly.
+                search.is_none_or(|needle| pr.title.contains(needle) || pr.body.contains(needle))
+            })
+            .map(|pr| PullRequestSummary {
+                key: pr.key.clone(),
+                title: pr.title.clone(),
+                body: pr.body.clone(),
+                head_ref: pr.head_ref.clone(),
+            })
+            .collect();
+        rows.sort_by(|a, b| a.key.cmp(&b.key));
+        Ok(rows)
+    }
+
+    fn checks_for_ref(&self, git_ref: &str) -> Result<Vec<Check>, PullRequestError> {
+        self.note(format!("checks {git_ref}"));
+        self.lock()
+            .checks
+            .get(git_ref)
+            .cloned()
+            .ok_or_else(|| Self::refused(&format!("nothing known about `{git_ref}`")))
+    }
+
+    fn required_checks(&self, branch: &str) -> Result<Vec<String>, PullRequestError> {
+        self.note(format!("required {branch}"));
+        Ok(self.lock().required.clone())
+    }
+
+    fn recent_commits(&self, branch: &str, depth: usize) -> Result<Vec<String>, PullRequestError> {
+        self.note(format!("commits {branch} {depth}"));
+        Ok(self.lock().commits.iter().take(depth).cloned().collect())
+    }
+
+    fn mark_ready(&self, key: &PullRequestKey) -> Result<(), PullRequestError> {
+        self.note(format!("ready {key}"));
+        let mut inner = self.lock();
+        let pr = inner
+            .prs
+            .get_mut(key.as_str())
+            .ok_or_else(|| Self::missing(key))?;
+        pr.draft = false;
+        Ok(())
+    }
+
+    fn add_label(&self, key: &PullRequestKey, label: &str) -> Result<(), PullRequestError> {
+        self.note(format!("label {key} {label}"));
+        let mut inner = self.lock();
+        let pr = inner
+            .prs
+            .get_mut(key.as_str())
+            .ok_or_else(|| Self::missing(key))?;
+        pr.labels.push(label.to_owned());
+        Ok(())
+    }
+
+    fn merge(&self, key: &PullRequestKey) -> Result<(), PullRequestError> {
+        self.note(format!("merge {key}"));
+        let mut inner = self.lock();
+        let pr = inner
+            .prs
+            .get_mut(key.as_str())
+            .ok_or_else(|| Self::missing(key))?;
+        pr.state = PullRequestState::Merged;
+        Ok(())
+    }
+
+    fn sync_with_base(&self, key: &PullRequestKey) -> Result<(), PullRequestError> {
+        self.note(format!("sync {key}"));
+        if self.lock().sync_succeeds {
+            Ok(())
+        } else {
+            Err(Self::refused("the branch is already level with its base"))
+        }
+    }
+
+    fn rerun_failed_checks(&self, key: &PullRequestKey) -> Result<(), PullRequestError> {
+        self.note(format!("rerun {key}"));
+        Ok(())
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/deliver/witness.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver/witness.rs
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The delivery loop's pull request steps, run end to end. The forge is not
+//! GitHub.
+//!
+//! Before the port, these steps ran `gh pr create`, `gh pr view`, `gh pr
+//! ready` and `gh pr merge` from inside `deliver`. So none of them could be
+//! reached without the GitHub CLI installed, logged in, and pointed at a real
+//! repository. Every test that survived had to stop at a decoded payload.
+//!
+//! Here the same shipped functions run to the end over
+//! [`FixtureForge`](super::fixture::FixtureForge), which spawns nothing. One
+//! process starts in all of this. It is the `git push` in
+//! [`open`](super::open), against a bare repository in a temp directory.
+
+use std::path::Path;
+use std::process::Command;
+
+use stella_autonomy::{BlockingPolicy, CiConclusion, Mergeability, ReviewState};
+use stella_protocol::pull_request::{Check, CheckOutcome, PullRequestProvider, PullRequestState};
+
+use super::fixture::FixtureForge;
+
+/// One check, in the port's vocabulary.
+fn check(name: &str, outcome: CheckOutcome) -> Check {
+    Check {
+        name: name.to_owned(),
+        outcome,
+    }
+}
+
+/// Run `git` in `root`. Fail the test with its stderr if git refuses.
+fn git(root: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git is installed");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A work tree on `branch`, with one commit and a bare remote to push to.
+fn workspace_with_remote(branch: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let remote = dir.path().join("remote.git");
+    let work = dir.path().join("work");
+    std::fs::create_dir_all(&work).expect("the work tree");
+
+    let bare = Command::new("git")
+        .args(["init", "--bare", "-q"])
+        .arg(&remote)
+        .output()
+        .expect("git is installed");
+    assert!(bare.status.success());
+
+    git(&work, &["init", "-q"]);
+    git(&work, &["config", "user.email", "loop@example.invalid"]);
+    git(&work, &["config", "user.name", "the loop"]);
+    git(&work, &["checkout", "-q", "-b", branch]);
+    std::fs::write(work.join("README.md"), "witness\n").expect("a file to commit");
+    git(&work, &["add", "README.md"]);
+    git(&work, &["commit", "-q", "-m", "first"]);
+    git(
+        &work,
+        &["remote", "add", "origin", &remote.to_string_lossy()],
+    );
+    dir
+}
+
+/// **The witness.** Open, observe, mark ready and merge, with no GitHub.
+///
+/// It fails on the code this replaced, for the plainest reason there is.
+/// Those four functions took no forge, so there was no way to hand them one.
+/// Each shelled out to `gh`, which a test cannot supply.
+///
+/// It asserts the journal, not just the end state. A merge that never asked
+/// the forge to merge would pass against a fixture that merged by itself.
+#[test]
+fn the_delivery_steps_run_against_a_forge_that_is_not_github() {
+    let branch = "fix/1-a-witness";
+    let dir = workspace_with_remote(branch);
+    let work = dir.path().join("work");
+
+    let forge = FixtureForge::new();
+    forge.set_required(&["fmt + clippy + test"]);
+    forge.set_commits(&["aaaa", "bbbb", "cccc"]);
+    forge.set_checks(
+        "main",
+        vec![check("fmt + clippy + test", CheckOutcome::Passed)],
+    );
+    for sha in ["aaaa", "bbbb", "cccc"] {
+        forge.set_checks(
+            sha,
+            vec![check("fmt + clippy + test", CheckOutcome::Passed)],
+        );
+    }
+    forge.set_checks(
+        branch,
+        vec![check("fmt + clippy + test", CheckOutcome::Running)],
+    );
+
+    let pr = super::open(
+        &forge,
+        &work,
+        branch,
+        "1",
+        "fix(x): a witness",
+        stella_autonomy::SIGNATURE,
+    )
+    .expect("the pull request opens");
+    assert_eq!(pr, "1");
+
+    let opened = forge.pr(&pr).expect("the forge holds it");
+    assert!(opened.draft, "it opens as a draft");
+    assert!(
+        opened.body.contains("Closes #1"),
+        "the body closes its issue: {:?}",
+        opened.body
+    );
+
+    let policy = BlockingPolicy::default();
+
+    let waiting = super::observe(&forge, &pr, &policy).expect("the forge answers");
+    assert_eq!(waiting.observation.ci, CiConclusion::Pending);
+    assert_eq!(waiting.observation.base_ci, CiConclusion::Green);
+    assert_eq!(waiting.observation.mergeable, Mergeability::Clean);
+    assert_eq!(waiting.observation.review, ReviewState::None);
+    assert!(waiting.observation.draft);
+    assert!(!waiting.settled);
+
+    forge.set_checks(
+        branch,
+        vec![check("fmt + clippy + test", CheckOutcome::Passed)],
+    );
+    let green = super::observe(&forge, &pr, &policy).expect("the forge answers");
+    assert_eq!(green.observation.ci, CiConclusion::Green);
+
+    super::mark_ready(&forge, &pr).expect("it comes out of draft");
+    assert!(!forge.pr(&pr).expect("still there").draft);
+
+    super::merge(&forge, &pr).expect("it merges");
+    assert_eq!(
+        forge.pr(&pr).expect("still there").state,
+        PullRequestState::Merged
+    );
+
+    let settled = super::observe(&forge, &pr, &policy).expect("the forge answers");
+    assert!(
+        settled.settled,
+        "a merged pull request has nothing left to decide"
+    );
+
+    let journal = forge.journal();
+    for call in ["open fix/1-a-witness", "get 1", "ready 1", "merge 1"] {
+        assert!(
+            journal.iter().any(|entry| entry == call),
+            "`{call}` is missing from {journal:?}"
+        );
+    }
+}
+
+/// A pull request whose every required check is stuck on the base is waived.
+///
+/// The second read the observation needs is the base's own history. That runs
+/// through the port too, so the whole of `observe` works without GitHub.
+#[test]
+fn a_check_stuck_on_the_base_is_waived_rather_than_blocking() {
+    let forge = FixtureForge::new();
+    forge.set_required(&["flaky"]);
+    forge.set_commits(&["aaaa", "bbbb", "cccc", "dddd"]);
+    for sha in ["aaaa", "bbbb", "cccc", "dddd", "main"] {
+        forge.set_checks(sha, vec![check("flaky", CheckOutcome::Failed)]);
+    }
+
+    let key = forge
+        .open(&stella_protocol::pull_request::PullRequestDraft {
+            head_ref: "fix/2".to_owned(),
+            title: "t".to_owned(),
+            body: "b".to_owned(),
+            draft: true,
+        })
+        .expect("the fixture opens it");
+    forge.set_checks("fix/2", vec![check("flaky", CheckOutcome::Failed)]);
+
+    let reading = super::observe(&forge, key.as_str(), &BlockingPolicy::default())
+        .expect("the forge answers");
+    assert_eq!(reading.waived.len(), 1, "{:?}", reading.waived);
+    assert!(
+        reading.waived[0].starts_with("flaky "),
+        "a check red on every recent base commit is nobody's to fix: {:?}",
+        reading.waived
+    );
+}
+
+/// The stale-verdict remedy asks for a base sync first. It re-runs only when
+/// the forge says there is nothing to sync.
+#[test]
+fn refreshing_prefers_a_base_sync_and_falls_back_to_a_rerun() {
+    let forge = FixtureForge::new();
+    super::refresh_against_base(&forge, "7").expect("the sync succeeds");
+    assert_eq!(forge.journal(), vec!["sync 7".to_owned()]);
+
+    let declining = FixtureForge::new();
+    declining.set_sync_succeeds(false);
+    super::refresh_against_base(&declining, "7").expect("the rerun succeeds");
+    assert_eq!(
+        declining.journal(),
+        vec!["sync 7".to_owned(), "rerun 7".to_owned()]
+    );
+}
+
+/// A restarted loop finds what it was carrying by asking the forge.
+#[test]
+fn the_listings_read_the_forge_rather_than_a_remembered_list() {
+    let forge = FixtureForge::new();
+    for (head, body) in [
+        ("stella/fix-1", "Closes #1"),
+        ("stella/fix-2", "Closes #2"),
+        ("someone-else/fix-3", "Closes #3"),
+    ] {
+        forge
+            .open(&stella_protocol::pull_request::PullRequestDraft {
+                head_ref: head.to_owned(),
+                title: "t".to_owned(),
+                body: body.to_owned(),
+                draft: true,
+            })
+            .expect("the fixture opens it");
+    }
+
+    assert_eq!(
+        super::open_prs_for_prefix(&forge, "stella/").expect("the forge answers"),
+        vec!["1".to_owned(), "2".to_owned()]
+    );
+    assert_eq!(
+        super::open_prs_for_issue(&forge, "2").expect("the forge answers"),
+        vec!["2".to_owned()]
+    );
+    assert_eq!(
+        super::prs_matching(&forge, "3").expect("the forge answers"),
+        vec!["3".to_owned()]
+    );
+}
+
+/// Local proof is recorded on the pull request, so it survives a restart.
+#[test]
+fn a_locally_verified_change_carries_its_label_into_the_next_read() {
+    let forge = FixtureForge::new();
+    let key = forge
+        .open(&stella_protocol::pull_request::PullRequestDraft {
+            head_ref: "fix/9".to_owned(),
+            title: "t".to_owned(),
+            body: "b".to_owned(),
+            draft: true,
+        })
+        .expect("the fixture opens it");
+    forge.set_checks("fix/9", Vec::new());
+
+    super::mark_verified_locally(&forge, key.as_str()).expect("the label lands");
+
+    // No required check means nothing the forge will gate on, so the label is
+    // the whole verdict.
+    let reading = super::observe(&forge, key.as_str(), &BlockingPolicy::default())
+        .expect("the forge answers");
+    assert!(reading.verified_locally);
+    assert_eq!(reading.observation.ci, CiConclusion::Green);
+}
+
+/// An unreadable forge reports a healthy base rather than an emergency.
+#[test]
+fn a_base_nobody_can_read_is_not_reported_broken() {
+    let forge = FixtureForge::new();
+    forge.set_required(&["ci"]);
+    assert!(
+        !super::base_is_broken(&forge, "main"),
+        "the fixture knows nothing about `main`, and a guess would file a \
+         breakage report about nothing"
+    );
+
+    forge.set_checks("main", vec![check("ci", CheckOutcome::Failed)]);
+    assert!(super::base_is_broken(&forge, "main"));
+}
+
+/// No pull request `gh` command survives outside the adapter.
+///
+/// The port only helps while every caller uses it. This reads the delivery
+/// loop's own source. It fails on a `gh` spawned anywhere in it, which stops
+/// the next change adding one beside the port rather than behind it.
+/// `crate::pull_request_provider` is the one file allowed to spell it.
+///
+/// Two readers are named as exceptions, because they are not about pull
+/// requests. `self_driving_cmd.rs` asks whether the CLI is installed, and
+/// reads the last workflow run on `main` for `report`'s wake-or-sleep
+/// verdict. `drive/deploy.rs` watches the release workflow. Neither one
+/// opens, reads or merges a pull request.
+#[test]
+fn the_delivery_loop_spawns_no_gh_of_its_own() {
+    const NOT_ABOUT_PULL_REQUESTS: [&str; 2] = ["self_driving_cmd.rs", "deploy.rs"];
+
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+    let mut pending = vec![src.join("self_driving_cmd")];
+    let mut files = vec![src.join("self_driving_cmd.rs")];
+    while let Some(path) = pending.pop() {
+        for entry in std::fs::read_dir(&path).expect("the delivery loop's source") {
+            let child = entry.expect("a directory entry").path();
+            if child.is_dir() {
+                pending.push(child);
+            } else if child.extension().is_some_and(|ext| ext == "rs") {
+                files.push(child);
+            }
+        }
+    }
+    for file in files {
+        let named = file
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if NOT_ABOUT_PULL_REQUESTS.contains(&named.as_str()) {
+            continue;
+        }
+        let text = std::fs::read_to_string(&file).expect("a source file");
+        if text.contains("Command::new(\"gh\")") {
+            offenders.push(file.display().to_string());
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these spawn `gh` outside the pull request adapter: {offenders:?}"
+    );
+}

--- a/crates/stella-cli/src/self_driving_cmd/deliver_verb.rs
+++ b/crates/stella-cli/src/self_driving_cmd/deliver_verb.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! `stella self-driving deliver` — the pull request verbs a person runs by
+//! hand.
+//!
+//! [`super::drive`] is the loop that runs these steps on its own.
+//! [`super::deliver`] is the I/O half both of them go through. This is the
+//! one-shot door. Open a pull request. Read one. Merge one.
+
+use super::{DeliverCmd, config, deliver, state};
+use crate::query_format::QueryFormat;
+
+/// One pull request verb, run once.
+///
+/// Every arm that acts reads the forge again first. None of them trusts a
+/// verdict handed to it. `merge` in particular does **not** take "the caller
+/// already ran `next`" as proof. The forge moves between calls. A merge
+/// allowed by a stale read is the very failure the machine's
+/// `Mergeability::Unknown` arm exists to stop.
+pub(super) fn run(cmd: &DeliverCmd) -> Result<(), String> {
+    let root = state::repo_root();
+    let forge = crate::pull_request_provider::GhPullRequests::new();
+
+    match cmd {
+        DeliverCmd::Open {
+            issue,
+            branch,
+            title,
+        } => {
+            let attribution = config::load(&root).attribution;
+            let pr = deliver::open(
+                &forge,
+                &root,
+                branch,
+                issue,
+                title,
+                &attribution.pull_request,
+            )?;
+            println!("opened #{pr} for #{issue} from {branch}");
+            Ok(())
+        }
+
+        DeliverCmd::Observe { pr, format } => {
+            let obs =
+                deliver::observe(&forge, pr, &config::load(&state::repo_root()).merge)?.observation;
+            if *format == QueryFormat::Json {
+                println!(
+                    "{}",
+                    serde_json::to_string(&obs).map_err(|e| e.to_string())?
+                );
+            } else {
+                println!(
+                    "pr #{pr}: ci={:?} base_ci={:?} mergeable={:?} review={:?} draft={}",
+                    obs.ci, obs.base_ci, obs.mergeable, obs.review, obs.draft
+                );
+            }
+            Ok(())
+        }
+
+        DeliverCmd::Next {
+            pr,
+            fixes,
+            rebases,
+            no_review,
+            format,
+        } => {
+            let transition = decide(pr, *fixes, *rebases, *no_review)?;
+            if *format == QueryFormat::Json {
+                println!(
+                    "{}",
+                    serde_json::to_string(&transition).map_err(|e| e.to_string())?
+                );
+            } else {
+                println!(
+                    "pr #{pr}: {:?} -> {:?}",
+                    transition.state, transition.action
+                );
+            }
+            Ok(())
+        }
+
+        DeliverCmd::Merge {
+            pr,
+            fixes,
+            rebases,
+            no_review,
+        } => {
+            let transition = decide(pr, *fixes, *rebases, *no_review)?;
+            if transition.action != stella_autonomy::Action::Merge {
+                // Refused, never skipped in silence. A caller that asked to
+                // merge and got nothing has to be able to tell "already
+                // merged" from "not allowed yet".
+                return Err(format!(
+                    "pr #{pr} is not mergeable yet — the machine says {:?} ({:?})",
+                    transition.action, transition.state
+                ));
+            }
+            deliver::merge(&forge, pr)?;
+            println!("merged #{pr}");
+            Ok(())
+        }
+    }
+}
+
+/// Read the forge. Run the pure machine over what it said.
+fn decide(
+    pr: &str,
+    fixes: u32,
+    rebases: u32,
+    no_review: bool,
+) -> Result<stella_autonomy::Transition, String> {
+    let forge = crate::pull_request_provider::GhPullRequests::new();
+    let obs = deliver::observe(&forge, pr, &config::load(&state::repo_root()).merge)?.observation;
+    let policy = stella_autonomy::DeliverPolicy {
+        require_approval: !no_review,
+        ..stella_autonomy::DeliverPolicy::default()
+    };
+    let attempts = stella_autonomy::Attempts { fixes, rebases };
+
+    // The state is worked out afresh each call. It is never stored. The forge
+    // is the truth about a pull request. A stored state that disagreed with it
+    // would be the stale read this design avoids. `CiPending` is the neutral
+    // way in, and every arm of the machine is reachable from it.
+    Ok(stella_autonomy::deliver_next(
+        stella_autonomy::PrState::CiPending,
+        &obs,
+        attempts,
+        &policy,
+    ))
+}

--- a/crates/stella-cli/src/self_driving_cmd/drive.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive.rs
@@ -61,12 +61,15 @@
 use std::collections::HashMap;
 
 use stella_autonomy::{
-    Action, Attempts, CarriedPr, CiConclusion, Contention, ContentionPolicy, ContentionVerdict,
-    DeliverPolicy, IssueRef, LoopObservation, LoopState, LoopStep, PrDisposition, PrRef, PrState,
-    UnblockAttempt, contention_verdict, deliver_next, step,
+    CarriedPr, Contention, ContentionPolicy, ContentionVerdict, IssueRef, LoopObservation,
+    LoopState, LoopStep, PrDisposition, PrRef, PrState, UnblockAttempt, contention_verdict, step,
 };
 use stella_fleet::issue_claim_key;
+use stella_protocol::pull_request::PullRequestProvider;
 
+// One deterministic step for one pull request, split out of this file so it
+// stays under the size ceiling.
+mod advance;
 mod deploy;
 mod ending;
 mod notify;
@@ -125,6 +128,9 @@ pub(super) fn drive(
     let settings = super::hooks::settings_for(&root);
     let doctrine = cfg.doctrine;
     let provider = crate::issue_provider::GhIssueProvider::from_manifest(&cfg.manifest);
+    // The forge, behind its port. Built once for the run and handed to every
+    // step that reads or drives a pull request, so nothing below spells `gh`.
+    let forge = crate::pull_request_provider::GhPullRequests::new();
 
     // Answered before the session record, the label installs and the
     // claims. Checking the loop's aim must not move its hand.
@@ -362,7 +368,7 @@ pub(super) fn drive(
     let mut triaged: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut tally = Tally::default();
 
-    resume(durable, &cfg, &mut state);
+    resume(&forge, durable, &cfg, &mut state);
 
     // Armed once the run is committed to looping, so a signal during the
     // set-up above still takes the default disposition and kills the process
@@ -403,6 +409,7 @@ pub(super) fn drive(
         }
 
         let obs = observe(
+            &forge,
             &root,
             durable,
             &provider,
@@ -546,7 +553,7 @@ pub(super) fn drive(
                     ranked,
                     |k| state.claimed.iter().any(|c| c.0 == k) || spent.contains_key(k),
                     doctrine.contention,
-                    |k| super::contention::for_issue(&root, k),
+                    |k| super::contention::for_issue(&forge, &root, k),
                     |k| super::claim::acquire(&root, k),
                     |k, evidence| {
                         deferrals += 1;
@@ -682,6 +689,7 @@ pub(super) fn drive(
                 // loop's: a single leftover branch must not halt a run that has
                 // other issues to get on with.
                 let outcome = match super::work::start(
+                    &forge,
                     &root,
                     &resolved,
                     &mut budget,
@@ -776,6 +784,7 @@ pub(super) fn drive(
                             .attribution
                             .title(&format!("{} (#{})", resolved.title, issue.0));
                         let pr = match super::deliver::open(
+                            &forge,
                             &root,
                             &branch,
                             &issue.0,
@@ -804,7 +813,7 @@ pub(super) fn drive(
                             // On the pull request, not in this process, so it
                             // survives a restart and a human can see which
                             // merges rested on local evidence.
-                            if let Err(error) = super::deliver::mark_verified_locally(&pr) {
+                            if let Err(error) = super::deliver::mark_verified_locally(&forge, &pr) {
                                 audit::record(
                                     durable,
                                     Audit::Transient,
@@ -862,8 +871,17 @@ pub(super) fn drive(
             }
 
             LoopStep::Deliver { pr } => {
-                let settled = match advance(
-                    &cfg.merge, &pr.0, &mut spent, no_review, &mut tally, durable, &settings,
+                let settled = match advance::advance(
+                    &advance::Pass {
+                        forge: &forge,
+                        policy_blocking: &cfg.merge,
+                        no_review,
+                        durable,
+                        settings: &settings,
+                    },
+                    &pr.0,
+                    &mut spent,
+                    &mut tally,
                 ) {
                     Ok(settled) => settled,
                     Err(error) => {
@@ -1028,8 +1046,13 @@ pub(super) fn drive(
 ///
 /// Not fatal if the forge cannot be read: that is the same transient condition
 /// the loop is built to wait through, and a later pass picks them up.
-fn resume(durable: &Durable, cfg: &super::config::LoopConfig, state: &mut LoopState) {
-    match super::deliver::open_prs_for_prefix(cfg.attribution.branch_prefix()) {
+fn resume(
+    forge: &dyn PullRequestProvider,
+    durable: &Durable,
+    cfg: &super::config::LoopConfig,
+    state: &mut LoopState,
+) {
+    match super::deliver::open_prs_for_prefix(forge, cfg.attribution.branch_prefix()) {
         Ok(carried) if !carried.is_empty() => {
             audit::record(
                 durable,
@@ -1058,216 +1081,6 @@ fn resume(durable: &Durable, cfg: &super::config::LoopConfig, state: &mut LoopSt
             None,
             &format!("could not read open pull requests to resume ({error}); continuing"),
         ),
-    }
-}
-
-/// Advance one pull request by exactly one deterministic transition.
-fn advance(
-    policy_blocking: &stella_autonomy::BlockingPolicy,
-    pr: &str,
-    spent: &mut HashMap<String, Spent>,
-    no_review: bool,
-    tally: &mut Tally,
-    durable: &Durable,
-    settings: &crate::settings::Settings,
-) -> Result<Settlement, String> {
-    let entry = spent.entry(pr.to_owned()).or_default();
-    let reading = super::deliver::observe(pr, policy_blocking)?;
-    if reading.settled {
-        // Nothing left to decide. Reached either because the merge below
-        // succeeded and the cleanup after it did not, or because a human got
-        // there first — both are this pull request being done.
-        audit::record(
-            durable,
-            Audit::PrMerged,
-            Some(pr),
-            "already settled on the forge — carrying it no further",
-        );
-        // Deliberately not `Merged`: this arm is reached both when a human
-        // merged it first and when the merge below succeeded but the pass
-        // after it did not, and only one of those is this loop's merge to
-        // report. Closing on it would credit the loop with a closure it did
-        // not make, and the human who merged is the one who knows whether the
-        // issue is finished.
-        return Ok(Settlement::Otherwise);
-    }
-    // Said out loud every time. A loop that merges past a check the repository
-    // marks required, without naming which one and on what grounds, is
-    // indistinguishable from one that is simply broken.
-    if !reading.waived.is_empty() {
-        audit::record(
-            durable,
-            Audit::Waived,
-            Some(pr),
-            &format!(
-                "not blocking on {} — {}{}",
-                reading.waived.len(),
-                reading.waived.join("; "),
-                if reading.verified_locally {
-                    ". This change was proved here instead"
-                } else {
-                    ". This change has no local proof either"
-                }
-            ),
-        );
-    }
-
-    let obs = reading.observation;
-    let policy = DeliverPolicy {
-        require_approval: !no_review,
-        ..DeliverPolicy::default()
-    };
-
-    let transition = deliver_next(
-        PrState::CiPending,
-        &obs,
-        Attempts {
-            fixes: entry.fixes,
-            rebases: entry.rebases,
-        },
-        &policy,
-    );
-
-    audit::record(
-        durable,
-        Audit::PrObserved,
-        Some(pr),
-        &format!(
-            "ci={:?} base={:?} mergeable={:?} review={:?} -> {:?}",
-            obs.ci, obs.base_ci, obs.mergeable, obs.review, transition.action
-        ),
-    );
-
-    // Counted whether or not it changes the action: waiting on somebody else's
-    // broken base is time this loop spent, and a high count is a fact about the
-    // repository rather than about the loop.
-    if obs.base_ci == CiConclusion::Red {
-        durable.update_stats(|s| s.base_broken_waits += 1);
-    }
-
-    notify::observed(&durable.repo_root, settings, entry, transition.state, pr);
-
-    match transition.action {
-        Action::Merge => {
-            super::deliver::merge(pr)?;
-            tally.merged += 1;
-            durable.update_stats(|s| s.prs_merged += 1);
-            audit::record(durable, Audit::PrMerged, Some(pr), "merged");
-            // After the merge, so the event means it landed. The
-            // already-settled arm above fires none: a human merged that one.
-            notify::performed(
-                &durable.repo_root,
-                settings,
-                super::hooks::HookEvent::PullRequestMerged,
-                pr,
-                None,
-            );
-            Ok(Settlement::Merged)
-        }
-        Action::Escalate { reason } => {
-            tally.escalated += 1;
-            durable.update_stats(|s| s.prs_escalated += 1);
-            audit::record(
-                durable,
-                Audit::PrEscalated,
-                Some(pr),
-                &format!("handed to a human: {reason:?}"),
-            );
-            Ok(Settlement::Otherwise)
-        }
-        Action::MarkReady => {
-            super::deliver::mark_ready(pr)?;
-            audit::record(
-                durable,
-                Audit::PrObserved,
-                Some(pr),
-                "ci is green — taken out of draft",
-            );
-            notify::performed(
-                &durable.repo_root,
-                settings,
-                super::hooks::HookEvent::PullRequestReadyForReview,
-                pr,
-                None,
-            );
-            Ok(Settlement::Pending)
-        }
-        Action::PushFix => {
-            // A red that the base already explains is not this pull request's
-            // to fix, and `base_conclusion` cannot see it: it compares what is
-            // failing *now*, and a check that ran against a base which has
-            // since been repaired keeps its old verdict forever. The pull
-            // request looks guilty of a failure that no longer exists
-            // anywhere.
-            //
-            // Asking the forge to run it again is the cheapest way to find
-            // out, and costs nothing but CI minutes when the answer is "still
-            // red" — at which point the fix path below runs on the next poll
-            // with the re-run already spent. One per pull request: a loop that
-            // re-ran on every red would never reach the fix, and would spin on
-            // a genuine failure for as long as the operator left it up.
-            if !entry.rerun {
-                entry.rerun = true;
-                match super::deliver::refresh_against_base(pr) {
-                    Ok(()) => {
-                        audit::record(
-                            durable,
-                            Audit::PrObserved,
-                            Some(pr),
-                            "red against a base that has since gone green — merged the base in for a \
-                             fresh verdict before treating it as ours",
-                        );
-                        return Ok(Settlement::Pending);
-                    }
-                    Err(error) => audit::record(
-                        durable,
-                        Audit::Transient,
-                        Some(pr),
-                        &format!("could not ask for a re-run ({error}); treating the red as ours"),
-                    ),
-                }
-            }
-
-            // Counted even though this slice does not author the fix: the
-            // ceiling is what stops a loop pushing the same broken change
-            // forever, and a counter that only moved on success would never
-            // reach it.
-            entry.fixes += 1;
-            // Both counters move, because two things are true and a reader of
-            // either number alone would be misled. A fix was owed — that is
-            // `fixes_pushed`, and it is what the attempt ceiling reads. And
-            // the pull request was handed to a human — that is
-            // `prs_escalated`, and it is what a dashboard reads as "needs
-            // someone".
-            //
-            // Counting only the first left the audit log recording
-            // `pr_escalated` twice while `prs_escalated` stayed at zero: two
-            // records of one event that disagreed about what it was.
-            durable.update_stats(|s| {
-                s.fixes_pushed += 1;
-                s.prs_escalated += 1;
-            });
-            tally.escalated += 1;
-            audit::record(
-                durable,
-                Audit::PrEscalated,
-                Some(pr),
-                "needs a fix, which this build does not author — leaving it for a human",
-            );
-            Ok(Settlement::Otherwise)
-        }
-        Action::Rebase => {
-            entry.rebases += 1;
-            durable.update_stats(|s| s.rebases += 1);
-            audit::record(
-                durable,
-                Audit::PrEscalated,
-                Some(pr),
-                "needs a rebase, which this build does not perform — leaving it",
-            );
-            Ok(Settlement::Otherwise)
-        }
-        Action::Wait => Ok(Settlement::Pending),
     }
 }
 
@@ -1394,6 +1207,7 @@ fn next_claimable(
 /// how to handle, and a second way to stop would be a second definition of
 /// stopping.
 fn observe(
+    forge: &dyn PullRequestProvider,
     root: &std::path::Path,
     durable: &Durable,
     provider: &crate::issue_provider::GhIssueProvider,
@@ -1422,7 +1236,7 @@ fn observe(
     // The base is read on every poll rather than cached, because "somebody
     // repaired main" is exactly the event this loop must notice without being
     // told. A latch here would be the thing that stops it self-resuming.
-    let base_broken = super::deliver::base_is_broken(base);
+    let base_broken = super::deliver::base_is_broken(forge, base);
 
     // Nothing else is worth asking while the base is fine, and each of these
     // is a network call.
@@ -1442,7 +1256,7 @@ fn observe(
     let filed = super::backlog::open_base_breakage(provider).filed();
     let contention = filed
         .as_ref()
-        .map(|key| super::contention::for_base_fix(root, key))
+        .map(|key| super::contention::for_base_fix(forge, root, key))
         .unwrap_or_default();
 
     // `grant_valid` and `budget_exhausted` are declarations, not observations,

--- a/crates/stella-cli/src/self_driving_cmd/drive/advance.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive/advance.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! One fixed step for one pull request.
+//!
+//! [`super::drive`] holds the poll loop and the queue walk. This holds the arm
+//! that acts. Read the forge. Run the pure machine over what it said. Do the
+//! one thing it returned.
+
+use std::collections::HashMap;
+
+use stella_autonomy::{Action, Attempts, CiConclusion, DeliverPolicy, PrState, deliver_next};
+use stella_protocol::pull_request::PullRequestProvider;
+
+use super::{Audit, Durable, Settlement, Spent, Tally, audit, notify};
+
+/// What a delivery pass carries for the whole run.
+///
+/// Grouped so the per-pull-request arguments stand out. The rest never change
+/// between them.
+pub(super) struct Pass<'a> {
+    /// The forge, behind its port.
+    pub(super) forge: &'a dyn PullRequestProvider,
+    /// Which checks may block a merge.
+    pub(super) policy_blocking: &'a stella_autonomy::BlockingPolicy,
+    /// Whether a human's approval is asked for before a merge.
+    pub(super) no_review: bool,
+    /// Where the audit line and the run's statistics go.
+    pub(super) durable: &'a Durable,
+    /// The workspace's settings, for the notifications a transition raises.
+    pub(super) settings: &'a crate::settings::Settings,
+}
+
+/// Move one pull request by exactly one fixed step.
+pub(super) fn advance(
+    pass: &Pass<'_>,
+    pr: &str,
+    spent: &mut HashMap<String, Spent>,
+    tally: &mut Tally,
+) -> Result<Settlement, String> {
+    let Pass {
+        forge,
+        policy_blocking,
+        no_review,
+        durable,
+        settings,
+    } = *pass;
+    let entry = spent.entry(pr.to_owned()).or_default();
+    let reading = crate::self_driving_cmd::deliver::observe(forge, pr, policy_blocking)?;
+    if reading.settled {
+        // Nothing left to decide. The merge below may have worked while the
+        // cleanup after it did not. Or a human got there first. Either way,
+        // this pull request is done.
+        audit::record(
+            durable,
+            Audit::PrMerged,
+            Some(pr),
+            "already settled on the forge — carrying it no further",
+        );
+        // Not `Merged`. This arm is reached when a human merged it first, and
+        // also when the merge below worked and the pass after it did not. Only
+        // one of those is this loop's merge to report. Closing on it would credit the loop with a closure it did
+        // not make, and the human who merged is the one who knows whether the
+        // issue is finished.
+        return Ok(Settlement::Otherwise);
+    }
+    // Said out loud every time. A loop that merges past a check the repository
+    // marks required, without naming which one and on what grounds, is
+    // indistinguishable from one that is simply broken.
+    if !reading.waived.is_empty() {
+        audit::record(
+            durable,
+            Audit::Waived,
+            Some(pr),
+            &format!(
+                "not blocking on {} — {}{}",
+                reading.waived.len(),
+                reading.waived.join("; "),
+                if reading.verified_locally {
+                    ". This change was proved here instead"
+                } else {
+                    ". This change has no local proof either"
+                }
+            ),
+        );
+    }
+
+    let obs = reading.observation;
+    let policy = DeliverPolicy {
+        require_approval: !no_review,
+        ..DeliverPolicy::default()
+    };
+
+    let transition = deliver_next(
+        PrState::CiPending,
+        &obs,
+        Attempts {
+            fixes: entry.fixes,
+            rebases: entry.rebases,
+        },
+        &policy,
+    );
+
+    audit::record(
+        durable,
+        Audit::PrObserved,
+        Some(pr),
+        &format!(
+            "ci={:?} base={:?} mergeable={:?} review={:?} -> {:?}",
+            obs.ci, obs.base_ci, obs.mergeable, obs.review, transition.action
+        ),
+    );
+
+    // Counted whether or not it changes the action. Waiting on somebody
+    // else's broken base is time this loop spent. A high count says something
+    // about the repository, not about the loop.
+    if obs.base_ci == CiConclusion::Red {
+        durable.update_stats(|s| s.base_broken_waits += 1);
+    }
+
+    notify::observed(&durable.repo_root, settings, entry, transition.state, pr);
+
+    match transition.action {
+        Action::Merge => {
+            crate::self_driving_cmd::deliver::merge(forge, pr)?;
+            tally.merged += 1;
+            durable.update_stats(|s| s.prs_merged += 1);
+            audit::record(durable, Audit::PrMerged, Some(pr), "merged");
+            // After the merge, so the event means it landed. The
+            // already-settled arm above fires none: a human merged that one.
+            notify::performed(
+                &durable.repo_root,
+                settings,
+                crate::self_driving_cmd::hooks::HookEvent::PullRequestMerged,
+                pr,
+                None,
+            );
+            Ok(Settlement::Merged)
+        }
+        Action::Escalate { reason } => {
+            tally.escalated += 1;
+            durable.update_stats(|s| s.prs_escalated += 1);
+            audit::record(
+                durable,
+                Audit::PrEscalated,
+                Some(pr),
+                &format!("handed to a human: {reason:?}"),
+            );
+            Ok(Settlement::Otherwise)
+        }
+        Action::MarkReady => {
+            crate::self_driving_cmd::deliver::mark_ready(forge, pr)?;
+            audit::record(
+                durable,
+                Audit::PrObserved,
+                Some(pr),
+                "ci is green — taken out of draft",
+            );
+            notify::performed(
+                &durable.repo_root,
+                settings,
+                crate::self_driving_cmd::hooks::HookEvent::PullRequestReadyForReview,
+                pr,
+                None,
+            );
+            Ok(Settlement::Pending)
+        }
+        Action::PushFix => {
+            // A red the base already explains is not this pull request's to
+            // fix. `base_conclusion` cannot see it. It compares what is
+            // failing *now*, and a check that ran against a base somebody has
+            // since repaired keeps its old verdict. The pull request looks
+            // guilty of a failure that happens nowhere.
+            //
+            // Asking the forge to run it again is the cheapest way to find
+            // out. When the answer is "still red" it costs only CI minutes,
+            // and the fix path below runs on the next poll with the re-run
+            // already spent. One per pull request: a loop that
+            // re-ran on every red would never reach the fix, and would spin on
+            // a genuine failure for as long as the operator left it up.
+            if !entry.rerun {
+                entry.rerun = true;
+                match crate::self_driving_cmd::deliver::refresh_against_base(forge, pr) {
+                    Ok(()) => {
+                        audit::record(
+                            durable,
+                            Audit::PrObserved,
+                            Some(pr),
+                            "red against a base that has since gone green — merged the base in for a \
+                             fresh verdict before treating it as ours",
+                        );
+                        return Ok(Settlement::Pending);
+                    }
+                    Err(error) => audit::record(
+                        durable,
+                        Audit::Transient,
+                        Some(pr),
+                        &format!("could not ask for a re-run ({error}); treating the red as ours"),
+                    ),
+                }
+            }
+
+            // Counted even though this slice writes no fix. The ceiling is
+            // what stops a loop pushing the same broken change for ever. A
+            // counter that moved only on success would never reach it.
+            entry.fixes += 1;
+            // Both counters move, because two things are true and a reader of
+            // either number alone would be misled. A fix was owed — that is
+            // `fixes_pushed`, and it is what the attempt ceiling reads. And
+            // the pull request was handed to a human — that is
+            // `prs_escalated`, and it is what a dashboard reads as "needs
+            // someone".
+            //
+            // Counting only the first left the audit log recording
+            // `pr_escalated` twice while `prs_escalated` stayed at zero: two
+            // records of one event that disagreed about what it was.
+            durable.update_stats(|s| {
+                s.fixes_pushed += 1;
+                s.prs_escalated += 1;
+            });
+            tally.escalated += 1;
+            audit::record(
+                durable,
+                Audit::PrEscalated,
+                Some(pr),
+                "needs a fix, which this build does not author — leaving it for a human",
+            );
+            Ok(Settlement::Otherwise)
+        }
+        Action::Rebase => {
+            entry.rebases += 1;
+            durable.update_stats(|s| s.rebases += 1);
+            audit::record(
+                durable,
+                Audit::PrEscalated,
+                Some(pr),
+                "needs a rebase, which this build does not perform — leaving it",
+            );
+            Ok(Settlement::Otherwise)
+        }
+        Action::Wait => Ok(Settlement::Pending),
+    }
+}

--- a/crates/stella-cli/src/self_driving_cmd/drive/tests.rs
+++ b/crates/stella-cli/src/self_driving_cmd/drive/tests.rs
@@ -225,14 +225,16 @@ fn scratch_loop_state(dir: &std::path::Path) -> Durable {
 /// `step`'s own tests, so the machine's stop branches were correct and
 /// unreachable: nothing the host could observe would ever return them.
 ///
-/// The whole assertion runs offline. A parked observation is taken before any
-/// forge read precisely so a stopped loop spends nothing, which is what lets
-/// this drive the real `observe` rather than a stand-in for it.
+/// Neither half touches a network. A parked read is taken before any forge
+/// read, so a stopped loop spends nothing. The unparked read goes to a fixture
+/// forge that knows nothing about `main`. That is the unread base, and
+/// `base_is_broken` calls it healthy.
 #[test]
 fn a_stop_flag_parks_the_machine_and_dropping_it_returns_work() {
     let dir = tempfile::tempdir().expect("state dir");
     let durable = scratch_loop_state(dir.path());
     let provider = crate::issue_provider::GhIssueProvider::default();
+    let forge = super::super::deliver::fixture::FixtureForge::new();
     let state = LoopState {
         planned: true,
         batch: 3,
@@ -241,7 +243,7 @@ fn a_stop_flag_parks_the_machine_and_dropping_it_returns_work() {
     let doctrine = stella_autonomy::Doctrine::default();
 
     std::fs::write(super::super::stop::stop_file(&durable.dir), "").expect("write the stop flag");
-    let parked = observe(dir.path(), &durable, &provider, "main", 3, 0);
+    let parked = observe(&forge, dir.path(), &durable, &provider, "main", 3, 0);
     assert!(parked.stop_requested, "the flag must reach the observation");
     assert!(
         matches!(
@@ -258,7 +260,7 @@ fn a_stop_flag_parks_the_machine_and_dropping_it_returns_work() {
     // The other half, and the one the design turns on: nothing latched, so the
     // block stops being returned on the next poll with no resume input at all.
     std::fs::remove_file(super::super::stop::stop_file(&durable.dir)).expect("drop the flag");
-    let resumed = observe(dir.path(), &durable, &provider, "main", 3, 0);
+    let resumed = observe(&forge, dir.path(), &durable, &provider, "main", 3, 0);
     assert!(
         !resumed.stop_requested,
         "dropping the flag must clear the stop with no resume signal"

--- a/crates/stella-cli/src/self_driving_cmd/work.rs
+++ b/crates/stella-cli/src/self_driving_cmd/work.rs
@@ -721,6 +721,7 @@ pub(super) struct Worktree {
 /// real `stella run` inside it with the issue quoted as data, then read the
 /// tree.
 pub(crate) fn start(
+    forge: &dyn stella_protocol::pull_request::PullRequestProvider,
     root: &Path,
     issue: &Issue,
     budget: &mut RunBudget,
@@ -760,7 +761,7 @@ pub(crate) fn start(
             // for days — so "nothing here will discard it for you" was a rule
             // that quietly retired an issue on every crash.
             let text = error.to_string();
-            if !discard_undelivered_attempt(root, issue.key.as_str(), &text) {
+            if !discard_undelivered_attempt(forge, root, issue.key.as_str(), &text) {
                 return Err(stale_attempt_hint(root, issue.key.as_str(), &text));
             }
             runtime
@@ -859,17 +860,22 @@ pub(crate) fn start(
 /// that died before it produced anything — or produced something nobody can
 /// see, which is the same thing from here.
 ///
-/// An open pull request stops this cold. So does an unreadable forge: `gh`
-/// failing is not evidence that nothing was delivered, and discarding on a
+/// An open pull request stops this cold. So does an unreadable forge: a read
+/// that failed is not evidence that nothing was delivered, and discarding on a
 /// network blip would throw away real work.
-fn discard_undelivered_attempt(root: &Path, key: &str, error: &str) -> bool {
+fn discard_undelivered_attempt(
+    forge: &dyn stella_protocol::pull_request::PullRequestProvider,
+    root: &Path,
+    key: &str,
+    error: &str,
+) -> bool {
     if !error.contains("already exists") {
         return false;
     }
 
     // Ask the forge before touching anything. An error here is a refusal, not
     // a licence.
-    let Ok(open) = super::deliver::open_prs_for_issue(key) else {
+    let Ok(open) = super::deliver::open_prs_for_issue(forge, key) else {
         return false;
     };
     if !open.is_empty() {

--- a/crates/stella-protocol/src/lib.rs
+++ b/crates/stella-protocol/src/lib.rs
@@ -80,6 +80,7 @@ pub mod plan_graph;
 pub mod proof;
 pub mod provenance;
 pub mod provider;
+pub mod pull_request;
 pub mod question;
 pub mod recall;
 pub mod receipt;

--- a/crates/stella-protocol/src/pull_request.rs
+++ b/crates/stella-protocol/src/pull_request.rs
@@ -1,0 +1,383 @@
+//! The pull request kernel, and the port a forge is reached through.
+//!
+//! The sibling of [`issue`](crate::issue), one plane over. Issues got their
+//! seam first. The loop reads `Issue` values, and a tracker is an
+//! `IssueProvider`. Pull requests did not. The delivery half of the loop
+//! still spelled `gh pr view` and `gh pr merge` into its own reader, and two
+//! GitHub REST endpoints beside them. This module is the matching seam. A
+//! forge becomes an implementation of [`PullRequestProvider`], and the loop
+//! reads [`PullRequest`] values.
+//!
+//! # The model carries facts, never verdicts
+//!
+//! A provider answers what the forge said. Draft or not, what state, which
+//! checks with which outcome, who reviewed. It decides nothing else. Which
+//! checks may block a merge is policy. So is whether a red base excuses a red
+//! pull request, and what to do next. All of it stays above the port, in
+//! `stella-cli`'s `deliver` module and in `stella-autonomy`'s pure machine.
+//!
+//! # The port is synchronous
+//!
+//! [`IssueProvider`](crate::issue::IssueProvider) is async, and its callers
+//! each build a runtime to block on it. This one is not. Every caller is a
+//! plain verb of the delivery loop, and the shipped adapter runs a
+//! subprocess, which blocks whatever calls it. A provider that speaks HTTP
+//! holds its own runtime, the way those callers already do.
+
+use serde::{Deserialize, Serialize};
+
+/// A forge's own name for one pull request — `"4022"` on GitHub.
+///
+/// A newtype for [`IssueKey`](crate::issue::IssueKey)'s reason. A bare
+/// `String` beside a branch name and a title is a swap the compiler cannot
+/// see.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct PullRequestKey(pub String);
+
+impl PullRequestKey {
+    /// The key as the forge spells it.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PullRequestKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for PullRequestKey {
+    fn from(raw: &str) -> Self {
+        Self(raw.to_owned())
+    }
+}
+
+/// What went wrong reaching a forge.
+///
+/// The cases are [`IssueError`](crate::issue::IssueError)'s, chosen the same
+/// way: by what a caller has to do differently. An unavailable forge is
+/// retried or degraded. An unauthenticated one needs a human. A missing pull
+/// request is a permanent answer. A payload that will not parse is a bug in
+/// the provider.
+#[derive(Debug, thiserror::Error)]
+pub enum PullRequestError {
+    /// The provider's transport is not installed or not on `PATH`.
+    #[error("pull request provider `{provider}` is unavailable: {reason}")]
+    Unavailable {
+        /// The provider id that could not be reached.
+        provider: String,
+        /// What was missing, in terms a human can act on.
+        reason: String,
+    },
+    /// The transport is present but the caller is not authenticated to it.
+    #[error("pull request provider `{provider}` is not authenticated: {reason}")]
+    Unauthenticated {
+        /// The provider id that refused.
+        provider: String,
+        /// What the forge said.
+        reason: String,
+    },
+    /// No pull request with that key.
+    #[error("no such pull request: {key}")]
+    NotFound {
+        /// The key that resolved to nothing.
+        key: PullRequestKey,
+    },
+    /// The forge answered, and the answer did not parse.
+    #[error(
+        "pull request provider `{provider}` returned a payload this build cannot read: {reason}"
+    )]
+    Malformed {
+        /// The provider id whose payload was rejected.
+        provider: String,
+        /// The parse failure.
+        reason: String,
+    },
+    /// The forge answered with a failure of its own.
+    #[error("pull request provider `{provider}` failed: {reason}")]
+    Failed {
+        /// The provider id that failed.
+        provider: String,
+        /// What it said.
+        reason: String,
+    },
+}
+
+/// Where one check got to.
+///
+/// Four outcomes rather than a pass/fail pair, because the loop branches on
+/// all four. [`Running`](CheckOutcome::Running) means wait.
+/// [`Inert`](CheckOutcome::Inert) means this check will never answer, so
+/// nothing should wait on it. The other two are the verdicts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckOutcome {
+    /// It ran and it passed.
+    Passed,
+    /// It ran and it failed. A service that broke while running its own check
+    /// belongs here too. For every purpose the loop has, that is a failure.
+    Failed,
+    /// It has not answered yet.
+    Running,
+    /// It was skipped, cancelled, or reported neutral. Not a pass and not a
+    /// failure: it did not run. A loop that waited on one would wait for ever
+    /// on a job that is skipped by design.
+    Inert,
+}
+
+/// One check as a forge reports it, reduced to what a decision reads.
+///
+/// Whatever dialect the forge speaks, a provider answers a name and an
+/// outcome. The name is the join key. A pull request's failure is excused by
+/// its base only when the check *of that name* fails there too.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Check {
+    /// What the forge calls this check.
+    pub name: String,
+    /// Where it got to.
+    pub outcome: CheckOutcome,
+}
+
+/// Where a pull request has got to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PullRequestState {
+    /// Still open, merged into nothing yet.
+    Open,
+    /// Merged.
+    Merged,
+    /// Closed without merging.
+    Closed,
+}
+
+impl PullRequestState {
+    /// Whether nothing is left to decide about this pull request.
+    ///
+    /// Both end states, so a caller cannot ask about one and forget the
+    /// other. A merged pull request reports its mergeability as
+    /// [`Unknown`](MergeStatus::Unknown). A decision machine reads that as
+    /// "wait", and waits for ever unless something says the wait is over.
+    #[must_use]
+    pub fn settled(self) -> bool {
+        matches!(self, Self::Merged | Self::Closed)
+    }
+}
+
+/// Whether the forge believes this pull request can be merged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeStatus {
+    /// It merges cleanly.
+    Clean,
+    /// It conflicts with its base.
+    Conflicted,
+    /// Nobody can say yet. A forge reports this before it has worked the
+    /// answer out. So it gets its own case, not a hopeful
+    /// [`Clean`](MergeStatus::Clean). Reading it as clean is how a merge is
+    /// tried into a conflict.
+    Unknown,
+}
+
+/// What human review concluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewDecision {
+    /// Someone approved it.
+    Approved,
+    /// Someone asked for changes.
+    ChangesRequested,
+    /// Nobody has reviewed it, or the repository asks for no review.
+    None,
+}
+
+/// One read of a pull request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequest {
+    /// The forge's number for it.
+    pub key: PullRequestKey,
+    /// Open, merged, or closed.
+    pub state: PullRequestState,
+    /// Whether it is still a draft.
+    pub draft: bool,
+    /// The branch it merges into, as the forge names it. Never a
+    /// remote-tracking name. A caller that resolved `origin/<base>` locally
+    /// would read whatever the last fetch left behind.
+    pub base_ref: String,
+    /// The branch it merges from.
+    pub head_ref: String,
+    /// Its title.
+    pub title: String,
+    /// Its description.
+    pub body: String,
+    /// Whether the forge thinks it merges.
+    pub merge_status: MergeStatus,
+    /// What review concluded.
+    pub review: ReviewDecision,
+    /// Every check the forge ties to its head, in whatever dialect they
+    /// arrived.
+    pub checks: Vec<Check>,
+    /// The labels on it.
+    pub labels: Vec<String>,
+}
+
+/// A prospective pull request, before a forge has assigned it a number.
+///
+/// A separate type from [`PullRequest`], not one with an empty key.
+/// [`IssueDraft`](crate::issue::IssueDraft) splits off from an issue for the
+/// same reason. State, mergeability, review and checks are the forge's to
+/// decide. A type whose wrong states cannot be written beats one whose caller
+/// has to remember which fields are ignored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestDraft {
+    /// The branch to merge from. It must already be pushed.
+    pub head_ref: String,
+    /// The title.
+    pub title: String,
+    /// The description.
+    pub body: String,
+    /// Whether to open it as a draft.
+    pub draft: bool,
+}
+
+/// A pull request as a listing reports it.
+///
+/// Lighter than [`PullRequest`]. A listing carries no checks, and a caller
+/// reading a list does not want one check read per row. The fields are what
+/// the loop's three listings ask about: which branch a restarted run was
+/// carrying, and whether another pull request already names an issue.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestSummary {
+    /// The forge's number for it.
+    pub key: PullRequestKey,
+    /// Its title.
+    pub title: String,
+    /// Its description.
+    pub body: String,
+    /// The branch it merges from.
+    pub head_ref: String,
+}
+
+/// Reading and driving pull requests on one forge.
+///
+/// Every method answers a fact or makes one change. None of them decides
+/// anything. See the module docs.
+pub trait PullRequestProvider: Send + Sync {
+    /// Stable id for this provider, e.g. `"github"` — what an error names and
+    /// what a workspace binds to.
+    fn id(&self) -> &str;
+
+    /// Open a pull request and return the key the forge assigned it.
+    ///
+    /// The key is the whole return value, for the reason
+    /// [`IssueProvider::file`](crate::issue::IssueProvider::file)'s is. A pull
+    /// request the caller cannot name again can be neither read nor merged.
+    fn open(&self, draft: &PullRequestDraft) -> Result<PullRequestKey, PullRequestError>;
+
+    /// Read one pull request, checks included.
+    fn get(&self, key: &PullRequestKey) -> Result<PullRequest, PullRequestError>;
+
+    /// Open pull requests, optionally narrowed by the forge's own text search.
+    ///
+    /// The search is the forge's, so its precision is the forge's too. A
+    /// caller that needs an exact match filters what comes back. It does not
+    /// trust the query.
+    fn list_open(&self, search: Option<&str>) -> Result<Vec<PullRequestSummary>, PullRequestError>;
+
+    /// Every check the forge associates with a ref — a branch name or a commit
+    /// id.
+    ///
+    /// Named to the forge, never resolved locally first, so no local state is
+    /// left to go stale.
+    ///
+    /// An error means nobody could say. That is not the same as an empty list.
+    /// A caller weighing a pull request against its base needs both answers.
+    /// An unread base is no evidence that the base is fine.
+    fn checks_for_ref(&self, git_ref: &str) -> Result<Vec<Check>, PullRequestError>;
+
+    /// The check names this repository requires to merge into `branch`.
+    ///
+    /// An error covers two cases. There may be no permission to read the
+    /// protection document, or no protection set at all. A caller treats them
+    /// the same, because it learns nothing about what is required. What it
+    /// does then is policy, not the provider's business.
+    fn required_checks(&self, branch: &str) -> Result<Vec<String>, PullRequestError>;
+
+    /// The newest `depth` commit ids on `branch`, newest first.
+    ///
+    /// Feeds one question. Has a check failed on the base for long enough to
+    /// be nobody's to fix?
+    fn recent_commits(&self, branch: &str, depth: usize) -> Result<Vec<String>, PullRequestError>;
+
+    /// Take a pull request out of draft.
+    fn mark_ready(&self, key: &PullRequestKey) -> Result<(), PullRequestError>;
+
+    /// Add a label.
+    fn add_label(&self, key: &PullRequestKey, label: &str) -> Result<(), PullRequestError>;
+
+    /// Merge it.
+    ///
+    /// A pull request that is **already** merged is where this method was
+    /// going. So a provider answers `Ok` for it, not an error. Racing a human
+    /// who merged by hand must not read as a failure.
+    fn merge(&self, key: &PullRequestKey) -> Result<(), PullRequestError>;
+
+    /// Merge the base branch into this pull request's head.
+    ///
+    /// The remedy for a check that ran against a base somebody has since
+    /// repaired. A forge may decline, because the branch is already level with
+    /// its base. That is an answer, and it arrives as an error a caller can
+    /// fall back from.
+    fn sync_with_base(&self, key: &PullRequestKey) -> Result<(), PullRequestError>;
+
+    /// Run this pull request's failed checks again.
+    ///
+    /// The fallback when there is no staleness to clear. A pull request with
+    /// nothing failing has nothing to re-run. That is an error, not a quiet
+    /// success: a caller reached this because it saw red.
+    fn rerun_failed_checks(&self, key: &PullRequestKey) -> Result<(), PullRequestError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Both terminal states settle, and an open one does not.
+    ///
+    /// This is what stops a loop re-reading a pull request it has already
+    /// merged. Merged reports [`MergeStatus::Unknown`], which reads as "wait"
+    /// for as long as anything keeps asking.
+    #[test]
+    fn merged_and_closed_are_the_states_with_nothing_left_to_decide() {
+        assert!(PullRequestState::Merged.settled());
+        assert!(PullRequestState::Closed.settled());
+        assert!(!PullRequestState::Open.settled());
+    }
+
+    /// Every type crossing a crate boundary round-trips (AGENTS.md #4).
+    #[test]
+    fn a_pull_request_round_trips_through_json() {
+        let pr = PullRequest {
+            key: PullRequestKey::from("4022"),
+            state: PullRequestState::Open,
+            draft: true,
+            base_ref: "main".to_owned(),
+            head_ref: "fix/4022".to_owned(),
+            title: "a title".to_owned(),
+            body: "Closes #4022".to_owned(),
+            merge_status: MergeStatus::Clean,
+            review: ReviewDecision::None,
+            checks: vec![Check {
+                name: "fmt + clippy + test".to_owned(),
+                outcome: CheckOutcome::Passed,
+            }],
+            labels: vec!["stella-verified-locally".to_owned()],
+        };
+        let text = serde_json::to_string(&pr).expect("serialize");
+        assert_eq!(
+            serde_json::from_str::<PullRequest>(&text).expect("deserialize"),
+            pr
+        );
+    }
+}

--- a/docs/spec/agent-native-delivery.md
+++ b/docs/spec/agent-native-delivery.md
@@ -392,7 +392,34 @@ provider = "jira-prod"
 
 One binding per workspace by default. A monorepo that files OSS bugs to GitHub
 and internal work to Jira is a real case and is **deferred, not denied** —
-see §12.
+see §12. The forge binding is not expressible at all yet: see §4.7.
+
+### 4.7 Pull requests are a second port on the same plane
+
+§4.1 through §4.5 describe the **issue** provider. The forge is a separate
+question — opening a pull request, reading its checks, merging it — and it was
+not a question anything in the tree could express: the delivery loop shelled
+out to `gh pr view`, `gh pr merge` and two GitHub REST endpoints from inside
+its own reader.
+
+It is now a port of its own, `stella_protocol::pull_request::PullRequestProvider`,
+beside `IssueProvider`. Its model carries facts and no verdicts: a pull
+request's state, its base branch, its checks as a name and an outcome, what
+review concluded. Which of those checks may block a merge, and whether a red
+base excuses a red pull request, stay above the port in `stella-cli`'s
+`deliver` module.
+
+It differs from the issue port twice over:
+
+- **It is synchronous.** Every caller is a synchronous verb of the delivery
+  loop, and the shipped adapter runs a subprocess. A provider that speaks HTTP
+  holds its own runtime, the way `backlog`'s `ranked` already does for the
+  issue port.
+- **It has no manifest layer yet.** GitHub ships as the one adapter,
+  `stella-cli`'s `pull_request_provider`, chosen in code rather than by a
+  `.stella/issues/<name>.toml` sibling. §4.5's argument applies here too — a
+  second real forge is what would prove the format — and the port is what
+  makes that a change to one file rather than to the loop.
 
 ---
 


### PR DESCRIPTION
## What & why

The backlog plane got its seam first: the loop reads `Issue` values and a
tracker is an `IssueProvider`. Pull requests did not.
`self_driving_cmd::deliver` ran `gh pr create`, `gh pr view`, `gh pr ready`,
`gh pr merge`, `gh pr update-branch`, `gh run rerun` and two GitHub REST
endpoints itself, and decoded GitHub's two check dialects in the same file. So
"which forge" was not a decision anything in the tree could express, and none
of those steps could be reached by a test without the GitHub CLI installed,
logged in, and pointed at a real repository.

**The port.** `stella_protocol::pull_request::PullRequestProvider`, beside
`IssueProvider`. Its model carries facts and no verdicts: state, base branch,
head branch, checks as a name plus one of four outcomes (`Passed`, `Failed`,
`Running`, `Inert`), review decision, labels. Twelve methods, each one a fact
or one change.

**The adapter.** `crates/stella-cli/src/pull_request_provider.rs` — the only
place a pull request `gh` command is now spelled, and the only place GitHub's
field names live. The check-run-versus-commit-status dialect split moved there
with it, along with the tests that witness that bug.

**What stayed above the port.** Which checks may block a merge, whether a red
base excuses a red pull request, and what to do about a stale verdict all stay
in `deliver` and in `stella-autonomy`'s pure machine. `deliver.rs` now spells
no `gh` at all; it takes a `&dyn PullRequestProvider` and maps the port's
vocabulary onto the machine's, the way `issue_provider::to_queue_issue`
already does for the ranker.

**Exemplar.** `crates/stella-cli/src/issue_provider.rs` and
`crates/stella-protocol/src/issue.rs` — this is the same split one plane over,
with the same confinement of one forge's spellings to one private module.

**One deliberate divergence: the port is synchronous.** `IssueProvider` is
async and its callers each build a runtime to block on it. Every caller here
is a plain verb of the delivery loop, and the shipped adapter runs a
subprocess, which blocks whatever calls it. A provider that speaks HTTP holds
its own runtime, the way `backlog::ranked` already does for the issue port.
`doc:agent-native-delivery` §4.7 records that, and the one gap it leaves: no
manifest layer for forges yet, which §4.5's own argument says a second real
forge is what would prove.

Closes #5558

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-cli/src/self_driving_cmd/deliver/witness.rs` — six tests, all
offline:

- `the_delivery_steps_run_against_a_forge_that_is_not_github` drives
  open → observe (pending) → observe (green) → mark ready → merge → observe
  (settled) through an in-memory `FixtureForge` that spawns nothing, and
  asserts the fixture's call journal so a merge that never asked the forge to
  merge cannot pass. The one process it starts is the `git push` in
  `deliver::open`, against a bare repository in a temp directory.
- `a_check_stuck_on_the_base_is_waived_rather_than_blocking` reaches the base
  history read too, so all of `observe` runs without GitHub.
- `refreshing_prefers_a_base_sync_and_falls_back_to_a_rerun`,
  `the_listings_read_the_forge_rather_than_a_remembered_list`,
  `a_locally_verified_change_carries_its_label_into_the_next_read`,
  `a_base_nobody_can_read_is_not_reported_broken`.

**Why they fail on `main`:** those functions took no forge there, so there is
no way to hand them one — the feature is genuinely absent. Each shelled out to
`gh`, which a test cannot supply.

`the_delivery_loop_spawns_no_gh_of_its_own` is the falsifiable half: it reads
the delivery loop's own source and fails on a `Command::new("gh")` outside the
adapter. `git grep -c 'Command::new("gh")' origin/main -- 'crates/stella-cli/src/self_driving_cmd*'`
reports six on `main` today (two in `self_driving_cmd.rs`, four in
`deliver.rs`, one in `drive/deploy.rs`). Two are named as exceptions in the
test, with the reason: `self_driving_cmd.rs`'s `gh --version` preflight and
workflow-run read, and `drive/deploy.rs`'s release-workflow watch. Neither
opens, reads or merges a pull request.

Serde round-trip for the new protocol types:
`a_pull_request_round_trips_through_json`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli -p stella-protocol --all-targets -- -D warnings`
      (scoped per CLAUDE.md — the workspace run is CI's)
- [x] `cargo test -p stella-cli --bin stella` (3043 passed),
      `cargo test -p stella-protocol pull_request`
- [x] `make guards-fast` green, including `prose`, `line-citations` and
      `file-size`; `make doc-warnings CARGO_SCOPE="-p stella-protocol -p stella-cli"`
- [x] Docs updated: `doc:agent-native-delivery` §4.7 is new, and §4.6 points at it
- [x] CLA signed
- [x] `Closes #5558` in this description **and** as a commit trailer

## Fix over file

- [x] Extra fixes in this PR:

1. **`drive/tests.rs`'s stop-flag test used to reach the real `gh`.** Its
   second observation ran unparked, so it called `deliver::base_is_broken`,
   which shelled out. Its own doc claimed the whole assertion ran offline. It
   now reads the fixture forge, so both halves genuinely do.
2. **Two files split at the size ceiling.** `self_driving_cmd.rs` sat at 1494
   lines and `drive.rs` at 1498, four and six under the 1500-line limit;
   threading the port crossed both. `drive::advance` and its new `Pass` struct
   moved to `drive/advance.rs`, and the one-shot `deliver` verbs to
   `self_driving_cmd/deliver_verb.rs`. No baseline entry was added — neither
   file is grandfathered, and AGENTS.md's rule is to split.
3. **`advance` was over clippy's argument ceiling** once the forge joined it.
   The run-scoped arguments became `Pass<'a>`, so the per-pull-request ones
   stand out from the settings that never change between them.

- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies at all
- [x] No new outbound network calls — the adapter runs exactly the `gh`
      commands `deliver` already ran
- [x] New cross-boundary types round-trip through serde (test included)

## Anything reviewers should know?

**What this does not do.** The forge is still chosen in code rather than by a
manifest, so a workspace cannot bind to a non-GitHub forge yet. That is
recorded in `doc:agent-native-delivery` §4.7 rather than filed as an issue: it
is an open design question with no defect behind it, and §4.5 already says
what would settle it — a second real forge to prove the format against.

**Deleted tests.** None deleted outright. `deliver.rs`'s dialect tests
(`a_commit_status_is_read_as_concluded_not_as_pending`,
`a_pending_commit_status_still_reads_as_pending`,
`the_two_dialects_join_on_one_name`,
`a_commit_status_broken_on_the_base_excuses_the_pull_request`,
`only_an_actions_run_link_names_a_run_to_rerun`,
`the_base_is_named_to_the_forge_not_a_remote_tracking_ref`,
`a_completed_check_with_no_conclusion_is_not_green`,
`the_real_gh_payload_maps_onto_an_observation`) moved to
`pull_request_provider.rs` with the dialect they witness, some renamed to
match their new home — `the_real_gh_payload_maps_onto_an_observation` became
`a_gh_pr_view_payload_maps_onto_a_pull_request` plus
`a_running_check_leaves_the_observation_pending`, which split the decode from
the mapping now that they sit either side of the port.

**Prose.** `pull_request_provider.rs`, `pull_request.rs`, `fixture.rs`,
`witness.rs`, `deliver_verb.rs` and `drive/advance.rs` are new files, so the
reading-grade ratchet holds them to 6.00. Their comments are written short for
that reason; nothing was added to any prose baseline.
