### PR TITLE
fix(stella-cli): a driver session id the clock cannot make collide

### DIFF
--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -199,13 +199,32 @@ pub(crate) fn run_plugin(cmd: &PluginCmd, globals: &crate::cli::GlobalArgs) -> R
 ///
 /// Minted the way `self_driving_cmd::state::new_run_id` mints a run id — a
 /// timestamp plus a salt off the clock's sub-second remainder and the process
-/// id — so two sessions started in the same second are still distinguishable.
+/// id — plus a counter, which is what actually makes two sessions of one run
+/// distinct.
+///
+/// The clock cannot carry that on its own, and reading the salt as though it
+/// could is what broke: `SystemTime`'s resolution is the platform's rather
+/// than the nanosecond its type suggests, so two sessions opened back to back
+/// can sample the same `subsec_nanos`, and the mask keeps 16 bits, which
+/// repeat every 65536ns even where the clock is fine. One invocation opens
+/// sessions in a loop, so it draws from that space over and over — and
+/// `one_invocation_opens_a_session_for_each_sleep_the_driver_asks_for` failed
+/// on a run whose three sessions carried two ids.
+///
+/// So the counter holds uniqueness within the process and the clock is left
+/// the jobs it can do: `secs` to date the id, the pid-mixed salt to separate
+/// two processes that start inside one second.
 pub(crate) fn session_id() -> String {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static OPENED: AtomicU32 = AtomicU32::new(0);
+
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
     let salt = (now.subsec_nanos() ^ std::process::id()) & 0xffff;
-    format!("drive-{}-{salt:04x}", now.as_secs())
+    let opened = OPENED.fetch_add(1, Ordering::Relaxed);
+    format!("drive-{}-{salt:04x}-{opened:04x}", now.as_secs())
 }
 
 /// `stella plugin drive <name>` — drive an installed plugin until it stops.

--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -1386,6 +1386,26 @@ fn one_invocation_opens_a_session_for_each_sleep_the_driver_asks_for() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// The id above has to be unique without the clock's help.
+///
+/// `one_invocation_opens_a_session_for_each_sleep_the_driver_asks_for` asks
+/// the same question through a whole driver run, which makes it a costly place
+/// to learn the answer: it opens three sessions, so it only fails when a
+/// collision lands among three draws, and it did — three sessions, two ids, on
+/// a run that was measuring something else.
+///
+/// This asks it directly, and over enough draws that the old salt cannot pass.
+/// 4096 ids from a 16-bit space collide with probability that rounds to one,
+/// and every draw inside a second shares the `secs` field, so nothing else in
+/// the id separates them.
+#[test]
+fn every_session_id_a_process_mints_is_distinct() {
+    let minted: std::collections::BTreeSet<String> =
+        (0..4096).map(|_| crate::plugin_cmd::session_id()).collect();
+
+    assert_eq!(minted.len(), 4096, "a process must not mint one id twice");
+}
+
 // A plugin is a package: the tools, skills and records it ships (#3380). Those
 // tests live in `contributions.rs`, split out when this file crossed the
 // 1500-line ceiling (#4440).


### PR DESCRIPTION
## What & why

`one_invocation_opens_a_session_for_each_sleep_the_driver_asks_for` failed on **#6443**'s `fmt + clippy + test` run — a branch touching only `stella-model`'s live-smoke declarations, so the failure was never that PR's. The panic names the cause:

```
assertion `left == right` failed: each session was opened under its own id
  left: 2
 right: 3
```

and the run's own log shows which two of the three matched:

```
session drive-1788818129-8a89 ended: sleep 0s before the next one
session drive-1788818129-7e8a ended: sleep 0s before the next one
session drive-1788818129-8a89 ended: sleep 0s before the next one
```

`session_id`'s doc comment claimed a timestamp plus a salt made "two sessions started in the same second still distinguishable." It does not. Within one process `process::id()` is constant, so the salt varies only with `subsec_nanos`, masked to 16 bits — a space that repeats every 65536ns — and `SystemTime` resolves to whatever the platform gives rather than the nanosecond its type suggests. A driver run opens sessions in a loop, drawing from that space repeatedly, so this is a question of how many sessions a run opens, not of whether it can ever collide.

The fix gives the id a process-local counter and leaves the clock the jobs it can do: `secs` dates the id, the pid-mixed salt separates two processes starting inside one second. Nothing parses the id — `DriverSessionEntry::session_id` stores it as an opaque `String` — so the added field costs no reader.

Refs #6443

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`every_session_id_a_process_mints_is_distinct` mints 4096 ids in one process and asserts all are distinct. Checked the artisanal way — the source fix stashed, the test kept:

| | result |
|---|---|
| old `session_id` | `FAILED` — `left: 3974, right: 4096` (122 collisions), exit 101 |
| new `session_id` | `ok. 1 passed`, exit 0 |

It asks directly what the driver-run test asks over three draws, which is why that test only failed once a collision happened to land inside its three. The originally-failing test also passes here: `one_invocation_opens_a_session_for_each_sleep_the_driver_asks_for ... ok`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — scoped per CLAUDE.md ("CI builds and tests; this laptop does not"); the workspace run is this PR's CI
- [x] `cargo test -p stella-cli --bin stella <filter>` — scoped, same reason; CI runs the suite
- [x] Docs updated where behavior changed — `session_id`'s doc comment stated the guarantee that failed, so it is rewritten to say what actually carries uniqueness
- [x] Guards: `check-file-size` (OK, nothing over by this change), `check-prose`, `check-line-citations`, `check-left-behind`, `check-dead-code-allows` — all OK
- [x] No `Closes` — this PR uses `Refs #6443`, so no issue is gated on it

## Fix over file

- [x] Extra fixes in this PR: none — one logical change
- [x] Filed: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps (`std::sync::atomic` only)
- [x] No new outbound network calls
- [x] No new cross-boundary types

## Anything reviewers should know?

**The id gains a field**: `drive-<secs>-<salt>` becomes `drive-<secs>-<salt>-<opened>`. Nothing reads the shape — `session_log.rs`'s fixtures use literals like `drive-1-abcd` and compare whole strings — so this is additive, but it does change what a human sees in a driver log.

**The counter is per process, not per machine.** Two concurrent `stella plugin drive` processes both start at `0000`, and the pid-mixed salt is what separates them, exactly as before. That is unchanged and is the axis this PR does not strengthen: the failure being fixed is intra-process, and widening to cross-process uniqueness would want a different construction than a 16-bit salt.

**How this reached the sweep**: found while checking CI on #6443, whose diff cannot touch `stella-cli`. Per AGENTS.md's CI-red rule this is "a failure in code unrelated to the change", so it lands here on its own branch rather than widening #6443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DQSQWajBtMT98m8KnEmyq

---
_Generated by [Claude Code](https://claude.ai/code/session_014DQSQWajBtMT98m8KnEmyq)_

## Summary by Sourcery

Prevent collisions among session IDs created during a single driver process by adding a process-local counter to the ID.

Bug Fixes:
- Ensure driver session IDs remain unique when multiple sessions are opened within the same process.

Enhancements:
- Update session ID documentation to describe the process-local counter and the clock’s limited role in uniqueness.

Tests:
- Add a regression test that mints 4096 session IDs and verifies they are all distinct.