### PR TITLE
fix(stella-model): declare the live-smoke providers this repo cannot reach

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -19,6 +19,21 @@
 # says which credential it wanted. To exercise a subset deliberately, name
 # it: `-- --ignored anthropic_smoke`.
 #
+# A secret this repository does not hold is DECLARED rather than absent.
+# `crates/stella-model/tests/live_smoke/arming.rs` carries the list: one row
+# per provider that cannot run, naming what is missing, the run that
+# established it, and the issue that owns it (ADR 0039, #5595). Today eight
+# of the nine sit there — six with no credential in the repository secrets,
+# and Anthropic and Z.ai with a working key and an empty account. A green run
+# means one live call plus eight declared rows, and the log prints each one.
+#
+# The rows are checked against this job's environment, so they cannot go
+# stale in silence. Add one of the secrets below and the run goes RED, naming
+# the row to delete; that is how a provider gets re-armed. The two unfunded
+# providers still call their endpoints — an empty account is refused before
+# anything is billed — and pass only on a refusal that names the balance, so
+# a wire-shape regression on Anthropic still fails this job.
+#
 # A red run on a configured provider needs a human read of the failure, not
 # an assumption: this suite deliberately does NOT auto-classify a failure
 # into "wire-shape regression" vs. "account/auth/quota/billing problem" (a

--- a/crates/stella-cli/src/plugin_cmd.rs
+++ b/crates/stella-cli/src/plugin_cmd.rs
@@ -197,15 +197,35 @@ pub(crate) fn run_plugin(cmd: &PluginCmd, globals: &crate::cli::GlobalArgs) -> R
 
 /// A session identifier the driver echoes into its own records.
 ///
-/// Minted the way `self_driving_cmd::state::new_run_id` mints a run id — a
-/// timestamp plus a salt off the clock's sub-second remainder and the process
-/// id — so two sessions started in the same second are still distinguishable.
+/// The salt is 16 bits of the clock's sub-second remainder, xored with the
+/// process id. It keeps two processes apart, the way
+/// `self_driving_cmd::state::new_run_id` does for a run id. It cannot keep
+/// two sessions apart: 16 bits of nanoseconds repeat every 65.5 microseconds,
+/// and one invocation opens its sessions in a loop. Two sessions of one run
+/// collided on it in CI, and the session log then held two rows under one id.
+///
+/// The counter is what makes the id unique. It advances once per mint for the
+/// life of the process, so no two sessions opened here can share one.
 pub(crate) fn session_id() -> String {
+    static MINTED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
-    let salt = (now.subsec_nanos() ^ std::process::id()) & 0xffff;
-    format!("drive-{}-{salt:04x}", now.as_secs())
+    mint_session_id(
+        now,
+        std::process::id(),
+        MINTED.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+    )
+}
+
+/// [`session_id`] over its three inputs.
+///
+/// Split out so the uniqueness property can be checked against a clock that
+/// does not move, which is the case that collided. A test cannot hold the
+/// real clock still.
+fn mint_session_id(now: std::time::Duration, pid: u32, minted: u64) -> String {
+    let salt = (now.subsec_nanos() ^ pid) & 0xffff;
+    format!("drive-{}-{salt:04x}-{minted:04x}", now.as_secs())
 }
 
 /// `stella plugin drive <name>` — drive an installed plugin until it stops.

--- a/crates/stella-cli/src/plugin_cmd/tests.rs
+++ b/crates/stella-cli/src/plugin_cmd/tests.rs
@@ -1386,6 +1386,45 @@ fn one_invocation_opens_a_session_for_each_sleep_the_driver_asks_for() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// Two sessions of one run share a second, a process id, and often the same
+/// 16 bits of nanoseconds. The id must still tell them apart.
+///
+/// Asserted against a clock held still, because that is the case that
+/// collided: run 34163526157 opened three sessions and the session log held
+/// two of them under `drive-1788818129-8a89`. A test cannot stop the real
+/// clock, so the mint takes its inputs.
+#[test]
+fn two_sessions_minted_off_one_clock_reading_get_different_ids() {
+    let frozen = std::time::Duration::new(1_788_818_129, 500_000);
+    let first = crate::plugin_cmd::mint_session_id(frozen, 4242, 0);
+    let second = crate::plugin_cmd::mint_session_id(frozen, 4242, 1);
+    assert_ne!(
+        first, second,
+        "a stopped clock and one process must still mint two ids"
+    );
+    assert!(first.starts_with("drive-1788818129-"), "{first}");
+}
+
+/// The salt still carries the process id, so two runs on one machine stay
+/// apart even when each is on its first session.
+#[test]
+fn two_processes_minting_their_first_session_get_different_ids() {
+    let frozen = std::time::Duration::new(1_788_818_129, 500_000);
+    assert_ne!(
+        crate::plugin_cmd::mint_session_id(frozen, 4242, 0),
+        crate::plugin_cmd::mint_session_id(frozen, 9999, 0)
+    );
+}
+
+/// The property the two above are about, over the real mint: a run's sessions
+/// are opened back to back, and no two of them may share an id.
+#[test]
+fn a_run_of_sessions_mints_no_duplicate_id() {
+    let minted: std::collections::BTreeSet<String> =
+        (0..512).map(|_| crate::plugin_cmd::session_id()).collect();
+    assert_eq!(minted.len(), 512, "every session id must be its own");
+}
+
 // A plugin is a package: the tools, skills and records it ships (#3380). Those
 // tests live in `contributions.rs`, split out when this file crossed the
 // 1500-line ceiling (#4440).

