### PR TITLE
feat(loop-bench): fail the nightly when most of its trials never finished

### DIFF
--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -15,6 +15,12 @@ name: nightly-bench
 # it caught cycling. Those signals are visible on a cheap model, which is what
 # makes a nightly affordable at well under a dollar a night.
 #
+# It also gates on whether the night happened at all: a run where more of the
+# requested trials raised than finished exits 8, because a loop verdict over
+# the surviving minority describes a task set nobody asked for. Harbor's agent
+# timeout is what usually kills them, and the remedy is a task set or a timeout
+# this runner can finish, never a greener reading of the same night.
+#
 # NOT on `pull_request`/`push`: every run spends real money and needs Docker,
 # harbor, and a provider key. Schedule + manual dispatch only, exactly like
 # `live-smoke.yml`.
@@ -296,6 +302,7 @@ jobs:
               5) echo "**FAIL (report)** — the run completed but the JSON report could not be written." ;;
               6) echo "**FAIL (no winner)** — \`--require-winner\` was set and no arm cleared both bars." ;;
               7) echo "**FAIL (reconciliation)** — the job directory held trials this run did not ask for, so every figure above covers a task set that is not the requested one." ;;
+              8) echo "**FAIL (unfinished)** — more of the requested trials raised than finished, so every figure above covers a night that mostly did not happen. Look at the exceptions on the table before reading anything else." ;;
               "") echo "**FAIL** — loop-bench never ran; an earlier step failed." ;;
               *) echo "**FAIL** — exit $EXIT_CODE is outside the harness's contract: a build failure or a crash, not a verdict." ;;
             esac

--- a/bench/loop-bench/README.md
+++ b/bench/loop-bench/README.md
@@ -117,15 +117,28 @@ have exited on a step cap, and treating that as a death would invent crashes.
 | `5` | the run finished and the `--json-out` report could not be written (the JSON is dumped on stdout instead) |
 | `6` | `--compare --require-winner` and no arm cleared both bars |
 | `7` | the job dir holds trials this run did not ask for, so every figure covers a task set that is not the requested one |
+| `8` | more of the requested trials raised than finished, so every figure covers a run that mostly did not happen |
 
 `1` outranks `4`: when both fire, the loop failure is the actionable one, and a
-broken loop explains the missing passes anyway. `1` outranks `6` and `7`
+broken loop explains the missing passes anyway. `1` outranks `6`, `7` and `8`
 likewise — a broken loop makes an arm's numbers untrustworthy as a comparison.
+`8` outranks `4` and `6`: a pass rate or a winner read off a run that mostly
+did not happen is not a measurement.
 
-A crash is deliberately **not** an exit code. The gate is loop health, and a
-trial the machine killed is not evidence about the loop — the same reason
-`UNREADABLE` and `BUDGET-CAP` do not gate. What it must never again be is
-silent, or dressed as `ran (unsolved)`.
+One crash is **not** an exit code. The gate is loop health, and a trial the
+machine killed is not evidence about the loop — the same reason `UNREADABLE`
+and `BUDGET-CAP` do not gate. What it must never again be is silent, or
+dressed as `ran (unsolved)`.
+
+`8` is where that reasoning runs out. Once the killed trials outnumber the
+live ones, what survives is not the task set the run asked for, and a verdict
+over it describes a night that mostly did not happen. The rule is a
+strict majority rather than a tuned count: it needs no history to set, and it
+follows `--tasks`, `--n` and `--trials` when they move the denominator. The
+29 nightly runs from 2026-08-10 to 2026-09-07 that uploaded a report each
+asked for four trials — one lost none, fourteen lost one, five lost two, nine
+lost three, none lost all four. The rule fires on those nine, eight of which
+were already red for loop health; the ninth reported green.
 
 ## Requested vs reported (#1299)
 

--- a/bench/loop-bench/src/lib.rs
+++ b/bench/loop-bench/src/lib.rs
@@ -89,6 +89,33 @@
 //! which of the two failed. It is off unless a floor is configured, because
 //! the pass rate this harness produces is a flash-tier model's under a cap:
 //! a floor is only meaningful once a job's own history has established one.
