### PR TITLE
docs(adr): decide that a credit balance lives outside the engine

### DIFF
--- a/docs/adr/0037-a-credit-balance-lives-outside-the-engine.md
+++ b/docs/adr/0037-a-credit-balance-lives-outside-the-engine.md
@@ -41,8 +41,16 @@ The engine says what it did, and it can do that today. `ExecutionRollupRow` in
 outcome, the token counts, and the cost of one turn.
 `crates/stella-store/src/enterprise_telemetry.rs` folds that row into a closed
 shape with no content in it, then queues it for delivery. Its export ledger
-gives each execution one secret number, and builds the event id from it. Two
-sends of one execution carry the same id, so the sink can drop the copy.
+gives each execution one locally stored nonce, and `from_finalized_rollup`
+hashes that nonce with the enrollment, workspace and execution identifiers into
+the event id. Two sends of one execution carry the same id, so the sink can
+drop the copy.
+
+That id is a deduplication key and nothing more. The nonce sits in the local
+`enterprise_export_ledger`, the hash takes no server-held secret, and a person
+who controls the installation can read the one and recompute the other. The
+sink still has to reconcile or authenticate what arrives before it bills
+against a disputed account.
 
 A seller can bill from that. It is the evidence side of metering, and it is
 built.

--- a/docs/adr/0037-a-credit-balance-lives-outside-the-engine.md
+++ b/docs/adr/0037-a-credit-balance-lives-outside-the-engine.md
@@ -1,0 +1,65 @@
+---
+id: adr/0037-a-credit-balance-lives-outside-the-engine
+title: "ADR 0037: A credit balance lives outside the engine"
+status: implemented
+---
+
+# ADR 0037: A credit balance lives outside the engine
+
+- Status: accepted
+- Date: 2026-09-07
+- Decides: `#2891`
+- Not part of the Phase 0 series.
+
+## Context
+
+Oxagen plans to sell support tiers and usage credits. The open issue asks this
+repository to build a tier record, a ledger of credit grants and draw-downs, a
+way to meter calls to a private model, and commands that print a balance.
+
+The issue also asks a question before any of that, and asks for the answer in
+writing. A user owns the disk. A user can edit any file on it. Can a file
+there be the record of what a customer owes?
+
+Stella ships under the AGPL. Anyone may read the code, change it, and build
+it. A meter a user can rewrite counts nothing. A balance a user can rewrite is
+a number, not a debt.
+
+Stella also sends nothing out by default. Rule 3 in `AGENTS.md` says so. One
+seat type may send a small work summary to one named address. The fields it
+may send are listed in `crates/stella-store/src/content_free.rs`. A person has
+to edit that list before a new field can pass the gate.
+
+Billing is the usual reason a product grows a new way out. This one must not.
+
+## Decision
+
+**The seller holds the balance and the tier. The engine holds neither.**
+
+The engine says what it did, and it can do that today. `ExecutionRollupRow` in
+`crates/stella-store/src/usage.rs` carries the provider, the model, the
+outcome, the token counts, and the cost of one turn.
+`crates/stella-store/src/enterprise_telemetry.rs` folds that row into a closed
+shape with no content in it, then queues it for delivery. Its export ledger
+gives each execution one secret number, and builds the event id from it. Two
+sends of one execution carry the same id, so the sink can drop the copy.
+
+A seller can bill from that. It is the evidence side of metering, and it is
+built.
+
+## Consequences
+
+- No money ledger lands here. Grants and draw-downs are the seller's record.
+- No command prints a balance read off local disk. A command may print a
+  balance the seller's service returned, and it has to name that source.
+- A tier may be read from an org-managed settings file. The three-scope merge
+  already lets that file beat a project file. A project file may never raise
+  its own tier.
+- Metered use rides the delivery path that exists. A new field on it still
+  costs a hand edit to the allowed list.
+- The sink counts. The engine reports.
+
+## What this does not decide
+
+Prices, tier names, and what one credit buys are a product call. This record
+does not make it. The rest of the open issue waits on that call.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -103,6 +103,7 @@ open; nothing before Phase 3 forces it.
 | [0034](0034-silence-is-not-a-grant.md) | Silence Is Not a Grant | Accepted |
 | [0035](0035-a-wrappers-verdict-lands-on-the-round-that-earned-it.md) | A Wrapper's Verdict Lands on the Round That Earned It | Accepted |
 | [0036](0036-a-driver-takes-a-pull-request-out-of-draft.md) | A Driver Takes a Pull Request Out of Draft | Accepted |
