### PR TITLE
fix(stella-tools): name a long sleep that shares a line with real work

### DIFF
--- a/crates/stella-core/src/driver/loop_escalation.rs
+++ b/crates/stella-core/src/driver/loop_escalation.rs
@@ -556,6 +556,15 @@ pub(crate) const STALL_STEER_PREFIX: &str = "[stuck-loop warning] this turn is s
 /// would have to carry a `command` field whose entire value is a sleep before
 /// it could contribute.
 ///
+/// `shell_text::blocking_sleep_seconds` is the wider sibling, and `bash`'s
+/// per-call advisory uses it: a long sleep beside real work blocks the call
+/// for the whole interval, and the advisory says so. This rung keeps the
+/// strict one because the threshold above was picked from a distribution
+/// measured with it, and the wider reading raises the incidental group's
+/// numbers as well as the pathological group's. Re-measuring that
+/// distribution takes a panel, and until someone runs one the rung stays
+/// blind to a sleep that shares a line.
+///
 /// Saturating, never wrapping: the seconds come from model-authored text, and
 /// `sleep 99999999999999999999` must not be an arithmetic overflow panic
 /// (AGENTS.md #5).

--- a/crates/stella-core/src/shell_text.rs
+++ b/crates/stella-core/src/shell_text.rs
@@ -28,7 +28,7 @@
 ///
 /// Four near-copies of this list had accumulated in `stella-tools`' `bash.rs`
 /// — the `cd` skip list, the grep-scan boundary, `segment_args` and
-/// [`bare_sleep_seconds`] — and they had already diverged: the grep boundary
+/// [`blocking_sleep_seconds`] — and they had already diverged: the grep boundary
 /// omitted `&`, so `ls & grep -rn "struct X" .` scanned past the background
 /// operator (#2301).
 ///