+//!
+//! # The third gate: most of the run never finished (`#6025`)
+//!
+//! A trial harbor killed is not evidence about the loop, which is why
+//! `CRASHED` is a row verdict and not an exit code. That holds while the dead
+//! trials are the minority. It stops holding once they outnumber the live
+//! ones: what survives is not the pinned task set the nightly job calls its
+//! fixed seed, and a verdict over it is a verdict about a run that mostly did
+//! not happen.
+//!
+//! [`most_trials_crashed`] is that check — red when more than half the
+//! requested trials raised. It makes a third claim, distinct from the other
+//! two: `loop_broken` says the loop misbehaved, [`below_pass_floor`] says the
+//! agent solved too little, and this says the night measured too little to
+//! say either.
+//!
+//! A majority rather than a tuned count, so it needs no history to set and it
+//! survives a change to the task set: `--tasks`, `--n` and `--trials` all move
+//! the denominator, and a count pinned to four would then mean something else.
+//!
+//! What it costs is measured, not assumed. The 29 nightly runs from
+//! 2026-08-10 to 2026-09-07 that uploaded a report each asked for four trials.
+//! One night lost none, fourteen lost one, five lost two, and nine lost three;
+//! no night lost all four. This rule fires on those nine, and eight of them
+//! were already red for loop health. The ninth is the night it exists for:
+//! run 33306583016, on 2026-08-30, reported a green nightly over three trials
+//! that never finished.
 
 pub mod artifacts;
 pub mod compare;
@@ -655,6 +682,23 @@ pub fn below_pass_floor(reports: &[TrialReport], min_pass: usize) -> bool {
     min_pass > 0 && tally(reports).solved < min_pass
 }
 
+/// The third gate (`#6025`) — more of the requested trials raised than
+/// finished, so the run is too small a sample to gate on.
+///
+/// Read off [`Tally::crashed`], which is harbor's own record that a trial
+/// raised. A `NOT-RUN` row is a different absence and needs no help from here:
+/// it gates red on its own through [`TrialReport::loop_broken`].
+///
+/// A strict majority, so a run that lost exactly half still reports its
+/// figures. Two trials out of four are two observations; one out of four is an
+/// anecdote wearing a pass rate. See the crate docs for the nights this was
+/// measured against and why the rule is a proportion rather than a count.
+#[must_use]
+pub fn most_trials_crashed(reports: &[TrialReport]) -> bool {
+    let counts = tally(reports);
+    counts.crashed * 2 > counts.total
+}
+
 /// The JSON a CI consumer trends over time.
 ///
 /// An object, where a single run used to emit a bare array of trials (#1299).
@@ -817,6 +861,16 @@ pub fn print_table(reports: &[TrialReport]) {
             "  ⚠ {crashed}/{n} trial(s) did not finish — harbor recorded an exception. \
              Those are infrastructure outcomes, NOT the model getting the task wrong; \
              the {solved}/{n} pass rate is over a run that partly did not happen."
+        );
+    }
+    // The same fact once it is a majority, said in the words the exit code
+    // uses, so the table names the gate that decided the run rather than
+    // leaving a reader to compare two numbers.
+    if most_trials_crashed(reports) {
+        println!(
+            "  ⚠ that is most of the run: the figures above cover {}/{n} trial(s) \
+             that finished, which is too small a sample to gate on.",
+            n - crashed
         );
     }
     // A per-verdict tally, so a run is greppable at a glance.

--- a/bench/loop-bench/src/main.rs
+++ b/bench/loop-bench/src/main.rs
@@ -51,16 +51,21 @@
 //!   comparison is a measurement, and "no winner" is a legitimate answer to it.
 //! - `7` — the job directory holds trials this run did not ask for, so every
 //!   figure was computed over a task set that is not the requested one (#1299).
+//! - `8` — more of the requested trials raised than finished, so every figure
+//!   covers a run that mostly did not happen (`#6025`).
 //!
 //! `1` outranks `4`: when both fire, the loop failure is the one a human can
 //! act on, and a broken loop explains the missing passes anyway. `1` outranks
-//! `6` and `7` for the same reason.
+//! `6`, `7` and `8` for the same reason. `8` outranks `4` and `6`: a pass rate
+//! or a winner read off a run that mostly did not happen is not a measurement.
 //!
