### PR TITLE
ci: link ADR-045 from the dod-check stub header

### DIFF
--- a/.github/workflows/dod-check.yml
+++ b/.github/workflows/dod-check.yml
@@ -12,6 +12,8 @@
 # a moving ref both fails `action-pins` and lets another repository change
 # what runs here without a commit in this one. Re-pin when the implementation
 # changes, which is a reviewable one-line diff naming the version it moved to.
+# The decision and what it costs are recorded in macanderson/oxagen's
+# docs/adr/ADR-045-pin-cross-repo-reusable-workflows.md.
 name: dod-check
 
 on:
@@ -30,4 +32,4 @@ permissions:
 
 jobs:
   dod:
-    uses: macanderson/oxagen/.github/workflows/dod-check.yml@2b61b052014ebce8e4d75dc2e7905d6fda9895e8 # oxagen main, #2663
+    uses: macanderson/oxagen/.github/workflows/dod-check.yml@2dd72c9957f8520ee673862de894ed64f4b2380c # oxagen main, #2664


### PR DESCRIPTION
## What & Why

`Refs macanderson/oxagen#2664`, items 4 and 6. No behaviour change — a header
line and, in stella's case, the ref it names.

**Link the decision.** The stub header argues for pinning; it did not say where
that argument was recorded, so the next reader would rediscover it from a
comment. `ADR-045` now holds it, including what pinning costs (a fix in the
implementation does not reach a caller until it re-pins) and one property worth
knowing — pinning the workflow does not pin `scr-dod-check.mjs`, which a called
workflow always resolves from oxagen `main`.

**Name the same commit as the siblings.** #2664 asks that all four stubs point at
one oxagen commit. Three were brought to `2dd72c9` in the previous sweep; this
brings the fourth.

## Verification

The file parses and the job's `uses:` resolves to a commit that exists on
oxagen `main`. The trigger list is untouched, and the job name (`dod`) is set
here rather than by the implementation, so the required check's name does not
move — which is #2664's stated risk.

Live evidence that the trigger half works, from the sibling that landed first:
arenabench#20 was opened as a draft and marked ready at `22:33:06Z`; a `dod` run
was created at `22:33:08Z` ([run 34167050035](https://github.com/macanderson/arenabench/actions/runs/34167050035)).
That is #2664 item 3, observed rather than asserted.

Refs macanderson/oxagen#2664

## Summary by Sourcery

Align the dod-check stub with the shared workflow revision and link its pinning decision record.

Enhancements:
- Document the ADR governing the pinned cross-repository reusable workflow reference in the stub header.

CI:
- Update the dod-check workflow to reference the shared oxagen workflow at the commit used by its sibling stubs.