--- a/crates/stella-model/tests/live_smoke.rs
+++ b/crates/stella-model/tests/live_smoke.rs
@@ -25,6 +25,16 @@
 //! credential-less run printed nothing and reported nine passes in 0.01s
 //! having contacted nothing (#3856).
 //!
+//! **A provider is armed, or a row says why it is not.** `arming::UNARMED`
+//! is that list, and the reason on each row is checked against the
+//! environment on every run — see [`arm`]. Six providers have no credential
+//! in this repository's Actions secrets and two sit behind an empty account,
+//! so the scheduled job was red every week for two causes a reader had to
+//! separate by hand (`#5595`). A declared row is not a skip: it holds a
+//! `NoCredential` provider to having no credential, and it still calls an
+//! `Unfunded` provider's endpoint and still fails it on anything but a
+//! refusal that names the balance.
+//!
 //! **What is NOT gated**: the drift guards over [`LIVE_PROVIDERS`] — the
 //! table this suite drives — run on every `cargo test`, with no credential
 //! and no network call. The gate above is right for spending money; it was
@@ -78,12 +88,22 @@
 //! a real cache write is exercised, not just accepted-but-inert) and asserting
 //! the call succeeds.
 
+// `#[path]` because an integration test file is its own crate root, so a bare
+// `mod arming;` would look for `tests/arming.rs` — a sibling of this file, and
+// a name that says nothing about which suite it belongs to. Cargo compiles
+// only the top-level files in `tests/` as test binaries, so the child sits in
+// a folder named for its parent, which is the layout AGENTS.md prescribes
+// under `src/`.
+#[path = "live_smoke/arming.rs"]
+mod arming;
+
+use arming::UnarmedReason;
 use stella_model::AuxCredentials;
 use stella_model::catalog::Catalog;
 use stella_model::credential::{ApiKey, CredentialsFile};
 use stella_model::factory::{Dialect, ProviderSpec, build_provider};
 use stella_model::provider::Provider;
-use stella_protocol::{CompletionMessage, CompletionRequest, ProviderError};
+use stella_protocol::{CompletionMessage, CompletionRequest, CompletionResult, ProviderError};
 
 /// Serializes the tests in this file that mutate `STELLA_LIVE_SMOKE` (the
 /// gate-behavior witnesses below) against every test that reads it
@@ -698,6 +718,62 @@ fn armed_provider(provider: &LiveProvider) -> Box<dyn Provider> {
     }
 }
 
+/// The adapter a `*_smoke` test calls, or `None` when the matrix declares
+/// this provider unarmed and there is nothing to call.
+///
+/// The staleness check comes first, so a row that stopped matching the
+/// environment fails the run before the row can excuse anything. It reads
+/// [`resolve_key`] rather than [`armed_key`] on purpose: whether a secret is
+/// configured is a fact about the job, and an unset `STELLA_LIVE_SMOKE`
+/// must not read as a secret going missing.
+fn arm(provider: &LiveProvider) -> Option<Box<dyn Provider>> {
+    if let Some(entry) = arming::unarmed(provider.id) {
+        let resolves = {
+            let _guard = env_lock();
+            resolve_key(provider.id, provider.env_var, provider.aliases).is_some()
+        };
+        if let Some(stale) = arming::stale_declaration(entry, resolves) {
+            panic!("{stale}");
+        }
+        if entry.reason == UnarmedReason::NoCredential {
+            eprintln!(
+                "[live_smoke] {}: unarmed by declaration (#{}) — {}",
+                provider.id, entry.issue, entry.note
+            );
+            return None;
+        }
+    }
+    Some(armed_provider(provider))
+}
+
+/// Judge a completed live call. `on_success` writes the provider's own
+/// success line, which is the one part that differs between adapters.
+///
+/// Shared by [`smoke`] and [`anthropic_smoke`], so neither the failure arm
+/// nor the declaration check can drift between them.
+fn settle(
+    provider: &LiveProvider,
+    outcome: Result<CompletionResult, ProviderError>,
+    on_success: impl FnOnce(&CompletionResult),
+) {
+    match outcome {
+        Ok(result) => {
+            if let Some(stale) = arming::success_contradicts(provider.id) {
+                panic!("{stale}");
+            }
+            on_success(&result);
+        }
+        // What this can no longer be is an unknown slug: the factory's seed
+        // floor rejects those before any wire call, and
+        // `every_live_smoke_slug_resolves_against_the_catalog_seed` catches
+        // them offline before that.
+        Err(error) => match arming::failure_settles(provider.id, &error) {
+            Ok(confirmed) => eprintln!("{confirmed}"),
+            Err(report) => panic!("{report}"),
+        },
+    }
+}
+
 // ---- failure diagnosis: what a red smoke actually establishes ------------
 
 /// Longest prefix (in characters) of the provider's own error text a failed
