### PR TITLE
docs(scr): AGENTS.md names the closes-nothing waiver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1872,7 +1872,10 @@ macanderson org repos.
   CI — not just the implementation. A PR that advances an issue without
   finishing it links it with `Refs #N` rather than `Closes #N`: `Refs`
   does not close, so the merge gate does not hold that PR against the
-  issue's DoD. A PR may carry both, and is gated only on what it closes.
+  issue's DoD. A PR may carry both, and is gated only on what it closes. A
+  PR that closes nothing is waived by a label, and which one is a claim:
+  `no-issue` for a trivial change, `closes-nothing` for a substantial one
+  that closes no issue by design.
 - **[SCR-004](docs/scr/SCR-004-residue-becomes-issues.md) — Fix over
   file:** Fix what you notice in the PR you are making; two unrelated fixes
   in one PR is fine. File an issue only when a fix cannot responsibly ride


### PR DESCRIPTION
## What & why

`Refs macanderson/oxagen#2551`. Item 8 of that issue's DoD asks that `AGENTS.md`'s compiled summary of SCR-003 match the record. The doc sync (#6450) carries the new `closes-nothing` waiver into this repo; the summary bullet does not follow it.

That matters because the compiled block is the copy an agent actually loads at session start. Without this, a session here meets the `dod` gate and cannot learn from its own context that `closes-nothing` exists — the findable-remedy problem oxagen#2551 exists to fix, one layer up.

**Nothing will go red without it.** `scr-corpus-check.mjs` compares the `AGENTS.md` bullets by id and title, deliberately not by body, because bodies legitimately differ per repo (SCR-001's bullet names each repo's own toolchain command). So this drift is invisible to the corpus gate — which is the shape its own header warns about, and what oxagen#2673 already was.

Found by a scheduled PR sweep across the org: #6450 and macanderson/context-graph-protocol#170 each touch `docs/scr/` and nothing else, so four of five repos would carry a stale summary after that sweep landed. The same one-sentence commit goes to all four siblings.

**Sequencing.** This is independent of #6450 and can land in either order. Between the two merges the repo is briefly inconsistent one way or the other; neither direction fails a gate.

## The witness

- [ ] This PR includes a witness test (fails on `main`, passes here)
- [x] No witness needed (pure refactor / docs / CI) — one sentence of prose in `AGENTS.md`. There is no assertion to write: the gate that could check it (`scr-corpus-check`) compares bullet ids and titles by design, and widening it to bodies would fail on SCR-001, which is legitimately per-repo.

## The gate

Nothing here compiles — one markdown file — so the cargo rungs are CI's.

- [x] `python3 scripts/check-prose.py` — OK, none added (judged against `b3b9d74f0887`)
- [x] `python3 scripts/check-line-citations.py` — OK, none added
- [x] The bullet is **byte-identical** to oxagen's copy in macanderson/oxagen#2742 — extracted the `SCR-003` block from both `AGENTS.md` files and diffed; no difference. Same check run against context-graph-protocol, cgp-website and arenabench: all four identical.
- [ ] `shellcheck` — **UNAVAILABLE, THIS CHECK DID NOT RUN.** The agent container ships none (#3830). No shell changed here regardless.
- [ ] `cargo fmt --check` / `clippy` / `test --workspace` — not run; no Rust changed, CI owns them
- [x] CLA signed

## Fix over file

- [x] Extra fixes in this PR: none
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] N/A — no cross-boundary types

## Anything reviewers should know?

**What this does not establish.** That the wording is *right* — that is oxagen#2742's review. This establishes only that this repo's summary says the same thing as oxagen's, which is what item 8 asks and what the corpus contract requires.

Opened as a draft: it is one of four identical sibling PRs, and the reviewer may prefer to take them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ae6QzuSditxAU2T528g8u

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ae6QzuSditxAU2T528g8u)_

## Summary by Sourcery

Align the AGENTS.md SCR-003 summary with the documented no-issue waiver policy.

Enhancements:
- Update the compiled SCR-003 guidance in AGENTS.md to document the `no-issue` and `closes-nothing` waiver labels for pull requests that close no issue.

Documentation:
- Synchronize the AGENTS.md SCR-003 summary with the repository’s documented waiver policy.