### PR TITLE
docs(bench): repair the pipeline A/B plan's blockers and pin its loop_mode values

### DIFF
--- a/bench/evidence/pipeline-ab/README.md
+++ b/bench/evidence/pipeline-ab/README.md
@@ -46,18 +46,29 @@ All of it is in `preregistration.json`. The short form:
 
 ## What blocks the run today
 
-1. **The bench adapter cannot pick a path.** `loop_argv` in
-   `bench/harbor_adapter/stella_harbor/loop_mode.py` emits no `--pipeline`
-   flag. Neither arm can be launched as written.
-2. **The evidence cannot say which path ran.** `extract_trial` in
-   `score_dev_baseline.py` drops `stella_loop_mode`, so `trials.jsonl` carries
-   no field that answers it. The analysis below needs that field.
-3. **The control arm has to build.** Its crate is gone from this workspace.
-   The build comes from an old checkout, with its own lock file and toolchain
-   pin. Budget real time for it.
+One thing, and it is tree-only. `#6195` has it.
 
-The first two are small and need no rig. They are tracked as `#6178` and
-`#6179`.
+**The control arm has no binary and the run scripts hold one arm.** Its crate
+is gone from this workspace, so its build comes from a checkout of
+`f4c24c12b`, with that commit's own lock file and toolchain pin.
+`build_sut.sh` refuses any difference between the working tree and the commit
+it is handed, so it has to run from that checkout rather than from `main` with
+the commit as an argument. `env.sh` then gives both arms one `STELLA_BINARY`
+path and one `$TB_ROOT`, so the second build overwrites the first. The same
+variable puts `$TB_REPO/bench/harbor_adapter` on `PYTHONPATH`, so aiming
+`TB_REPO` at the old checkout swaps in the old adapter too, and only the
+binary may differ between the arms.
+
+## Two blockers that have shipped
+
+The adapter could not pick a path: `loop_argv` in
+`bench/harbor_adapter/stella_harbor/loop_mode.py` emitted no `--pipeline` flag
+in any case (`#6178`). It emits `--pipeline <id>` now, from `STELLA_PIPELINE`.
+
+The evidence could not say which path ran: `score_dev_baseline.py` dropped
+`stella_loop_mode` off the trial manifest, so `trials.jsonl` carried no field
+that answered it (`#6179`). It writes that field as `loop_mode` now, and
+`--treatment-fired` below reads it.
 
 ## The analysis
 
@@ -73,15 +84,23 @@ python3 bench/evidence/compare_arms.py \
   bench/evidence/pipeline-ab-<date>/treatment/trials.jsonl \
   --tasks 89 \
   --cross-sut <control-sha>:<treatment-sha> \
