### PR TITLE
ci: a ticked DoD box clears the stale dod check

### DIFF
--- a/.github/workflows/dod-recheck.yml
+++ b/.github/workflows/dod-recheck.yml
@@ -1,62 +1,39 @@
+# DoD recheck (SCR-003) — caller stub.
+#
+# dod-check.yml fires on pull-request events. Its failure message tells the
+# author to tick the remaining boxes, and ticking one edits the ISSUE — an
+# event that workflow does not hear and cannot: a `workflow_call` file is
+# invoked by its caller's events, and the object being judged is not the object
+# those events are about. So the prescribed remedy fired nothing and the
+# required check stayed red at a verdict that was no longer true
+# (oxagen#2638).
+#
+# This file is the missing event. It subscribes to THIS repository's issue
+# edits and hands them to the shared implementation, which re-runs the failed
+# `dod` run on any open PR here that names the edited issue. Re-running the old
+# run rather than reporting a new check is what puts the new conclusion under
+# the same name on the same commit, which is what branch protection reads.
+#
+# There is no logic in this file, for the reason the dod-check stub gives:
+# ADR-039 keeps one implementation in oxagen rather than five that drift.
+#
+# The ref is a commit SHA, not `@main`: a cross-repo `uses:` resolved through a
+# moving ref both fails `action-pins` and lets another repository change what
+# runs here without a commit in this one.
 name: dod-recheck
-
-# Re-read a DoD checklist the moment the checklist changes (#6079).
-#
-# `dod-check` judges the linked issue's checklist, and fires on pull request
-# events. Those are two different objects. Ticking the last box on the issue —
-# the remedy the failure message names — raises no pull request event, so the
-# red `dod / dod` stands until someone touches the pull request.
-#
-# This workflow is the missing event. `scripts/dod-recheck.sh` finds the open
-# pull requests whose body names the edited issue and runs the failed check
-# again on each. The new run reports under the same name on the same commit,
-# which is all the branch rules read — so nothing here has to report a check
-# against a head this event does not own.
-#
-# Same shape as `main-red-clear.yml`, for the same bug one gate over: a check
-# that was right when it ran, on a commit with no event left to correct it.
 
 on:
   issues:
     types: [edited]
-  workflow_dispatch:
-    inputs:
-      issue:
-        description: The issue number whose pull requests should be re-checked
-        required: true
-        type: string
 
+# `actions: write` is what lets the implementation re-run a failed run. The
+# caller grants it: a reusable workflow's token is capped by ours, so declaring
+# it there is not enough.
 permissions:
-  contents: read
-  # To read each open pull request's body and head commit.
-  pull-requests: read
-  # To run the failed check again. This is the scope an agent session does not
-  # hold, which is why the re-run lives in a workflow rather than in the
-  # session that ticked the box.
   actions: write
-
-# One sweep per issue. A cancelled sweep costs nothing: the next one asks the
-# same questions and re-runs whatever is still failing.
-concurrency:
-  group: dod-recheck-${{ github.event.issue.number || inputs.issue }}
-  cancel-in-progress: true
+  contents: read
+  pull-requests: read
 
 jobs:
   recheck:
-    name: re-read the checklist the issue edit changed
-    # A title-only edit changes no checklist. GitHub sends `changes.body` only
-    # when the body moved, so this drops half the traffic before it starts a
-    # runner.
-    if: >-
-      github.event_name != 'issues'
-      || github.event.changes.body != null
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Re-run the dod check on every pull request naming this issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE: ${{ github.event.issue.number || inputs.issue }}
-        run: ./scripts/dod-recheck.sh "$ISSUE"
+    uses: macanderson/oxagen/.github/workflows/dod-recheck.yml@2dd72c9957f8520ee673862de894ed64f4b2380c # oxagen main, #2638


### PR DESCRIPTION
## What & Why

Two SCR-003 caller-stub gaps, both found by sweeps in oxagen. No logic changes
here — this repository carries stubs, and the implementation lives once in
oxagen (ADR-039).

### Ticking a DoD box did not clear the stale `dod` check

`dod-check.yml` fires on pull-request events. Its failure message tells the
author to tick the remaining boxes — and ticking one edits the **issue**, an
event that workflow does not hear and cannot: a `workflow_call` file is invoked
by its caller's events, and the object being judged is not the object those
events are about.

So the prescribed remedy fired nothing. The required check stayed red at a
verdict that was no longer true, and the PR stayed unmergeable until somebody
happened to touch it — with nothing saying the check was stale rather than
failing. `oxagen#2638` reports six of nine open PRs in one repo sitting red on
`dod` alone, with how many were stale never established.

`dod-recheck.yml` subscribes to **this** repository's issue edits and hands them
to the shared implementation, which re-runs the failed `dod` run on any open PR
here that names the edited issue. Re-running the old run rather than reporting a
new check is what puts the new conclusion under the same name on the same
commit, which is what branch protection reads. Only PRs whose `dod` actually
failed are touched.

### The stub had drifted from its siblings

`oxagen#2664` read all four caller stubs on 2026-09-05 and found two
divergences. Both are fixed here:

- **the ref floated on `@main`**, so a merge in oxagen changed what runs in this
  repository with no commit in it. Now pinned to `2dd72c9957f8`, with the reason
  stated — the same wording stella's stub has carried since oxagen#2663.
- **`ready_for_review` was missing**, so a PR opened as a draft and later marked
  ready kept whatever verdict its draft head got.

## One property worth knowing

The pinned ref pins the *workflow*, not the checker it runs. The shared workflow
fetches `scr-dod-check.mjs` from oxagen `@main`, because `github.sha` inside a
called workflow is this repository's commit and does not exist there. That is
how `dod-check.yml` has always worked; it is stated here rather than discovered.

## Verification

Both files parse, and neither carries logic to test — the predicate they reach
(`referencesIssue`) is unit-tested in oxagen, added with the implementation.

The honest limit: a `workflow_call` stub cannot be exercised until it is on the
default branch, because the event fires there. So the check that matters is the
first DoD box ticked on an issue this repository's PRs link — the recheck should
re-run `dod` with no push.

Refs macanderson/oxagen#2638
Refs macanderson/oxagen#2664

## Summary by Sourcery

Keep required DoD checks current by delegating issue-triggered rechecks to the pinned shared workflow.

New Features:
- Re-run stale failed DoD checks when linked issues are edited so checklist updates can clear the existing required check.

Bug Fixes:
- Ensure DoD checks are refreshed after pull requests transition from draft to ready for review.

Enhancements:
- Pin the shared DoD recheck workflow to a stable oxagen commit and grant the permissions required to re-run checks.

CI:
- Replace the local DoD recheck implementation with the shared oxagen reusable workflow for issue-edit events.

Documentation:
- Document the event boundary, workflow pinning rationale, and shared checker behavior for the DoD recheck stub.