### PR TITLE
ci(dod): re-pin the dod-check stub so the closes-nothing waiver reaches us

### DIFF
--- a/.github/workflows/dod-check.yml
+++ b/.github/workflows/dod-check.yml
@@ -32,4 +32,4 @@ permissions:
 
 jobs:
   dod:
-    uses: macanderson/oxagen/.github/workflows/dod-check.yml@2dd72c9957f8520ee673862de894ed64f4b2380c # oxagen main, #2664
+    uses: macanderson/oxagen/.github/workflows/dod-check.yml@587435a133e3c8ac8fb6473ca5212939f5f064aa # oxagen main, #2551


### PR DESCRIPTION
One line: the `dod-check` caller stub re-pinned from oxagen `2dd72c99` to `587435a1`.

## Why

`2dd72c99` predates the `closes-nothing` label (macanderson/oxagen#2551). The label exists in this repository, so a PR that closes no issue by design is told to apply it — and applying it changes nothing, because the pinned implementation never reads it. The remedy the failure message names does not work here.

This is the re-pin that pinning owes. oxagen ADR-045 chose a commit SHA over `@main` so another repository cannot change this repository's required check without a commit in it; the cost of that choice is exactly this PR, and paying it is how the choice stays honest.

## What else moves with it

The pin also picks up the fix for the hole found reviewing oxagen#2742: a waiver label short-circuited before the body was parsed, so `closes-nothing` **plus** `Closes #N` skipped that issue's DoD. Both waiver labels now refuse a PR that closes something.

## Verification

`gh api compare` reports one file, `+1/-1`, in every one of the four repos taking this change. Nothing but the ref moved.

Refs macanderson/oxagen#2551

## Summary by Sourcery

Re-pin the DoD check workflow to a revision that correctly handles issue-closing waiver labels.

Bug Fixes:
- Update the pinned DoD check workflow so the `closes-nothing` waiver is recognized and cannot bypass checks for PRs that close an issue.

CI:
- Re-pin the shared `dod-check` workflow from the outdated oxagen commit to the corrected revision.