-  --treatment-fired loop_mode=<the plugin path value> \
+  --treatment-fired loop_mode=PLUGIN:witness-v1 \
   --markdown bench/evidence/pipeline-ab-<date>/results.md \
   > bench/evidence/pipeline-ab-<date>/comparison.json
 ```
 
 Each arm must report the commit it was declared on. The two binary hashes must
-differ. Every treatment trial must show it ran the plugin path, and no control
-trial may. Any of those fails and the run is refused, with the numbers still
-printed so a reader can check the refusal.
+differ. Every treatment trial must carry `loop_mode=PLUGIN:witness-v1`, and no
+control trial may. Any of those fails and the run is refused, with the numbers
+still printed so a reader can check the refusal.
+
+The control arm's own `loop_mode` reads `PLUGIN:classic`. The adapter spells
+every `--pipeline <id>` arm `PLUGIN:<id>` and does not special-case `classic`,
+because which ids resolve to what is Stella's decision
+(`PipelineChoice::resolve`) and an adapter-side copy of it would be a second
+place to get it wrong. On the control arm's binary, `classic` is the built-in
+staged pipeline rather than a plugin. Read the string as the id the command
+line carried. The arm is the build.
 
 ## What counts as done
 

--- a/bench/evidence/pipeline-ab/preregistration.json
+++ b/bench/evidence/pipeline-ab/preregistration.json
@@ -3,7 +3,7 @@
   "issue": "https://github.com/macanderson/stella/issues/6155",
   "epic": "https://github.com/macanderson/stella/issues/4029",
   "status": "plan_fixed_run_not_started",
-  "status_note": "The design, outcomes, seeds and decision rule below are fixed and were written before any data existed. The run has not been executed. It needs a benchmark host, a spend-capable credential, a build of a crate this workspace deleted, and the two adapter preconditions named under `preconditions`. The fields under `to_be_recorded_before_the_first_paid_call` are the run's identity and must be filled in — and this file committed — before the first paid call, not after.",
+  "status_note": "The design, outcomes, seeds and decision rule below are fixed and were written before any data existed. The run has not been executed. It needs a benchmark host, a spend-capable credential, a build of a crate this workspace deleted, and the run scripts named under `preconditions`. The two adapter preconditions are met. The fields under `to_be_recorded_before_the_first_paid_call` are the run's identity and must be filled in — and this file committed — before the first paid call, not after; the two `loop_mode_field_values` are filled in already, because the adapter decides them and no data is needed to read them off it.",
   "plan_fixed_at": "2026-09-05",
   "question": "Is the plugin verification path at least as good as the built-in staged pipeline it replaced?",
   "why_it_is_owed": "docs/spec/pipeline-as-plugins.md §7 set one bar for deleting the built-in path: a side-by-side benchmark. The deletion shipped ahead of that bar as a recorded maintainer call. This run is the late payment.",
@@ -53,7 +53,7 @@
   },
   "analysis": {
     "tool": "bench/evidence/compare_arms.py",
-    "mode": "--cross-sut <control-sha>:<treatment-sha> --treatment-fired loop_mode=<plugin path value>",
+    "mode": "--cross-sut <control-sha>:<treatment-sha> --treatment-fired loop_mode=PLUGIN:witness-v1",
     "why_a_declared_mode": "the default refuses two builds, and it is right to. The declaration names both commits so a build from the wrong tree is caught, and names the per-trial field proving the treatment arm ran the plugin path so a dropped selector is caught.",
     "reward_rule": "the external verifier's reward is authoritative; a trial that produced no reward scores 0 and stays in the denominator; a task absent from an arm scores 0 in that arm",
     "bootstrap_seed": 20260905,
@@ -72,22 +72,25 @@
   "refusals": {
     "wrong_build": "an arm whose trials report a commit other than the one declared for it",
     "one_binary": "two arms reporting one binary hash, whatever their commits say",
-    "path_not_exercised": "a treatment trial that cannot report which loop it ran, or a control trial reporting the plugin path",
+    "path_not_exercised": "a treatment trial that cannot report which loop it ran, or a control trial carrying the treatment arm's declared loop_mode value",
     "posture_moved": "the two arms declaring different assurance arms, which means more than the build changed"
   },
   "rules": "no reruns, no outcome-selected stops, no task excluded, no threshold moved after data. Operational aborts are named in the report and relaunch under a new job name. A provider 402 or a host failure is not a task failure and is listed separately from the per-task table.",
   "preconditions": {
     "adapter_cannot_select_a_pipeline": {
-      "what": "bench/harbor_adapter/stella_harbor/loop_mode.py's loop_argv emits no --pipeline flag at all, so neither arm can be launched by today's adapter",
-      "issue": "https://github.com/macanderson/stella/issues/6178"
+      "what": "bench/harbor_adapter/stella_harbor/loop_mode.py's loop_argv emitted no --pipeline flag at all, so neither arm could be launched by the adapter",
+      "issue": "https://github.com/macanderson/stella/issues/6178",
+      "state": "met. loop_argv emits `--pipeline <id>` when STELLA_PIPELINE names one, and loop_mode_name publishes the matching name."
     },
     "evidence_cannot_say_which_loop_ran": {
-      "what": "score_dev_baseline.py's extract_trial does not carry stella_loop_mode into trials.jsonl, so no committed field answers the question the analysis mode above must ask",
-      "issue": "https://github.com/macanderson/stella/issues/6179"
+      "what": "score_dev_baseline.py's extract_trial did not carry stella_loop_mode into trials.jsonl, so no committed field answered the question the analysis mode above must ask",
+      "issue": "https://github.com/macanderson/stella/issues/6179",
+      "state": "met. score_dev_baseline.py reads stella_loop_mode off the trial manifest and writes it to trials.jsonl as loop_mode, which is the field --treatment-fired names below."
     },
-    "control_arm_must_build": {
-      "what": "the control arm's crate is gone from this workspace, so the build is from an old checkout with its own lockfile and toolchain pin. Budget time for getting that binary to exist at all.",
-      "issue": null
+    "control_arm_must_build_and_the_run_scripts_hold_one_arm": {
+      "what": "the control arm's crate is gone from this workspace, so its build comes from an old checkout with its own lockfile and toolchain pin. build_sut.sh refuses any difference between the working tree and the commit it is handed. env.sh gives both arms one STELLA_BINARY path and one TB_ROOT, so the second build overwrites the first. The same variable puts $TB_REPO/bench/harbor_adapter on PYTHONPATH, so aiming TB_REPO at the old checkout swaps the adapter too, and only the binary may differ between the arms.",
+      "issue": "https://github.com/macanderson/stella/issues/6195",
+      "state": "open. It is tree-only and needs no rig."
     }
   },
   "to_be_recorded_before_the_first_paid_call": {
@@ -102,8 +105,10 @@
     "taskset_sha256": null,
     "denominator": 89,
     "loop_mode_field_values": {
-      "control": null,
-      "treatment": null
+      "control": "PLUGIN:classic",
+      "treatment": "PLUGIN:witness-v1",
+      "how_they_are_derived": "loop_mode_name in bench/harbor_adapter/stella_harbor/loop_mode.py, over each arm's STELLA_PIPELINE value. bench/harbor_adapter/tests/test_pipeline_ab_preregistration.py holds the two strings above to what that function returns, so an adapter change that moves the vocabulary reddens CI instead of leaving this plan's --treatment-fired argument matching nothing.",
+      "why_the_control_value_says_PLUGIN": "the adapter spells every `--pipeline <id>` arm PLUGIN:<id> and does not special-case classic, because which ids resolve to what is Stella's decision (PipelineChoice::resolve) and an adapter-side copy of it would be a second place to get it wrong. On the control arm's binary, classic is the built-in staged pipeline rather than a plugin. Read the string as the id the command line carried, which is what it is. The arm is the build."
     },
     "adapter_revision": null
   }

--- a/bench/harbor_adapter/tests/test_pipeline_ab_preregistration.py
+++ b/bench/harbor_adapter/tests/test_pipeline_ab_preregistration.py
@@ -1,0 +1,112 @@
+"""The pipeline A/B's committed plan against the adapter that will run it.
+
+`bench/evidence/pipeline-ab/preregistration.json` fixes the two arms of the
+run `doc:pipeline-as-plugins` §7 owes, before any money is spent. Two of the
+values it fixes are not facts about the experiment at all — they are facts
+about this adapter: the `loop_mode` string each arm's trials will carry, which
+`compare_arms.py --treatment-fired` reads to prove the treatment arm ran the
+path under test and the control arm did not.
+
+A preregistration is worth what it can still be checked against. Written out
+by hand it is two strings in a JSON file, and `loop_mode_name` can move
+underneath them with nothing to notice: the run then launches with a
+`--treatment-fired` argument that matches no trial, and every treatment trial
+is refused for not reporting a path it did report. So the plan's two strings
+are held here to what the adapter actually returns for each arm's declared
+`STELLA_PIPELINE` value.
+
+It lives in this suite rather than beside the analysis tests because the
+question is about the adapter. `bench/evidence/tests` runs `--no-project`, so
+recomputing a published score never needs the harness installed; importing
+`stella_harbor` there would cost that.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("harbor", reason="Harbor is required to import the adapter")
+
+from stella_harbor.loop_mode import PIPELINE_ENV, loop_mode_name  # noqa: E402
+
+#: Repository root: this file is bench/harbor_adapter/tests/<name>.py.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_PREREGISTRATION = _REPO_ROOT / "bench" / "evidence" / "pipeline-ab" / "preregistration.json"
+
+
+def _plan() -> dict:
+    return json.loads(_PREREGISTRATION.read_text())
+
+
+def _declared_pipeline_id(arm: dict) -> str:
+    """The `--pipeline` id an arm's `invocation` names.
+
+    The plan states each arm as the command a person types, which is the form
+    a reader checks. `STELLA_PIPELINE` is how the adapter is told the same
+    thing, so the id is read back out of the invocation rather than recorded
+    twice.
+    """
+    tokens = arm["invocation"].split()
+    assert "--pipeline" in tokens, f"arm invocation names no pipeline: {arm['invocation']!r}"
+    return tokens[tokens.index("--pipeline") + 1]
+
+
+def _reader(pipeline: str):
+    def read(key: str) -> str | None:
+        return pipeline if key == PIPELINE_ENV else None
+
+    return read
+
+
+class TestLoopModeValues:
+    """Each arm's declared `loop_mode` is what this adapter will publish."""
+
+    @pytest.mark.parametrize("arm_name", ["control", "treatment"])
+    def test_the_declared_value_is_what_the_adapter_publishes(self, arm_name: str) -> None:
+        plan = _plan()
+        declared = plan["to_be_recorded_before_the_first_paid_call"][
+            "loop_mode_field_values"
+        ][arm_name]
+        pipeline_id = _declared_pipeline_id(plan["arms"][arm_name])
+
+        assert declared == loop_mode_name(_reader(pipeline_id)), (
+            f"the {arm_name} arm's preregistered loop_mode value differs "
+            "from what loop_mode_name returns for its declared "
+            "--pipeline id. Launching on this plan would refuse every "
+            "treatment trial for not reporting a path it did report."
+        )
+
+    def test_the_two_arms_are_told_apart_by_the_value(self) -> None:
+        """`--treatment-fired` can only separate two distinct strings.
+
+        `check_path_fired` asks whether each treatment trial carries the
+        declared value and whether any control trial does. One string for
+        both arms makes every trial pass the first test and every control
+        trial fail the second, so the check reports nothing about the run.
+        """
+        values = _plan()["to_be_recorded_before_the_first_paid_call"][
+            "loop_mode_field_values"
+        ]
+        assert values["control"] != values["treatment"]
+
+    def test_the_analysis_mode_names_the_treatment_value(self) -> None:
+        """The command in the plan is the command that will be run.
+
+        `analysis.mode` is copied onto the launch line by whoever runs this,
+        so a `--treatment-fired` argument spelling a different value than the
+        arm below it is a refusal waiting to happen at the far end of a paid
+        run.
+        """
+        plan = _plan()
+        treatment = plan["to_be_recorded_before_the_first_paid_call"][
+            "loop_mode_field_values"
+        ]["treatment"]
+        assert f"--treatment-fired loop_mode={treatment}" in plan["analysis"]["mode"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/docs/spec/pipeline-as-plugins.md
+++ b/docs/spec/pipeline-as-plugins.md
@@ -854,6 +854,16 @@ came out, so the remaining risk was carrying dead, unreferenced code rather
 than losing a working feature. Extraction of the remaining four plugins is
 still real, open work — deleting the built-in path does not mark it done.
 
+**The bar is unpaid, and the plan for paying it is committed.**
+`bench/evidence/pipeline-ab/` holds the preregistration: the two arms with the
+control's SUT commit pinned to the last tree where the built-in path builds,
+the task list and denominator, the replicate count, the seed, the spend stop
+rule, and the mapping from each of the three outcomes back onto this
+paragraph. All three close the bar, the loss included. The run needs a
+benchmark host and real spend; that directory's README names the one
+tree-only thing still standing in front of it, and the issue each half is
+tracked under.
+
 ---
 
 ## 8. Vera specifically


### PR DESCRIPTION
## What & why

`bench/evidence/pipeline-ab/` is the committed plan for the side-by-side run
`doc:pipeline-as-plugins` §7 owes. It had gone stale in three ways, and all
three would cost the person who launches it.

**Two named blockers are fixed.** The preregistration and README both listed
`#6178` (the adapter emits no `--pipeline` flag) and `#6179` (`trials.jsonl`
carries no field saying which loop ran) as preconditions on the run. Both
shipped. `loop_argv` emits `--pipeline <id>` from `STELLA_PIPELINE`, and
`score_dev_baseline.py` writes `stella_loop_mode` into `trials.jsonl` as
`loop_mode`. Whoever read the plan next would have chased two fixed things.