@@ -186,7 +186,7 @@ pub fn shell_words(command: &str) -> Vec<String> {
 /// GNU `sleep` takes an optional unit suffix — `s`, `m`, `h`, `d` — and
 /// `sleep 10m` asks for exactly the 600 seconds `sleep 600` does. Reading only
 /// the bare number made every suffixed form invisible to
-/// [`bare_sleep_seconds`], and invisible in the worst direction: the `?` below
+/// [`blocking_sleep_seconds`], and invisible in the worst direction: the `?` below
 /// is a whole-command answer, so `sleep 10m; echo done` did not merely
 /// contribute zero, it classified as *not a sleep at all*.
 ///
@@ -210,39 +210,92 @@ fn sleep_arg_seconds(arg: &str) -> Option<u64> {
     Some((secs * per_unit_secs).round() as u64)
 }
 
-/// The accumulated seconds a *bare* sleep command blocks for, or `None` if
-/// any segment does real work beyond sleeping and a harmless no-op.
+/// The seconds a command spends waiting in `sleep`, or `None` when it calls
+/// `sleep` nowhere in the foreground.
 ///
-/// Only a bare sleep is worth naming: `sleep 2 && curl` retry backoffs are
-/// ordinary and must stay unflagged, so this requires **every** segment of
-/// the command to be `sleep N` or an inert no-op (`echo`, `printf`, `true`)
-/// — anything else (a real command sharing the line) disqualifies the whole
-/// command. That matches the pathological shape #2022 observed
-/// (`sleep 300; echo done`) rather than a compound one that happens to
-/// contain a sleep, and it is deliberately biased toward saying nothing: the
-/// expensive direction here is the false positive, because clamping or
-/// scolding a legitimate retry loop breaks real tasks.
+/// Every `sleep N` segment counts, whatever else shares the line. Only
+/// [`bare_sleep_seconds`] existed before, and it answered `None` the moment a
+/// segment did real work — so a sleep beside real work read as no sleep at
+/// all. That is the shape a paid panel lost two tasks to. One trial
+/// backgrounded a `pip install` and slept 490 seconds waiting on it; another
+/// slept 280 seconds and then tailed the log it was waiting for. Both blocked
+/// for the whole interval, both were invisible to `bash`'s per-call advisory,
+/// and together they were most of a quarter of that panel's measured tool time
+/// (`macanderson/arenabench` match `13f7f2bb533d`, tasks `pytorch-model-cli`
+/// and `rstan-to-pystan`, joined `tool_start` → `tool_result`).
 ///
-/// The accumulation across segments saturates for the reason
-/// `sleep_arg_seconds` does: two absurd sleeps on one line
+/// A retry backoff stays quiet because it is short, not because it shares a
+/// line: `sleep 2 && curl` reports its 2 seconds and the caller's threshold
+/// ignores them. Reporting the seconds and letting the caller pick a threshold
+/// is what separates the two cases honestly; command shape separated them by
+/// guessing, and guessed wrong on the two above.
+///
+/// A backgrounded segment is skipped. `sleep 300 &` returns to the prompt at
+/// once, so the call waits on nothing and there is nothing to report.
+///
+/// An argument that is not a duration — `sleep $DELAY` — contributes nothing
+/// and disqualifies nothing, so a command pairing it with `sleep 490` still
+/// reports the 490 seconds it certainly waits.
+///
+/// The accumulation saturates for the reason `sleep_arg_seconds` does: two
+/// absurd sleeps on one line
 /// (`sleep 99999999999999999999; sleep 99999999999999999999`) each saturate to
 /// `u64::MAX`, and a plain `+` on that pair is an overflow panic on model
 /// text in library code.
+pub fn blocking_sleep_seconds(command: &str) -> Option<u64> {
+    sleep_seconds_in(&shell_words(command))
+}
+
+/// The same seconds, but only for a command that does nothing *except*
+/// sleep — every segment is `sleep N` or an inert no-op (`echo`, `printf`,
+/// `true`).
+///
+/// This is the narrower question, and the turn-level stall rung
+/// (`crate::driver::loop_escalation`) is what asks it. That rung sums over
+/// every call in a window and steers the model at a threshold picked from a
+/// measured distribution: trials sleeping incidentally landed at 47, 73 and
+/// 114 seconds, trials sleeping instead of working at 307 and 1,089. Both
+/// groups were measured with this predicate, so moving the rung onto
+/// [`blocking_sleep_seconds`] would raise every number under a threshold
+/// chosen for the old ones, and the incidental group is the one that would
+/// cross first. Re-measuring that distribution needs a panel, so the rung
+/// keeps the predicate its threshold was calibrated against.
+///
+/// A backgrounded sleep is excluded here too, which can only lower the sum
+/// and so can only make that rung steer less often.
 pub fn bare_sleep_seconds(command: &str) -> Option<u64> {
     let words = shell_words(command);
-    let segments = segments(&words);
+    let bare = segments(&words).iter().all(|segment| match segment {
+        [] => true,
+        [cmd, _] if cmd == "sleep" => true,
+        [cmd, ..] => matches!(cmd.as_str(), "echo" | "printf" | "true"),
+    });
+    bare.then(|| sleep_seconds_in(&words)).flatten()
+}
 
+/// The shared walk behind both readings: sum every foreground `sleep N`,
+/// skipping a segment the shell backgrounds and an argument that is not a
+/// duration.
+fn sleep_seconds_in(words: &[String]) -> Option<u64> {
     let mut total_secs = 0u64;
     let mut saw_sleep = false;
-    for segment in &segments {
-        match segment {
-            [] => {}
-            [cmd, arg] if cmd == "sleep" => {
-                total_secs = total_secs.saturating_add(sleep_arg_seconds(arg)?);
-                saw_sleep = true;
-            }
-            [cmd, ..] if matches!(cmd.as_str(), "echo" | "printf" | "true") => {}
-            _ => return None,
+    let mut start = 0usize;
+    for end in 0..=words.len() {
+        let separator = words.get(end).filter(|w| is_operator_word(w.as_str()));
+        if end < words.len() && separator.is_none() {
+            continue;
+        }
+        let segment = &words[start..end];
+        start = end + 1;
+        if separator.map(String::as_str) == Some("&") {
+            continue;
+        }
+        if let [cmd, arg] = segment
+            && cmd == "sleep"
+            && let Some(secs) = sleep_arg_seconds(arg)
+        {
+            total_secs = total_secs.saturating_add(secs);
+            saw_sleep = true;
         }
     }
     saw_sleep.then_some(total_secs)
@@ -486,7 +539,10 @@ pub fn basename(word: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{bare_sleep_seconds, basename, is_operator_word, shell_words, shell_writes};
+    use super::{
+        bare_sleep_seconds, basename, blocking_sleep_seconds, is_operator_word, shell_words,
+        shell_writes,
+    };
 
     #[test]
     fn shell_words_splits_operators_attached_to_a_word_in_core() {
@@ -554,11 +610,73 @@ mod tests {
 
     /// The shapes #2022 measured, and the accumulation across one command.
     #[test]
-    fn a_bare_sleep_is_detected_and_summed() {
+    fn a_sleep_is_detected_and_summed() {
+        assert_eq!(blocking_sleep_seconds("sleep 300; echo done"), Some(300));
+        assert_eq!(blocking_sleep_seconds("sleep 120"), Some(120));
+        assert_eq!(blocking_sleep_seconds("sleep 30 && sleep 30"), Some(60));
+        assert_eq!(blocking_sleep_seconds("sleep 2.5"), Some(3));
+    }
+
+    /// The two shapes that cost a paid panel most of a quarter of its tool
+    /// time. Each one waits for the whole interval; each one read as no sleep
+    /// at all while the rule required every segment to be a sleep or a no-op.
+    #[test]
+    fn a_long_sleep_beside_real_work_is_counted() {
+        // `pytorch-model-cli`: background the install, then block on a fixed
+        // wait rather than on the thing being waited for.
+        let backgrounded_install = "timeout 500 pip install --quiet torch &\nBGPID=$!\nsleep 490\nwait $BGPID 2>/dev/null\necho DONE";
+        assert_eq!(blocking_sleep_seconds(backgrounded_install), Some(490));
+
+        // `rstan-to-pystan`: sleep through the install, then read its log.
+        assert_eq!(
+            blocking_sleep_seconds("sleep 280; tail -30 apt_install.log; ps aux | grep apt"),
+            Some(280)
+        );
+    }
+
+    /// A retry backoff still reports, and reports something small — which is
+    /// what lets a caller's threshold tell it from the waits above without
+    /// guessing at command shape.
+    #[test]
+    fn a_retry_backoff_reports_its_own_short_wait() {
+        assert_eq!(
+            blocking_sleep_seconds("sleep 2 && curl -s http://localhost:8080"),
+            Some(2)
+        );
+        assert_eq!(
+            blocking_sleep_seconds("for i in $(seq 30); do check && break; sleep 1; done"),
+            Some(1)
+        );
+    }
+
+    /// A backgrounded sleep returns to the prompt at once, so the call waits
+    /// on nothing.
+    #[test]
+    fn a_backgrounded_sleep_blocks_nothing() {
+        assert_eq!(blocking_sleep_seconds("sleep 300 &"), None);
+        assert_eq!(blocking_sleep_seconds("sleep 300 & sleep 40"), Some(40));
+    }
+
+    /// A command that calls `sleep` nowhere reports nothing, and the word
+    /// alone is not a call: `sleep` has to be in command position with one
+    /// argument.
+    #[test]
+    fn a_command_that_never_sleeps_reports_nothing() {
+        assert_eq!(blocking_sleep_seconds("grep sleep /app/main.c"), None);
+        assert_eq!(blocking_sleep_seconds("cargo test -p stella-core"), None);
+    }
+
+    /// The narrow reading stays narrow, because the stall rung's threshold
+    /// was measured against it. A sleep beside real work is `None` here even
+    /// though the reading beside it counts every second of it.
+    #[test]
+    fn the_bare_reading_still_refuses_a_sleep_beside_real_work() {
+        assert_eq!(bare_sleep_seconds("sleep 280; tail -30 apt.log"), None);
+        assert_eq!(bare_sleep_seconds("echo waiting; sleep 300; ls"), None);
         assert_eq!(bare_sleep_seconds("sleep 300; echo done"), Some(300));
-        assert_eq!(bare_sleep_seconds("sleep 120"), Some(120));
-        assert_eq!(bare_sleep_seconds("sleep 30 && sleep 30"), Some(60));
-        assert_eq!(bare_sleep_seconds("sleep 2.5"), Some(3));
+        // A backgrounded sleep waits on nothing, so it lowers this sum too —
+        // the only direction that can make the rung steer less often.
+        assert_eq!(bare_sleep_seconds("sleep 300 &"), None);
     }
 
     /// Two absurd sleeps on ONE line, which is the pair the per-segment
@@ -571,11 +689,11 @@ mod tests {
     #[test]
     fn two_absurd_sleeps_in_one_command_saturate_rather_than_overflowing() {
         assert_eq!(
-            bare_sleep_seconds("sleep 99999999999999999999"),
+            blocking_sleep_seconds("sleep 99999999999999999999"),
             Some(u64::MAX)
         );
         assert_eq!(
-            bare_sleep_seconds("sleep 99999999999999999999; sleep 99999999999999999999"),
+            blocking_sleep_seconds("sleep 99999999999999999999; sleep 99999999999999999999"),
             Some(u64::MAX)
         );
     }
@@ -586,17 +704,18 @@ mod tests {
     /// so the pathological shape wearing a suffix bypassed the rung entirely.
     #[test]
     fn a_suffixed_sleep_is_read_in_seconds() {
-        assert_eq!(bare_sleep_seconds("sleep 300s"), Some(300));
-        assert_eq!(bare_sleep_seconds("sleep 5m"), Some(300));
-        assert_eq!(bare_sleep_seconds("sleep 10m; echo done"), Some(600));
-        assert_eq!(bare_sleep_seconds("sleep 1h"), Some(3600));
-        assert_eq!(bare_sleep_seconds("sleep 1d"), Some(86400));
-        assert_eq!(bare_sleep_seconds("sleep 2m && sleep 30"), Some(150));
-        // A suffix with no number is not a duration, and a duration this
-        // cannot read still disqualifies the whole command rather than
-        // silently counting as zero.
-        assert_eq!(bare_sleep_seconds("sleep m"), None);
-        assert_eq!(bare_sleep_seconds("sleep later"), None);
+        assert_eq!(blocking_sleep_seconds("sleep 300s"), Some(300));
+        assert_eq!(blocking_sleep_seconds("sleep 5m"), Some(300));
+        assert_eq!(blocking_sleep_seconds("sleep 10m; echo done"), Some(600));
+        assert_eq!(blocking_sleep_seconds("sleep 1h"), Some(3600));
+        assert_eq!(blocking_sleep_seconds("sleep 1d"), Some(86400));
+        assert_eq!(blocking_sleep_seconds("sleep 2m && sleep 30"), Some(150));
+        // A suffix with no number is not a duration, so it contributes
+        // nothing. On its own that leaves no sleep to report; beside a real
+        // one it leaves the seconds the command certainly waits.
+        assert_eq!(blocking_sleep_seconds("sleep m"), None);
+        assert_eq!(blocking_sleep_seconds("sleep later"), None);
+        assert_eq!(blocking_sleep_seconds("sleep $DELAY; sleep 490"), Some(490));
     }
 
     /// The shapes #3827 names, each one classified by its command word or its
@@ -737,8 +856,8 @@ mod tests {
         assert_eq!(basename("/abs/alpha.rs"), "alpha.rs");
     }
 
-    /// The expensive direction: anything doing real work beside the sleep
-    /// answers `None`, whatever the sleep is worth.
+    /// The expensive direction for the stall rung: anything doing real work
+    /// beside the sleep answers `None`, whatever the sleep is worth.
     #[test]
     fn a_sleep_beside_real_work_is_never_bare() {
         assert_eq!(

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -69,7 +69,7 @@ use crate::registry::Tool;
 
 mod words;
 
-use stella_core::shell_text::bare_sleep_seconds;
+use stella_core::shell_text::blocking_sleep_seconds;
 use words::{cd_escape_target, shell_words};
 
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
@@ -374,30 +374,35 @@ fn drift_advisory(command: &str, root: &Path) -> Option<String> {
     None
 }
 
-/// The per-call half of #2022: a bare `sleep` long enough to be worth naming
-/// in the result the model reads.
+/// The per-call half of #2022: a `sleep` long enough to be worth naming in
+/// the result the model reads.
 ///
-/// Deliberately the cheap rung, and deliberately low — 30s catches the shape
-/// on the very call that made it, before any accumulation. What it cannot see
-/// is the *turn*: loop detection reads interleaved calls as progress and the
-/// budget guard is spend-based, so idling costs $0. That blind spot is the
-/// engine's to close, over the seconds a whole turn has asked for
-/// (`stella_core`'s stall rung, `driver::loop_escalation`), and this advisory
-/// is not it.
+/// The cheap rung, and a low one — 30s catches the shape on the very call
+/// that made it, before any accumulation. What it cannot see is the *turn*:
+/// loop detection reads interleaved calls as progress and the budget guard is
+/// spend-based, so idling costs $0. That blind spot is the engine's to close,
+/// over the seconds a whole turn has asked for (`stella_core`'s stall rung,
+/// `driver::loop_escalation`), and this advisory is not it.
+///
+/// The threshold is also what keeps a retry backoff quiet, now that
+/// [`blocking_sleep_seconds`] counts a sleep beside real work. A `sleep 2 &&
+/// curl` reports two seconds and is ignored here; a `sleep 490` next to a
+/// backgrounded install reports 490 and is named.
 ///
 /// Honest visibility, not a refusal, on either rung: a static text-shape check
-/// on the command ([`bare_sleep_seconds`]), never a measured elapsed time, so
-/// it stays deterministic for the loop detector (never embed a timing here;
-/// see `stella-tool-timings-must-not-ride-tooloutput`).
+/// on the command ([`blocking_sleep_seconds`]), never a measured elapsed time,
+/// so it stays deterministic for the loop detector. A timing in
+/// [`stella_protocol::tool::ToolOutput`] makes identical calls look distinct
+/// and defeats that detector, which is why none is embedded here.
 const SLEEP_ADVISORY_THRESHOLD_SECS: u64 = 30;
 
-/// A footer naming a bare `sleep` that crossed the advisory threshold, and a
+/// A footer naming a `sleep` that crossed the advisory threshold, and a
 /// remedy the agent can actually perform.
 ///
 /// **The remedy has to name a tool that exists.** This advisory shipped for a
 /// while pointing at `read_output`/`wait_for` — the managed-process family,
 /// which #3244 deleted and the tool restore did not bring back. Every long
-/// bare `sleep` therefore handed the model a directive with no tool behind it,
+/// `sleep` therefore handed the model a directive with no tool behind it,
 /// which is worse than the silence it replaced: an instruction that cannot be
 /// followed teaches the model to discount the next one too. The text was
 /// restored verbatim along with the rest of `bash`, and the stale half was
@@ -407,17 +412,17 @@ const SLEEP_ADVISORY_THRESHOLD_SECS: u64 = 30;
 /// loop, which `bash` can do on its own, and which returns as soon as the
 /// condition holds instead of blocking the whole interval.
 fn sleep_advisory(command: &str) -> Option<String> {
-    let secs = bare_sleep_seconds(command)?;
+    let secs = blocking_sleep_seconds(command)?;
     if secs < SLEEP_ADVISORY_THRESHOLD_SECS {
         return None;
     }
     Some(format!(
-        "\n\nnote: this call blocked for {secs}s inside a bare `sleep` with no other work in \
-         it, and the whole interval was charged to the turn whether or not the thing you are \
-         waiting for finished early. If you are waiting on something, poll for the condition \
-         instead of sleeping through it — a bounded retry loop that checks and exits as soon \
-         as the check passes (for example `for i in $(seq 30); do <check> && break; sleep 1; \
-         done`) costs a fraction of a blind wait."
+        "\n\nnote: this call spent {secs}s inside `sleep`, and the whole interval was charged \
+         to the turn whether or not the thing you are waiting for finished early. If you are \
+         waiting on something, poll for the condition instead of sleeping through it — a \
+         bounded retry loop that checks and exits as soon as the check passes (for example \
+         `for i in $(seq 30); do <check> && break; sleep 1; done`) costs a fraction of a blind \
+         wait."
     ))
 }
 
@@ -1056,36 +1061,63 @@ mod tests {
     /// (`sleep 300; echo done`, `sleep 120` alone) is caught and its
     /// accumulated seconds are named, so the advisory can fire on it.
     #[test]
-    fn bare_sleep_is_detected_and_summed() {
-        assert_eq!(bare_sleep_seconds("sleep 300; echo done"), Some(300));
-        assert_eq!(bare_sleep_seconds("sleep 120"), Some(120));
-        assert_eq!(bare_sleep_seconds("sleep 60"), Some(60));
-        // Multiple bare sleeps in one call accumulate.
+    fn a_sleep_is_detected_and_summed() {
+        assert_eq!(blocking_sleep_seconds("sleep 300; echo done"), Some(300));
+        assert_eq!(blocking_sleep_seconds("sleep 120"), Some(120));
+        assert_eq!(blocking_sleep_seconds("sleep 60"), Some(60));
+        // Several sleeps in one call accumulate.
         assert_eq!(
-            bare_sleep_seconds("sleep 30 && sleep 30"),
+            blocking_sleep_seconds("sleep 30 && sleep 30"),
             Some(60),
             "accumulated sleep across the whole call, not just the last segment"
         );
         assert_eq!(
-            bare_sleep_seconds("sleep 2.5"),
+            blocking_sleep_seconds("sleep 2.5"),
             Some(3),
             "rounds to the nearest second"
         );
     }
 
-    /// The legitimate case must stay unflagged: a sleep inside a retry
-    /// backoff, or any command sharing the line with real work, is not the
-    /// pathological shape — only a command whose ENTIRE body is sleep-plus-
-    /// no-op is.
+    /// A short wait stays unflagged, and the threshold is what keeps it that
+    /// way. A retry backoff and a five-second pause before a `tail` both
+    /// report their seconds; neither crosses the line.
     #[test]
-    fn a_sleep_beside_real_work_is_not_flagged() {
-        assert_eq!(
-            bare_sleep_seconds("sleep 2 && curl -s http://localhost:8080"),
-            None
-        );
-        assert_eq!(bare_sleep_seconds("sleep 5; tail -f build.log"), None);
-        assert_eq!(bare_sleep_seconds("read_output --wait 2"), None);
-        assert_eq!(bare_sleep_seconds("echo waiting; sleep 5; ls"), None);
+    fn a_short_sleep_beside_real_work_is_not_flagged() {
+        for command in [
+            "sleep 2 && curl -s http://localhost:8080",
+            "sleep 5; tail -f build.log",
+            "echo waiting; sleep 5; ls",
+            "for i in $(seq 30); do curl -sf http://localhost:8080 && break; sleep 1; done",
+        ] {
+            assert_eq!(
+                sleep_advisory(command),
+                None,
+                "advice was appended for `{command}`"
+            );
+        }
+        // A command that never calls `sleep` has nothing to report at all.
+        assert_eq!(blocking_sleep_seconds("grep sleep /app/main.c"), None);
+    }
+
+    /// The two waits that cost `13f7f2bb533d` most of a quarter of its
+    /// measured tool time. Both sit beside real work, so both were silent
+    /// while the predicate demanded a command made of nothing but sleeps.
+    ///
+    /// `pytorch-model-cli` backgrounded a `pip install torch` and then blocked
+    /// on a fixed 490s wait instead of on the install; `rstan-to-pystan` slept
+    /// 280s and then tailed the apt log it was waiting for. Each one is what
+    /// the advisory's own remedy describes — poll for the condition — and
+    /// neither was ever told.
+    #[test]
+    fn a_long_sleep_beside_real_work_is_named() {
+        let backgrounded_install = "timeout 500 pip install --quiet torch &\nBGPID=$!\nsleep 490\nwait $BGPID 2>/dev/null\necho DONE";
+        let note = sleep_advisory(backgrounded_install).expect("over threshold");
+        assert!(note.contains("490s"), "{note}");
+
+        let blind_poll = "sleep 280; tail -30 apt_install.log; ps aux | grep apt";
+        let note = sleep_advisory(blind_poll).expect("over threshold");
+        assert!(note.contains("280s"), "{note}");
+        assert!(note.contains("poll"), "{note}");
     }
 
     #[test]


### PR DESCRIPTION
## What & why

`bash` appends a note when a call spends a long time in `sleep`. The note is
good — it names the seconds and tells the model to poll for the condition
instead of waiting blind. The predicate behind it was not: a command
qualified only when **every** segment was `sleep N` or an inert no-op, so a
long sleep beside real work reported nothing at all.

Two trials on the panel #3753 measures lost most of their budget in exactly
that shape, and neither was ever told:

| task | the call | waited |
|---|---|---|
| `pytorch-model-cli` | backgrounded `timeout 500 pip install torch &`, then `sleep 490`, then `wait $BGPID` | 490s |
| `rstan-to-pystan` | `sleep 280; tail -30 apt_install.log; ps aux \| grep apt` | 280s |

That is 770s of the 3,406s of tool time match `13f7f2bb533d` recorded, joining
`tool_start` to `tool_result` across its twelve event-carrying trials.

`shell_text::blocking_sleep_seconds` reads the seconds instead of guessing at
command shape: every foreground `sleep N` counts, whatever else shares the
line. A retry backoff stays quiet because the advisory's 30s threshold ignores
its two seconds, not because a `curl` sits beside it — reporting the number and
letting the caller choose a threshold is what separates the two cases without
guessing. A backgrounded `sleep 300 &` now counts as nothing, because the call
waits on nothing.

The turn-level stall rung (`driver::loop_escalation`) keeps the narrow reading,
now named `bare_sleep_seconds`. Its 120s threshold came from a measured
distribution — 47s, 73s and 114s for trials sleeping incidentally against 307s
and 1,089s for trials sleeping instead of working — and the wider reading
raises the incidental group under a threshold picked for the old numbers. That
rung sums over a window and steers the model, so a false positive there is
expensive. Re-measuring the distribution takes a panel, so the rung stays where
its evidence puts it, and both functions say so in their doc comments.

Refs #3753

This does not finish #3753. Its Definition of done asks for a measured
reduction on a comparable panel, or a documented finding that the share is
irreducible. The trace answers the second half in the negative — the share is
**not** irreducible — and that finding is posted on the issue. The first half
still needs a panel run, which costs money, so the issue stays open for it.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`bash::tests::a_long_sleep_beside_real_work_is_named` replays both commands
above and asserts the advisory names their seconds. Checked by pointing
`sleep_advisory` back at the old predicate: it fails with
`panicked at crates/stella-tools/src/bash.rs: over threshold` and passes once
the new predicate is restored.

`shell_text::tests::a_long_sleep_beside_real_work_is_counted` pins the same two
commands at the predicate,
`a_backgrounded_sleep_blocks_nothing` pins the `&` case, and
`the_bare_reading_still_refuses_a_sleep_beside_real_work` pins that the stall
rung's reading did not widen underneath it.

**Three tests changed name rather than disappearing**, so
`check-deleted-tests` has an answer here:

- `bash::tests::a_sleep_beside_real_work_is_not_flagged` →
  `a_short_sleep_beside_real_work_is_not_flagged`, and it now asserts on the
  advisory rather than on the predicate, because a short sleep beside real work
  is still unflagged while a long one is not.
- `bash::tests::bare_sleep_is_detected_and_summed` →
  `a_sleep_is_detected_and_summed`.
- `shell_text::tests::a_bare_sleep_is_detected_and_summed` →
  `a_sleep_is_detected_and_summed`.

The last two dropped the word `bare` because it no longer describes what they
check.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-core -p stella-tools --all-targets -- -D warnings`
- [x] `cargo test -p stella-core --lib` (876 pass) and `cargo test -p stella-tools --lib` (638 pass)
- [x] `make guards-fast`, including `check-prose`
- [x] Docs updated: both predicates and the advisory carry the reasoning; the
      stall rung's header says why it did not move
- [x] `Refs #3753` appears both above and as a commit trailer

The workspace build and test are CI's, per CLAUDE.md — the scoped runs above are
what ran here.

## Fix over file

- [x] Extra fixes in this PR: a backgrounded `sleep 300 &` used to count toward
      both readings even though the shell returns at once and the call waits on
      nothing. It is skipped now. For the stall rung this can only lower a sum,
      so it can only make that rung steer less often.
- [x] Filed, with the reason a fix could not ride this PR: nothing new was
      filed. #3753 stays open for the panel run its Definition of done needs,
      with the finding and a narrowed scope posted on it.

## Ground-rule check

- [x] No I/O added to `stella-core` — both predicates are pure functions over
      borrowed text, and neither reads a clock. A measured timing here would
      make loop detection nondeterministic, which is why the advisory reads the
      command's own text and not its elapsed time.
- [x] No new dependencies
- [x] No new outbound network calls

## Anything reviewers should know?

The number this changes is not yet measured. The advisory is a note the model
reads; whether being told converts into a shorter wait is a question for the
panel run #3753 still holds. What is measured is the silence: the two waits
above are in the trace, and the predicate was blind to both.

## Summary by Sourcery

Report long foreground sleeps in per-call bash advisories while retaining the calibrated narrow interpretation used by turn-level stall detection.

New Features:
- Extend sleep detection for per-call advisories to identify foreground sleeps even when they share a command with real work.

Bug Fixes:
- Ensure long blocking sleeps beside real work are reported instead of being treated as no sleep, while excluding backgrounded sleeps that do not block the call.

Enhancements:
- Preserve the narrower sleep interpretation for turn-level stall escalation until its threshold distribution can be remeasured.
- Refine sleep advisories to report the total blocking duration and recommend polling for the awaited condition.

Documentation:
- Update predicate and advisory documentation to explain the distinct blocking and bare-sleep interpretations and their calibrated thresholds.

Tests:
- Add coverage for long sleeps beside real work, backgrounded sleeps, retry backoffs, and continued narrow stall detection.