@@ -1219,17 +1295,12 @@ fn status_recovery_declines_rather_than_guesses() {
 /// Send `request` and report. Shared by every provider so the success log and
 /// the failure wording stay identical across adapters.
 async fn smoke(provider: &LiveProvider, built: Box<dyn Provider>, request: CompletionRequest) {
-    match built.complete(request).await {
-        Ok(r) => eprintln!(
+    settle(provider, built.complete(request).await, |r| {
+        eprintln!(
             "[live_smoke] {}: OK — model={} finish={:?} usage={:?} cost_usd={} text={:?}",
             provider.id, r.model, r.finish_reason, r.usage, r.cost_usd, r.text
-        ),
-        // What this can no longer be is an unknown slug: the factory's seed
-        // floor rejects those before any wire call, and
-        // `every_live_smoke_slug_resolves_against_the_catalog_seed` catches
-        // them offline before that.
-        Err(e) => panic!("{}", failure_report(provider.id, &e)),
-    }
+        );
+    });
 }
 
 /// Anthropic Messages API. Also the `cache_control` settlement: every
@@ -1254,11 +1325,14 @@ async fn smoke(provider: &LiveProvider, built: Box<dyn Provider>, request: Compl
 #[ignore = "live provider call — run with `-- --ignored`, STELLA_LIVE_SMOKE=1 and a credential"]
 async fn anthropic_smoke() {
     let provider = row("anthropic");
-    let built = armed_provider(provider);
+    let Some(built) = arm(provider) else { return };
     // The one provider whose system prompt is not tiny — see the probe's doc.
     let request = tiny_request(anthropic_cache_probe_system_prompt());
-    match built.complete(request).await {
-        Ok(r) => eprintln!(
+    // This test hand-rolls only its SUCCESS arm, to print the two cache
+    // counters. Everything else — the declaration check and the failure
+    // report — is [`settle`]'s, shared with every other provider.
+    settle(provider, built.complete(request).await, |r| {
+        eprintln!(
             "[live_smoke] anthropic: OK — model={} finish={:?} usage={:?} \
              cache_write_tokens={} cached_input_tokens={} text={:?}",
             r.model,
@@ -1267,12 +1341,8 @@ async fn anthropic_smoke() {
             r.usage.cache_write_tokens,
             r.usage.cached_input_tokens,
             r.text
-        ),
-        // Same report as every other provider's — see [`failure_report`].
-        // This test hand-rolls only its SUCCESS arm (to print the two cache
-        // counters); the failure arm must not drift from the shared one.
-        Err(e) => panic!("{}", failure_report(provider.id, &e)),
-    }
+        );
+    });
 }
 
 /// OpenAI Responses API.
@@ -1280,7 +1350,7 @@ async fn anthropic_smoke() {
 #[ignore = "live provider call — run with `-- --ignored`, STELLA_LIVE_SMOKE=1 and a credential"]
 async fn openai_smoke() {
     let provider = row("openai");
-    let built = armed_provider(provider);
+    let Some(built) = arm(provider) else { return };
     smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
@@ -1290,7 +1360,7 @@ async fn openai_smoke() {
 #[ignore = "live provider call — run with `-- --ignored`, STELLA_LIVE_SMOKE=1 and a credential"]
 async fn gemini_smoke() {
     let provider = row("gemini");
-    let built = armed_provider(provider);
+    let Some(built) = arm(provider) else { return };
     smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
@@ -1306,7 +1376,7 @@ async fn gemini_smoke() {
 #[ignore = "live provider call — run with `-- --ignored`, STELLA_LIVE_SMOKE=1 and a credential"]
 async fn vertex_smoke() {
     let provider = row("vertex");
-    let built = armed_provider(provider);
+    let Some(built) = arm(provider) else { return };
     smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
@@ -1319,7 +1389,7 @@ async fn vertex_smoke() {
 #[ignore = "live provider call — run with `-- --ignored`, STELLA_LIVE_SMOKE=1 and a credential"]
 async fn bedrock_smoke() {
     let provider = row("bedrock");
-    let built = armed_provider(provider);
+    let Some(built) = arm(provider) else { return };
     smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
@@ -1334,7 +1404,7 @@ async fn bedrock_smoke() {
 #[ignore = "live provider call — run with `-- --ignored`, STELLA_LIVE_SMOKE=1 and a credential"]
 async fn openrouter_smoke() {
     let provider = row("openrouter");
-    let built = armed_provider(provider);
+    let Some(built) = arm(provider) else { return };
     smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
@@ -1343,7 +1413,7 @@ async fn openrouter_smoke() {
 #[ignore = "live provider call — run with `-- --ignored`, STELLA_LIVE_SMOKE=1 and a credential"]
 async fn zai_smoke() {
     let provider = row("zai");
-    let built = armed_provider(provider);
+    let Some(built) = arm(provider) else { return };
     smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
@@ -1352,7 +1422,7 @@ async fn zai_smoke() {
 #[ignore = "live provider call — run with `-- --ignored`, STELLA_LIVE_SMOKE=1 and a credential"]
 async fn deepseek_smoke() {
     let provider = row("deepseek");
-    let built = armed_provider(provider);
+    let Some(built) = arm(provider) else { return };
     smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }
 
@@ -1361,6 +1431,6 @@ async fn deepseek_smoke() {
 #[ignore = "live provider call — run with `-- --ignored`, STELLA_LIVE_SMOKE=1 and a credential"]
 async fn xai_smoke() {
     let provider = row("xai");
-    let built = armed_provider(provider);
+    let Some(built) = arm(provider) else { return };
     smoke(provider, built, tiny_request(TINY_SYSTEM_PROMPT)).await;
 }

--- a/crates/stella-model/tests/live_smoke/arming.rs
+++ b/crates/stella-model/tests/live_smoke/arming.rs
@@ -1,0 +1,295 @@
+//! Which providers the live smoke suite is armed for, and why the rest are
+//! not.
+//!
+//! A provider in `LIVE_PROVIDERS` is armed, or it has a row in [`UNARMED`].
+//! There is no third state. [`stale_declaration`] re-asks each row's reason
+//! on every run, so a row cannot outlive what it claims.
+//!
+//! `doc:adr/0039-a-live-smoke-provider-is-armed-or-declared-unarmed` is the
+//! decision and the argument behind it.
+
+/// Why a provider is not armed here today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnarmedReason {
+    /// No credential for this provider reaches the job, so there is nothing
+    /// to call. The smoke prints the row and passes.
+    NoCredential,
+    /// The credential works and the account behind it holds no money. The
+    /// smoke calls the endpoint anyway, and passes only on a refusal that
+    /// names the balance.
+    Unfunded,
+}
+
+/// One declared gap in the live matrix.
+pub(crate) struct UnarmedProvider {
+    /// The `LIVE_PROVIDERS` id this row speaks for.
+    pub(crate) id: &'static str,
+    pub(crate) reason: UnarmedReason,
+    /// The number of the issue that owns the gap, so a green run points at
+    /// where it is being settled. Stored bare and printed with a `#`.
+    pub(crate) issue: &'static str,
+    /// What is missing, in the words a reader of a green run needs.
+    pub(crate) note: &'static str,
+}
+
+/// The providers this repository cannot smoke today.
+///
+/// Every note comes from a run. Run 34126157647 (2026-09-07) failed all
+/// eight. Six named the environment variable they wanted. Two carried the
+/// provider's own words about the balance.
+pub(crate) const UNARMED: &[UnarmedProvider] = &[
+    UnarmedProvider {
+        id: "anthropic",
+        reason: UnarmedReason::Unfunded,
+        issue: "5595",
+        note: "ANTHROPIC_API_KEY works and the account is empty. Anthropic answers HTTP 400 \
+               `Your credit balance is too low` (run 34126157647, 2026-09-07). It last passed \
+               on run 32007329950, 2026-08-17.",
+    },
+    UnarmedProvider {
+        id: "zai",
+        reason: UnarmedReason::Unfunded,
+        issue: "5595",
+        note: "ZAI_API_KEY works and the account is empty. Z.ai answers HTTP 429 `Insufficient \
+               balance or no resource package` (run 34126157647, 2026-09-07).",
+    },
+    UnarmedProvider {
+        id: "openai",
+        reason: UnarmedReason::NoCredential,
+        issue: "5595",
+        note: "no OPENAI_API_KEY in the repository secrets.",
+    },
+    UnarmedProvider {
+        id: "gemini",
+        reason: UnarmedReason::NoCredential,
+        issue: "5595",
+        note: "no GEMINI_API_KEY in the repository secrets.",
+    },
+    UnarmedProvider {
+        id: "deepseek",
+        reason: UnarmedReason::NoCredential,
+        issue: "5595",
+        note: "no DEEPSEEK_API_KEY in the repository secrets.",
+    },
+    UnarmedProvider {
+        id: "xai",
+        reason: UnarmedReason::NoCredential,
+        issue: "5595",
+        note: "no XAI_API_KEY in the repository secrets.",
+    },
+    UnarmedProvider {
+        id: "bedrock",
+        reason: UnarmedReason::NoCredential,
+        issue: "5595",
+        note: "no AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY in the repository secrets. An IAM \
+               user scoped to `bedrock:InvokeModel` is what this needs.",
+    },
+    UnarmedProvider {
+        id: "vertex",
+        reason: UnarmedReason::NoCredential,
+        issue: "5595",
+        note: "no GCP_SERVICE_ACCOUNT_KEY in the repository secrets, so the job mints no \
+               VERTEX_ACCESS_TOKEN. VERTEX_PROJECT_ID is absent too.",
+    },
+];
+
+/// The row for `provider_id`, when the matrix declares one unarmed.
+pub(crate) fn unarmed(provider_id: &str) -> Option<&'static UnarmedProvider> {
+    UNARMED.iter().find(|row| row.id == provider_id)
+}
+
+/// The message a row that stopped matching its environment fails with.
+///
+/// `credential_resolves` comes from the credential chain alone. The
+/// `STELLA_LIVE_SMOKE` gate never feeds it. Whether a secret is configured is
+/// a fact about the job, and turning the gate off must not read as a secret
+/// going missing.
+pub(crate) fn stale_declaration(
+    entry: &UnarmedProvider,
+    credential_resolves: bool,
+) -> Option<String> {
+    match (entry.reason, credential_resolves) {
+        (UnarmedReason::NoCredential, true) => Some(format!(
+            "[live_smoke] {}: the unarmed row is stale — it says no credential is configured, \
+             and one resolves. Delete the `{}` row from UNARMED \
+             (crates/stella-model/tests/live_smoke/arming.rs) and let the live call run.",
+            entry.id, entry.id
+        )),
+        (UnarmedReason::Unfunded, false) => Some(format!(
+            "[live_smoke] {}: the unarmed row is stale — it says the account is empty, which \
+             needs a working credential, and none resolves. Restore the credential, or change \
+             the `{}` row's reason to NoCredential \
+             (crates/stella-model/tests/live_smoke/arming.rs).",
+            entry.id, entry.id
+        )),
+        _ => None,
+    }
+}
+
+/// A success from a provider this table declares unfunded means the account
+/// has money again, so the row is wrong and the run says so.
+pub(crate) fn success_contradicts(provider_id: &str) -> Option<String> {
+    let entry = unarmed(provider_id)?;
+    (entry.reason == UnarmedReason::Unfunded).then(|| {
+        format!(
+            "[live_smoke] {provider_id}: the unarmed row is stale — it says the account is \
+             empty, and the call succeeded. Delete the `{provider_id}` row from UNARMED \
+             (crates/stella-model/tests/live_smoke/arming.rs) so this provider is watched again."
+        )
+    })
+}
+
+/// What a failed call settles for `provider_id`.
+///
+/// `Ok` carries the line a confirmed row prints; `Err` carries the report the
+/// run fails with. Only an `Unfunded` row can turn a failure into a pass, and
+/// only on the `Billing` verdict a reader of the log would act on. A rejected
+/// field resolves to WIRE SHAPE and still fails, which is what keeps the two
+/// unfunded adapters under the guard rather than outside it.
+pub(crate) fn failure_settles(
+    provider_id: &str,
+    error: &stella_protocol::ProviderError,
+) -> Result<String, String> {
+    let report = super::failure_report(provider_id, error);
+    let Some(entry) = unarmed(provider_id) else {
+        return Err(report);
+    };
+    if entry.reason != UnarmedReason::Unfunded
+        || super::resolve(error).1 != super::FailureCause::Billing
+    {
+        return Err(report);
+    }
+    Ok(format!(
+        "[live_smoke] {provider_id}: unarmed by declaration (#{}) — {} The provider confirmed it \
+         on this run: {}",
+        entry.issue,
+        entry.note,
+        super::bounded_detail(&error.to_string()),
+    ))
+}
+
+// ---- witnesses (always run; never touch the network) ---------------------
+
+/// A row that names nothing real is a row nobody can act on.
+#[test]
+fn every_unarmed_row_names_a_live_provider_an_issue_and_a_reason() {
+    let mut seen = std::collections::BTreeSet::new();
+    for entry in UNARMED {
+        assert!(
+            super::LIVE_PROVIDERS.iter().any(|p| p.id == entry.id),
+            "UNARMED names `{}`, which is not a LIVE_PROVIDERS row",
+            entry.id
+        );
+        assert!(
+            seen.insert(entry.id),
+            "duplicate UNARMED row for `{}`",
+            entry.id
+        );
+        assert!(
+            entry.issue.parse::<u32>().is_ok(),
+            "`{}` must cite the number of the issue that owns the gap",
+            entry.id
+        );
+        assert!(
+            entry.note.len() > 20,
+            "`{}` must say what is missing, not just that something is",
+            entry.id
+        );
+    }
+}
+
+/// The point of the table: a gap that closes itself says so.
+#[test]
+fn a_credential_that_resolves_makes_a_no_credential_row_stale() {
+    let entry = unarmed("openai").expect("openai is declared unarmed");
+    let stale = stale_declaration(entry, true).expect("a resolving credential is stale");
+    assert!(stale.contains("Delete the `openai` row"), "{stale}");
+    assert!(stale_declaration(entry, false).is_none());
+}
+
+/// The other direction: an `Unfunded` row claims the key works, so a key
+/// that stopped resolving means the row names the wrong thing.
+#[test]
+fn a_credential_that_vanishes_makes_an_unfunded_row_stale() {
+    let entry = unarmed("anthropic").expect("anthropic is declared unarmed");
+    let stale = stale_declaration(entry, false).expect("a vanished credential is stale");
+    assert!(
+        stale.contains("change the `anthropic` row's reason"),
+        "{stale}"
+    );
+    assert!(stale_declaration(entry, true).is_none());
+}
+
+/// The refusal an `Unfunded` row predicts, in the provider's own words, is
+/// the one failure that confirms the row instead of failing the run.
+///
+/// Both bodies are quoted from run 34126157647 (2026-09-07). Both reach
+/// `resolve` as `Terminal`. Anthropic spells an empty account as a 400 and
+/// Z.ai spells one as a 429, so the status settles neither. The body does.
+#[test]
+fn a_balance_refusal_confirms_an_unfunded_row() {
+    let anthropic = stella_protocol::ProviderError::Terminal(
+        "terminal provider error: Anthropic HTTP 400 Bad Request: {\"type\":\"error\",\"error\":\
+         {\"type\":\"invalid_request_error\",\"message\":\"Your credit balance is too low to \
+         access the Anthropic API.\"}}"
+            .to_string(),
+    );
+    let confirmed = failure_settles("anthropic", &anthropic).expect("a balance refusal confirms");
+    assert!(confirmed.contains("unarmed by declaration"), "{confirmed}");
+    assert!(
+        confirmed.contains("5595"),
+        "the confirmation must point at the issue that owns the gap: {confirmed}"
+    );
+
+    let zai = stella_protocol::ProviderError::Terminal(
+        "terminal provider error: Z.ai HTTP 429: Insufficient balance or no resource package. \
+         Please recharge."
+            .to_string(),
+    );
+    assert!(failure_settles("zai", &zai).is_ok());
+}
+
+/// The half that keeps the guard pointed at the adapter: a row saying the
+/// account is empty excuses an empty account and nothing else. Anthropic is
+/// the adapter `#240` was filed on, so a wire-shape failure there must still
+/// redden the run.
+#[test]
+fn a_wire_shape_failure_still_fails_a_provider_declared_unfunded() {
+    let malformed = stella_protocol::ProviderError::Malformed(
+        "missing field `content` at line 1 column 84".to_string(),
+    );
+    let report = failure_settles("anthropic", &malformed).expect_err("a wire-shape failure fails");
+    assert!(report.contains("WIRE SHAPE"), "{report}");
+
+    let rotated = stella_protocol::ProviderError::Auth(
+        "anthropic rejected the credential (HTTP 401): invalid x-api-key".to_string(),
+    );
+    let report = failure_settles("anthropic", &rotated).expect_err("a revoked key fails");
+    assert!(report.contains("CREDENTIAL"), "{report}");
+}
+
+/// A provider with no row is judged the way it always was, whatever its
+/// failure says.
+#[test]
+fn a_provider_with_no_row_is_never_excused_by_one() {
+    let billing = stella_protocol::ProviderError::Terminal(
+        "terminal provider error: OpenRouter HTTP 402: your credit balance is too low".to_string(),
+    );
+    assert!(failure_settles("openrouter", &billing).is_err());
+}
+
+/// The last direction a row can go stale: the account is funded again, the
+/// call succeeds, and a row saying it cannot is now wrong.
+#[test]
+fn a_success_fails_a_provider_declared_unfunded() {
+    let stale = success_contradicts("anthropic").expect("a funded call is stale");
+    assert!(stale.contains("Delete the `anthropic` row"), "{stale}");
+    assert!(
+        success_contradicts("openrouter").is_none(),
+        "an armed provider's success is a pass, not a contradiction"
+    );
+    assert!(
+        success_contradicts("openai").is_none(),
+        "a NoCredential row makes no call, so it has no success to contradict"
+    );
+}

--- a/docs/adr/0039-a-live-smoke-provider-is-armed-or-declared-unarmed.md
+++ b/docs/adr/0039-a-live-smoke-provider-is-armed-or-declared-unarmed.md
@@ -1,0 +1,102 @@
+---
+id: adr/0039-a-live-smoke-provider-is-armed-or-declared-unarmed
+title: "ADR 0039: A live smoke provider is armed or declared unarmed"
+status: implemented
+---
+
+# ADR 0039: A live smoke provider is armed or declared unarmed
+
+- Status: accepted
+- Date: 2026-09-07
+- Decides: `#5595`
+- Not part of the Phase 0 series.
+
+## Context
+
+`live-smoke.yml` makes one real call per provider adapter, once a week. It
+exists for one reason. The Anthropic adapter shipped a broken `thinking` shape
+for months. Only a live call found it (`#240`).
+
+Nine adapters are armed. One can run. Six have no credential in this
+repository's Actions secrets. Two sit behind an account with no money in it.
+Run 34126157647 (2026-09-07) ends `1 passed; 8 failed`. So did the four runs
+before it.
+
+The job has been red every week since 2026-08-24. It is red for two causes at
+once. A reader opens the log and sorts six "no credential" panics from two
+balance refusals by hand. Red that always means the same thing is red nobody
+reads. A real wire-shape regression would land in the middle of it.
+
+The two green runs before that are worse. Run 32007329950 (2026-08-17) reports
+`ok`. Its log shows eight providers printing `skipped — set STELLA_LIVE_SMOKE=1
+to run`. Green meant one call was made. `#3856` took that away. It made a named
+smoke that cannot run fail. It was right. It also left the job with no way to
+say what a run covers.
+
+Money would fix the symptom. Six keys and two top-ups, and nine live calls go
+green. That is a purchase, not a design. It is not available today. This record
+answers what the suite should say while that stays true.
+
+## Decision
+
+**A provider in `LIVE_PROVIDERS` is armed, or a row in `UNARMED` says why it is
+not. There is no third state.** The table sits beside the matrix it speaks for,
+in `crates/stella-model/tests/live_smoke/arming.rs`. A row names four things:
+the provider, what is missing, the run that showed it, and the issue that owns
+it. AGENTS.md asks for that same shape when an event has no consumer, or a
+provider posture has no witness.
+
+**The reason is re-asked on every run.** A row that stops matching fails the
+job and names itself:
+
+- A `NoCredential` row whose credential now resolves is stale. The run says
+  which row to delete.
+- An `Unfunded` row whose credential has gone is misfiled. That reason claims
+  the key works.
+- An `Unfunded` provider whose call succeeds has money again. The run says so
+  and fails.
+
+So a gap here cannot go quiet. Add `OPENAI_API_KEY` and the job turns red,
+asking to be re-armed.
+
+**An `Unfunded` provider still calls its endpoint.** An empty account is
+refused before anything is billed. The call costs nothing. The refusal is
+evidence. The smoke passes only on the `BILLING` verdict `resolve` already
+derives. That is the verdict a reader of the log would act on. A rejected field
+resolves to `WIRE SHAPE` and still fails. A revoked key resolves to
+`CREDENTIAL` and still fails.
+
+Anthropic is one of the two. It is the adapter `#240` was filed on. This is
+what keeps it under the guard.
+
+## Consequences
+
+A green run now carries a claim a reader can check. One provider called live.
+Eight declared, each with a reason and an issue. That is less coverage than
+nine live calls. It is more information than eight red panics.
+
+The six `NoCredential` providers have no coverage. They had none before. The
+difference is that the tree says so, in a file review reaches.
+
+The table is Rust, not YAML. The workflow still passes every secret, so adding
+one is what trips the staleness check. A list in YAML would have to be read by
+the suite anyway, and no test could reach it.
+
+`#5595` stays open on the purchase. Six keys, and two balances. Its checklist
+names what shipped and what money is still owed.
+
+## Alternatives considered
+
+**Skip a provider whose credential is absent.** `#3856` removed that. Its
+reason holds: a run that contacted nothing reported nine passes in 0.01
+seconds. A row is the opposite of a skip. It is written down, reviewed, and it
+fails when it stops being true.
+
+**Sniff the response body to auto-skip a billing failure.** The workflow header
+rules this out, and it is right. A body-driven skip would paper over a real
+regression. Nothing here skips on a body. `resolve` reads a body to name a
+cause the status code cannot, which it did before this change. The row decides
+whether that cause was predicted.
+
+**Drop the eight tests until the keys exist.** A deleted test cannot fail.
+Nothing would say the coverage went away.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -104,6 +104,7 @@ open; nothing before Phase 3 forces it.
 | [0035](0035-a-wrappers-verdict-lands-on-the-round-that-earned-it.md) | A Wrapper's Verdict Lands on the Round That Earned It | Accepted |
 | [0036](0036-a-driver-takes-a-pull-request-out-of-draft.md) | A Driver Takes a Pull Request Out of Draft | Accepted |
 | [0037](0037-a-credit-balance-lives-outside-the-engine.md) | A Credit Balance Lives Outside the Engine | Accepted |
+| [0039](0039-a-live-smoke-provider-is-armed-or-declared-unarmed.md) | A Live Smoke Provider Is Armed or Declared Unarmed | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -220,6 +221,14 @@ seller does. A user owns the disk, so a file there cannot be the record of what
 a customer owes, and this repository grows no ledger for money. The engine's
 part is to report what a turn cost, which the enterprise export path already
 does under the content-free rule.
+
+ADR 0039 settles what the live provider smoke suite says while it cannot reach
+eight of its nine endpoints. A provider is armed, or a row names what is
+missing, when that was checked, and the issue that owns it. The reason is
+re-asked on every run, so a row goes red the moment it stops being true — a
+credential that appears, one that vanishes, or an empty account that gets
+funded. A provider declared unfunded still calls its endpoint, because an empty
+account is refused for free and only a refusal naming the balance passes.
 
 ## The number is a shared cell
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -190,6 +190,11 @@
       "status": "implemented",
       "title": "ADR 0037: A credit balance lives outside the engine"
     },
+    "adr/0039-a-live-smoke-provider-is-armed-or-declared-unarmed": {
+      "path": "docs/adr/0039-a-live-smoke-provider-is-armed-or-declared-unarmed.md",
+      "status": "implemented",
+      "title": "ADR 0039: A live smoke provider is armed or declared unarmed"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",


### PR DESCRIPTION
## What & why

The weekly `live-smoke` job has been red every week since 2026-08-24. Nine
adapters are armed and one can run. Six have no credential in this
repository's Actions secrets, and Anthropic and Z.ai have a working key over
an empty account. Run 34126157647 (schedule, 2026-09-07) ends
`1 passed; 8 failed`, the same as the four runs before it.

Red that always means the same thing is red nobody reads, and a real
wire-shape regression would land in the middle of it. The two green runs
before that were worse: run 32007329950 (2026-08-17) reports `ok` with eight
providers printing `skipped — set STELLA_LIVE_SMOKE=1 to run`. Green meant one
call was made. #3856 took that away, correctly, and left the job with no way
to say what a run covers.

**A provider is now armed, or a row in `UNARMED` says why it is not.** The
table is `crates/stella-model/tests/live_smoke/arming.rs`. Each row names the
provider, what is missing, the run that showed it, and the issue that owns it
— the declared-gap shape AGENTS.md already asks for when an event has no
consumer or a provider posture has no witness.

**The reason is re-asked on every run**, so a row cannot outlive what it
claims:

- a `NoCredential` row whose credential resolves fails the job, naming the row
  to delete;
- an `Unfunded` row whose credential has gone fails, because that reason
  claims the key works;
- an `Unfunded` provider whose call succeeds fails, because the account has
  money again.

So the day someone adds `OPENAI_API_KEY`, the job turns red asking to be
re-armed. A gap declared here cannot go quiet.

**An `Unfunded` provider still calls its endpoint.** An empty account is
refused before anything is billed, so the call is free and the refusal is
evidence. The smoke passes only on the `BILLING` verdict `resolve` already
derives. A rejected field resolves to `WIRE SHAPE` and still fails; a revoked
key resolves to `CREDENTIAL` and still fails. That is what keeps Anthropic —
the adapter #240 was filed on — under the guard rather than outside it.

ADR 0039 records the decision. SCR-002 is why it is a record rather than a
question put to the maintainer: the previous pass on this issue asked which
providers to arm and stopped.

Closes #5595

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here), **or**
- [ ] No witness needed (pure refactor / docs / CI) — because:

Six of them, all offline, all in `arming.rs`. They fail on `main` because the
concept they assert does not exist there:

- `every_unarmed_row_names_a_live_provider_an_issue_and_a_reason` — every row
  points at a real `LIVE_PROVIDERS` id, is unique, cites an issue number, and
  says what is missing.
- `a_credential_that_resolves_makes_a_no_credential_row_stale` and
  `a_credential_that_vanishes_makes_an_unfunded_row_stale` — the self-retiring
  property, both directions.
- `a_balance_refusal_confirms_an_unfunded_row` — the two real bodies from run
  34126157647 pass their rows.
- `a_wire_shape_failure_still_fails_a_provider_declared_unfunded` — a
  `Malformed` and a 401 against Anthropic both still fail. This is the one
  that says the coverage was not traded away.
- `a_provider_with_no_row_is_never_excused_by_one` — a billing body from
  `openrouter`, which has no row, still fails.
- `a_success_fails_a_provider_declared_unfunded` — a funded call contradicts
  its row.

Two behaviors I also drove by hand, since a live job cannot be run from a
test:

- With no provider env vars and an empty `STELLA_HOME`, the six
  `NoCredential` smokes pass and print their rows, e.g.
  `[live_smoke] openai: unarmed by declaration (#5595) — no OPENAI_API_KEY in
  the repository secrets.`
- With `OPENAI_API_KEY` set, `openai_smoke` fails before any network call:
  `the unarmed row is stale — it says no credential is configured, and one
  resolves. Delete the `openai` row from UNARMED`.

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-model --all-targets -- -D warnings` — scoped, per
      CLAUDE.md's "CI builds and tests; this laptop does not". CI runs the
      workspace.
- [x] `cargo test -p stella-model --test live_smoke` — 32 passed, 9 ignored
- [x] `make guards-fast`, `make adr-numbering`, `make doc-links`,
      `python3 scripts/check-prose.py` — all green
- [x] Docs updated where behavior/flags changed — `live-smoke.yml`'s header
      now says what a green run means and how a provider gets re-armed
- [x] CLA signed
- [x] `Closes #5595` appears both above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR, two of them:

  **`anthropic_smoke` hand-rolled its own failure arm**, with a comment on it
  warning that the arm "must not drift from the shared one". It now shares
  `settle` with every other provider and hand-rolls only the success line that
  prints the two cache counters.

  **A driver session id could collide with its own sibling.**
  `plugin_cmd::session_id` salted a timestamp with 16 bits of the clock's
  sub-second remainder xored with the process id. Those bits repeat every 65.5
  microseconds, and one `stella plugin drive` invocation opens its sessions in
  a loop. This PR's first CI run hit it: run 34163526157 opened three sessions
  and the session log held two of them as `drive-1788818129-8a89`, failing
  `one_invocation_opens_a_session_for_each_sleep_the_driver_asks_for` on a
  change that touches neither file. A process-local counter now rides the id,
  so no two sessions one process opens can share one. Three witnesses, in
  `crates/stella-cli/src/plugin_cmd/tests.rs`: the property against a clock
  held still, the process-id half that still has to work, and 512 mints
  through the real `session_id` with no duplicate.

  `self_driving_cmd::state::new_run_id` has the same salt and is left alone.
  It is minted once per `stella self-driving run start` process, so the loop
  hazard is not there and two processes differ by pid. Saying so out loud
  rather than filing it, per CLAUDE.md.
- [x] Filed, with the reason a fix could not ride this PR: #6442 — the other
      half of #5595 is a purchase. Six provider keys and two account top-ups.
      It is written as a handoff: which secret, which provider, what to do
      when each one lands, and how to verify.

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps without justification below
- [x] No new outbound network calls (Stella never phones home) — the two
      `Unfunded` smokes call the endpoints they already called; nothing else
      changed about what this suite contacts

## Anything reviewers should know?

**This branch replaces #6443, which carried the same tree.** A peer session
renumbered the record 0038 to 0039 there, because open PR #6441 had already
claimed 0038 against the same tree. That left the branch creating a path and
deleting it, which `rebase-replay` correctly failed: rebasing onto a base that
carried #6441's 0038 would drop this branch's creation and keep the deletion,
reverting their record. The remedy is to flatten, and this history never
mentions 0038 at all. `git diff` against #6443's head is empty.

**The table is Rust, not YAML.** The workflow still passes every secret, which
is what makes adding one trip the staleness check. A disarm list in the
workflow could not be tested and the suite would have to read it anyway.

**`arming.rs` is reached through `#[path]`.** An integration test file is its
own crate root, so a bare `mod arming;` would look for `tests/arming.rs` — a
sibling with a name that says nothing about which suite owns it. The `#[path]`
puts the child in a folder named for its parent, which is the layout AGENTS.md
prescribes, and a comment at the `mod` line says so.

**The third DoD box has a real run behind it.** I dispatched
`live-smoke.yml` on this branch rather than assume. Run 34163434382 ends
`test result: ok. 9 passed; 0 failed`. One live call (`openrouter`,
`finish=Some(Length)`, `cost_usd=0.00001834`) and eight declared rows, each
printed by name. Anthropic and Z.ai both reached their endpoints and the log
carries the refusal that confirmed each row.

**What this does not do.** The six `NoCredential` providers have no live
coverage, exactly as before. The difference is that the tree says so in a file
review reaches, rather than a log nobody opens. #6442 is where that gets
bought back.

## Summary by Sourcery

Make live-smoke coverage explicit and self-validating by declaring unreachable providers while preserving detection of genuine provider regressions.

New Features:
- Declare unavailable live-smoke providers with their missing credentials or unfunded-account status, owning issue, and evidence.
- Continuously validate declarations so providers are re-armed when credentials, funding, or successful calls contradict their recorded status.

Bug Fixes:
- Prevent live-smoke runs from masking wire-shape and credential failures behind declared unfunded-provider coverage.
- Prevent plugin driver session identifiers from colliding when multiple sessions are created in rapid succession.

Enhancements:
- Consolidate live-smoke result handling across providers while preserving Anthropic-specific success metrics.

Documentation:
- Document the live-smoke coverage model and record it in ADR 0039 and the ADR index.

Tests:
- Add offline witnesses for declaration validity, stale declarations, billing refusals, preserved failure detection, and successful-call contradictions.
- Add plugin session identifier uniqueness tests across frozen clocks, process IDs, and repeated mints.