### PR TITLE
docs(scr): SCR-003 names the closes-nothing waiver

### DIFF
--- a/docs/scr/SCR-003-dod-verified-close.md
+++ b/docs/scr/SCR-003-dod-verified-close.md
@@ -49,9 +49,9 @@ revert — so there is no meaningful DoD to verify.
 
 `closes-nothing` says the change is substantial and closes no issue by
 design: an audit that files issues rather than closing them, a mechanical
-refactor, a sweep. Without it such a pull request had no honest route
-through the gate, because `Closes #N` would be untrue and `no-issue` claims
-a triviality that is not there.
+refactor, a sweep. Without it such a pull request had no route through the
+gate that was not a false claim: `Closes #N` would name a close that is not
+happening, and `no-issue` claims a triviality that is not there.
 
 They are labels rather than phrases in the description so that every use is
 enumerable (`is:pr label:no-issue`, `is:pr label:closes-nothing`): an escape

--- a/docs/scr/SCR-003-dod-verified-close.md
+++ b/docs/scr/SCR-003-dod-verified-close.md
@@ -41,24 +41,24 @@ comment instead of verifying a DoD. Mechanically, close these as **not
 planned** rather than completed: only a "completed" close claims the DoD was
 met, and it is the one `dod-close-guard` verifies.
 
-A pull request that closes no issue is waived from the merge gate by one of
-two labels, and which one is a claim about the change.
+A pull request that closes no issue is waived by one of two labels. Which
+one is itself a claim.
 
-`no-issue` says the change is trivial — a typo, a pinned-digest bump, a
-revert — so there is no meaningful DoD to verify.
+`no-issue` says the change is trivial: a typo, a bump, a revert. There is no
+DoD to verify.
 
-`closes-nothing` says the change is substantial and closes no issue by
-design: an audit that files issues rather than closing them, a mechanical
-refactor, a sweep. Without it such a pull request had no route through the
-gate that was not a false claim: `Closes #N` would name a close that is not
-happening, and `no-issue` claims a triviality that is not there.
+`closes-nothing` says the change is large and closes no issue by design. An
+audit that files issues rather than closing them. A refactor. A sweep.
+Without it, such a pull request had no route through the gate that was not a
+false claim. `Closes #N` would name a close that is not happening.
+`no-issue` claims a triviality that is not there.
 
-They are labels rather than phrases in the description so that every use is
-enumerable (`is:pr label:no-issue`, `is:pr label:closes-nothing`): an escape
-hatch nobody can audit becomes the default path. Keeping them separate is
-what lets a reviewer tell a small waived change from a large one at a
-glance. Reach for either when filing an issue would be pure ceremony, never
-to skip a DoD that should have been written.
+They are labels rather than phrases, so that every use is enumerable
+(`is:pr label:no-issue`, `is:pr label:closes-nothing`). An escape hatch
+nobody can audit becomes the default path. Two labels, not one, so a
+reviewer can tell a small waived change from a large one at a glance. Reach
+for either when filing an issue would be pure ceremony. Never to skip a DoD
+that should have been written.
 
 A pull request that advances an issue without finishing it links that issue
 with `Refs #N` instead of `Closes #N`. `Refs` does not close, so the merge

--- a/docs/scr/SCR-003-dod-verified-close.md
+++ b/docs/scr/SCR-003-dod-verified-close.md
@@ -41,13 +41,24 @@ comment instead of verifying a DoD. Mechanically, close these as **not
 planned** rather than completed: only a "completed" close claims the DoD was
 met, and it is the one `dod-close-guard` verifies.
 
-A pull request that closes no issue is waived from the merge gate by the
-`no-issue` label. It exists for changes with no meaningful DoD — a typo, a
-pinned-digest bump, a revert. It is a label rather than a phrase in the
-description so that every use is enumerable (`is:pr label:no-issue`): an
-escape hatch nobody can audit becomes the default path. Reach for it when
-filing an issue would be pure ceremony, never to skip a DoD that should have
-been written.
+A pull request that closes no issue is waived from the merge gate by one of
+two labels, and which one is a claim about the change.
+
+`no-issue` says the change is trivial — a typo, a pinned-digest bump, a
+revert — so there is no meaningful DoD to verify.
+
+`closes-nothing` says the change is substantial and closes no issue by
+design: an audit that files issues rather than closing them, a mechanical
+refactor, a sweep. Without it such a pull request had no honest route
+through the gate, because `Closes #N` would be untrue and `no-issue` claims
+a triviality that is not there.
+
+They are labels rather than phrases in the description so that every use is
+enumerable (`is:pr label:no-issue`, `is:pr label:closes-nothing`): an escape
+hatch nobody can audit becomes the default path. Keeping them separate is
+what lets a reviewer tell a small waived change from a large one at a
+glance. Reach for either when filing an issue would be pure ceremony, never
+to skip a DoD that should have been written.
 
 A pull request that advances an issue without finishing it links that issue
 with `Refs #N` instead of `Closes #N`. `Refs` does not close, so the merge


### PR DESCRIPTION
## What & Why

`Refs macanderson/oxagen#2551`. SCR-003 must stay byte-identical across the five
org repos (ADR-038), so this carries oxagen's wording verbatim. No logic here —
the check itself lives in oxagen.

**What changed.** The gate offered two exits, and a large PR that closes nothing
could take neither truthfully: `Closes #N` claims a close that is not happening,
and `no-issue` says the change is trivial. oxagen#1941 changed 3,285 files, filed
about 1,020 issues, closed none, and sat red on `dod` alone while every other
check passed — two automated passes stopped there rather than pick a false label.

`closes-nothing` is a second label rather than a widened `no-issue`, because the
two are different claims and SCR-003 itself asks that a reviewer still tell a
small trivial change from a large one that closes nothing. The label is created
in this repository too, so the remedy the failure message names can actually be
applied here.

## Verification

The file is byte-identical to oxagen's copy — checked by sha256 before and after,
and every one of the five was confirmed to match the pre-change version first, so
this is a sync rather than an overwrite of something that had diverged.

Refs macanderson/oxagen#2551

## Summary by Sourcery

Define separate waiver labels for trivial pull requests and substantial pull requests that intentionally close no issues.

New Features:
- Document the new `closes-nothing` waiver for large pull requests that intentionally close no issues.

Enhancements:
- Clarify the distinct purposes of the `no-issue` and `closes-nothing` labels and make their use auditable.

Documentation:
- Update SCR-003 guidance to distinguish trivial changes from substantial changes that close no issues.