**The third blocker had no issue and now has one.** `#6195` was filed after
the plan was written and covers more than "the crate is gone": `build_sut.sh`
refuses any difference between the working tree and the commit it is handed,
`env.sh` gives both arms one `STELLA_BINARY` path and one `$TB_ROOT` so the
second build overwrites the first, and the same variable puts
`$TB_REPO/bench/harbor_adapter` on `PYTHONPATH`, so aiming `TB_REPO` at the
old checkout swaps the adapter too. Both files say that now.

**The analysis argument was a placeholder.** `--treatment-fired
loop_mode=<plugin path value>` cannot be run. That value is decided by the
adapter, not by data, so it is fixed before the first paid call rather than
after: `loop_mode_field_values.control` is `PLUGIN:classic`, `.treatment` is
`PLUGIN:witness-v1`.

The control arm's value says `PLUGIN` because the adapter spells every
`--pipeline <id>` arm `PLUGIN:<id>` and leaves which ids resolve to what to
`PipelineChoice::resolve` — a deliberate choice from #4023, kept here rather
than overturned. On the control arm's binary `classic` is the built-in staged
pipeline, so both files explain the string instead of letting a reader guess.
`refusals.path_not_exercised` also read "a control trial reporting the plugin
path", which the control arm does by that wording; `check_path_fired` compares
against the treatment arm's declared value, and the refusal now says that.

