### PR TITLE
feat(stella-tools): put the code-graph index behind a graph feature

### DIFF
--- a/.github/workflows/tools-no-graph.yml
+++ b/.github/workflows/tools-no-graph.yml
@@ -1,0 +1,94 @@
+name: tools-no-graph
+
+# The only build in this project that compiles `stella-tools` without the
+# code-graph index.
+#
+# `stella-graph` and `stella-embed` sit behind the crate's `graph` feature,
+# which is on by default (#6286) — so `ci.yml`, `make gate`, the pre-push hook
+# and every release build resolve the feature and never look at the other
+# configuration. An unbuilt configuration rots: the first `stella_graph::` in
+# an ungated module, or a doc link to a `cfg`-ed item, compiles green
+# everywhere a contributor looks and breaks only for the embedding host or
+# plugin-only build the feature exists for.
+#
+# So this compiles it with the feature off. `--all-targets` because the tests
+# are where the ungated reference lands: the search integration tests carry a
+# crate-level `#![cfg(feature = "graph")]` and would silently start failing to
+# compile if a new one forgot it. Plus `cargo doc`, because rustdoc resolves
+# intra-doc links per feature set and a link to a `#[cfg(feature = "graph")]`
+# item is an error here and nowhere else — which is the exact failure this
+# workflow caught while it was being written.
+#
+# Its own file rather than a job in `ci.yml`, for the reason
+# `wire-schema.yml` and `macos-check.yml` have one: a second full compile of
+# this crate's dependency tree is minutes a diff touching neither crate has no
+# use for. Not a required check.
+on:
+  pull_request:
+    paths:
+      - "crates/stella-tools/**"
+      - "crates/stella-tool-facts/**"
+      - "crates/stella-graph/**"
+      - "crates/stella-embed/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/tools-no-graph.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/stella-tools/**"
+      - "crates/stella-tool-facts/**"
+      - "crates/stella-graph/**"
+      - "crates/stella-embed/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/tools-no-graph.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tools-no-graph-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile:
+    name: stella-tools still builds with no code-graph index
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Despite the action's name this does not build on `stable`:
+      # rust-toolchain.toml pins the repo to a concrete toolchain and rustup
+      # honors it for every cargo invocation inside the checkout. This step
+      # exists to put *a* rustup on PATH.
+      - name: Install Rust (rustup; the build uses the rust-toolchain.toml pin)
+        id: rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      - if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+
+      - name: clippy, no default features, all targets
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        run: cargo clippy -p stella-tools --no-default-features --all-targets --locked -- -D warnings
+
+      - name: rustdoc, no default features
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc -p stella-tools --no-deps --document-private-items --no-default-features --locked
+
+      - name: test, no default features
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        run: cargo test -p stella-tools --no-default-features --locked
+
+      # The subtraction the feature exists for, asserted rather than assumed.
+      # `cargo check` succeeding says nothing about what got linked, and the
+      # nine tree-sitter grammars are the cost an embedding host is opting out
+      # of.
+      - name: the index-free build links no tree-sitter grammar
+        if: ${{ !cancelled() && steps.rust.outcome == 'success' }}
+        run: ./scripts/check-no-graph-tree.sh

--- a/Makefile
+++ b/Makefile
@@ -963,6 +963,14 @@ recheck-lock-compositions-test: ## Test the lock re-check sweep, its fail-open b
 release-lockfile-test: ## Test that the release version stamp leaves Cargo.lock resolvable, new members included (hermetic; not part of `gate`)
 	./scripts/test-release-lockfile.sh
 
+# Not a gate step: it resolves two dependency trees, which is seconds a diff
+# touching neither crate has no use for, and the configuration it measures is
+# one no shipped build uses. .github/workflows/tools-no-graph.yml is where it
+# runs for real, beside the compile of that configuration.
+.PHONY: no-graph-tree
+no-graph-tree: ## Assert an index-free stella-tools links no tree-sitter grammar (#6286)
+	@./scripts/check-no-graph-tree.sh
+
 # Deliberately not a gate step: it judges the MERGED tree, which is a question
 # no pre-merge run can answer. .github/workflows/main-canary.yml is where it
 # runs for real; this target is here so the logic can be exercised by hand.

--- a/crates/stella-cli/src/tool_docs.rs
+++ b/crates/stella-cli/src/tool_docs.rs
@@ -34,6 +34,7 @@
 //! `make record-golden` establishes the fixture's shape — an env-var-blessed
 //! test that rewrites it, with the plain test run as the drift guard.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
@@ -70,14 +71,14 @@ const DOCS_DIR: &str = "docs/tools";
 /// declared.
 const RISK_NOTE: &str = "\
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.";
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.";
 
 // ── the committed example fixture ───────────────────────────────────────────
 
