### PR TITLE
refactor(stella-tools): move the task board out of the engine's crate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1757,10 +1757,10 @@ trailer `Refs #N` instead.
 
 ## Testing approach
 
-- **Property tests** for pure engine logic (`proptest`): loop detection,
-  retry history, skill selection, and the task board (`stella-core`), plus
-  retrieval fusion (`stella-context`), fleet planning (`stella-fleet`), and
-  render/scroll (`stella-tui`). These run on every `cargo test`. Compaction,
+- **Property tests** for pure decision logic (`proptest`): loop detection and
+  retry history (`stella-core`), skill selection (`stella-learn`), the task
+  board (`stella-tools`), retrieval fusion (`stella-context`), fleet planning
+  (`stella-fleet`), and render/scroll (`stella-tui`). These run on every `cargo test`. Compaction,
   eviction, and budget arithmetic are covered by unit tests, not properties —
   a property test for them is a welcome contribution. Witness-verification
   property tests (`flip_requires_a_prior_failing_observation` and its

--- a/crates/stella-cli/src/agent/prompt.rs
+++ b/crates/stella-cli/src/agent/prompt.rs
@@ -209,7 +209,7 @@ macro_rules! faithful_reporting {
 /// error handling, or premature abstraction in the persona interactive users
 /// actually get (#2690). The task-board sentence makes the sizing auditable
 /// rather than aspirational: the board (`task_*` tools,
-/// `stella_core::tasks::TaskBoard`) is the ledger of what was asked, so
+/// `stella_tools::tasks::TaskBoard`) is the ledger of what was asked, so
 /// "beyond the request" has a concrete test — work with no step on the board
 /// (#2690). The diagnose-before-switching half complements the
 /// engine's loop machinery from the prompt side: `driver/loop_escalation.rs`

--- a/crates/stella-cli/src/command_deck/forwarder.rs
+++ b/crates/stella-cli/src/command_deck/forwarder.rs
@@ -107,7 +107,7 @@ fn audit_record_incomplete_message(detail: &AuditWriteDetail<'_>) -> String {
 ///
 /// `plan_board` is the lane's task board (`ToolRegistry::task_board`). When a
 /// `ScopeReview` goes past, the approved plan's steps are seeded onto it —
-/// see [`stella_core::tasks::TaskBoard::seed_from_plan`] for why the two used
+/// see [`stella_tools::tasks::TaskBoard::seed_from_plan`] for why the two used
 /// to be unconnected, and what that cost. `None` for lanes with no board of
 /// their own.
 ///

--- a/crates/stella-cli/src/command_deck/session_clear.rs
+++ b/crates/stella-cli/src/command_deck/session_clear.rs
@@ -42,7 +42,7 @@
 //!
 //! Three things follow, and they are one decision, not three:
 //!
-//! 1. **The live board is emptied** ([`stella_core::tasks::TaskBoard::clear`]).
+//! 1. **The live board is emptied** ([`stella_tools::tasks::TaskBoard::clear`]).
 //!    It is registry-level shared state, so blanking the deck pane alone left
 //!    the real board intact behind an empty-looking Tasks tab, waiting for the
 //!    next snapshot to repaint every row.

--- a/crates/stella-cli/src/subsession.rs
+++ b/crates/stella-cli/src/subsession.rs
@@ -39,10 +39,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use stella_core::Engine;
-use stella_core::tasks::SpawnRequest;
 use stella_fleet::SystemGitCli;
 use stella_protocol::{AgentEvent, CompletionMessage};
 use stella_tools::hook_runner::HostHookRunner;
+use stella_tools::tasks::SpawnRequest;
 use stella_tui::{AgentMeta, AgentStatus, Inbound};
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::sync::{oneshot, watch};

--- a/crates/stella-cli/src/subsession/lane_events.rs
+++ b/crates/stella-cli/src/subsession/lane_events.rs
@@ -10,7 +10,7 @@
 //! `Store::task_cost` reports `$0.00` for work that ran and was paid for.
 //!
 //! A `task_assign` lane works one board task, and
-//! [`stella_core::tasks::SpawnRequest`]'s `task_id` names it at spawn time.
+//! [`stella_tools::tasks::SpawnRequest`]'s `task_id` names it at spawn time.
 //! So the tag here is a **constant**.
 //!
 //! A constant is also the safe answer. Board ids are per-session ordinals, so

--- a/crates/stella-cli/src/turn_files/stale_lane.rs
+++ b/crates/stella-cli/src/turn_files/stale_lane.rs
@@ -103,7 +103,7 @@ pub(super) fn note_stale_lane(
 /// pending cards too, because a plan the agent stopped walking is exactly
 /// the shape worth reporting, even from a one-card board.
 fn stale_lane_open_tasks(
-    board: &stella_core::tasks::TaskBoard,
+    board: &stella_tools::tasks::TaskBoard,
     files_changed: usize,
 ) -> Option<usize> {
     if files_changed < STALE_LANE_FILES {
@@ -121,9 +121,9 @@ fn stale_lane_open_tasks(
 
 #[cfg(test)]
 mod tests {
-    use stella_core::tasks::TaskBoard;
     use stella_diag::FieldValue::Uint;
     use stella_protocol::event::TaskStatus;
+    use stella_tools::tasks::TaskBoard;
 
     use super::*;
 

--- a/crates/stella-core/README.md
+++ b/crates/stella-core/README.md
@@ -3,10 +3,9 @@
 The step-driver. `Engine::run_turn` takes a message history, a budget guard and
 an event channel, and runs the model/tool loop to an answer: one model call per
 step, retry+backoff, context compaction, tool-output eviction, loop detection,
-USD metering. Alongside it live the workspace's other decision engines —
-routing, the task board — which the CLI drives directly rather than through a
-turn. The goal loop still lives here too, and is the one resident that is
-leaving (see "Direction" below).
+USD metering. Routing lives alongside it, driven by the CLI rather than
+through a turn. The goal loop still lives here too, and is the one resident
+that is leaving (see "Direction" below).
 
 **No I/O.** This crate never imports a provider SDK, never touches the
 filesystem, never spawns a process, never opens a socket. Anything needing the
@@ -169,7 +168,7 @@ lib.rs), never as a planning assumption.
 | [`src/subagent.rs`](src/subagent.rs) | `Engine::run_sub_agent` — a bounded child turn with its own carved budget and its own (discarded) transcript, returning only a capped summary. `goal.rs`'s verifier is one. |
 | [`src/goal.rs`](src/goal.rs) | The goal loop: worker turn → verifier verdict → feedback, bounded by round cap, budget and turn abort. The verifier runs as a sub-agent. **A wrapper living inside the engine crate** — slated to leave for the wrapper contract (#3380); do not grow it. |
 | [`src/router.rs`](src/router.rs) | Role → model resolution over a caller-supplied `ProviderProfile`, plus the per-provider circuit breaker. |
-| [`src/tasks.rs`](src/tasks.rs) | `TaskBoard` — the transition rules behind the `task_*` tools; records `SpawnRequest`s rather than spawning. |
+| [`src/running_task.rs`](src/running_task.rs) | `RunningTask` — the closure a host installs so an emitted event can be stamped with the board task running at that instant. The board itself is `stella_tools::tasks::board`. |
 
 ## Key concepts
 
@@ -321,8 +320,8 @@ which is why the engine's own suite is split across
 [`src/driver/tests/`](src/driver/tests) (`audit_fixes.rs` holds the 2026-07
 turn-driver audit witnesses; also `budget_boundaries.rs`,
 `usage_completeness.rs`). `proptest!` blocks live in
-[`src/retry.rs`](src/retry.rs), [`src/loop_detect.rs`](src/loop_detect.rs),
-[`src/tasks.rs`](src/tasks.rs); a failing case writes its seed to
+[`src/retry.rs`](src/retry.rs) and
+[`src/loop_detect.rs`](src/loop_detect.rs); a failing case writes its seed to
 `proptest-regressions/`, and that seed is committed. No feature flag, no env var, no
 fixture server and no network — driver tests wire scripted `Provider`s, counting
 `ToolExecutor`s and no-op `Sleeper`s, so the suite runs in seconds. Keep it that

--- a/crates/stella-core/src/event_sender.rs
+++ b/crates/stella-core/src/event_sender.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, RwLock};
 use stella_protocol::AgentEvent;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::tasks::RunningTask;
+use crate::running_task::RunningTask;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventSendError;
@@ -354,17 +354,16 @@ mod run_ending_tests {
     }
 }
 
-/// The task-tagging half (#5039), tested against a real
-/// [`crate::tasks::TaskBoard`] rather than a stub source: the thing that must
-/// be true is that a *board* answers, not that a closure does.
+/// The task-tagging half (#5039).
+///
+/// The companion case — that a real board, and not merely a closure, is what
+/// reaches the tag — is `stella_tools::tasks::board`'s
+/// `the_board_answers_the_event_senders_running_task`. It sits there because
+/// the board does, and the engine's crate must not take an edge to the tool
+/// executor to reach it.
 #[cfg(test)]
 mod task_tag_tests {
-    use std::sync::Mutex;
-
-    use stella_protocol::TaskStatus;
-
     use super::*;
-    use crate::tasks::TaskBoard;
 
     fn tool_start(call_id: &str) -> AgentEvent {
         AgentEvent::ToolStart {
@@ -384,58 +383,6 @@ mod task_tag_tests {
             out.push(event);
         }
         out
-    }
-
-    /// A sender with a board attached tags the work it carries with whichever
-    /// task the board says is running **at the moment of the send** — and
-    /// re-reads it, so moving to the next task moves the tag with it.
-    ///
-    /// The second half is the one a cached copy would get wrong, and it is
-    /// the whole reason `RunningTask` is a closure over the board.
-    #[test]
-    fn work_dispatched_while_a_task_runs_is_tagged_with_that_task() {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        let events = EventSender::new(tx);
-        let board = Arc::new(Mutex::new(TaskBoard::new()));
-        {
-            let mut guard = board.lock().expect("fresh board");
-            guard.seed_from_plan(&["read the layout", "fold the rail"]);
-        }
-        let source = Arc::clone(&board);
-        events.attach_running_task(RunningTask::from_fn(move || {
-            source.lock().expect("board").running()
-        }));
-
-        // Before any task starts, work is in no task's ledger.
-        events.send(tool_start("c0")).expect("receiver alive");
-
-        board
-            .lock()
-            .expect("board")
-            .set_status("1", TaskStatus::InProgress)
-            .expect("start task 1");
-        events.send(tool_start("c1")).expect("receiver alive");
-
-        {
-            let mut guard = board.lock().expect("board");
-            guard
-                .set_status("1", TaskStatus::Completed)
-                .expect("close task 1");
-            guard
-                .set_status("2", TaskStatus::InProgress)
-                .expect("start task 2");
-        }
-        events.send(tool_start("c2")).expect("receiver alive");
-
-        let tags: Vec<Option<String>> = drain(&mut rx)
-            .iter()
-            .map(|event| event.task_id().map(|id| id.as_str().to_string()))
-            .collect();
-        assert_eq!(
-            tags,
-            vec![None, Some("1".to_string()), Some("2".to_string())],
-            "each send reads the board as it stood at that instant"
-        );
     }
 
     /// Every clone shares one slot, which is what lets a host attach once and

--- a/crates/stella-core/src/lib.rs
+++ b/crates/stella-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod receipts;
 pub mod restore;
 pub mod retry;
 pub mod router;
+pub mod running_task;
 pub mod shell_text;
 pub mod skill_invocation;
 pub(crate) mod speculation;
@@ -36,7 +37,6 @@ pub mod steering;
 pub mod step;
 pub mod subagent;
 mod summarize;
-pub mod tasks;
 pub mod waiting;
 
 pub use budget::{BudgetGuard, BudgetOutcome};
@@ -59,6 +59,7 @@ pub use loop_detect::{
 pub use ports::{Clock, LiveService, ToolExecutor};
 pub use retry::{RetryOutcome, RetryPolicy, retry_with_backoff};
 pub use router::{RoleTable, Router};
+pub use running_task::RunningTask;
 pub use step::{
     AbortKind, BudgetSnapshot, CANCELLED_REASON, CHECKPOINT_VERSION, CancelToken, Checkpoint,
     CheckpointError, StepOutcome, TurnState,
@@ -68,5 +69,4 @@ pub use subagent::{
     SubAgentOutcome, SubAgentReport, SubAgentSpec, SubAgentSpendLedger, drain_sub_agent_spend,
     forwards_to_parent, push_sub_agent_spend,
 };
-pub use tasks::{RunningTask, SpawnRequest, TaskBoard, TaskBoardError};
 pub use waiting::{WaitCall, WaitRequest};

--- a/crates/stella-core/src/running_task.rs
+++ b/crates/stella-core/src/running_task.rs
@@ -1,0 +1,71 @@
+//! Which task the session works on, asked rather than stored.
+//!
+//! The engine stamps `task_id` on the work it emits. The board that knows
+//! the answer sits in `stella-tools`, beside the six `task_*` tools that
+//! move it. [`RunningTask`] is the port between the two. A host hands the
+//! engine a closure, and [`crate::event_sender::EventSender`] calls it as it
+//! sends.
+//!
+//! So the engine reaches the closure. It never reaches the board's rules,
+//! and it has no need to. That is what lets AGENTS.md rule 12 be answered
+//! here.
+
+use std::sync::Arc;
+
+use stella_protocol::TaskId;
+
+/// A live read of the running board task, for a producer that must stamp an
+/// event without owning the board.
+///
+/// It reads through a closure instead of caching the answer. A cached
+/// `Option<TaskId>` would be a second place the running task is written
+/// down. Six tools move the board. So do a plan seeding, a `/clear`, and
+/// every sub-agent assignment. The copy would go stale on the path nobody
+/// thought about. Reading through leaves one authority and nothing to
+/// refresh.
+///
+/// The cost is one board lock per stamped event. Only an event that can
+/// carry a tag pays it, and only when it is not stamped already (see
+/// `EventSender::send`). That is a small part of a turn's stream and none of
+/// its per-token traffic.
+///
+/// # What a lane's source answers for its delegates
+///
+/// An in-process delegate ([`crate::subagent`]) sends its events to the lane
+/// that dispatched it. They carry that lane's running task. That is the
+/// reading we want. Work the lead handed off for task 4 is task 4's evidence
+/// and task 4's cost. A ledger that dropped it would under-report every task
+/// that fanned out.
+///
+/// A `task_assign` worker is the other shape. It has its own session and its
+/// own board, and that board is empty, so a read of it answers `None`. Its
+/// host attaches a constant source instead. The constant names the one task
+/// the lane was spawned to work (`stella-cli`'s `subsession::lane_events`).
+/// Each form names the authority that knows. The worker's own board is not
+/// it. Board ids are per-session ordinals, so its `"1"` is not the lead's
+/// `"1"`.
+#[derive(Clone)]
+pub struct RunningTask(Arc<dyn Fn() -> Option<TaskId> + Send + Sync>);
+
+impl RunningTask {
+    /// Build a source from anything that can answer the question — in
+    /// practice a closure over the host's shared board handle.
+    #[must_use]
+    pub fn from_fn(read: impl Fn() -> Option<TaskId> + Send + Sync + 'static) -> Self {
+        Self(Arc::new(read))
+    }
+
+    /// Which task is running at this instant, if any.
+    #[must_use]
+    pub fn current(&self) -> Option<TaskId> {
+        (self.0)()
+    }
+}
+
+impl std::fmt::Debug for RunningTask {
+    /// The closure has no useful form to print. So this reports what a reader
+    /// of a log line wants: the answer it gives right now.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("RunningTask").field(&self.current()).finish()
+    }
+}

--- a/crates/stella-core/tests/task_board_is_not_engine_code.rs
+++ b/crates/stella-core/tests/task_board_is_not_engine_code.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The task board is not engine code (AGENTS.md rule 12).
+//!
+//! `TaskBoard` sat in `stella-core` for as long as the crate existed.
+//! `scripts/check-core-reachability.py` read it as engine code the whole
+//! time. The cause was `RunningTask`, a closure the host installs on the
+//! event sender, sharing its file. That guard walks whole modules. One
+//! reached item carries the rest of its module in with it. It is the shape
+//! the record plane got in through: one call to `record_hash` towing a
+//! fourteen-thousand-line plane.
+//!
+//! Splitting the file makes the guard's answer match what the engine reaches.
+//! This test pins the split. Nothing fails to compile when the board comes
+//! back. A later author who adds a `pub mod tasks;` beside `driver` re-makes
+//! the old condition, and the guard still reports it reached.
+//!
+//! A source scan, not a type-level check, because Rust cannot say "this
+//! crate does not export that". The scanner is checked first, so a read that
+//! found nothing fails here rather than passing.
+
+use std::path::{Path, PathBuf};
+
+fn src_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+/// Every `.rs` file under `src/`, as (path relative to `src/`, contents).
+fn sources() -> Vec<(String, String)> {
+    fn walk(dir: &Path, root: &Path, out: &mut Vec<(String, String)>) {
+        let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read {dir:?}: {e}"));
+        for entry in entries {
+            let path = entry.expect("a directory entry").path();
+            if path.is_dir() {
+                walk(&path, root, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                let rel = path
+                    .strip_prefix(root)
+                    .expect("every hit is under src/")
+                    .display()
+                    .to_string();
+                let body = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{rel}: {e}"));
+                out.push((rel, body));
+            }
+        }
+    }
+
+    let root = src_dir();
+    let mut out = Vec::new();
+    walk(&root, &root, &mut out);
+    out
+}
+
+/// The scanner reads real files and finds the port that must still be here.
+///
+/// Delete `RunningTask`, or break the walk so it returns nothing, and the
+/// test below would pass over an empty list. This is what catches that.
+#[test]
+fn the_scanner_sees_the_crate_it_is_scanning() {
+    let files = sources();
+    assert!(
+        files.len() > 20,
+        "the engine's crate is larger than this; the walk found only {}",
+        files.len()
+    );
+    assert!(
+        files
+            .iter()
+            .any(|(rel, _)| rel == "running_task.rs" || rel == "running_task/mod.rs"),
+        "the port the engine does reach must be here: {:?}",
+        files.iter().map(|(rel, _)| rel).collect::<Vec<_>>()
+    );
+    assert!(
+        files
+            .iter()
+            .any(|(rel, body)| rel == "event_sender.rs" && body.contains("RunningTask")),
+        "the event sender is what installs the port"
+    );
+}
+
+/// The board's own words appear nowhere in the engine's crate.
+///
+/// `RunningTask` is all the engine needs. It asks which task runs and stamps
+/// the answer. The rules, the spawn queue and their error type belong to the
+/// six `task_*` tools that move them. They live with those tools, in
+/// `stella_tools::tasks::board`.
+#[test]
+fn the_engines_crate_names_no_board_type() {
+    let forbidden = ["TaskBoard", "TaskBoardError", "SpawnRequest"];
+    let offenders: Vec<String> = sources()
+        .into_iter()
+        .flat_map(|(rel, body)| {
+            forbidden
+                .iter()
+                .filter(|name| body.contains(**name))
+                .map(|name| format!("{rel} names {name}"))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "the task board left stella-core and must not return — put board \
+         logic in stella_tools::tasks::board, and reach the running task \
+         through stella_core::RunningTask:\n  {}",
+        offenders.join("\n  ")
+    );
+}

--- a/crates/stella-protocol/src/event/payload.rs
+++ b/crates/stella-protocol/src/event/payload.rs
@@ -358,9 +358,9 @@ pub struct TaskItem {
     /// which is the self-report [`TaskContract`] exists to end.
     ///
     /// Optional because the board predates contracts and a session may still
-    /// create a task without one; `stella_core::tasks` refuses the *close*, not
-    /// the creation, so an undeclared task is visible on the board rather than
-    /// rejected at the door.
+    /// create a task without one; `stella_tools::tasks::board` refuses the
+    /// *close*, not the creation, so an undeclared task is visible on the
+    /// board rather than rejected at the door.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub contract: Option<crate::task_contract::TaskContract>,
 }

--- a/crates/stella-protocol/src/plan_graph.rs
+++ b/crates/stella-protocol/src/plan_graph.rs
@@ -360,7 +360,7 @@ pub struct Divergence {
 /// # Why the subject and not a task id
 ///
 /// The proposal names the work in words. Board ids belong to the task board
-/// (`stella_core::tasks::TaskBoard::create` never reuses one), so a proposal
+/// (`stella_tools::tasks::TaskBoard::create` never reuses one), so a proposal
 /// that minted its own would open a second id space beside it. The id is the
 /// board's to assign when the insertion is actually made.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/stella-protocol/src/task_id.rs
+++ b/crates/stella-protocol/src/task_id.rs
@@ -76,7 +76,7 @@ impl TaskId {
     /// total — a board id is already exactly this.
     ///
     /// Total, and unvalidated: what may be a board id is
-    /// `stella_core::tasks::TaskBoard`'s decision (it mints them), and
+    /// `stella_tools::tasks::TaskBoard`'s decision (it mints them), and
     /// `stella-protocol` carries no logic by rule — a second validator here
     /// would be one rule in two places.
     #[must_use]

--- a/crates/stella-store/src/migrations/task_contract.rs
+++ b/crates/stella-store/src/migrations/task_contract.rs
@@ -11,7 +11,7 @@
 //! closed task deserved to close.
 //!
 //! Nothing about the live guarantee changes, and that is worth being precise
-//! about rather than overclaiming: `stella_core::tasks::TaskBoard` holds the
+//! about rather than overclaiming: `stella_tools::tasks::TaskBoard` holds the
 //! session's real board in memory and never rehydrates from SQLite, so
 //! `set_status`'s refusal has always read the real contract. This is the audit
 //! record catching up with the type.

--- a/crates/stella-store/src/task_board.rs
+++ b/crates/stella-store/src/task_board.rs
@@ -9,7 +9,7 @@
 //! ## Why `/clear` deletes a session's rows (#1692)
 //!
 //! `/clear` is a session destroy-and-reset: it empties the live board
-//! (`stella_core::tasks::TaskBoard::clear`), and board ids restart at "1".
+//! (`stella_tools::tasks::TaskBoard::clear`), and board ids restart at "1".
 //! Leaving the mirror alone would be wrong in both directions — a post-clear
 //! task "1" silently upserts over an unrelated pre-clear task's row, and
 //! every pre-clear id ABOVE the new board's length survives as a row this

--- a/crates/stella-tools/README.md
+++ b/crates/stella-tools/README.md
@@ -27,7 +27,8 @@ keep; the rest are coordination state that dies with the session:
   which spawns read-only child turns through a host-attached dispatcher.
 - **The session task board** — `task_create` / `task_list` / `task_start` /
   `task_complete` / `task_cancel` / `task_assign`
-  ([`src/tasks.rs`](src/tasks.rs)); `task_assign` additionally queues a
+  ([`src/tasks.rs`](src/tasks.rs), over the board in
+  [`src/tasks/board.rs`](src/tasks/board.rs)); `task_assign` additionally queues a
   sub-agent spawn request the session driver drains.
 - **Session scratch state** — `save_state` / `get_state` / `list_state` /
   `delete_state` ([`src/scratch.rs`](src/scratch.rs)), backed by a
@@ -176,6 +177,7 @@ old path still works.
 | [`src/search.rs`](src/search.rs), [`src/search/`](src/search) | The `search` tool and its strategy rungs, including the semantic rung whose embedding write-through is why the tool is read-only without being speculation-safe. [`src/search/budget.rs`](src/search/budget.rs) is the depth ladder and the character budget behind it — pure sums, no I/O; it came down from `stella-core`, where the engine never called it. |
 | [`src/subagent.rs`](src/subagent.rs) | The `delegate` tool: sub-agent delegation over a host-attached dispatcher (#922), with turn controls and a spend ledger the engine drains at step boundaries. |
 | [`src/tasks.rs`](src/tasks.rs) | The six `task_*` tools over the session board, plus `task_assign`'s spawn queue. |
+| [`src/tasks/board.rs`](src/tasks/board.rs) | `TaskBoard` — the transition rules those six tools enforce; records `SpawnRequest`s rather than spawning. It left `stella-core` because the engine names the board through a closure and never the type. |
 | [`src/scratch.rs`](src/scratch.rs) | The scratch state plane: `ScratchDir` and the four state tools. |
 | [`src/environment.rs`](src/environment.rs) | `get_environment` and the shared environment-identity probes the CLI prompt renders from (#2697). |
 | [`policy`](../stella-tool-facts/src/policy.rs) | `ToolPolicy` — the operator's `"tools"` switches, resolved exact-name-first, then group, then wildcard; scope composition by union of denials. |

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -745,7 +745,7 @@ impl ToolRegistry {
     /// last drain — the session driver calls this exactly once per
     /// execution and dispatches each request through the fleet seam, so no
     /// request is ever handled twice.
-    pub fn take_spawn_requests(&self) -> Vec<stella_core::tasks::SpawnRequest> {
+    pub fn take_spawn_requests(&self) -> Vec<crate::tasks::SpawnRequest> {
         std::mem::take(&mut *self.spawn_queue.lock().unwrap_or_else(|p| p.into_inner()))
     }
 

--- a/crates/stella-tools/src/tasks.rs
+++ b/crates/stella-tools/src/tasks.rs
@@ -1,11 +1,11 @@
 //! The `task_*` tools — the model's handle on the session task board
-//! (`stella_core::tasks::TaskBoard`).
+//! ([`board::TaskBoard`], which moved here from `stella-core`).
 //!
 //! Six tools share one board: `task_create` / `task_list` / `task_start` /
 //! `task_complete` / `task_cancel` mutate or read it, and `task_assign`
 //! additionally queues a [`SpawnRequest`] for the session driver to turn
 //! into a real sub-agent spawn (spawning is I/O and never happens here —
-//! see the module docs on `stella_core::tasks`). The board and the queue
+//! see [`board`]'s module docs). The board and the queue
 //! are `Arc<Mutex<…>>` handles shared between the tool instances and the
 //! [`crate::ToolRegistry`] that exposes/drains them.
 
@@ -14,7 +14,6 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use serde_json::Value;
-use stella_core::tasks::{SpawnRequest, TaskBoard};
 use stella_protocol::tool::{ToolOutput, ToolSchema};
 use stella_protocol::{
     Check, CheckMechanism, DefinitionOfDone, Judge, TaskContract, TaskItem, TaskStatus,
@@ -22,6 +21,9 @@ use stella_protocol::{
 
 use crate::registry::Tool;
 
+pub mod board;
+
+pub use board::{SpawnRequest, TaskBoard, TaskBoardError};
 pub use stella_tool_facts::catalog::TASK_START as START;
 
 /// The six tools that read or move the session board.
@@ -83,16 +85,12 @@ fn require_str<'a>(input: &'a Value, field: &str) -> Result<&'a str, ToolOutput>
 /// (#3167): an unknown id is the model naming a task that is not on the board
 /// at all, while every other variant is the model attempting a transition the
 /// board's current state does not allow.
-fn board_error_class(e: &stella_core::tasks::TaskBoardError) -> stella_protocol::ErrorClass {
+fn board_error_class(e: &TaskBoardError) -> stella_protocol::ErrorClass {
     match e {
-        stella_core::tasks::TaskBoardError::UnknownTask { .. } => {
-            stella_protocol::ErrorClass::NotFound
-        }
-        stella_core::tasks::TaskBoardError::Terminal { .. }
-        | stella_core::tasks::TaskBoardError::AnotherTaskInProgress { .. }
-        | stella_core::tasks::TaskBoardError::ContractUnsatisfied { .. } => {
-            stella_protocol::ErrorClass::InvalidInput
-        }
+        TaskBoardError::UnknownTask { .. } => stella_protocol::ErrorClass::NotFound,
+        TaskBoardError::Terminal { .. }
+        | TaskBoardError::AnotherTaskInProgress { .. }
+        | TaskBoardError::ContractUnsatisfied { .. } => stella_protocol::ErrorClass::InvalidInput,
     }
 }
 

--- a/crates/stella-tools/src/tasks/board.rs
+++ b/crates/stella-tools/src/tasks/board.rs
@@ -1,20 +1,27 @@
-//! The session task board — pure decision logic for the `task_*` tools
-//! (`task_create` / `task_list` / `task_complete` / `task_cancel` /
-//! `task_assign`).
+//! The session task board — the transition rules behind the `task_*` tools
+//! (`task_create` / `task_list` / `task_start` / `task_complete` /
+//! `task_cancel` / `task_assign`).
 //!
-//! The board is owned data with no I/O: the tools crate mutates it through
-//! these methods, the CLI tap snapshots it into `AgentEvent::TaskUpdate`
-//! events (the sole render path — the TUI folds snapshots, never reads this
-//! struct), and the store mirrors snapshots for cross-session findability.
-//! Keeping the transition rules here makes them property-testable without a
-//! registry or a runtime.
+//! The board is owned data with no I/O: [`super`]'s six tools mutate it
+//! through these methods, the CLI tap snapshots it into
+//! `AgentEvent::TaskUpdate` events (the sole render path — the TUI folds
+//! snapshots, never reads this struct), and the store mirrors snapshots for
+//! cross-session findability. Keeping the transition rules in one place makes
+//! them property-testable without a registry or a runtime.
 //!
 //! `task_assign` does not spawn anything itself — spawning is I/O. It
 //! validates the transition and records a [`SpawnRequest`]; the session
-//! driver drains them (`stella-tools`' `ToolRegistry::take_spawn_requests`)
-//! and runs each on its own deck sub-session lane.
-
-use std::sync::Arc;
+//! driver drains them ([`crate::ToolRegistry::take_spawn_requests`]) and runs
+//! each on its own deck sub-session lane.
+//!
+//! # Why it lives beside the tools rather than in the engine
+//!
+//! It was in `stella-core`, and nothing in the engine ever named it:
+//! `driver`, `step` and `ports` reach the board only through
+//! `stella_core::RunningTask`, a closure the host installs on the event
+//! sender. Pure logic earns a place in the engine's crate by being engine
+//! logic, not by being pure (AGENTS.md rule 12) — and the six tools that do
+//! name it are here.
 
 use stella_protocol::{Closure, TaskContract, TaskId, TaskItem, TaskStatus};
 
@@ -67,63 +74,6 @@ pub struct SpawnRequest {
     /// the sub-agent's prompt verbatim (the "communication" of
     /// `task_assign`).
     pub briefing: String,
-}
-
-/// A live read of [`TaskBoard::running`], for a producer that must stamp an
-/// event without owning the board.
-///
-/// A closure over the board rather than a copy of its answer, and that is the
-/// whole design. A cached `Option<TaskId>` would be a second place the running
-/// task is written down, updated by whoever remembered to — and the board is
-/// mutated by six tools, a plan seeding, a `/clear` and every sub-agent
-/// assignment, so the copy would go stale on the path nobody thought about.
-/// Reading through means there is one authority and no refresh to forget.
-///
-/// The cost is a board lock per stamped event. It is paid only for the events
-/// that can carry a tag and have not already been stamped (see
-/// `EventSender::send`), which is a small fraction of a turn's stream and none
-/// of its per-token traffic.
-///
-/// # What a lane's source answers for its delegates
-///
-/// An in-process delegate ([`crate::subagent`]) forwards its events to the
-/// lane that dispatched it, so they are stamped with **that lane's** running
-/// task. That is the intended reading rather than a leak: work the lead
-/// delegated in service of task 4 is task 4's evidence and task 4's cost, and
-/// a ledger that dropped it would under-report every task that fanned out.
-///
-/// A `task_assign` worker is the other shape — its own session, its own board,
-/// and that board is empty, so a read of it answers `None`. Its host attaches
-/// a **constant** source instead, naming the one task the lane was spawned to
-/// work (`stella-cli`'s `subsession::lane_events`). Constant rather
-/// than a read for the same reason the lead's is a read: each names the
-/// authority that actually knows, and the worker's own board is not it — board
-/// ids are per-session ordinals, so its `"1"` is a different task from the
-/// lead's `"1"`.
-#[derive(Clone)]
-pub struct RunningTask(Arc<dyn Fn() -> Option<TaskId> + Send + Sync>);
-
-impl RunningTask {
-    /// Build a source from anything that can answer the question — in
-    /// practice a closure over the host's shared board handle.
-    #[must_use]
-    pub fn from_fn(read: impl Fn() -> Option<TaskId> + Send + Sync + 'static) -> Self {
-        Self(Arc::new(read))
-    }
-
-    /// Which task is running at this instant, if any.
-    #[must_use]
-    pub fn current(&self) -> Option<TaskId> {
-        (self.0)()
-    }
-}
-
-impl std::fmt::Debug for RunningTask {
-    /// The closure has no useful representation, so this reports what a reader
-    /// of a log line actually wants: the answer it gives right now.
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("RunningTask").field(&self.current()).finish()
-    }
 }
 
 /// The task board: an insertion-ordered list of [`TaskItem`]s with ordinal
@@ -807,5 +757,94 @@ mod tests {
         board
             .set_status("1", TaskStatus::Cancelled)
             .expect("cancel is not a claim that the work was done");
+    }
+}
+
+/// The board answering `stella_core::RunningTask` for real, rather than a
+/// closure standing in for it.
+///
+/// `stella-core`'s `event_sender::task_tag_tests` covers the sender's own
+/// half with plain closures. What it cannot cover from there is this: the
+/// authority the tag reads is a *board*, and the board lives in this crate,
+/// which the engine's crate must not depend on.
+#[cfg(test)]
+mod event_tag_tests {
+    use std::sync::{Arc, Mutex};
+
+    use stella_core::{EventSender, RunningTask};
+    use stella_protocol::{AgentEvent, TaskStatus};
+
+    use super::TaskBoard;
+
+    fn tool_start(call_id: &str) -> AgentEvent {
+        AgentEvent::ToolStart {
+            call: stella_protocol::ToolCall {
+                call_id: call_id.to_string(),
+                name: "edit_file".to_string(),
+                input: serde_json::json!({ "path": "src/auth.rs" }),
+            },
+            sub_agent_id: None,
+            task_id: None,
+        }
+    }
+
+    fn drain(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AgentEvent>) -> Vec<AgentEvent> {
+        let mut out = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            out.push(event);
+        }
+        out
+    }
+
+    /// A sender with a board attached tags the work it carries with whichever
+    /// task the board says is running **at the moment of the send** — and
+    /// re-reads it, so moving to the next task moves the tag with it.
+    ///
+    /// The second half is the one a cached copy would get wrong, and it is
+    /// the whole reason `RunningTask` is a closure over the board.
+    #[test]
+    fn the_board_answers_the_event_senders_running_task() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let events = EventSender::new(tx);
+        let board = Arc::new(Mutex::new(TaskBoard::new()));
+        {
+            let mut guard = board.lock().expect("fresh board");
+            guard.seed_from_plan(&["read the layout", "fold the rail"]);
+        }
+        let source = Arc::clone(&board);
+        events.attach_running_task(RunningTask::from_fn(move || {
+            source.lock().expect("board").running()
+        }));
+
+        // Before any task starts, work is in no task's ledger.
+        events.send(tool_start("c0")).expect("receiver alive");
+
+        board
+            .lock()
+            .expect("board")
+            .set_status("1", TaskStatus::InProgress)
+            .expect("start task 1");
+        events.send(tool_start("c1")).expect("receiver alive");
+
+        {
+            let mut guard = board.lock().expect("board");
+            guard
+                .set_status("1", TaskStatus::Completed)
+                .expect("close task 1");
+            guard
+                .set_status("2", TaskStatus::InProgress)
+                .expect("start task 2");
+        }
+        events.send(tool_start("c2")).expect("receiver alive");
+
+        let tags: Vec<Option<String>> = drain(&mut rx)
+            .iter()
+            .map(|event| event.task_id().map(|id| id.as_str().to_string()))
+            .collect();
+        assert_eq!(
+            tags,
+            vec![None, Some("1".to_string()), Some("2".to_string())],
+            "each send reads the board as it stood at that instant"
+        );
     }
 }

--- a/crates/stella-transcript/examples/demo.rs
+++ b/crates/stella-transcript/examples/demo.rs
@@ -248,7 +248,7 @@ fn fixture() -> Run {
                 summary: "recalled 5 frames · 408 tok · 126ms · 5 episode".to_string(),
                 detail: vec![
                     "symbol  fn find — stella-cli/src/config_wiring.rs · 34 tok".to_string(),
-                    "symbol  fn find — stella-core/src/tasks.rs · 118 tok".to_string(),
+                    "symbol  fn find — stella-tools/src/tasks/board.rs · 118 tok".to_string(),
                 ],
                 before_step: 0,
                 inspect: None,

--- a/docs/spec/agent-native-delivery.md
+++ b/docs/spec/agent-native-delivery.md
@@ -105,7 +105,7 @@ persists. An agent that writes a perfect diff and a lazy issue has destroyed
 most of the value of the run, because the next run starts from the issue.
 
 This is why the answer is not "give Stella a native work store." Stella
-already has a task board (`stella-core::tasks`) and a fleet plan DAG
+already has a task board (`stella-tools::tasks::board`) and a fleet plan DAG
 (`stella-fleet::plan`), and both are correctly scoped to a *single run*. A
 run-scoped board cannot hold residue, because residue is by definition what
 outlives the run.

--- a/docs/wire/agentevent.d.ts
+++ b/docs/wire/agentevent.d.ts
@@ -1422,9 +1422,9 @@ export interface TaskItem {
    * which is the self-report [`TaskContract`] exists to end.
    *
    * Optional because the board predates contracts and a session may still
-   * create a task without one; `stella_core::tasks` refuses the *close*, not
-   * the creation, so an undeclared task is visible on the board rather than
-   * rejected at the door.
+   * create a task without one; `stella_tools::tasks::board` refuses the
+   * *close*, not the creation, so an undeclared task is visible on the
+   * board rather than rejected at the door.
    */
   contract?: TaskContract | null;
   /**

--- a/docs/wire/agentevent.schema.json
+++ b/docs/wire/agentevent.schema.json
@@ -2191,7 +2191,7 @@
               "type": "null"
             }
           ],
-          "description": "What this task means by done (SPEC 7.1).\n\n`None` is *nobody has said yet*, and is not the same fact\nas [`TaskContract::ReadOnly`], which is *somebody looked and there is\nnothing to prove*. A board that collapsed the two would let an\nundeclared task close on the same terms as one declared harmless —\nwhich is the self-report [`TaskContract`] exists to end.\n\nOptional because the board predates contracts and a session may still\ncreate a task without one; `stella_core::tasks` refuses the *close*, not\nthe creation, so an undeclared task is visible on the board rather than\nrejected at the door."
+          "description": "What this task means by done (SPEC 7.1).\n\n`None` is *nobody has said yet*, and is not the same fact\nas [`TaskContract::ReadOnly`], which is *somebody looked and there is\nnothing to prove*. A board that collapsed the two would let an\nundeclared task close on the same terms as one declared harmless —\nwhich is the self-report [`TaskContract`] exists to end.\n\nOptional because the board predates contracts and a session may still\ncreate a task without one; `stella_tools::tasks::board` refuses the\n*close*, not the creation, so an undeclared task is visible on the\nboard rather than rejected at the door."
         },
         "description": {
           "description": "What needs to be done, if the creator elaborated beyond the subject.",

--- a/docs/wire/serveframe.d.ts
+++ b/docs/wire/serveframe.d.ts
@@ -2561,9 +2561,9 @@ export interface TaskItem {
    * which is the self-report [`TaskContract`] exists to end.
    *
    * Optional because the board predates contracts and a session may still
-   * create a task without one; `stella_core::tasks` refuses the *close*, not
-   * the creation, so an undeclared task is visible on the board rather than
-   * rejected at the door.
+   * create a task without one; `stella_tools::tasks::board` refuses the
+   * *close*, not the creation, so an undeclared task is visible on the
+   * board rather than rejected at the door.
    */
   contract?: TaskContract | null;
   /**

--- a/docs/wire/serveframe.schema.json
+++ b/docs/wire/serveframe.schema.json
@@ -4236,7 +4236,7 @@
               "type": "null"
             }
           ],
-          "description": "What this task means by done (SPEC 7.1).\n\n`None` is *nobody has said yet*, and is not the same fact\nas [`TaskContract::ReadOnly`], which is *somebody looked and there is\nnothing to prove*. A board that collapsed the two would let an\nundeclared task close on the same terms as one declared harmless —\nwhich is the self-report [`TaskContract`] exists to end.\n\nOptional because the board predates contracts and a session may still\ncreate a task without one; `stella_core::tasks` refuses the *close*, not\nthe creation, so an undeclared task is visible on the board rather than\nrejected at the door."
+          "description": "What this task means by done (SPEC 7.1).\n\n`None` is *nobody has said yet*, and is not the same fact\nas [`TaskContract::ReadOnly`], which is *somebody looked and there is\nnothing to prove*. A board that collapsed the two would let an\nundeclared task close on the same terms as one declared harmless —\nwhich is the self-report [`TaskContract`] exists to end.\n\nOptional because the board predates contracts and a session may still\ncreate a task without one; `stella_tools::tasks::board` refuses the\n*close*, not the creation, so an undeclared task is visible on the\nboard rather than rejected at the door."
         },
         "description": {
           "description": "What needs to be done, if the creator elaborated beyond the subject.",

--- a/scripts/prose-baseline.txt
+++ b/scripts/prose-baseline.txt
@@ -1858,10 +1858,6 @@ crates/stella-core/src/subagent/tests/spend_and_cancellation.rs historical-refer
 crates/stella-core/src/subagent/tests/spend_and_cancellation.rs issue-reference 5
 crates/stella-core/src/subagent/tests/witness.rs issue-reference 1
 crates/stella-core/src/summarize.rs issue-reference 2
-crates/stella-core/src/tasks.rs filler-adverb 3
-crates/stella-core/src/tasks.rs honesty-declaration 4
-crates/stella-core/src/tasks.rs interface-jargon 1
-crates/stella-core/src/tasks.rs issue-reference 5
 crates/stella-core/src/waiting.rs historical-reference 1
 crates/stella-core/src/waiting.rs issue-reference 3
 crates/stella-core/tests/engine_emits_no_stage.rs historical-reference 1
@@ -3217,6 +3213,10 @@ crates/stella-tools/src/tasks.rs honesty-declaration 2
 crates/stella-tools/src/tasks.rs issue-reference 3
 crates/stella-tools/src/tasks.rs meta-writing 1
 crates/stella-tools/src/tasks.rs rust-jargon 1
+crates/stella-tools/src/tasks/board.rs filler-adverb 3
+crates/stella-tools/src/tasks/board.rs honesty-declaration 4
+crates/stella-tools/src/tasks/board.rs interface-jargon 1
+crates/stella-tools/src/tasks/board.rs issue-reference 5
 crates/stella-tools/src/temp_roots.rs filler-adverb 2
 crates/stella-tools/src/validate.rs filler-adverb 1
 crates/stella-tools/src/validate.rs issue-reference 1

--- a/scripts/prose-density-baseline.txt
+++ b/scripts/prose-density-baseline.txt
@@ -26,7 +26,7 @@
 crates/stella-autonomy 38.25
 crates/stella-cli 23.45
 crates/stella-context 18.11
-crates/stella-core 29.97
+crates/stella-core 28.26
 crates/stella-diag 25.12
 crates/stella-diff 27.80
 crates/stella-embed 18.00
@@ -46,7 +46,7 @@ crates/stella-runtime 35.64
 crates/stella-serve 25.96
 crates/stella-store 24.08
 crates/stella-tool-facts 33.40
-crates/stella-tools 34.59
+crates/stella-tools 34.00
 crates/stella-transcript 24.62
 crates/stella-tty 21.00
 crates/stella-tui 19.87

--- a/scripts/prose-grade-baseline.txt
+++ b/scripts/prose-grade-baseline.txt
@@ -701,7 +701,6 @@ crates/stella-core/src/subagent/tests/seams.rs 8.66
 crates/stella-core/src/subagent/tests/spend_and_cancellation.rs 9.70
 crates/stella-core/src/subagent/tests/witness.rs 11.32
 crates/stella-core/src/summarize.rs 11.36
-crates/stella-core/src/tasks.rs 9.93
 crates/stella-core/src/waiting.rs 9.64
 crates/stella-core/tests/engine_emits_no_stage.rs 12.23
 crates/stella-core/tests/hard_drop_write_back.rs 10.73
@@ -1383,6 +1382,7 @@ crates/stella-tools/src/staleness.rs 11.72
 crates/stella-tools/src/subagent.rs 10.56
 crates/stella-tools/src/subagent/tests.rs 10.37
 crates/stella-tools/src/tasks.rs 8.39
+crates/stella-tools/src/tasks/board.rs 9.79
 crates/stella-tools/src/temp_roots.rs 11.87
 crates/stella-tools/src/validate.rs 10.34
 crates/stella-tools/src/workspace_scope.rs 9.92


### PR DESCRIPTION
## What & why

Epic #5113 names two modules still sitting in `stella-core` that the step path
does not reach: `starvation.rs` and `tasks.rs`. I read both against AGENTS.md
rule 12 before moving anything, and they came out differently.

### `tasks.rs` — a port and a plane sharing one file

The file held two unrelated things.

| Item | Reached from `driver` / `step` / `ports`? | Importers outside `stella-core` |
| --- | --- | --- |
| `RunningTask` | **Yes.** `event_sender.rs` calls it to stamp `task_id` on the work the engine emits, and `driver.rs`, `step.rs`, `driver/waiting.rs`, `driver/drive.rs` and six more all take `EventSender`. | `stella-tools`' `ToolRegistry::running_task`, `stella-cli`'s `subsession::lane_events` |
| `TaskBoard`, `TaskBoardError`, `SpawnRequest` | **No.** `rg 'TaskBoard\|SpawnRequest' crates/stella-core/src/{driver,driver.rs,step,step.rs,ports,ports.rs}` finds nothing on `main`. | `stella-tools`' `tasks.rs` + `registry.rs`, `stella-cli`'s `subsession.rs` + `turn_files/stale_lane.rs` |

Sharing one file is why `scripts/check-core-reachability.py` never flagged the
board: the walker resolves `crate::tasks` to a module and pulls the whole file
in, so `RunningTask` carried 700 lines of tool logic with it. That is the shape
the record plane got in through — the epic body says so itself: "attaches to the
step path by **one** call — `receipts.rs` → `context_record::hash::record_hash`".
The answer there was to relocate the attachment point (`record_hash` →
`stella-protocol`) and evict the rest. Same answer here.

So:

- `TaskBoard`, `TaskBoardError` and `SpawnRequest` → `crates/stella-tools/src/tasks/board.rs`,
  re-exported from `stella_tools::tasks` so every importer writes one path.
  `stella-tools` owns the six `task_*` tools, already holds `TaskBoardHandle` /
  `SpawnQueue`, and `stella-cli` (the only other importer) depends on it. No new
  crate: none of AGENTS.md § "When a new crate is justified"'s three tests is met,
  and the rule there says extend an existing crate.
- `RunningTask` → `crates/stella-core/src/running_task.rs`. It is a port, not
  board logic: a closure the host installs, which the engine calls without ever
  learning what answers it. `stella_core::RunningTask` keeps its path.

Exemplar: `skills/` leaving for `stella-learn` while `skills/invoke.rs` stayed
behind as `stella_core::skill_invocation` — the same split, one epic child earlier.

### `starvation.rs` — the checklist is wrong, and it stays

`crates/stella-core/src/driver/restore.rs` names `crate::starvation` in shipped
code, not from a test. `summarize_overflow_span` sizes the overflow summarizer's
`max_output_tokens` with `with_reasoning_headroom(SUMMARY_OUTPUT_CONTRACT)`, and
the branch below it recovers a starved call through `starved_of_output` +
`starved_retry_cap`. The crate's `#[cfg(test)]` boundary in that file is far
below both. That is the engine's own overflow path, so the module is step-path
and moving it would be wrong. I have said so on #5113 rather than moving code to
match a checklist.

`scripts/core-reachability-baseline.txt` is untouched: neither module was ever in
it, because the guard already read both as reached. Nothing was recorded to turn a
gate green.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-core/tests/task_board_is_not_engine_code.rs`:

- `the_engines_crate_names_no_board_type` scans every `.rs` under
  `crates/stella-core/src/` for `TaskBoard`, `TaskBoardError` and `SpawnRequest`.
  On `main` it reports three offenders — `git grep -l TaskBoard origin/main -- crates/stella-core/src`
  prints `event_sender.rs`, `lib.rs` and `tasks.rs` — so it fails there and passes
  here.
- `the_scanner_sees_the_crate_it_is_scanning` checks the scanner first, the way
  #6288's `dependency_boundary.rs` does: a walk that returned nothing, or a
  deleted `RunningTask`, fails here instead of making the assertion above
  vacuous.

A source scan rather than a type-level assertion because Rust cannot express
"this crate does not export that", and because nothing fails to compile when the
board comes back — a later `pub mod tasks;` beside `driver` re-creates exactly
the condition the module walker cannot see.

`make core-reachability` is green before and after, and that is the point rather
than an omission: the guard's module granularity is what hid this, so it could
not be the witness for its own blind spot.

## The gate

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p stella-core -p stella-tools -p stella-cli -p stella-store -p stella-protocol --all-targets -- -D warnings` — exit 0
- [x] `cargo test -p stella-core` (895 pass), `cargo test -p stella-tools --lib` (637 pass), `cargo test -p stella-cli --bins stale_lane` (6 pass)
- [x] `make guards-fast`, `make doc-links`, `make invariants`, `make core-reachability`, `python3 scripts/check-prose.py` — all green
- [x] `make doc-warnings CARGO_SCOPE="-p stella-core -p stella-tools"` and `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-cli -p stella-store -p stella-protocol --no-deps --document-private-items` — clean, which is what covers the four intra-doc links repointed at `stella_tools::tasks::TaskBoard`
- [x] Docs updated: both crate READMEs, AGENTS.md's testing list, `doc:agent-native-delivery`, and the eleven doc comments across five crates that cited `stella_core::tasks`
- [x] `Refs #5113` appears above and as a commit trailer. It advances the epic
      rather than finishing it: the fourth box is still open, tracked in `#6286`
      (the `stella-graph` feature gate), so a closing keyword here would hold
      that box against this PR at the dod gate.

No workspace build was run here — CI is the evidence for that (AGENTS.md, "CI
builds and tests; this laptop does not").

## Fix over file

- [x] Extra fixes in this PR, both off-topic and both fixed here rather than filed:
  - AGENTS.md's property-test list still said skill selection lives in
    `stella-core`; it moved to `stella-learn` an epic child ago. Corrected in the
    same sentence the task board moved out of.
  - `crates/stella-transcript/examples/demo.rs` renders a sample recall row
    citing a source path; it named a file this branch moved, so the demo would
    have taught a path nobody can open. Repointed.
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred.

## Ground-rule check

- [x] No I/O added to `stella-core` — the change removes code from it and adds a
      closure type with no I/O. No new deps in any manifest.
- [x] No new outbound network calls
- [x] No new cross-boundary serde types

## Anything reviewers should know?

**Wire artifacts changed, and only a doc string moved.**
`crates/stella-protocol/src/event/payload.rs`'s `TaskItem::contract` doc named
`stella_core::tasks`, and that string is embedded in `docs/wire/`. It is
regenerated with `bash scripts/export-agentevent-schema.sh`; the diff is four
files, all `description` text, no field, tag or shape change.

**One test was renamed across a crate boundary.**
`stella-core`'s `event_sender::task_tag_tests::work_dispatched_while_a_task_runs_is_tagged_with_that_task`
is gone, and is now
`stella-tools`' `tasks::board::event_tag_tests::the_board_answers_the_event_senders_running_task`
— same body, same assertions. It had to move: it drives a real `TaskBoard`, and
`stella-core` must not take an edge to the tool executor to reach one. The three
sibling cases that use plain closures stayed in `stella-core`, and each module
now points at the other. Naming it here because `check-deleted-tests` compares
two trees and will see the deletion.

`scripts/prose-*.txt` carry the moved file's entries to the new path and nothing
else. `crates/stella-tools/src/tasks/board.rs` records 9.79 rather than the 9.93
it had, because the module header was rewritten; no ceiling was raised, and no
unrelated file was retightened.

Refs #5113

## Summary by Sourcery

Move the session task board out of `stella-core` and leave only its event-tagging port in the engine crate.

Enhancements:
- Move task-board decision logic and spawn request types from `stella-core` into `stella-tools`, while preserving the public `stella_tools::tasks` access path.
- Keep `RunningTask` as a lightweight engine-facing port in `stella-core`, decoupling event tagging from the task-board implementation.
- Clarify crate ownership and update affected code references and documentation to reflect the new task-board boundary.

Documentation:
- Update crate documentation, testing guidance, inline references, and generated wire documentation for the task-board relocation.

Tests:
- Add a source-level witness that prevents task-board types from returning to `stella-core`.
- Move the real task-board event-tagging test into `stella-tools` while retaining engine-side sender coverage.

Chores:
- Leave the starvation module in `stella-core` because it is part of the engine's restore and overflow path.
- Correct the property-test ownership documentation for skill selection and the task board.
