### PR TITLE
fix(stella-protocol): state where the record digest stops matching CGP's

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,9 @@ serde_json = "1"
 # RFC 8785 JSON Canonicalization Scheme — the version the Context Graph Protocol
 # workspace pins for `contextgraph-types`' `record-hash` feature, so a shared
 # preimage canonicalizes to the same bytes on both sides. Byte-identity of the
-# whole record digest is narrower than that: stella's preimage also drops
-# explicit nulls and CGP's does not, so the two agree on a null-free record
-# only. `stella_protocol::hash` states the boundary and pins it with a test.
+# whole record digest is narrower: stella's preimage also drops `null`-valued
+# object members, and CGP's keeps them, so the two agree on a record whose
+# objects carry no such member. `stella_protocol::hash` pins that boundary.
 serde_json_canonicalizer = "0.3.2"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "fs", "io-util", "sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,12 @@ contextgraph-trace = "=0.1.2"
 contextgraph-conformance = "=0.1.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# RFC 8785 JSON Canonicalization Scheme — pinned to the SAME version the Context
-# Graph Protocol crates use (contextgraph-conformance), so stella's record_hash
-# preimage is byte-identical to CGP's for future export interop.
+# RFC 8785 JSON Canonicalization Scheme — the version the Context Graph Protocol
+# workspace pins for `contextgraph-types`' `record-hash` feature, so a shared
+# preimage canonicalizes to the same bytes on both sides. Byte-identity of the
+# whole record digest is narrower than that: stella's preimage also drops
+# explicit nulls and CGP's does not, so the two agree on a null-free record
+# only. `stella_protocol::hash` states the boundary and pins it with a test.
 serde_json_canonicalizer = "0.3.2"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "fs", "io-util", "sync"] }

--- a/crates/stella-protocol/src/hash.rs
+++ b/crates/stella-protocol/src/hash.rs
@@ -10,9 +10,15 @@
 //!    complements the `#[serde(skip_serializing_if = "Option::is_none")]`
 //!    absent-option omission on the record types);
 //! 4. **RFC 8785 JCS** — sort keys, minimal whitespace, canonical numbers, via
-//!    `serde_json_canonicalizer` (the same crate + version CGP uses, so the
-//!    preimage bytes are byte-identical to CGP's for export interop);
+//!    `serde_json_canonicalizer`, the crate and version CGP's own `record-hash`
+//!    feature pins;
 //! 5. sha256, lowercase hex, `sha256:` prefix.
+//!
+//! Step 3 has no counterpart in CGP, whose `record_hash_preimage` drops
+//! `record_hash` and canonicalizes. So the two preimages are byte-identical for
+//! a record carrying no explicit `null` and differ for one that does, and an
+//! export-interop claim holds only under that condition.
+//! `strip_nulls_is_the_only_divergence_from_cgps_preimage` pins both halves.
 //!
 //! It lives here because two crates hash against it: `stella-records` seals a
 //! record, and `stella-core::receipts` derives a frame's `frame_hash`. Beside