@@ -153,9 +154,13 @@ fn repo_root() -> PathBuf {
 
 // ── collecting every declared schema ────────────────────────────────────────
 
-/// Every schema the native [`ToolRegistry`] advertises. One registry: every
-/// catalog row registers unconditionally, so the constructor's surface IS the
-/// documented surface.
+/// Every schema the native [`ToolRegistry`] advertises. One registry, built
+/// with this crate's own feature resolution — `stella-cli` takes
+/// `stella-tools` with default features, so `search` is present here and the
+/// constructor's surface IS the documented surface. A row whose
+/// [`Availability`] names a build feature says so on its own page, so a host
+/// that compiled the feature out reads which tool it does not have
+/// (`#6286`).
 ///
 /// With one pin, [`pin_capability_conditional_schemas`], because one tool
 /// chooses its description from a capability the *generator's own host* has or
@@ -347,11 +352,14 @@ fn output_schema() -> Value {
 
 // ── rendering ───────────────────────────────────────────────────────────────
 
-fn availability_word(availability: Availability) -> &'static str {
+fn availability_word(availability: Availability) -> Cow<'static, str> {
     // Matched exhaustively on purpose: a new Availability variant should fail
     // to compile here rather than render as something plausible.
     match availability {
-        Availability::Always => "always",
+        Availability::Always => Cow::Borrowed("always"),
+        // The feature is named, because "conditional" would leave a reader
+        // asking the source which condition (`#6286`).
+        Availability::BuildFeature(name) => Cow::Owned(format!("build feature `{name}`")),
     }
 }
 
@@ -549,7 +557,7 @@ fn usage_comment(name: &str, fixture: &Fixture) -> String {
             let (also, subject) = if has_former_names(name) {
                 (
                     ", and neither does any name it dispatched under before (the rename \
-                     ledger in crates/stella-tools/src/catalog.rs)",
+                     ledger in crates/stella-tool-facts/src/catalog.rs)",
                     "no name this tool has answered to was",
                 )
             } else {
@@ -768,7 +776,7 @@ fn render_tool(entry: &ToolEntry, schema: &ToolSchema, fixture: &Fixture) -> Str
          # Where each field comes from:\n\
          #   name / description / input_schema      the tool's own ToolSchema\n\
          #   read_only / available_for_speculation / category / availability\n\
-         #   risk_level                             crates/stella-tools/src/catalog.rs\n\
+         #   risk_level                             crates/stella-tool-facts/src/catalog.rs\n\
          #   output_schema                          stella_protocol::ToolOutput",
         name = entry.name,
     );
@@ -869,7 +877,7 @@ fn render_index(entries: &[&ToolEntry], fixture: &Fixture) -> String {
     out.push_str(&format!(
         "One TOML page per dispatchable tool — {count} of them — generated from the \
          declarations by `crates/stella-cli/src/tool_docs.rs` and re-derived by the \
-         `tool-docs` gate step. A tool added to `crates/stella-tools/src/catalog.rs` \
+         `tool-docs` gate step. A tool added to `crates/stella-tool-facts/src/catalog.rs` \
          without regenerating turns the gate red; there is no path where a new tool \
          ships undocumented.\n\n",
         count = entries.len()
@@ -879,13 +887,18 @@ fn render_index(entries: &[&ToolEntry], fixture: &Fixture) -> String {
          `read_only`, `available_for_speculation`, `risk_level`, category, and a \
          commented example input and output payload.\n\n\
          `risk_level` is a reviewed judgement declared beside the flags it sits with \
-         in `crates/stella-tools/src/catalog.rs`, graded against the rubric on \
+         in `crates/stella-tool-facts/src/catalog.rs`, graded against the rubric on \
          `ToolEntry::risk` (#2716, #3060). It answers a different question from \
          `read_only` — what one honest call costs the world, rather than whether the \
          workspace changes — and is deliberately not derived from the booleans above \
          it, which would be a relabelling rather than information. A policy grant is \
          expressed as a ceiling over this grade; every tool that is not a built-in \
          (MCP, custom manifest) is graded `high` for being unreviewed.\n\n\
+         `availability` reads `always` for a tool every build registers, and names a \
+         cargo feature for one that needs the host to have compiled something. \
+         `search` is the only conditional row today: it ranks over the code-graph \
+         index, so a `stella-tools` built without the `graph` feature registers no \
+         `search` at all. The feature is on by default, so the shipping CLI has it.\n\n\
          One field remains a stated absence rather than a value, because inventing it \
          would manufacture a source of truth nobody reviewed:\n\n\
          - **`output_schema` is the envelope only.** Every tool answers in \

--- a/crates/stella-tool-facts/src/catalog.rs
+++ b/crates/stella-tool-facts/src/catalog.rs
@@ -41,23 +41,44 @@ use stella_protocol::RiskLevel;
 /// *allowed* is [`crate::policy::ToolPolicy`]'s business, driven by
 /// `settings.json`.
 ///
-/// Every current row registers unconditionally, so [`Availability::Always`]
-/// is the whole enum today. The type survives (rather than collapsing into a
-/// boolean or vanishing) because it is the declared seam a conditionally
-/// registered tool re-enters through, and because the doc generator
-/// (`stella-cli/src/tool_docs.rs`) renders each row's availability from it.
+/// This is the declared seam a conditionally registered tool re-enters
+/// through, and the doc generator (`stella-cli/src/tool_docs.rs`) renders
+/// each row's availability from it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Availability {
     /// Registers in every session, with no configuration and no prerequisite.
     Always,
+    /// Registers only when the host binary was compiled with the named cargo
+    /// feature of `stella-tools` (`#6286`).
+    ///
+    /// A compile-time prerequisite is still the environment supplying
+    /// something, so it belongs here rather than in
+    /// [`crate::policy::ToolPolicy`]: nothing an operator writes in
+    /// `settings.json` can turn it on. Every shipped build enables the
+    /// default feature set, so a row here is present for a `stella` user and
+    /// absent only in a host that opted the feature out.
+    BuildFeature(&'static str),
 }
 
 impl Availability {
-    /// Whether the native `stella_tools::registry::ToolRegistry` is what registers
-    /// this tool. True for every current variant; a future CLI-layered
-    /// declaration would answer false.
+    /// Whether the native `stella_tools::registry::ToolRegistry` is what
+    /// registers this tool. True for every current variant; a future
+    /// CLI-layered declaration would answer false.
     pub const fn is_native(self) -> bool {
-        matches!(self, Availability::Always)
+        matches!(self, Availability::Always | Availability::BuildFeature(_))
+    }
+
+    /// Whether a build compiling `features` registers this tool.
+    ///
+    /// `features` is what the host says it compiled — `stella_tools`
+    /// publishes its own as `BUILD_FEATURES`. An unconditional row is
+    /// satisfied by every build, including one that names no feature at all.
+    #[must_use]
+    pub fn satisfied_by(self, features: &[&str]) -> bool {
+        match self {
+            Availability::Always => true,
+            Availability::BuildFeature(name) => features.contains(&name),
+        }
     }
 }
 
@@ -169,8 +190,13 @@ macro_rules! catalog {
     };
 }
 
-use Availability::Always;
+use Availability::{Always, BuildFeature};
 use RiskLevel::{Destructive, High, Low, Medium};
+
+/// The `stella-tools` cargo feature that compiles the code-graph index in.
+/// Named once, so the row below and the host publishing its own feature list
+/// cannot spell it differently.
+const GRAPH: Availability = BuildFeature("graph");
 
 // Column order: (read_only, speculation_safe, risk, availability, group, label).
 // The
@@ -193,7 +219,13 @@ catalog! {
     "delete_file"         => (false, false, Destructive, Always, "file", "delete"),
     // Read-only, but NOT speculation-safe: the semantic rung writes
     // embeddings through into `codegraph.db` while it ranks.
-    "search"              => (true, false, Low, Always, "search", "search"),
+    //
+    // The one row that is not unconditional. Every rung it ranks over is
+    // built on the code-graph index, so a host that compiled `stella-tools`
+    // without the `graph` feature does not register it (`#6286`). That is a
+    // subtraction other hosts opt into: the shipped CLI takes the default
+    // feature set, where this row reads exactly as `Always` did.
+    "search"              => (true, false, Low, GRAPH, "search", "search"),
     // The session task board. In-memory and session-scoped: every row here is
     // `Low` because what it mutates cannot outlive the process, which is the
     // clearest demonstration that `risk` is not `read_only` spelled twice.
@@ -582,9 +614,18 @@ pub fn always_on() -> Vec<&'static str> {
 }
 
 /// Every tool the native registry can register — the ceiling the docs quote.
-/// Identical to [`always_on`] while every row is unconditional.
 pub fn native() -> Vec<&'static str> {
     names_where(Availability::is_native)
+}
+
+/// The names a build compiling `features` registers, sorted.
+///
+/// This is what a registry pins itself against: [`always_on`] is the rows no
+/// build can drop, and this adds the rows whose
+/// [`Availability::BuildFeature`] the caller says it compiled.
+/// `stella_tools::BUILD_FEATURES` is the list the shipped registry passes.
+pub fn registered_with(features: &[&str]) -> Vec<&'static str> {
+    names_where(|a| a.satisfied_by(features))
 }
 
 /// The read-only partition across the whole catalog, sorted. What dispatch
@@ -693,6 +734,40 @@ mod tests {
         for name in always_on() {
             assert!(native_set.contains(name), "{name} must be native");
         }
+    }
+
+    /// **Witness (`#6286`).** A row behind a build feature is registered by a
+    /// build that compiled it and by no other, and the unconditional rows are
+    /// unaffected either way. Before `Availability` grew the option this
+    /// asserts on, a conditionally registered tool had nowhere to say so and
+    /// the catalog advertised it regardless of what the host had compiled.
+    #[test]
+    fn a_build_feature_row_registers_only_where_the_feature_is_compiled() {
+        assert!(
+            Availability::BuildFeature("graph").satisfied_by(&["graph"]),
+            "a build naming the feature registers the row"
+        );
+        assert!(
+            !Availability::BuildFeature("graph").satisfied_by(&[]),
+            "a build naming no feature does not"
+        );
+        assert!(
+            !Availability::BuildFeature("graph").satisfied_by(&["other"]),
+            "another feature is not this one"
+        );
+        assert!(
+            Availability::Always.satisfied_by(&[]),
+            "an unconditional row is satisfied by every build"
+        );
+
+        // `search` is the row, and the derived views agree with it.
+        assert!(!always_on().contains(&"search"));
+        assert!(registered_with(&["graph"]).contains(&"search"));
+        assert!(!registered_with(&[]).contains(&"search"));
+        // Every other row is present in both, so the feature subtracts one
+        // tool rather than reshaping the table.
+        assert_eq!(registered_with(&[]), always_on());
+        assert_eq!(registered_with(&["graph"]).len(), always_on().len() + 1);
     }
 
     /// `speculation_safe` narrows `read_only`; it never widens it. A

--- a/crates/stella-tools/Cargo.toml
+++ b/crates/stella-tools/Cargo.toml
@@ -24,12 +24,15 @@ stella-store = { path = "../stella-store" }
 # file (#2178).
 stella-home = { path = "../stella-home" }
 # The code-graph index the `search` tool ranks over: symbols, callers,
-# imports, and the stored file/chunk vectors.
-stella-graph = { path = "../stella-graph" }
+# imports, and the stored file/chunk vectors. Optional, behind the `graph`
+# feature — see `[features]` below.
+stella-graph = { path = "../stella-graph", optional = true }
 # The embedding seam plus its HTTP backend — `search`'s semantic rung. This
 # crate is where the network is allowed to live: `stella-graph` stores vectors
-# and ranks them, and never learns what produced them (invariant 1).
-stella-embed = { path = "../stella-embed", features = ["http"] }
+# and ranks them, and never learns what produced them (invariant 1). Optional
+# for the same reason and behind the same feature: nothing outside `search`
+# takes it.
+stella-embed = { path = "../stella-embed", features = ["http"], optional = true }
 # The differ `write_file` and `edit_file` run over the bytes they read and the
 # bytes they wrote (`own_change`), so a mutation the work-tree measurement
 # cannot see — a gitignored path, a workspace with no journal — still renders
@@ -60,6 +63,20 @@ toml.workspace = true
 # dispatch timeout does. Tests see a normal dependency, so the witness keeps
 # compiling with no second entry below.
 futures-util.workspace = true
+
+# `graph` compiles the code-graph index in: the `search` tool and the
+# `Codegraph` implementation of `graph_fact::WorkspaceGraph`. On by default,
+# so `stella-cli` and every shipped build resolve exactly the dependency set
+# they resolved before (`#6286`).
+#
+# Off, this crate builds with no tree-sitter grammar and no bundled SQLite,
+# which is what an embedding host or a plugin-only build wants. It is a
+# subtraction those hosts opt into, never one the CLI takes: `search` is then
+# not registered, and it says so through `Availability::BuildFeature("graph")`
+# in `stella-tool-facts`'s catalog rather than going quietly absent.
+[features]
+default = ["graph"]
+graph = ["dep:stella-graph", "dep:stella-embed"]
 
 # The Job Object API behind `exec::GroupKillGuard`'s Windows arm (#3550) —
 # `CreateJobObjectW`, `AssignProcessToJobObject`, `TerminateJobObject`. It is

--- a/crates/stella-tools/README.md
+++ b/crates/stella-tools/README.md
@@ -116,6 +116,30 @@ depend on the crate for exactly one thing —
 `subprocess_env::scrub_sensitive_env`, so their own spawns share the single
 credential deny-list rather than growing a second one that drifts.
 
+### The `graph` feature
+
+`stella-graph` and `stella-embed` sit behind a `graph` cargo feature. It is
+on by default, so `stella-cli` and every shipped build resolve the same
+dependency set they always did.
+
+Turn it off and this crate builds with no tree-sitter grammar. That drops 22
+edges from the dependency tree, which is what an embedding host or a
+plugin-only build is trying not to compile. It also drops the `search` tool,
+because every rung of `search` ranks over the code-graph index. The catalog
+declares that rather than leaving the row quietly unregistered:
+`stella-tool-facts` grades it `Availability::BuildFeature("graph")`, this
+crate publishes what it built as `BUILD_FEATURES`, and
+`tests/graph_feature_witness.rs` checks that the two agree in both builds.
+
+A build with no index still answers the mutation tools' graph questions. It
+answers `None` to all of them, through `graph_fact::Unindexed`, which is what
+the trait already means by "no index answered".
+
+`.github/workflows/tools-no-graph.yml` compiles, documents and tests the
+feature-off configuration, and `make no-graph-tree` asserts the tree-sitter
+edges are really gone. rusqlite is not gone: `stella-store` is still an
+unconditional dependency, and `#6423` tracks that seam.
+
 ## Boundary — does this change belong here?
 
 This crate owns the built-in tools — everything the model can invoke by name

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -334,7 +334,7 @@ fn refuse_if_outside(argument: &str, ctx: &crate::ctx::ToolCtx) -> Option<String
 ///
 /// **A bash result carries no tool-preference advice, ever.** There used to be
 /// a second note here, appended whenever a grep pattern looked symbol-shaped,
-/// pointing the model at [`crate::search`]. It was measured on a 20-task
+/// pointing the model at the `search` tool. It was measured on a 20-task
 /// Terminal-Bench panel and it was pure loss: it fired on **44 of 415 tool
 /// results across 10 of 20 tasks** and produced **zero** `search` calls. It
 /// fired on hardware probes (`cat /proc/cpuinfo | grep -i vmx`), on package

--- a/crates/stella-tools/src/delete.rs
+++ b/crates/stella-tools/src/delete.rs
@@ -30,7 +30,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use stella_protocol::tool::{ToolOutput, ToolSchema};
 
-use crate::graph_fact::{Codegraph, GraphFact, WorkspaceGraph};
+use crate::graph_fact::{GraphFact, WorkspaceGraph};
 use crate::registry::Tool;
 use crate::rootfd::{EntryKind, RootHandle};
 
@@ -43,7 +43,7 @@ pub struct DeleteFile {
 impl Default for DeleteFile {
     fn default() -> Self {
         Self {
-            graph: std::sync::Arc::new(Codegraph),
+            graph: crate::graph_fact::workspace_graph(),
         }
     }
 }

--- a/crates/stella-tools/src/graph_fact.rs
+++ b/crates/stella-tools/src/graph_fact.rs
@@ -20,6 +20,7 @@
 //! success strings the stagnation detector keys on (#3176).
 
 use std::path::Path;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use stella_protocol::tool::ToolOutput;
@@ -75,14 +76,53 @@ pub trait WorkspaceGraph: Send + Sync {
     fn register(&self, root: &Path, file: &Path) -> Option<bool>;
 }
 
+/// The graph a file mutation asks in this build.
+///
+/// `Codegraph` under the `graph` feature, `Unindexed` without it. A host that
+/// built no index has none to ask. [`WorkspaceGraph`] already answers `None`
+/// to that, so the fact drops out, the way it does in a workspace nobody has
+/// run `stella init` in.
+#[must_use]
+pub fn workspace_graph() -> Arc<dyn WorkspaceGraph> {
+    #[cfg(feature = "graph")]
+    {
+        Arc::new(Codegraph)
+    }
+    #[cfg(not(feature = "graph"))]
+    {
+        Arc::new(Unindexed)
+    }
+}
+
+/// The answer a build with no index gives: nothing, to both questions.
+///
+/// `None` is how this trait says no index answered. A build with no index is
+/// that case for every path. So a mutation states no graph fact. It does not
+/// state a zero.
+#[cfg(not(feature = "graph"))]
+pub struct Unindexed;
+
+#[cfg(not(feature = "graph"))]
+impl WorkspaceGraph for Unindexed {
+    fn inbound_refs(&self, _root: &Path, _file: &Path) -> Option<u32> {
+        None
+    }
+
+    fn register(&self, _root: &Path, _file: &Path) -> Option<bool> {
+        None
+    }
+}
+
 /// The workspace's own code graph (`.stella/private/codegraph.db`).
 ///
 /// Every method opens the index, asks, and closes: a mutation is rare next
 /// to a query, and a handle held for the session's lifetime would keep a
 /// write connection open against a store `stella observe` and the session's
 /// own watcher are also writing.
+#[cfg(feature = "graph")]
 pub struct Codegraph;
 
+#[cfg(feature = "graph")]
 impl Codegraph {
     /// The index, or `None` when this workspace has none.
     ///
@@ -99,6 +139,7 @@ impl Codegraph {
     }
 }
 
+#[cfg(feature = "graph")]
 impl WorkspaceGraph for Codegraph {
     fn inbound_refs(&self, root: &Path, file: &Path) -> Option<u32> {
         let graph = Codegraph::open(root)?;
@@ -170,5 +211,5 @@ pub fn from_output(output: &ToolOutput) -> Vec<GraphFact> {
         .unwrap_or_default()
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "graph"))]
 mod tests;

--- a/crates/stella-tools/src/lib.rs
+++ b/crates/stella-tools/src/lib.rs
@@ -12,7 +12,11 @@
 //!
 //! - the **working surface** — one shell ([`bash`]), the file CRUD quartet
 //!   ([`read`] / [`mod@write`] / [`edit`] / [`delete`]), and one unified code
-//!   search ([`search`], lexical and semantic in a single `query` parameter);
+//!   search (`search`, lexical and semantic in a single `query` parameter),
+//!   whose every rung ranks over the code-graph index and which therefore
+//!   compiles only under the `graph` feature. That feature is on by default,
+//!   so a `stella` user has it; [`BUILD_FEATURES`] is what this build
+//!   compiled;
 //! - the **coordination surface** — the sub-agent spawn tool (`delegate`), the
 //!   session task board (`task_create` / `task_list` / `task_start` /
 //!   `task_complete` / `task_cancel` / `task_assign`), the session scratch
@@ -77,6 +81,14 @@ mod recheck;
 pub mod registry;
 pub mod rootfd;
 pub mod scratch;
+// Present only under the `graph` feature (`#6286`): every rung ranks over the
+// code-graph index. A build without it registers no `search` tool, which the
+// catalog declares as `Availability::BuildFeature("graph")` rather than
+// leaving the row silently unregistered. A plain comment rather than a `///`
+// doc: an outer doc block on a `mod` line joins the module's own `//!`
+// header, and rustdoc then resolves that header's intra-doc links in this
+// file's scope, where none of them exist.
+#[cfg(feature = "graph")]
 pub mod search;
 mod shell_resolve;
 pub mod skill_grant;
@@ -100,6 +112,18 @@ pub mod workspace_scope;
 pub mod write;
 
 pub use registry::ToolRegistry;
+
+/// The cargo features of this build that a catalog row may name.
+///
+/// [`stella_tool_facts::catalog::Availability::BuildFeature`] declares a
+/// compile-time prerequisite by name; this is the other end of that seam, so
+/// a caller asking "does this binary register `search`" reads one list
+/// instead of re-deriving a `cfg`. It is the argument
+/// [`stella_tool_facts::catalog::registered_with`] takes.
+pub const BUILD_FEATURES: &[&str] = &[
+    #[cfg(feature = "graph")]
+    "graph",
+];
 
 /// Turn a workspace-relative `path` into a full path, refusing one that names
 /// a location outside `root`.

--- a/crates/stella-tools/src/loop_comparability/tests.rs
+++ b/crates/stella-tools/src/loop_comparability/tests.rs
@@ -291,8 +291,16 @@ fn every_non_exempt_tool_is_driven_by_the_sentinel() {
 /// identical strings are identical.
 #[tokio::test]
 async fn declared_comparability_holds_when_the_tool_is_actually_run() {
+    let registered = crate::catalog::registered_with(crate::BUILD_FEATURES);
     for (name, posture) in REGISTRY {
         let Some(probe) = probe(name) else { continue };
+        // A row this build does not register has no success path to drive
+        // (`#6286`). Read off the catalog rather than a `cfg` here, so the skip
+        // is the same declaration the registry itself follows and a row that
+        // stops registering for a reason nobody declared still fails.
+        if !registered.contains(name) {
+            continue;
+        }
         let (first, second) = drive_twice(name, &probe).await;
         assert!(
             !first.is_error() && !second.is_error(),

--- a/crates/stella-tools/src/registry.rs
+++ b/crates/stella-tools/src/registry.rs
@@ -193,7 +193,6 @@ impl ToolRegistry {
             Arc::new(crate::write::WriteFile::with_ledger(read_ledger.clone())),
             Arc::new(crate::edit::EditFile::with_ledger(read_ledger)),
             Arc::new(crate::delete::DeleteFile::default()),
-            Arc::new(crate::search::Search::from_env()),
             Arc::new(crate::tasks::TaskCreate(task_board.clone())),
             Arc::new(crate::tasks::TaskList(task_board.clone())),
             Arc::new(crate::tasks::TaskStart(task_board.clone())),
@@ -219,6 +218,16 @@ impl ToolRegistry {
             // as complete.
             Arc::new(crate::ask::AskQuestion::new(question.clone())),
         ];
+        // Every rung of `search` reads the code-graph index. Build without
+        // the `graph` feature and there is no search to register (`#6286`).
+        // The catalog says so as `Availability::BuildFeature("graph")`, and
+        // `BUILD_FEATURES` says what this binary built, so the table and the
+        // registry agree.
+        //
+        // A push, not a `cfg` inside the list above. An attribute on a `vec!`
+        // argument is macro input. The compiler does not strip it.
+        #[cfg(feature = "graph")]
+        entries.push(Arc::new(crate::search::Search::from_env()));
         match scratch {
             Ok(scratch) => entries.extend([
                 Arc::new(crate::scratch::SaveState(scratch.clone())) as Arc<dyn Tool>,

--- a/crates/stella-tools/src/registry/tests.rs
+++ b/crates/stella-tools/src/registry/tests.rs
@@ -333,9 +333,9 @@ fn registry_advertises_exactly_the_catalog_tool_set() {
     let names: Vec<&str> = schemas.iter().map(|s| s.name.as_str()).collect();
     assert_eq!(
         names,
-        crate::catalog::always_on(),
+        crate::catalog::registered_with(crate::BUILD_FEATURES),
         "registry disagrees with catalog::CATALOG — register the tool, or \
-         add/remove its line in stella-tools/src/catalog.rs"
+         add/remove its line in stella-tool-facts/src/catalog.rs"
     );
 }
 
@@ -347,7 +347,7 @@ fn an_undeclared_tool_fails_the_catalog_pin_by_name() {
     let (_root, reg) = bare_registry();
     let schemas = reg.schemas();
     let live: Vec<&str> = schemas.iter().map(|s| s.name.as_str()).collect();
-    let mut catalog_missing_one = crate::catalog::always_on();
+    let mut catalog_missing_one = crate::catalog::registered_with(crate::BUILD_FEATURES);
     let dropped = catalog_missing_one.pop().expect("catalog is non-empty");
     assert_ne!(
         live, catalog_missing_one,

--- a/crates/stella-tools/src/write.rs
+++ b/crates/stella-tools/src/write.rs
@@ -78,7 +78,7 @@ impl WriteFile {
     pub fn with_ledger(ledger: Arc<ReadLedger>) -> Self {
         Self {
             ledger,
-            graph: Arc::new(crate::graph_fact::Codegraph),
+            graph: crate::graph_fact::workspace_graph(),
         }
     }
 

--- a/crates/stella-tools/tests/chunk_retrieval_witnesses.rs
+++ b/crates/stella-tools/tests/chunk_retrieval_witnesses.rs
@@ -105,6 +105,12 @@
 //! been observed in a ranking. #3097 is not closed by this file's existence;
 //! it is closed by one green run of it with a real key.
 
+// Every test in this file drives `search`, which exists only under the
+// `graph` feature (`#6286`). Gated at the crate root so a
+// `--no-default-features` build compiles this target to an empty test
+// binary instead of failing on a module that is not there.
+#![cfg(feature = "graph")]
+
 use std::path::{Path, PathBuf};
 
 use stella_embed::{Embedder, Resolution, SimilarityPosture};

--- a/crates/stella-tools/tests/codegraph_redirect_witness.rs
+++ b/crates/stella-tools/tests/codegraph_redirect_witness.rs
@@ -22,6 +22,12 @@
 //! test that set it in a shared binary would be mutating state every
 //! concurrently-running test in that binary can observe.
 
+// Every test in this file drives `search`, which exists only under the
+// `graph` feature (`#6286`). Gated at the crate root so a
+// `--no-default-features` build compiles this target to an empty test
+// binary instead of failing on a module that is not there.
+#![cfg(feature = "graph")]
+
 use std::path::Path;
 
 /// The path a reader resolves, or a panic naming why it could not.

--- a/crates/stella-tools/tests/gather_cache_witness.rs
+++ b/crates/stella-tools/tests/gather_cache_witness.rs
@@ -12,6 +12,12 @@
 //! asserts the first search **did** gather, so the second search's behaviour
 //! is a real saving (or a real re-gather) rather than an absence of work.
 
+// Every test in this file drives `search`, which exists only under the
+// `graph` feature (`#6286`). Gated at the crate root so a
+// `--no-default-features` build compiles this target to an empty test
+// binary instead of failing on a module that is not there.
+#![cfg(feature = "graph")]
+
 use stella_tools::ctx::ToolCtx;
 use stella_tools::registry::Tool;
 use stella_tools::search::Search;

--- a/crates/stella-tools/tests/graph_feature_witness.rs
+++ b/crates/stella-tools/tests/graph_feature_witness.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! **Witness (`#6286`).** The tools this build offers are the tools it built.
+//!
+//! Every rung of `search` reads the code-graph index. Turn the `graph`
+//! feature off and there is no `search` to register.
+//!
+//! The risk is not the missing tool. It is the table still listing it. The
+//! prompt's tool block, `custom::RESERVED_NAMES` and the doc generator all
+//! read `catalog::CATALOG`, and none of them sees a `cfg`.
+//!
+//! `stella_tools::BUILD_FEATURES` says what this build compiled.
+//! `catalog::Availability::BuildFeature` says what a row needs. This test
+//! runs either way and checks that the two agree.
+
+use stella_tools::{BUILD_FEATURES, ToolRegistry, catalog};
+
+/// The one row this feature governs.
+const CONDITIONAL_TOOL: &str = "search";
+
+fn advertised_names() -> Vec<String> {
+    let root = tempfile::tempdir().expect("a temp workspace root");
+    let registry = ToolRegistry::new(root.path().to_path_buf());
+    registry
+        .schemas()
+        .iter()
+        .map(|schema| schema.name.clone())
+        .collect()
+}
+
+#[test]
+fn the_registry_advertises_exactly_what_this_build_compiled() {
+    let advertised = advertised_names();
+    let declared = catalog::registered_with(BUILD_FEATURES);
+    assert_eq!(
+        advertised, declared,
+        "the live registry and the catalog disagree about what this build \
+         registers — a host would be handed a schema for a tool it does not \
+         have, or denied one it does"
+    );
+}
+
+#[test]
+fn the_conditional_tool_follows_its_feature() {
+    let advertised = advertised_names();
+    let compiled = BUILD_FEATURES.contains(&"graph");
+    assert_eq!(
+        advertised.iter().any(|name| name == CONDITIONAL_TOOL),
+        compiled,
+        "`{CONDITIONAL_TOOL}` must register when the `graph` feature is \
+         compiled and not otherwise; BUILD_FEATURES = {BUILD_FEATURES:?}"
+    );
+    // The rest of the surface is unconditional, so a build with no features
+    // still carries every other row.
+    for name in catalog::always_on() {
+        assert!(
+            advertised.iter().any(|live| live == name),
+            "`{name}` is unconditional and must register in every build"
+        );
+    }
+}

--- a/crates/stella-tools/tests/name_rung_calibration.rs
+++ b/crates/stella-tools/tests/name_rung_calibration.rs
@@ -33,6 +33,12 @@
 //! own `MEASURED:` marker in `crates/stella-tools/src/search/names.rs`
 //! carries the row of the sweep that read it.
 
+// Every test in this file drives `search`, which exists only under the
+// `graph` feature (`#6286`). Gated at the crate root so a
+// `--no-default-features` build compiles this target to an empty test
+// binary instead of failing on a module that is not there.
+#![cfg(feature = "graph")]
+
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 

--- a/crates/stella-tools/tests/relevance_calibration.rs
+++ b/crates/stella-tools/tests/relevance_calibration.rs
@@ -131,6 +131,12 @@
 //! `nomic-embed-text`) and a `QUERIES` table long enough that one loose label
 //! cannot move the reported result by a quarter of its value.
 
+// Every test in this file drives `search`, which exists only under the
+// `graph` feature (`#6286`). Gated at the crate root so a
+// `--no-default-features` build compiles this target to an empty test
+// binary instead of failing on a module that is not there.
+#![cfg(feature = "graph")]
+
 use std::path::{Path, PathBuf};
 
 use stella_embed::rank::{

--- a/crates/stella-tools/tests/search_latency_replay.rs
+++ b/crates/stella-tools/tests/search_latency_replay.rs
@@ -82,6 +82,12 @@
 //! terms; what a quiet machine adds up to is what the next run of this
 //! harness should record.
 
+// Every test in this file drives `search`, which exists only under the
+// `graph` feature (`#6286`). Gated at the crate root so a
+// `--no-default-features` build compiles this target to an empty test
+// binary instead of failing on a module that is not there.
+#![cfg(feature = "graph")]
+
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 

--- a/crates/stella-tools/tests/search_recall.rs
+++ b/crates/stella-tools/tests/search_recall.rs
@@ -89,6 +89,12 @@
 //! set, and asks a different question: what the ranker's four weights are
 //! worth. This file holds the ranking still; that one sweeps it.
 
+// Every test in this file drives `search`, which exists only under the
+// `graph` feature (`#6286`). Gated at the crate root so a
+// `--no-default-features` build compiles this target to an empty test
+// binary instead of failing on a module that is not there.
+#![cfg(feature = "graph")]
+
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -8,11 +8,13 @@ status: living
 
 # `docs/tools/`
 
-One TOML page per dispatchable tool — 19 of them — generated from the declarations by `crates/stella-cli/src/tool_docs.rs` and re-derived by the `tool-docs` gate step. A tool added to `crates/stella-tools/src/catalog.rs` without regenerating turns the gate red; there is no path where a new tool ships undocumented.
+One TOML page per dispatchable tool — 19 of them — generated from the declarations by `crates/stella-cli/src/tool_docs.rs` and re-derived by the `tool-docs` gate step. A tool added to `crates/stella-tool-facts/src/catalog.rs` without regenerating turns the gate red; there is no path where a new tool ships undocumented.
 
 Each page carries the tool's name, description, input schema, output schema, `read_only`, `available_for_speculation`, `risk_level`, category, and a commented example input and output payload.
 
-`risk_level` is a reviewed judgement declared beside the flags it sits with in `crates/stella-tools/src/catalog.rs`, graded against the rubric on `ToolEntry::risk` (#2716, #3060). It answers a different question from `read_only` — what one honest call costs the world, rather than whether the workspace changes — and is deliberately not derived from the booleans above it, which would be a relabelling rather than information. A policy grant is expressed as a ceiling over this grade; every tool that is not a built-in (MCP, custom manifest) is graded `high` for being unreviewed.
+`risk_level` is a reviewed judgement declared beside the flags it sits with in `crates/stella-tool-facts/src/catalog.rs`, graded against the rubric on `ToolEntry::risk` (#2716, #3060). It answers a different question from `read_only` — what one honest call costs the world, rather than whether the workspace changes — and is deliberately not derived from the booleans above it, which would be a relabelling rather than information. A policy grant is expressed as a ceiling over this grade; every tool that is not a built-in (MCP, custom manifest) is graded `high` for being unreviewed.
+
+`availability` reads `always` for a tool every build registers, and names a cargo feature for one that needs the host to have compiled something. `search` is the only conditional row today: it ranks over the code-graph index, so a `stella-tools` built without the `graph` feature registers no `search` at all. The feature is on by default, so the shipping CLI has it.
 
 One field remains a stated absence rather than a value, because inventing it would manufacture a source of truth nobody reviewed:
 
@@ -33,7 +35,7 @@ One field remains a stated absence rather than a value, because inventing it wou
 | [`list_state`](list_state.toml) | scratch | always | yes | yes | none observed |
 | [`read_file`](read_file.toml) | file | always | yes | yes | none observed |
 | [`save_state`](save_state.toml) | scratch | always | no | no | none observed |
-| [`search`](search.toml) | search | always | yes | no | none observed |
+| [`search`](search.toml) | search | build feature `graph` | yes | no | none observed |
 | [`task_assign`](task_assign.toml) | task | always | no | no | none observed |
 | [`task_cancel`](task_cancel.toml) | task | always | no | no | none observed |
 | [`task_complete`](task_complete.toml) | task | always | no | no | yes |

--- a/docs/tools/ask_question.toml
+++ b/docs/tools/ask_question.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "ask_question"
@@ -16,14 +16,14 @@ read_only = true
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/bash.toml
+++ b/docs/tools/bash.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "bash"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "high"
 
 description = '''

--- a/docs/tools/delegate.toml
+++ b/docs/tools/delegate.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "delegate"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "high"
 
 description = '''

--- a/docs/tools/delete_file.toml
+++ b/docs/tools/delete_file.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "delete_file"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "destructive"
 
 description = '''

--- a/docs/tools/delete_state.toml
+++ b/docs/tools/delete_state.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "delete_state"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/edit_file.toml
+++ b/docs/tools/edit_file.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "edit_file"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "medium"
 
 description = '''

--- a/docs/tools/get_environment.toml
+++ b/docs/tools/get_environment.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "get_environment"
@@ -16,14 +16,14 @@ read_only = true
 available_for_speculation = true
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/get_state.toml
+++ b/docs/tools/get_state.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "get_state"
@@ -16,14 +16,14 @@ read_only = true
 available_for_speculation = true
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/list_state.toml
+++ b/docs/tools/list_state.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "list_state"
@@ -16,14 +16,14 @@ read_only = true
 available_for_speculation = true
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/read_file.toml
+++ b/docs/tools/read_file.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "read_file"
@@ -16,14 +16,14 @@ read_only = true
 available_for_speculation = true
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/save_state.toml
+++ b/docs/tools/save_state.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "save_state"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/search.toml
+++ b/docs/tools/search.toml
@@ -6,24 +6,24 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "search"
 category = "search"
-availability = "always"
+availability = "build feature `graph`"
 read_only = true
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 # The description below is the BASELINE: what a host with no embedder

--- a/docs/tools/task_assign.toml
+++ b/docs/tools/task_assign.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "task_assign"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/task_cancel.toml
+++ b/docs/tools/task_cancel.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "task_cancel"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/task_complete.toml
+++ b/docs/tools/task_complete.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "task_complete"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/task_create.toml
+++ b/docs/tools/task_create.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "task_create"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/task_list.toml
+++ b/docs/tools/task_list.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "task_list"
@@ -16,14 +16,14 @@ read_only = true
 available_for_speculation = true
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/task_start.toml
+++ b/docs/tools/task_start.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "task_start"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "low"
 
 description = '''

--- a/docs/tools/write_file.toml
+++ b/docs/tools/write_file.toml
@@ -6,7 +6,7 @@
 # Where each field comes from:
 #   name / description / input_schema      the tool's own ToolSchema
 #   read_only / available_for_speculation / category / availability
-#   risk_level                             crates/stella-tools/src/catalog.rs
+#   risk_level                             crates/stella-tool-facts/src/catalog.rs
 #   output_schema                          stella_protocol::ToolOutput
 
 name = "write_file"
@@ -16,14 +16,14 @@ read_only = false
 available_for_speculation = false
 
 # risk_level: how bad one honest call is — a reviewed judgement, declared in
-# crates/stella-tools/src/catalog.rs beside the flags above and graded against
+# crates/stella-tool-facts/src/catalog.rs beside the flags above and graded against
 # the rubric on `ToolEntry::risk` (#2716, #3060). A DIFFERENT axis from
 # `read_only`: `delegate` mutates no file and spends real money, while
-# `task_create` mutates a board that dies with the session. Deliberately not
-# derived from the two booleans above — that would be a relabelling, not
-# information. A policy grant is expressed as a ceiling over this grade, and
-# every non-built-in tool (MCP, custom manifest) is graded `high` for being
-# unreviewed.
+# `task_create` mutates a board that dies with the session. It is not derived
+# from the two booleans above. That would only relabel them.
+#
+# A policy grant is a ceiling over this grade. Every tool that is not a
+# built-in (MCP, a custom manifest) is graded `high` for being unreviewed.
 risk_level = "medium"
 
 description = '''

--- a/scripts/check-no-graph-tree.sh
+++ b/scripts/check-no-graph-tree.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Did the `graph` feature really drop anything? (`#6286`)
+#
+# `cargo check -p stella-tools --no-default-features` says the code builds
+# with no code-graph index. It says nothing about what is still linked. A
+# crate elsewhere in the tree can switch an `optional = true` back on, and the
+# build looks the same and costs the same. So this reads the dependency tree
+# instead.
+#
+# The tree-sitter grammars are what a small host is trying not to build. The
+# feature-off tree must have none of them. The feature-on tree must have some,
+# or the two trees look alike and this check has stopped asking anything.
+#
+# rusqlite is out of scope here. `stella-tools` always takes `stella-store`,
+# and `stella-store` always takes rusqlite, so a small build still bundles
+# SQLite. Splitting that seam is its own job, tracked in `#6423`.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+with_graph=$(cargo tree -p stella-tools -e normal | grep -c 'tree-sitter' || true)
+without_graph=$(cargo tree -p stella-tools --no-default-features -e normal | grep -c 'tree-sitter' || true)
+
+if [ "$without_graph" -ne 0 ]; then
+  echo "no-graph-tree: FAIL — --no-default-features still pulls ${without_graph} tree-sitter edge(s)"
+  echo "  the graph feature is meant to drop them; run:"
+  echo "    cargo tree -p stella-tools --no-default-features -e normal -i tree-sitter"
+  fail=1
+fi
+
+if [ "$with_graph" -eq 0 ]; then
+  echo "no-graph-tree: FAIL — the default build pulls no tree-sitter edge either"
+  echo "  the check above cannot tell the two configurations apart."
+  echo "  A grammar was renamed, or the default feature set lost 'graph'."
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "no-graph-tree: ok — ${with_graph} tree-sitter edges with the graph feature, 0 without"
+fi
+
+exit "$fail"


### PR DESCRIPTION
## What & why

`crates/stella-tools/Cargo.toml` took `stella-graph` — and `stella-embed` beside it — as unconditional path dependencies. Every host that linked the crate built nine tree-sitter grammars whether or not it wanted code search. Both are optional now, behind a `graph` feature.

`default = ["graph"]`, so `stella-cli` and every shipped build resolve exactly the dependency set they resolved before. This is a subtraction other hosts opt into, never one the CLI takes.

Measured, not asserted:

```
$ cargo tree -p stella-tools -e normal | rg -c tree-sitter
22
$ cargo tree -p stella-tools --no-default-features -e normal | rg -c tree-sitter
0
```

### Which of the two paths, and why

The issue named two ways to keep the surface honest when the feature is off. **This takes the second: `search` is not registered, and the catalog says so.**

`stella_tool_facts::catalog::Availability` grew a `BuildFeature(&'static str)` option — the seam its own doc comment already said it was being kept for. `search` declares `BuildFeature("graph")`, `stella_tools::BUILD_FEATURES` publishes what the binary compiled, `catalog::registered_with(features)` joins the two, and the registry's own pin reads that instead of `always_on()`. So the table and the live registry agree by construction in either build, and a host is never handed a schema for a tool it does not have.

The first path — moving `stella_graph`'s `DENY_DIRS`, `WorkspaceIgnore` and `admitted::{Admits, admission}` down to a leaf so the file-scan rung still answers with no index — is a second extraction in the shape #5119 used, and would have made this a much larger change for a rung that is not what the issue is about.

### What still works with the feature off

The mutation tools keep their graph seam. `graph_fact::Codegraph` is behind the feature; `graph_fact::workspace_graph()` returns it, or `Unindexed`, which answers `None` to both trait questions. `None` is already what `WorkspaceGraph` means by "no index answered", so a `write_file` or `delete_file` in an index-free build states no graph fact rather than a plausible zero.

### Which crates enable the feature, and why

Nobody enables it explicitly. Every crate that depends on `stella-tools` — `stella-cli`, `stella-tui`, `stella-runtime`, `stella-fleet`, `stella-serve` — takes it with default features, which is where `graph` lives. So the shipping binary is unchanged, and the feature is something a host outside this workspace turns *off*.

Closes #6286
Refs #5113

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Two:

**`crates/stella-tools/tests/graph_feature_witness.rs`** runs under either feature set and checks that the live registry advertises exactly `catalog::registered_with(BUILD_FEATURES)`. Falsified by hand: set `search`'s row back to `Always` and run it with `--no-default-features` —

```
assertion `left == right` failed: the live registry and the catalog disagree
about what this build registers — a host would be handed a schema for a tool
it does not have, or denied one it does
  left:  [... "save_state", "task_assign" ...]
  right: [... "save_state", "search", "task_assign" ...]
```

**`catalog.rs`'s `a_build_feature_row_registers_only_where_the_feature_is_compiled`** pins `satisfied_by` in both directions and shows the feature subtracts one row rather than reshaping the table (`registered_with(&[]) == always_on()`). On `main` this does not compile: the option it asserts on does not exist there.

## The gate

Per CLAUDE.md ("CI builds and tests; this laptop does not") nothing here was run over the workspace. The PR's evidence is its CI run. Scoped locally, both feature sets, all green:

- `cargo clippy -p stella-tools --all-targets -- -D warnings`
- `cargo clippy -p stella-tools --no-default-features --all-targets -- -D warnings`
- `cargo clippy -p stella-tool-facts --all-targets -- -D warnings`
- `cargo clippy -p stella-cli --all-targets -- -D warnings`
- `cargo doc -p stella-tools` with and without default features, `RUSTDOCFLAGS=-D warnings`
- `cargo test -p stella-tools --all-targets`, with and without default features
- `cargo test -p stella-tool-facts`
- `cargo test -p stella-cli --bin stella tool_docs`
- `make guards-fast` (prose, grade, lockfile, fmt, every toolchain-free guard)

The rustdoc runs are not ceremony. Both caught real breaks the clippy runs did not: a doc link to a now-`cfg`-ed `Codegraph` fails only with the feature off, and an outer `///` on the `pub mod search;` line re-parented `search.rs`'s `//!` header so rustdoc resolved its intra-doc links in `lib.rs`'s scope. Both are fixed; the second is written down where the next author will hit it.

- [x] Docs updated: `crates/stella-tools/README.md` gains a "The `graph` feature" section; `docs/tools/` regenerated with `make tool-docs-update`.
- [x] `Closes #6286` appears above **and** as a commit trailer.

### New CI leg

`.github/workflows/tools-no-graph.yml` — its own file, path-filtered, not a required check, on `wire-schema.yml`'s and `macos-check.yml`'s argument. It runs clippy, rustdoc and the tests for the feature-off configuration, then `scripts/check-no-graph-tree.sh` (`make no-graph-tree`), which asserts the tree-sitter edges are gone. That guard checks **both** directions: the feature-on tree must still carry grammars, or a rename that made the match empty would pass it silently forever.

## Fix over file

- [x] Extra fixes in this PR:
  1. **`crates/stella-cli/src/tool_docs.rs` cited a file that has moved.** Five references to `crates/stella-tools/src/catalog.rs`; the table lives in `stella-tool-facts` now. The citation was dead on every generated page under `docs/tools/`, which is why the regenerated diff touches all twenty files.
  2. **`RISK_NOTE` in the same file broke two of this repository's prose rules** — it opened with a filler adverb and closed on an `X, not Y` foil. Rewritten, which also bought back the reading-grade the longer path cost every generated page.
- [x] Filed, with the reason a fix could not ride this PR: #6423

## What this does NOT do — read this before ticking the DoD

**rusqlite is still in the index-free tree**, and #6286's Definition of done asked for it to be gone:

```
$ cargo tree -p stella-tools --no-default-features -e normal -i rusqlite
rusqlite v0.40.2
└── stella-store
    └── stella-tools
```

`stella-tools` takes `stella-store` unconditionally, and `stella-store` takes rusqlite with a bundled `libsqlite3-sys`. Dropping it means a port trait or a second near-leaf extraction for `foundry_gate`'s `stella_store::AdoptedTool` re-export and the registry's `mcp_usage` handle — a design call, larger than this session, and a different subject from the one this issue names. Filed as **#6423** with the repro, the two seams, and its own definition of done. `scripts/check-no-graph-tree.sh` says the same thing in its header rather than measuring something it cannot yet assert.

The DoD box for that line is ticked against the tree-sitter half only, and says so.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new dependencies at all — this PR only makes two existing ones optional
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**No tests were deleted.** Seven integration test files under `crates/stella-tools/tests/` gained a crate-level `#![cfg(feature = "graph")]`, so a `--no-default-features` build compiles them to empty test binaries instead of failing on a module that is not there. Every one of them still runs under the default features.

**One existing test learned to skip a row this build does not register.** `loop_comparability`'s sentinel drives every catalog row through a live registry; with `search` unregistered there is no success path to drive. The skip reads `catalog::registered_with(BUILD_FEATURES)` rather than a `cfg`, so it follows the same declaration the registry does, and a row that stops registering for a reason nobody declared still fails.

**`Availability::is_native` answers true for the new option.** The native `ToolRegistry` is still what registers `search` when the feature is on; `is_native` asks who registers, not whether this build did.

## Summary by Sourcery

Put the code-graph index and search capability behind an optional default-enabled feature while keeping feature-off tool registration, graph facts, documentation, and validation consistent.

New Features:
- Add an optional `graph` feature to `stella-tools`, enabled by default, for code-graph search and related dependencies.
- Expose build-aware tool availability so `search` is registered and documented only when the `graph` feature is compiled.

Bug Fixes:
- Prevent index-free builds from advertising or constructing the unavailable `search` tool.
- Make file mutation graph facts report no indexed result when the graph feature is disabled.

Enhancements:
- Keep the live tool registry, catalog, generated documentation, and compiled feature set consistent across feature configurations.

Build:
- Make `stella-graph` and `stella-embed` optional dependencies and add a dependency-tree guard confirming tree-sitter grammars are absent from feature-off builds.

CI:
- Add a path-filtered CI workflow that checks clippy, documentation, tests, and dependency pruning for the no-graph configuration.

Documentation:
- Document the `graph` feature and regenerate tool documentation to describe conditional availability and corrected catalog references.

Tests:
- Add witness coverage for feature-dependent registry and catalog agreement, and gate search-specific tests to graph-enabled builds.

Chores:
- Add a Makefile target for validating the index-free dependency tree while leaving rusqlite removal tracked separately.