-//! A crash is deliberately **not** an exit code. It is a verdict on the row
-//! and a count under the table, because the gate here is loop health and a
-//! trial the machine killed is not evidence about the loop — the same reason
+//! One crash is **not** an exit code. It is a verdict on the row and a count
+//! under the table, because the gate here is loop health and a trial the
+//! machine killed is not evidence about the loop — the same reason
 //! `UNREADABLE` and `BUDGET-CAP` do not gate. What it must never again be is
-//! silent, or dressed as `ran (unsolved)`.
+//! silent, or dressed as `ran (unsolved)`. `8` is where that reasoning runs
+//! out: once the killed trials are the majority, the survivors are too small a
+//! sample to gate on. See the library docs for the nights that measured it.
 
 use std::path::Path;
 use std::process::Command;
@@ -71,8 +76,8 @@ use clap::Parser;
 use loop_bench::compare::{arm_trials, default_guards, print_comparison};
 use loop_bench::reconcile::Requested;
 use loop_bench::{
-    Analysis, TrialReport, analyze, below_pass_floor, json_report, print_analysis,
-    print_reconciliation, tally,
+    Analysis, TrialReport, analyze, below_pass_floor, json_report, most_trials_crashed,
+    print_analysis, print_reconciliation, tally,
 };
 use stella_learn::comparison::{ArmTrials, ComparisonConfig, Metric, compare};
 