+| [0037](0037-a-credit-balance-lives-outside-the-engine.md) | A Credit Balance Lives Outside the Engine | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -213,6 +214,12 @@ one, and the loop had no ask to follow that with, so a person took every pull
 request it opened out of draft by hand. The host reads the forge and runs the
 machine over its own answer before it acts, on the rule the merge already
 followed. The draft still holds back a pull request that never goes green.
+
+ADR 0037 settles who holds a customer's credit balance and support tier. The
+seller does. A user owns the disk, so a file there cannot be the record of what
+a customer owes, and this repository grows no ledger for money. The engine's
+part is to report what a turn cost, which the enterprise export path already
+does under the content-free rule.
 
 ## The number is a shared cell
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -185,6 +185,11 @@
       "status": "implemented",
       "title": "ADR 0036: A driver takes a pull request out of draft"
     },
+    "adr/0037-a-credit-balance-lives-outside-the-engine": {
+      "path": "docs/adr/0037-a-credit-balance-lives-outside-the-engine.md",
+      "status": "implemented",
+      "title": "ADR 0037: A credit balance lives outside the engine"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",


### PR DESCRIPTION
## What & why

The commercial plane issue asks this repository for a tier record, a credit
ledger, metering, and commands that print a balance. It asks one question
before any of that, and asks for the answer in writing: can a file on a user's
own disk be the record of what a customer owes?

It cannot. Stella ships under the AGPL, so anyone may rewrite a meter or a
balance kept there. Stella also sends nothing out by default, and billing is
the usual reason a product grows a new way out.

ADR 0037 records the answer. The seller holds the balance and the tier; the
engine holds neither. The engine's part is to report what a turn cost, and
that path is already built: `ExecutionRollupRow` in
`crates/stella-store/src/usage.rs` carries the provider, model, token counts
and cost, and `crates/stella-store/src/enterprise_telemetry.rs` folds it into
a closed content-free shape with an event id a replay cannot forge.

SCR-002 is why this is a record rather than a question: an architecture
decision is decided and written down, never escalated. The issue itself asked
for exactly this — "Decide explicitly whether the local ledger is *evidence*
(signed, reconciled server-side) or *authority*, and write the decision down".

Prices, tier names, and what one credit buys stay a product call. The record
says so, and the issue stays open on that.

Refs #2891

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [ ] This PR includes a witness test (fails on `main`, passes here), **or**
- [x] No witness needed (pure refactor / docs / CI) — because: this adds one
      ADR plus its index and manifest entries. No behavior changes. The
      checkable half is the gate: `adr-numbering` fails if the number is not
      unique or the index does not list it, and `doc-links` fails if the
      manifest entry is missing.

I considered adding a guard that rejects a credit or balance column on the
content-free allowlist, and left it out. There is no billing code for it to
guard, and AGENTS.md names a test for a path nothing reaches as work not owed.

## The gate

- [x] `cargo fmt --check`
- [ ] clippy over the workspace — no Rust changed; CI runs it
- [ ] the workspace test suite — no Rust changed; CI runs it
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [x] CLA signed
- [x] The closing keyword appears both above and as a commit trailer. It is
      `Refs`, because this advances the issue rather than finishing it.

Run locally: `make guards-fast` (green), `make adr-numbering`, `make doc-links`,
`make invariants`, `python3 scripts/check-prose.py --absolute`.

## Fix over file

- [x] Extra fixes in this PR: none
- [x] Filed, with the reason a fix could not ride this PR: nothing new was
      filed. The rest of the issue needs a maintainer call — what the tiers
      are, what one credit buys, and what a customer pays — so it stays on the
      issue it is already on, whose body this PR's author rewrites to match.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

The decision reaches past the trust boundary the issue asked about, to the
consequence that follows from it: no money ledger lands here at all. The
reasoning is that the evidence channel the issue would duplicate is already in
the tree. Push back on that in review if the duplication is wanted.

The vision page's roadmap line for the credits ledger reads as a control-plane
milestone, which the figcaption above it already attributes to the seller, so
no marketing copy changed here.

## Summary by Sourcery

Record that credit balances and support tiers live outside the engine while usage reporting remains the engine's responsibility.

Enhancements:
- Document the architectural decision that credit balances and support tiers are owned and reconciled by the seller, while the engine reports usage evidence without holding a local financial ledger.

Documentation:
- Add ADR 0037 and register it in the ADR index and documentation manifest.