Refs #6155
Refs #6195

`#6155`'s remaining checklist all needs the run — a benchmark host and real
spend — so this advances it without finishing it. `#6195`'s last box (the
README's third blocker names the issue) is satisfied here; its other four need
the rig.

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

`bench/harbor_adapter/tests/test_pipeline_ab_preregistration.py` holds each
arm's preregistered `loop_mode` value to what `loop_mode_name` returns for
that arm's declared `--pipeline` id, checks the two arms are told apart by
distinct values, and checks `analysis.mode` names the treatment value. So an
adapter change that moves the vocabulary reddens CI rather than leaving a paid
run to be refused for not reporting a path it did report.

All four cases fail on `main` — the values are `null` there, and
`analysis.mode` carries the placeholder:

```
FAILED ...::test_the_declared_value_is_what_the_adapter_publishes[control]
FAILED ...::test_the_declared_value_is_what_the_adapter_publishes[treatment]
FAILED ...::test_the_two_arms_are_told_apart_by_the_value - assert None != None
FAILED ...::test_the_analysis_mode_names_the_treatment_value
```

All four pass here (`4 passed`), and the whole adapter suite is green
(`808 passed, 2 skipped`), as is `bench/evidence/tests` (`81 passed`).

## The gate

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`
- [x] Docs updated where behavior/flags changed (README, `--help`, doc comments)
- [x] CLA signed (the bot prompts on your first PR — nothing to do per commit)
- [x] `Closes #N` appears **both** above and as a commit trailer — squash builds
      the commit body from commit messages, so the description alone won't carry it