@@ -296,6 +301,9 @@ fn run_single(args: &Args, tasks: &[String]) -> i32 {
     if let Some(code) = contamination_exit(&analysis) {
         return code;
     }
+    if let Some(code) = unfinished_exit(&analysis) {
+        return code;
+    }
     // The second, opt-in gate (#873). Checked after loop health so a run that
     // fails both reports the actionable half.
     if below_pass_floor(reports, args.min_pass) {
@@ -328,6 +336,25 @@ fn contamination_exit(analysis: &Analysis) -> Option<i32> {
          the figures above are not this run's"
     );
     Some(7)
+}
+
+/// Exit `8` when most of the requested trials never finished (`#6025`).
+///
+/// Checked after contamination and before the pass floor. Contamination says
+/// the figures belong to some other run; this says they belong to a fraction
+/// of this one, and both have to be settled before a pass rate computed from
+/// them means anything.
+fn unfinished_exit(analysis: &Analysis) -> Option<i32> {
+    if !most_trials_crashed(&analysis.trials) {
+        return None;
+    }
+    let counts = tally(&analysis.trials);
+    eprintln!(
+        "UNFINISHED: {}/{} trial(s) never finished; the figures above cover a run \
+         that mostly did not happen",
+        counts.crashed, counts.total
+    );
+    Some(8)
 }
 
 /// The first name in `names` that also appeared earlier in it, or `None` when
@@ -366,6 +393,7 @@ fn run_comparison(args: &Args, tasks: &[String]) -> i32 {
     let mut arms: Vec<ArmTrials> = Vec::with_capacity(configs.len());
     let mut loop_broken = false;
     let mut contaminated: Option<i32> = None;
+    let mut unfinished: Option<i32> = None;
     for (index, model) in configs.iter().enumerate() {
         let job_name = arm_job_name(&args.job_name, index, model);
         let analysis = match collect_arm(args, tasks, model, &job_name) {
@@ -380,6 +408,10 @@ fn run_comparison(args: &Args, tasks: &[String]) -> i32 {
         // problem: the arms are compared trial-for-trial, so a stale directory
         // under one of them moves a lift that no model produced.
         contaminated = contaminated.or_else(|| contamination_exit(&analysis));
+        // One arm that mostly did not run is the whole comparison's problem
+        // too: a lift is a difference between two arms, and an arm measured
+        // over one surviving trial cannot supply half of one.
+        unfinished = unfinished.or_else(|| unfinished_exit(&analysis));
         arms.push(arm_trials(model, model, &analysis.trials));
     }
 
@@ -404,6 +436,9 @@ fn run_comparison(args: &Args, tasks: &[String]) -> i32 {
         return 1;
     }
     if let Some(code) = contaminated {
+        return code;
+    }
+    if let Some(code) = unfinished {
         return code;
     }
     if args.require_winner && !report.verdict.is_winner() {

--- a/bench/loop-bench/src/tests.rs
+++ b/bench/loop-bench/src/tests.rs
@@ -467,6 +467,98 @@ fn a_not_run_task_still_counts_against_the_floor() {
     assert!(below_pass_floor(&reports, 2), "1/2 is below a floor of 2");
 }
 
+/// The shape of nightly run 33306583016, on 2026-08-30. Four trials were
+/// asked for. Three died on harbor's agent timeout after real work, and one
+/// solved. Every loop that ran was healthy, so the night reported green.
+#[test]
+fn a_night_where_most_trials_died_no_longer_reports_green() {
+    let job = tempfile::tempdir().expect("job dir");
+    let mut requested = vec!["solved-one".to_string()];
+    let trial = trial_dir(
+        job.path(),
+        "solved-one__t1",
+        &[
+            r#"{"type":"tool_start","call":{"name":"bash"}}"#,
+            r#"{"type":"complete"}"#,
+        ],
+    );
+    write_reward(&trial, "1.0");
+
+    for task in ["timed-out-a", "timed-out-b", "timed-out-c"] {
+        let trial = trial_dir(
+            job.path(),
+            &format!("{task}__t1"),
+            &[
+                r#"{"type":"tool_start","call":{"name":"bash"}}"#,
+                r#"{"type":"tool_start","call":{"name":"edit_file"}}"#,
+            ],
+        );
+        write_result(
+            &trial,
+            serde_json::json!({
+                "task_name": task,
+                "exception_info": exception(
+                    "AgentTimeoutError",
+                    "agent exceeded its 750 second time limit",
+                ),
+            }),
+        );
+        requested.push(task.to_string());
+    }
+
+    let analysis = analyze(job.path(), Some(one_trial_each(&requested)));
+    let counts = analysis.tally();
+    assert_eq!(counts.total, 4);
+    assert_eq!(counts.crashed, 3);
+    assert_eq!(counts.solved, 1);
+    assert_eq!(
+        counts.loop_broken, 0,
+        "every trial that ran exercised the loop, so the first gate says nothing"
+    );
+    assert!(
+        !below_pass_floor(&analysis.trials, 0),
+        "the pass floor is off by default and cannot catch this either"
+    );
+    assert!(
+        most_trials_crashed(&analysis.trials),
+        "3 of 4 requested trials never finished: the run is not a measurement"
+    );
+}
+
+/// The rule is a strict majority. Half the trials surviving is a smaller
+/// sample, not an absent one. Most nights lost one or two of four. A gate
+/// that fired there would be red most nights, and no loop fix would clear
+/// it — the trap that keeps `--min-pass` at zero.
+#[test]
+fn losing_half_the_trials_still_reports_its_figures() {
+    let healthy = |task: &str| TrialReport {
+        task: task.into(),
+        tool_calls: 4,
+        terminal_event: true,
+        ..Default::default()
+    };
+    let killed = |task: &str| TrialReport {
+        crash: Some("AgentTimeoutError: agent exceeded its time limit".into()),
+        ..healthy(task)
+    };
+
+    let none = vec![healthy("a"), healthy("b"), healthy("c"), healthy("d")];
+    assert!(!most_trials_crashed(&none), "no crash, no gate");
+
+    let two = vec![healthy("a"), healthy("b"), killed("c"), killed("d")];
+    assert_eq!(tally(&two).crashed, 2);
+    assert!(!most_trials_crashed(&two), "2 of 4 is half, not most");
+
+    let three = vec![healthy("a"), killed("b"), killed("c"), killed("d")];
+    assert!(most_trials_crashed(&three), "3 of 4 is most");
+
+    let one_of_one = vec![killed("a")];
+    assert!(
+        most_trials_crashed(&one_of_one),
+        "a single-trial run that died is a run that did not happen"
+    );
+}
+
 /// #1299, hole 1: a trial that did real work and then died reports `CRASHED`,
 /// not `ran (unsolved)`. The old wording said the agent tried the task and got
 /// it wrong; what actually happened is that the machine killed it.

--- a/docs/adr/0038-a-night-that-mostly-died-is-not-a-run.md
+++ b/docs/adr/0038-a-night-that-mostly-died-is-not-a-run.md
@@ -1,0 +1,96 @@
+---
+id: adr/0038-a-night-that-mostly-died-is-not-a-run
+title: "ADR 0038: A night that mostly died is not a run"
+status: implemented
+---
+
+# ADR 0038: A night that mostly died is not a run
+
+- Status: accepted
+- Date: 2026-09-07
+- Decides: `#6025`
+
+## Context
+
+`nightly-bench.yml` asks `loop-bench` for four trials a night. Two gates read
+the result. `loop_broken` is always on. `below_pass_floor` is off. A third
+signal is counted, printed, and read by no gate. It is `Tally::crashed`, which
+is harbor's own record that a trial raised.
+
+Most nights, most trials raise. Harbor kills them on its agent timeout. It
+does so after 750 or 900 seconds of real work. The table already says this, in
+`loop-bench`'s own words: "the pass rate is over a run that partly did not
+happen." Nothing acted on it.
+
+Take the 29 nights from 2026-08-10 to 2026-09-07 that left a report. Each
+asked for four trials. One night lost none. Fourteen lost one. Five lost two.
+Nine lost three. No night lost all four.
+
+Nine nights lost most of the run. Eight were red for loop health anyway. The
+ninth was green. Run 33306583016, on 2026-08-30, passed the nightly on one
+solved trial and three that never finished.
+
+Each number here comes from that run's own `report.json`, read out of the
+artifact it uploaded.
+
+## Options
+
+Leave it ungated and say it louder. A harbor timeout is the machine's fact,
+not the engine's. That is why `CRASHED` is a row verdict and not an exit code.
+It is why `UNREADABLE` and `BUDGET-CAP` gate nothing. One dead trial in four
+leaves a smaller sample, not an absent one.
+
+Or add a crash ceiling: red when more than N trials raised. It needs a number.
+`#6025` argued that a number wants a few nights of history first. That
+argument has kept `LOOP_BENCH_MIN_PASS` at zero since the day it landed.
+
+## Decision
+
+Gate it, as a share rather than a count. `loop_bench::most_trials_crashed` is
+red when more than half the asked-for trials raised. `unfinished_exit` in
+`bench/loop-bench/src/main.rs` turns that into exit `8`.
+
+The gate makes a third claim. `loop_broken` says the loop went wrong.
+`below_pass_floor` says the agent solved too little. This one says the night
+saw too little to say either.
+
+It runs after loop health and after the sample check, and before the pass
+floor. So a run that trips more than one still names the half a human can act
+on. And it never prints a pass rate over a sample this thin.
+
+A share, not a tuned count, is what makes it shippable today. A pass floor is
+a bar on a quality number whose normal value nobody knows yet. It does need
+history. This is a bar on how much of the night ran. Its value follows from
+what the run asked for. Below half, what is left is not the pinned task set
+that `nightly-bench.yml` calls its fixed seed. A share also follows `--tasks`,
+`--n` and `--trials` when they move the total. A count pinned to four would
+come to mean something else.
+
+## Why this is the durable choice
+
+The workflow already refuses to start with no provider key. Its reason is
+written down: a green nightly gate that measured nothing is the exact failure
+`bench.yml` complains about. A night where three of four trials die reaches
+that state by another road. The gate had no way to say so.
+
+CLAUDE.md states the general rule. A green that flatters us is worse than a
+loss. A signal that answers the next question over is worse than no signal,
+because someone believes it.
+
+The cost is measured, not argued. Over the 29 nights the rule fires nine
+times. It flips one verdict. So it does not become the always-red gate that
+nobody reads. That risk is the whole case for leaving this alone.
+
+Red here also tells you what to do. It says the task set, the agent timeout,
+or the runner cannot finish what the night asks for. That is a real defect in
+the measure. Fix one of the three. Never read the same night greener.
+
+## Consequences
+
+- `bench/loop-bench/src/lib.rs` gains a third gate and a crate-doc section
+  beside the two already there. The table prints the majority case in the
+  words the exit code uses.
+- `.github/workflows/nightly-bench.yml` names exit `8` in its header and in
+  its summary.
+- The nightly may go red on a night the other two gates pass. That is the
+  point. The ninth night above is the one it is for.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -104,6 +104,7 @@ open; nothing before Phase 3 forces it.
 | [0035](0035-a-wrappers-verdict-lands-on-the-round-that-earned-it.md) | A Wrapper's Verdict Lands on the Round That Earned It | Accepted |
 | [0036](0036-a-driver-takes-a-pull-request-out-of-draft.md) | A Driver Takes a Pull Request Out of Draft | Accepted |
 | [0037](0037-a-credit-balance-lives-outside-the-engine.md) | A Credit Balance Lives Outside the Engine | Accepted |
+| [0038](0038-a-night-that-mostly-died-is-not-a-run.md) | A Night That Mostly Died Is Not a Run | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -220,6 +221,12 @@ seller does. A user owns the disk, so a file there cannot be the record of what
 a customer owes, and this repository grows no ledger for money. The engine's
 part is to report what a turn cost, which the enterprise export path already
 does under the content-free rule.
+
+ADR 0038 gives `loop-bench` a third gate. Most nightly trials are killed on
+harbor's agent timeout, and that count read no gate — so a night where three of
+four trials never finished could report green over the fourth. The gate is a
+proportion, not a tuned count: red when more than half the requested trials
+raised. Against 29 observed nights it fires nine times and changes one verdict.
 
 ## The number is a shared cell
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -190,6 +190,11 @@
       "status": "implemented",
       "title": "ADR 0037: A credit balance lives outside the engine"
     },
+    "adr/0038-a-night-that-mostly-died-is-not-a-run": {
+      "path": "docs/adr/0038-a-night-that-mostly-died-is-not-a-run.md",
+      "status": "implemented",
+      "title": "ADR 0038: A night that mostly died is not a run"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",

--- a/website/content/docs/guides/ci-engine-gate.mdx
+++ b/website/content/docs/guides/ci-engine-gate.mdx
@@ -367,7 +367,9 @@ four results as above, and exits with code `1` if any trial comes back
 list came up empty, or the report couldn't be written. Exit code `3` means
 no trial results were found at all. That's an infrastructure problem, not a
 loop problem. Exit code `4` means the loop worked fine, but fewer trials
-passed than `--min-pass` required.
+passed than `--min-pass` required. Exit code `8` means more of the trials
+died than finished. A verdict over what is left is a verdict about a night
+that mostly did not run.
 
 stella runs this nightly, not on every pull request, since it needs Docker,
 a task runner, a provider key, and real money. Two details of that setup are


### PR DESCRIPTION
## What & why

`#6025` asked a question and asked for the answer to be written down: should
"most of tonight's trials never finished" be a gate of its own, or stay
ungated and be reported louder? It also said the current state reads as a
decision nobody made.

**The claim on the issue was that it is blocked on paid benchmark runs. It is
not.** Nothing here spends anything. The 29 nights of history the decision
wanted are already uploaded as workflow artifacts, and every number below was
read out of them with `gh api` — free.

Decided, per SCR-002: **gate it**, as a share rather than a tuned count.

- `loop_bench::most_trials_crashed` is red when more than half the requested
  trials raised. It reads `Tally::crashed`, which is harbor's own record.
- `unfinished_exit` in `bench/loop-bench/src/main.rs` turns that into exit
  `8`, in both the single-config and `--compare` paths. It runs after loop
  health (`1`) and reconciliation (`7`) and before the pass floor (`4`), so a
  run that trips several still names the actionable half, and no pass rate or
  comparison winner is ever published over a sample this thin.
- The table prints the majority case in the words the exit code uses, and
  `nightly-bench.yml`'s summary spells out `8`.

**Why a share and not a number.** The issue argued a ceiling needs a number
and a number needs history. A pass floor does, because it is a bar on a
quality measurement whose normal value nobody knows. This is a bar on how much
of the run happened, and its value follows from what the run asked for: below
half, the survivors are not the pinned task set `nightly-bench.yml` calls its
fixed seed. A share also follows `--tasks`, `--n` and `--trials` when they
move the denominator, where a count pinned to four would come to mean
something else.

**What it costs, measured.** Every `nightly-bench` run since 2026-08-10 that
uploaded a report — 29 of them — asked for four trials. Read from each run's
own `report.json` (`tally.crashed` / `tally.total`):

| crashed / 4 | nights |
|---|---|
| 0 | 1 |
| 1 | 14 |
| 2 | 5 |
| 3 | 9 |
| 4 | 0 |

The rule fires on the nine nights that lost three. Eight were already red for
loop health. The ninth is the night this exists for: run **33306583016**, on
2026-08-30, reported a **green** nightly on one solved trial and three that
never finished. So the gate flips exactly one verdict in 29 nights — it is not
the always-red gate that argued for leaving this ungated.

Closes #6025

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

Two, in `bench/loop-bench/src/tests.rs`:

- `a_night_where_most_trials_died_no_longer_reports_green` builds run
  33306583016's shape from real trial directories: four requested, three
  `AgentTimeoutError` after real work, one solved. It asserts what `main`
  does — `loop_broken == 0`, and `below_pass_floor` off — and then that the
  new gate fires.
- `losing_half_the_trials_still_reports_its_figures` pins the boundary: 0, 2
  and 3 crashes of four, plus a one-trial run.

Verified the artisanal way rather than by relying on a compile error: with
`most_trials_crashed` forced to `false` (the `main` behaviour, no such gate),
both tests FAIL; restored, all 48 lib tests pass.

## The gate

- [x] `cargo fmt --check` — clean
- [x] clippy — `cargo clippy -p loop-bench --all-targets -- -D warnings`, clean.
      Scoped to the crate per CLAUDE.md ("CI builds and tests; this laptop does
      not"); the workspace run is CI's.
- [x] tests — `cargo test -p loop-bench`: 48 + 5 pass
- [x] `make doc-warnings CARGO_SCOPE="-p loop-bench"` — clean
- [x] `make guards-fast` — green, including `prose`, `line-citations`,
      `adr-numbering` and `doc-links`
- [x] Docs updated: the crate docs gain a "third gate" section beside the two
      already there, `bench/loop-bench/README.md` gains the exit-`8` row and
      the reasoning, and `nightly-bench.yml`'s header says what it now gates on
- [x] CLA signed
- [x] `Closes #6025` appears above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: two. The module header and README paragraph that
      both said "a crash is deliberately **not** an exit code" were left true
      only of one crash, so they are rewritten rather than left contradicting
      the code beside them. And
      `website/content/docs/guides/ci-engine-gate.mdx` lists `loop-bench`'s
      exit codes for a reader copying the pattern; exit `8` joins that list,
      since a gate reporting over a night that mostly did not run is the
      guide's own thesis.
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls

## Anything reviewers should know?

**The ADR.** SCR-002 says a design decision is recorded as an ADR, so this is
`docs/adr/0038-a-night-that-mostly-died-is-not-a-run.md`. 0037 is claimed by
open PR #6437, checked before taking 0038.

**The alternative I rejected, and its strongest form.** "A harbor timeout is
the machine's fact, not the engine's" is the reasoning that already keeps
`CRASHED` a row verdict rather than an exit code, and it is right for one dead
trial in four. It stops being right at a majority: the workflow already
refuses to start with no provider key on the stated grounds that a green
nightly that measured nothing is the exact failure `bench.yml` complains
about, and three of four trials dying reaches that state by a different road.

**This makes the nightly red more often, on purpose.** Red here is
actionable: it says the task set, the agent timeout, or the runner cannot
finish what the night asks for. The remedy is to fix one of those, never a
greener reading of the same night. The observed rate — one extra red in 29
nights — is what makes that affordable.

## Summary by Sourcery

Gate nightly benchmark results when a majority of requested trials fail to finish, preventing thin samples from producing misleading green verdicts.

New Features:
- Add a nightly benchmark gate that fails when more than half of the requested trials crash or never finish.
- Report unfinished-majority failures through exit code 8 in single-configuration and comparison runs, including clear table and CI summaries.

Bug Fixes:
- Prevent nightly benchmarks from reporting a green verdict or publishing misleading pass-rate and comparison results when most requested trials did not finish.

Enhancements:
- Document the third benchmark gate, its precedence, rationale, and observed impact across nightly history.

CI:
- Update the nightly benchmark workflow to recognize and explain exit code 8.

Documentation:
- Record the gating decision in ADR 0038 and update the ADR index, manifest, benchmark README, and CI engine-gate guide.

Tests:
- Add witness coverage for a real majority-crash nightly shape and the strict-majority boundary.