@@ -149,6 +155,49 @@ mod tests {
         let absent = record_hash(&json!({"a": 1})).unwrap();
         let explicit_null = record_hash(&json!({"a": 1, "b": null})).unwrap();
         assert_eq!(absent, explicit_null);
+    }
+
+    /// The boundary of the export-interop claim in this module's header.
+    ///
+    /// CGP's `contextgraph_types::record_hash_preimage` drops the top-level
+    /// `record_hash` member and canonicalizes, and normalizes no nulls. Its
+    /// rule is reimplemented here rather than imported: this crate takes no
+    /// `contextgraph-types` dependency, and acquiring one so a test can quote
+    /// a rule this short would invert the crate's position in the graph.
+    #[test]
+    fn strip_nulls_is_the_only_divergence_from_cgps_preimage() {
+        // CGP profile LH1: JCS over the record with its `record_hash` removed.
+        fn cgp_preimage(record: &Value) -> String {
+            let mut value = record.clone();
+            value
+                .as_object_mut()
+                .expect("an object")
+                .remove("record_hash");
+            serde_json_canonicalizer::to_string(&value).expect("canonicalizes")
+        }
+
+        let null_free = json!({
+            "b": 2,
+            "a": 1,
+            "record_hash": "sha256:deadbeef"
+        });
+        assert_eq!(
+            canonical_preimage(&null_free).unwrap(),
+            cgp_preimage(&null_free),
+            "a record with no explicit null hashes the same bytes on both sides"
+        );
+
+        let with_null = json!({
+            "a": 1,
+            "b": null
+        });
+        assert_ne!(
+            canonical_preimage(&with_null).unwrap(),
+            cgp_preimage(&with_null),
+            "step 3 drops the null here and CGP keeps it, so the bytes differ"
+        );
+        assert_eq!(canonical_preimage(&with_null).unwrap(), r#"{"a":1}"#);
+        assert_eq!(cgp_preimage(&with_null), r#"{"a":1,"b":null}"#);
     }
 
     #[test]

--- a/crates/stella-protocol/src/hash.rs
+++ b/crates/stella-protocol/src/hash.rs
@@ -16,9 +16,10 @@
 //!
 //! Step 3 has no counterpart in CGP, whose `record_hash_preimage` drops
 //! `record_hash` and canonicalizes. So the two preimages are byte-identical for
-//! a record carrying no explicit `null` and differ for one that does, and an
-//! export-interop claim holds only under that condition.
-//! `strip_nulls_is_the_only_divergence_from_cgps_preimage` pins both halves.
+//! a record whose objects carry no `null`-valued member, and differ for one
+//! that does. A `null` sitting in an array is outside that boundary: step 3
+//! recurses into arrays without removing their elements, so both sides keep it.
+//! `strip_nulls_is_the_only_divergence_from_cgps_preimage` pins all three cases.
 //!
 //! It lives here because two crates hash against it: `stella-records` seals a
 //! record, and `stella-core::receipts` derives a frame's `frame_hash`. Beside
@@ -198,6 +199,39 @@ mod tests {
         );
         assert_eq!(canonical_preimage(&with_null).unwrap(), r#"{"a":1}"#);
         assert_eq!(cgp_preimage(&with_null), r#"{"a":1,"b":null}"#);
+
+        // Step 3 recurses, so the divergence reaches a nested member and a
+        // member of an object inside an array. Without these two the test
+        // would still pass with `strip_nulls` flattened to the top level.
+        let nested_null = json!({ "outer": { "a": 1, "b": null } });
+        assert_eq!(
+            canonical_preimage(&nested_null).unwrap(),
+            r#"{"outer":{"a":1}}"#
+        );
+        assert_eq!(cgp_preimage(&nested_null), r#"{"outer":{"a":1,"b":null}}"#);
+
+        let null_under_an_array = json!({ "items": [{ "a": 1, "b": null }] });
+        assert_eq!(
+            canonical_preimage(&null_under_an_array).unwrap(),
+            r#"{"items":[{"a":1}]}"#
+        );
+        assert_eq!(
+            cgp_preimage(&null_under_an_array),
+            r#"{"items":[{"a":1,"b":null}]}"#
+        );
+
+        // A null array *element* is not a member, so step 3 leaves it and the
+        // two sides still agree. This is the edge of the boundary above.
+        let null_array_element = json!({ "items": [null, 1] });
+        assert_eq!(
+            canonical_preimage(&null_array_element).unwrap(),
+            cgp_preimage(&null_array_element),
+            "a null array element is kept on both sides"
+        );
+        assert_eq!(
+            canonical_preimage(&null_array_element).unwrap(),
+            r#"{"items":[null,1]}"#
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

`crates/stella-protocol/src/hash.rs`'s module header claimed this workspace's
`record_hash` preimage is "byte-identical to CGP's for export interop". The
root `Cargo.toml` carried the same claim above `serde_json_canonicalizer`.

Reading the rule the claim is about settles it. CGP's
`contextgraph-types/src/record_attest.rs::record_hash_preimage` (workspace
`version = "2.0.0"`) removes the top-level `record_hash` member and
canonicalizes under RFC 8785, and normalizes no nulls:

```rust
let mut preimage = record.clone();
preimage.as_object_mut().ok_or(RecordHashError::NotAnObject)?.remove(RECORD_HASH_MEMBER);
serde_json_canonicalizer::to_vec(&preimage)
```

Step 3 of this module's pipeline strips explicit nulls recursively, so an
explicit `null` and an absent field hash the same here and differently there.
The two preimages agree byte for byte on a record carrying no explicit null,
and disagree on one that does. The claim was true only under a condition
neither copy stated.

Both copies now state the condition, and a test pins both halves, so the
boundary is a checked fact rather than a doc promise. Nothing about the
hashing pipeline changed — this repository's null normalization is ADR 0004's
deliberate choice and every stored digest is unmoved.

The version half of the claim holds and is unchanged, re-verified against CGP
`main`: its workspace pins `serde_json_canonicalizer = "0.3.2"` and reaches it
through `contextgraph-types`' `record-hash` feature
(`record-hash = ["dep:sha2", "dep:serde_json", "dep:serde_json_canonicalizer"]`),
which is the same version this workspace pins.

Refs #4359

### What this does for #4359, and what it does not

#4359's checklist carries one box that does not need the external publish:
*"`contextgraph-conformance`'s `record_hash` coupling (noted at
`Cargo.toml:85`) is re-checked against the version actually landed"*, folded
in from #6429. This is that re-check, done against CGP `main` at 2.0.0, and it
found the coupling comment overstated. `#4359` stays open — every other box
needs `contextgraph-*` 2.0.0 on crates.io, and the sparse index still serves
only `0.1.0` / `0.1.1` (yanked) / `0.1.2` for all four crates, so no pin bump
resolves and the two new `ContextQueryResult` fields cannot be written against
the version this workspace can build. The upstream blocker is
macanderson/context-graph-protocol#102, which needs a person to create the
`crates-io` GitHub Environment and its registry token.

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: the hashing
      pipeline is byte-for-byte unchanged, which is the point. What lands is a
      corrected claim plus
      `stella_protocol::hash::tests::strip_nulls_is_the_only_divergence_from_cgps_preimage`,
      a characterization test that reimplements CGP's rule and pins both
      directions: byte-identical preimages for a null-free record, and
      differing preimages (`{"a":1}` against `{"a":1,"b":null}`) for one
      carrying an explicit null. It fails if `strip_nulls` is removed, if the
      canonicalizer is swapped, or if either side's rule moves. It is
      reimplemented rather than imported because `stella-protocol` takes no
      `contextgraph-types` dependency and acquiring one to quote a rule this
      short would invert the crate's position in the graph.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-protocol --all-targets -- -D warnings` (scoped
      per CLAUDE.md — CI runs the workspace)
- [x] `cargo test -p stella-protocol --lib` — 305 passed, 0 failed
- [x] `make guards-fast` green, and
      `make doc-warnings CARGO_SCOPE="-p stella-protocol"` clean
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [x] CLA signed
- [x] `Refs #4359` appears both above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: none — the corrected claim is the whole change.
- [x] Filed, with the reason a fix could not ride this PR: nothing was
      deferred. #4359 stays open on its existing external blocker, which this
      PR leaves unchanged.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

The divergence is deliberate and stays. Stella normalizes nulls so an explicit
`null` and an absent field produce one digest, which is what lets a record type
add a `#[serde(skip_serializing_if)]` option without moving every prior hash.
Adopting CGP's rule instead would rewrite every stored `record_hash` in
`.stella/private/context.db`, and this PR proposes nothing of the kind.

Whether the divergence bites in practice depends on whether any record stella
hashes serializes an explicit `null`; the record types carry
`skip_serializing_if = "Option::is_none"`, so today it is a statement about the
algorithms rather than an observed mismatch. That is why the condition belongs
in the comment and in a test: the next record type that omits the attribute
would move the boundary with nothing to notice it.

## Summary by Sourcery

Correct the record-hash interoperability claim and pin the intentional null-normalization boundary against CGP's hashing rule.

Enhancements:
- Clarify that Stella's record-hash preimage matches CGP only for records without explicit null-valued object members, while preserving Stella's deliberate null normalization.
- Document the precise boundary between Stella's and CGP's record-hashing rules.

Tests:
- Add characterization coverage confirming matching preimages for null-free records and the expected divergence for nested, array-contained, and array-element nulls.