No Rust changed, so the two workspace-wide cargo boxes are CI's, per CLAUDE.md
("CI builds and tests; this laptop does not"). Run locally: `make guards-fast`
(green), `python3 scripts/check-prose.py` (OK), `make doc-links` (OK),
`make bench-suites` (OK), and the two pytest suites above. `Refs` rather than
`Closes` in both the description and the commit trailer, since neither issue
is finished.

## Fix over file

- [x] Extra fixes in this PR: the `refusals.path_not_exercised` wording and
      §7's missing pointer to the plan, both found while reading the plan
      against the tree — **or** none
- [x] Filed, with the reason a fix could not ride this PR: nothing new was
      deferred; `#6195` already exists and needs a rig — **or** nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home)

## Anything reviewers should know?

The one judgement call: `loop_mode_name` publishes `PLUGIN:classic` for the
control arm, which names the built-in staged pipeline rather than a plugin.
Special-casing `classic` in the adapter was considered and rejected — the
existing test says plainly why the adapter does not guess at the installed
roster, and `check_path_fired` separates the arms correctly on distinct
strings either way. The honest fix belongs where the reader reads: the
preregistration records the value and says what it means, before any data
exists, and the new test holds it there.

## Summary by Sourcery

Bring the pipeline A/B benchmark plan up to date and make its preregistered path checks consistent with adapter behavior.

Enhancements:
- Update the pipeline A/B benchmark plan to reflect shipped adapter and evidence support, document the remaining build and environment blocker, and pin the control and treatment loop-mode values used for analysis.

Documentation:
- Clarify the pipeline A/B run prerequisites, analysis validation, control-arm loop-mode semantics, and link the committed plan from the pipeline-as-plugins specification.

Tests:
- Add adapter tests that verify preregistered loop-mode values match published adapter values, distinguish the two arms, and match the treatment analysis configuration.