### PR TITLE
docs(spec): the campaign fold lives in stella-autonomy, not stella-core

### DIFF
--- a/docs/spec/self-driving-foundry.md
+++ b/docs/spec/self-driving-foundry.md
@@ -53,7 +53,7 @@ each row is a dependency of a later section.
 
 | Primitive | Where | State |
 |---|---|---|
-| Self-driving cycle loop (plan, fix batch, audit aperture, tickets, bench, AIMD calibration) | `scripts/self-driving.sh`, `stella self-driving …`, pure core in the `stella-autonomy` crate | Shipped. No manifest, no in-flight resume, env-var configured. |
+| Self-driving cycle loop (plan, fix batch, audit aperture, tickets, bench, AIMD calibration) | `scripts/self-driving.sh`, `stella self-driving …`, pure core in `crates/stella-autonomy/src/lib.rs` and its modules | Shipped. No manifest, no in-flight resume, env-var configured. |
 | Service supervision (launchd/systemd, `RunAtLoad`, opt-in `KeepAlive`, resolver shim, `resume-all`) | `stella daemon install/uninstall/resume-all`, `crates/stella-cli/src/daemon/service.rs` | Shipped (#1587). The self-driving shell loop still carries its own macOS-only duplicate installer. |
 | Branch-pinned SUT builds, cached by commit | `sut.py`, `sut_build.py` (detached worktree + zigbuild) in the [arenabench repo](https://github.com/macanderson/arenabench), GUI branch picker | Shipped. `sut_ref` is match-level only and does not round-trip TOML (§5.2). |
 | Match configuration and artifacts (seats, attempts, `stella-events.jsonl` per trial, `result.json`, reward at `verifier_result.rewards.reward`) | `{config,model,runner,telemetry}.py` in the arenabench repo | Shipped. |

--- a/docs/spec/self-driving-foundry.md
+++ b/docs/spec/self-driving-foundry.md
@@ -53,7 +53,7 @@ each row is a dependency of a later section.
 
 | Primitive | Where | State |
 |---|---|---|
-| Self-driving cycle loop (plan, fix batch, audit aperture, tickets, bench, AIMD calibration) | `scripts/self-driving.sh`, `stella self-driving …`, pure core in `crates/stella-core/src/self_driving.rs` | Shipped. No manifest, no in-flight resume, env-var configured. |
+| Self-driving cycle loop (plan, fix batch, audit aperture, tickets, bench, AIMD calibration) | `scripts/self-driving.sh`, `stella self-driving …`, pure core in the `stella-autonomy` crate | Shipped. No manifest, no in-flight resume, env-var configured. |
 | Service supervision (launchd/systemd, `RunAtLoad`, opt-in `KeepAlive`, resolver shim, `resume-all`) | `stella daemon install/uninstall/resume-all`, `crates/stella-cli/src/daemon/service.rs` | Shipped (#1587). The self-driving shell loop still carries its own macOS-only duplicate installer. |
 | Branch-pinned SUT builds, cached by commit | `sut.py`, `sut_build.py` (detached worktree + zigbuild) in the [arenabench repo](https://github.com/macanderson/arenabench), GUI branch picker | Shipped. `sut_ref` is match-level only and does not round-trip TOML (§5.2). |
 | Match configuration and artifacts (seats, attempts, `stella-events.jsonl` per trial, `result.json`, reward at `verifier_result.rewards.reward`) | `{config,model,runner,telemetry}.py` in the arenabench repo | Shipped. |
@@ -98,13 +98,21 @@ emitter; no trainer port; no weights registry; two daemon surfaces.
 otherwise the loop skips from `HARVEST` to `MEASURE`.
 
 Placement follows the house rule (AGENTS.md #2 — no I/O in the
-engine):
+engine). The pure half goes in `stella-autonomy`, not `stella-core`.
+The engine's step path never reaches a campaign fold, and AGENTS.md's
+rule that `stella-core` holds only the step path keeps it out of the
+engine crate. `core-reachability` refuses to record a new resident
+there. `stella-autonomy` already holds the
+self-driving decision math, and it is the only home both `stella-cli`
+and `stella-observatory` may read — which is what Phase 5's Observatory
+campaign view needs, because the Observatory must not link
+`stella-core`.
 
-- **`stella-core/src/self_driving/campaign.rs`** — the pure half. Ledger
+- **`stella-autonomy/src/campaign.rs`** — the pure half. Ledger
   record types, the fold to a `CampaignPosition`, stage-transition
   legality, exit-predicate evaluation, suspension classification,
-  idempotency-key derivation. Property-tested like the rest of
-  `self_driving.rs`.
+  idempotency-key derivation. Property-tested like the rest of that
+  crate.
 - **`stella-cli/src/self_driving_cmd/campaign.rs`** — the I/O half.
   Manifest load/validate, ledger append (single writer, same discipline
   as `state.rs`), stage executors that shell out to arenabench, the

--- a/docs/spec/self-driving-missions.md
+++ b/docs/spec/self-driving-missions.md
@@ -25,7 +25,7 @@ manifest differently, this one wins (§11).
 ## 1. The gap this closes
 
 Today's self-driving loop is a stewardship engine: fix a batch, audit, file,
-bench, ship, repeat (`crates/stella-core/src/self_driving.rs`). It is
+bench, ship, repeat (the `stella-autonomy` crate). It is
 deliberately never-terminating and has no destination — "no defects" is a
 statement about a lens, not the code. `doc:self-driving-foundry` adds the
 destination for one hard-coded case: Stella improving Stella, scored by
@@ -361,7 +361,7 @@ Measurement is a port, not a concretion (AGENTS.md #1). The pure plane sees
 only its output:
 
 ```rust
-// stella-core/src/self_driving/mission.rs — types only; the trait's
+// stella-autonomy/src/mission.rs — types only; the trait's
 // implementations live with the I/O in stella-cli.
 pub struct Measurement {
     pub twin: TwinId,
@@ -586,7 +586,7 @@ impact" cuts code, not evidence.
 ### 9.1 Two reports, one fold
 
 Both are pure functions of (manifest, ledger) in
-`stella-core/src/self_driving/mission.rs`, rendered by `status`, journaled at
+`stella-autonomy/src/mission.rs`, rendered by `status`, journaled at
 GATE, and byte-identical however many times they are recomputed — the same
 projection discipline as the rest of the plane, with the same rule: the
 ledger is ground truth and the report is a view of it.
@@ -711,12 +711,14 @@ Append-only, per that list's own rule.
 Placement follows the house split (AGENTS.md #1 and #2), matching how
 foundry placed the campaign machinery:
 
-- **`stella-core/src/self_driving/mission.rs`** — pure: manifest types and
+- **`stella-autonomy/src/mission.rs`** — pure: manifest types and
   validation (dimensions, budget axes, probe/playbook shapes, declared-metric
   parity), `Measurement`/verdict types, the improvement-witness check, the
-  allocator, the report folds. Serde round-trip tests for every type that
-  crosses the core/CLI boundary (AGENTS.md #4); property tests beside the
-  existing `self_driving` ones.
+  allocator, the report folds. It sits beside the campaign fold, out of
+  `stella-core`, for the reason `doc:self-driving-foundry` §3 gives: the
+  engine's step path never reaches it. Serde round-trip tests for every type
+  that crosses into `stella-cli` (AGENTS.md #4); property tests beside the
+  crate's existing ones.
 - **`stella-cli/src/self_driving_cmd/mission.rs`** — I/O: manifest load,
   evaluator adapters (`arenabench` shell-out, `command`), probe execution,
   tamper-set computation, ledger append.


### PR DESCRIPTION
## What & why

Both self-driving design documents told the next implementer to put the campaign
and mission folds in `crates/stella-core/src/self_driving/`, and pointed at
`crates/stella-core/src/self_driving.rs` as the pure core to read first. That
module is not on `main`. The self-driving decision math lives in
`stella-autonomy`, and `ls crates/stella-core/src/self_driving.rs` fails.

The instruction is worse than stale: it names a placement the gate refuses. The
engine's step path never reaches a campaign ledger fold, so `make
core-reachability` fails on a new resident of `stella-core`, and
`scripts/core-reachability-baseline.txt` accepts no new entry — its own header
says `--update` refuses to add one. Anyone following `doc:self-driving-foundry`
§3 would have written the module and then had nowhere to land it.

`stella-autonomy` is where AGENTS.md's crate table already routes self-driving
decision math. It is a leaf that `stella-cli` and `stella-observatory` both
read, which is what the foundry's Phase 5 Observatory campaign view needs,
because the Observatory must not link `stella-core`. The I/O half stays at
`crates/stella-cli/src/self_driving_cmd/`, which does exist and is unchanged.

Six citations move, across `docs/spec/self-driving-foundry.md` and
`docs/spec/self-driving-missions.md`. The three historical citations in the
foundry's parts bin (`stella-cli/src/trace.rs`, `stella-pipeline/src/replay.rs`)
are left alone — those correctly name code that was deleted, and the rows
already say so.

Refs #2081

## The witness

- [x] No witness needed (pure refactor / docs / CI) — because: the change is
      two documentation files. CONTRIBUTING's carve-out covers it.

Verified instead with `make guards-fast` (green, the fmt check included),
`make doc-links` (OK, 1250 citations resolve) and
`python3 scripts/check-prose.py` (OK, none added).

## The gate

- [x] The fmt check — ran as part of `make guards-fast`
- [ ] Workspace clippy — CI's job; no Rust changed
- [ ] The workspace suite — CI's job; no Rust changed
- [x] Docs updated where behavior/flags changed — this PR is the doc update
- [x] CLA signed
- [x] `Refs #2081` appears above and as a commit trailer. This PR does not close
      the epic, so it uses `Refs`.

## Fix over file

- [x] Extra fixes in this PR: none — the two documents are one logical change.
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred
      by this change. See the note below on what the epic still needs.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps

## Anything reviewers should know?

I picked up #2081 to test the claim on record that it is "blocked: frontier
research needing external training compute". That claim is only partly right,
and the epic body is stale in ways a fresh agent would trip over. I am posting
the verified reading as a comment on the issue rather than rewriting somebody
else's body. The short version: nothing of the campaign or mission machinery
exists in `crates/` today, phases 0-3 of the spec need no compute at all, and
only Phase 4's trainer port and Phase 5's rig soak do.

## Summary by Sourcery

Align the self-driving specifications with the repository’s actual crate boundaries by moving the documented pure campaign and mission folds from `stella-core` to `stella-autonomy`.

Enhancements:
- Correct self-driving specifications to place pure campaign and mission decision logic in `stella-autonomy` rather than the unreachable `stella-core` crate.
- Clarify the crate boundaries and rationale for keeping self-driving I/O in `stella-cli` while allowing Observatory consumers to read the autonomy logic.

Documentation:
- Update six self-driving specification references to point to the current `stella-autonomy` locations and align the documented implementation plan with repository reachability rules.