### PR TITLE
docs(adr): the host does not pick the tests that verify a change

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,21 +145,23 @@ Lint/typecheck are rightly excluded from the flip oracle. But they can still
   the pre-submit audit — lint before the confirmation run, since a veto
   makes the confirmation moot — and degrades open on every unavailable
   path.
-- **Impacted-test scope for Rust.** No shipping surface exposes impacted-test
-  selection today. The design (#443, #862) resolves Rust `use`/`mod` edges
-  through the workspace module tree — including cross-crate paths — and
-  narrows to the owning cargo packages; an unrelated crate is left out, and a
-  missing or stale index stands down loudly. What remains is **using** impacted
-  selection as ladder evidence, and the constraint that shapes it: the oracle's identity
-  is the *normalized command*, and the impacted selection is derived from
-  the diff — which does not exist when the baseline pre-run fires. A
-  per-turn narrowed command would differ between baseline and candidate and
-  the oracle would rightly ignore the pass. The viable route is the
-  isolated-candidate path, where the session tree stays pristine through
-  execution: both halves of the flip can be observed at verify time with
-  the *same* diff-derived `cargo test -p …` invocation. That is a
-  restructuring of when the baseline is observed, not a bolt-on — design
-  first, then build.
+- **Impacted-test scope for Rust.** *Settled — the host does not select
+  (ADR 0040).* The selector this item described is gone: #3236 deleted
+  `CodeGraph::importer_paths` when the tool purge took its consumer, and
+  `run_tests` is a retired name in `crates/stella-tool-facts/src/catalog.rs`.
+  The raw relation `store::importers_of` is still indexed.
+
+  The constraint that shaped the item survives and is why it is settled rather
+  than pending. The flip's identity is the *normalized command*, and an
+  impacted selection is derived from the diff, which does not exist when the
+  baseline pre-run fires. A per-turn narrowed command would differ between
+  baseline and candidate and the flip would rightly ignore the pass. The
+  isolated-candidate route this item named would observe both halves at verify
+  time with the same diff-derived invocation — and it asks the host to derive a
+  command, run it, and credit the pair, which is the host authoring the proof it
+  then evaluates. A verification plugin holding the granted root may narrow for
+  itself; what it reports is its own claim, graded
+  `EvidenceProvenance::PluginReported`.
 - **Touched-tests set widening.** *Superseded.* The ladder runs exactly one
   typed invocation per iteration (the configured `--test-command`, else the
   witness command) and re-runs it after every revise turn, so there is no
@@ -229,7 +231,8 @@ verifier-pass never beats a warned deterministic pass.
 | 2 | §1 assertion-density check (#863), §4 structured verifier evidence (#864), §6 verdict provenance (#865) | **Done** — #863 earlier; PR #1035 |
 | 3 | §2 failure fingerprints (#867), §4 early distress guidance (#868, already satisfied), §5 score refinement (#869) | **Done** — PR #1049 |
 | 4 | §1 mutation check (#870), §4 calibration telemetry (#871) | **Done** — PRs #1052, #1055 |
-| — | §1 diff-coverage (needs a coverage-tooling decision), §3 impacted selection as ladder evidence (see the design constraint above) | Remaining |
+| — | §1 diff-coverage (needs a coverage-tooling decision) | Remaining |
+| — | §3 impacted selection as verification evidence | **Settled** — ADR 0040 |
 
 The per-PR degradation gate (`pipeline/tests/degradation_gate.rs`, PR #1038,
 `docs/spec/verification-gate.md`) now pins every decision and its spend, so each

--- a/crates/stella-plugin/src/host_call.rs
+++ b/crates/stella-plugin/src/host_call.rs
@@ -1133,6 +1133,35 @@ mod tests {
         }
     }
 
+    /// `run_test` runs the command the grant carried. A plugin cannot swap in
+    /// one of its own.
+    ///
+    /// [`RunTestArgs`] has one field for that reason (ADR 0040). Picking the
+    /// tests that decide "done" is authoring the proof. A `program` or `args`
+    /// key here would turn a capability consented to as "re-run my tests" into
+    /// an ungated shell in the granted root. Nothing else held the shape:
+    /// `RunTestArgs` derives no JSON schema, so `docs/wire/wrapper.wire.json`
+    /// never described it, and the `wire-schema` gate cannot see a field added
+    /// here.
+    #[test]
+    fn a_run_test_ask_cannot_carry_its_own_invocation() {
+        assert!(
+            decode(r#"{"call":"run_test","id":1,"args":{"candidate":"cand-1"}}"#).is_ok(),
+            "the handle alone is the whole ask"
+        );
+        for (extra, key) in [
+            (r#""program":"pytest""#, "program"),
+            (r#""args":["-k","impacted"]"#, "args"),
+            (r#""command":"cargo test -p stella-core""#, "command"),
+        ] {
+            let error = decode(&format!(
+                r#"{{"call":"run_test","id":1,"args":{{"candidate":"cand-1",{extra}}}}}"#
+            ))
+            .expect_err("a narrowed invocation is refused, never ignored");
+            assert!(error.to_string().contains(key), "{key}: {error}");
+        }
+    }
+
     /// The #3500 rule, on the union: an unknown key is a typo, and a typo that
     /// decodes cleanly is a plugin author debugging a silence.
     #[test]

--- a/crates/stella-plugin/src/host_call.rs
+++ b/crates/stella-plugin/src/host_call.rs
@@ -1139,10 +1139,14 @@ mod tests {
     /// [`RunTestArgs`] has one field for that reason (ADR 0040). Picking the
     /// tests that decide "done" is authoring the proof. A `program` or `args`
     /// key here would turn a capability consented to as "re-run my tests" into
-    /// an ungated shell in the granted root. Nothing else held the shape:
-    /// `RunTestArgs` derives no JSON schema, so `docs/wire/wrapper.wire.json`
-    /// never described it, and the `wire-schema` gate cannot see a field added
-    /// here.
+    /// an ungated shell in the granted root.
+    ///
+    /// A field added to the struct fails to compile in `wire_corpus.rs`, which
+    /// builds its `run_test` example as a struct literal. The *refusal* was
+    /// held by nothing: `RunTestArgs` derives no JSON schema, so
+    /// `docs/wire/wrapper.wire.json` carries an example and no shape the
+    /// `wire-schema` gate can check. Drop `deny_unknown_fields` and a narrowed
+    /// command is silently ignored instead of refused.
     #[test]
     fn a_run_test_ask_cannot_carry_its_own_invocation() {
         assert!(

--- a/crates/stella-runtime/src/wrapper/test_run.rs
+++ b/crates/stella-runtime/src/wrapper/test_run.rs
@@ -20,7 +20,7 @@
 //! the granted root. A plugin that wants a narrower suite runs it in its own
 //! process, against the root its grant names, and reports it as its own claim.
 //! `stella_plugin`'s `a_run_test_ask_cannot_carry_its_own_invocation` is what
-//! fails when the shape is widened.
+//! fails when the refusal is dropped.
 //!
 //! # The handle is re-resolved host-side, every time
 //!

--- a/crates/stella-runtime/src/wrapper/test_run.rs
+++ b/crates/stella-runtime/src/wrapper/test_run.rs
@@ -13,6 +13,15 @@
 //! program, no argv, no timeout. The plan is the one the grant already carried,
 //! so a plugin that wanted to know what ran already knows.
 //!
+//! The absent argv is a decision rather than a slice boundary (ADR 0040). A
+//! plugin choosing which tests decide "done" and the host running them is the
+//! host crediting a proof whose red half it never watched, and the field would
+//! turn a capability consented to as "re-run my tests" into an ungated shell in
+//! the granted root. A plugin that wants a narrower suite runs it in its own
+//! process, against the root its grant names, and reports it as its own claim.
+//! `stella_plugin`'s `a_run_test_ask_cannot_carry_its_own_invocation` is what
+//! fails when the shape is widened.
+//!
 //! # The handle is re-resolved host-side, every time
 //!
 //! That is the whole security shape of this capability and it is one sentence:

--- a/docs/adr/0040-host-does-not-pick-the-tests.md
+++ b/docs/adr/0040-host-does-not-pick-the-tests.md
@@ -97,12 +97,16 @@ should be that loose. The tight door is the one to refuse.
 again. It looks like a small additive field. It turns a capability a human
 consented to as `calls = ["run_test"]` into an ungated shell. That shell runs at
 the host's authority, in the granted root. This workspace has one shell, `bash`,
-and the user approves what it runs. Nothing held the shape:
-`RunTestArgs` derives no JSON schema, so `docs/wire/wrapper.wire.json` never
-described it, and the `wire-schema` gate cannot see a field added to it. Delete
-its `deny_unknown_fields` today and the host quietly drops a narrowed command a
-plugin sends. No test in the tree fails.
-`a_run_test_ask_cannot_carry_its_own_invocation` is that test.
+and the user approves what it runs.
+
+Adding a field to the struct does redden something: `wire_corpus.rs` builds its
+`run_test` example as a Rust struct literal, so a new field fails to compile
+there. The *refusal* was held by nothing. `RunTestArgs` derives no JSON schema,
+so `docs/wire/wrapper.wire.json` carries an example message and no shape the
+`wire-schema` gate can check. Delete its `deny_unknown_fields` and the host
+quietly drops a narrowed command a plugin sends, rather than refusing it. Before
+`a_run_test_ask_cannot_carry_its_own_invocation`, no test in the tree failed on
+that — measured, with the attribute removed.
 
 **Run the narrowed set at both moments in an isolated candidate.** Sound, and
 `ROADMAP.md` §3 named it. The session tree stays clean through the turn, so the

--- a/docs/adr/0040-host-does-not-pick-the-tests.md
+++ b/docs/adr/0040-host-does-not-pick-the-tests.md
@@ -86,9 +86,12 @@ guess. The code graph is an import index over tree-sitter parses. It cannot see
 reflection, dynamic imports, fixtures, data files, or a test that drives a built
 binary. A call with that name hands back a list the plugin cannot check and has
 every reason to trust. The guess is still the host's. `recall` is the door to
-the same index that says what it is: importer frames among its results, scored,
+the same index that says what it is. It fans out over `codegraph.db`, and the
+code-graph provider renders importer frames among what comes back — scored,
 budget-packed, labelled as retrieval. A plugin asks it for material rather than
-for a verdict.
+for a verdict. It is a loose door: `RecallArgs` carries a goal and a limit, so a
+plugin cannot anchor a query on the exact file it cares about. A heuristic
+should be that loose. The tight door is the one to refuse.
 
 **A `program` and `args` pair on `RunTestArgs`.** Someone will propose this
 again. It looks like a small additive field. It turns a capability a human

--- a/docs/adr/0040-host-does-not-pick-the-tests.md
+++ b/docs/adr/0040-host-does-not-pick-the-tests.md
@@ -1,0 +1,110 @@
+---
+id: adr/0040-host-does-not-pick-the-tests
+title: "ADR 0040: The host does not pick the tests"
+status: implemented
+---
+
+# ADR 0040: The host does not pick the tests
+
+- Status: accepted
+- Date: 2026-09-07
+- Decides: `#1292`
+- Not part of the Phase 0 series.
+
+## Context
+
+Running a whole suite to prove one change is slow. Running only the tests a
+change touches is cheap. `#1292` asked for that saving. It also asked for the
+result to count as evidence.
+
+The selector it names is gone. `run_tests` is a retired name in
+`crates/stella-tool-facts/src/catalog.rs`. `#3236` deleted
+`CodeGraph::importer_paths` when the tool purge took its only caller.
+`crates/stella-graph/src/graph.rs` says so, in
+`the_importer_relation_lists_files_whose_imports_resolve_here`. The raw
+relation is still indexed. Nothing picks tests with it.
+
+Host-run verification is gone as well (`#3865`). A check runs inside an
+installed plugin's `[oracle]`. Stella grades that evidence against the plugin's
+own rule and never runs it again. So the open question is not whether to narrow
+a suite. It is who may pick the command, and what a pass may then claim.
+
+Timing is the hard part. `ROADMAP.md` §3 has said so since before the pipeline
+was deleted. A flip is one command watched twice: red, then green. The red half
+is watched before the turn. `grant_shared_tree` in
+`crates/stella-cli/src/wrapper_candidate.rs` runs the granted command once and
+stamps `TestPlan::baseline` with what it saw. An impacted set comes from the
+diff. At that moment there is no diff. Pick before the turn and there is nothing
+to pick on. Pick after it and the two halves are different commands. That pair
+is not a flip.
+
+## Decision
+
+**The host does not pick the tests, and gains no capability that does.** No
+`HostCall` returns an impacted set. `run_test` runs the command the grant
+carried.
+
+**A plugin may narrow inside its own oracle.** On the shared-tree path the
+grant carries a real root. A plugin holding it can work out any command it
+likes and run it in its own process. What comes back is
+`EvidenceProvenance::PluginReported`. That is the grade `#3511` already set for
+everything a plugin watches, and it is the grade a self-picked suite earns.
+
+**A narrowed run cannot borrow the wide run's red half.** The baseline belongs
+to the granted `program` and `args`. A plugin that reports
+`FlipObservation::Achieved` about some other command is claiming a flip whose
+red nobody saw. The provenance says whose claim that is. The host does not
+raise it.
+
+## Consequences
+
+Stella ships no impacted-test selector, and will not bring one back. A slow
+suite still costs one baseline run of the `--test-command` the user named. That
+run buys the red half. Without it, a green suite afterwards proves nothing.
+
+A plugin cannot narrow on a fan-out candidate. `CandidateHandle` is opaque by
+design. `crates/stella-runtime/src/wrapper/test_run.rs` puts it plainly: a
+plugin says which workspace, never where it is. With no path there is nothing to
+run a command against. Narrowing there would need the host to run the plugin's
+command, which is what this record refuses.
+
+`ROADMAP.md` §3 described the deleted selector in the present tense. It also
+named the isolated-candidate path as the way in. Both are rewritten to what the
+tree holds, and point here.
+
+## Alternatives considered
+
+**The host works out the impacted set and narrows the command.** Then the host
+authors the proof it grades. `crates/stella-cli/src/wrapper_candidate.rs`
+already refuses the smaller version: deriving a witness file from a runner's
+convention. `BeforeTurnResponse::witness` exists because of that refusal.
+Picking which tests decide "done" is the larger claim. The host cannot be the
+one to make it.
+
+**A `HostCall::ImpactedTests` a plugin asks for.** It reads as a fact. It is a
+guess. The code graph is an import index over tree-sitter parses. It cannot see
+reflection, dynamic imports, fixtures, data files, or a test that drives a built
+binary. A call with that name hands back a list the plugin cannot check and has
+every reason to trust. The guess is still the host's. `recall` is the door to
+the same index that says what it is: importer frames among its results, scored,
+budget-packed, labelled as retrieval. A plugin asks it for material rather than
+for a verdict.
+
+**A `program` and `args` pair on `RunTestArgs`.** Someone will propose this
+again. It looks like a small additive field. It turns a capability a human
+consented to as `calls = ["run_test"]` into an ungated shell. That shell runs at
+the host's authority, in the granted root. This workspace has one shell, `bash`,
+and the user approves what it runs. Nothing held the shape:
+`RunTestArgs` derives no JSON schema, so `docs/wire/wrapper.wire.json` never
+described it, and the `wire-schema` gate cannot see a field added to it. Delete
+its `deny_unknown_fields` today and the host quietly drops a narrowed command a
+plugin sends. No test in the tree fails.
+`a_run_test_ask_cannot_carry_its_own_invocation` is that test.
+
+**Run the narrowed set at both moments in an isolated candidate.** Sound, and
+`ROADMAP.md` §3 named it. The session tree stays clean through the turn, so the
+same diff-derived command runs red on the base and green on the candidate. It
+needs the host to derive a command, run it on a tree it picked, and credit the
+pair. Every clause there is one this record refuses. A plugin can build the same
+thing for itself once it can reach a candidate's tree. What it reports stays its
+own claim.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -106,6 +106,7 @@ open; nothing before Phase 3 forces it.
 | [0037](0037-a-credit-balance-lives-outside-the-engine.md) | A Credit Balance Lives Outside the Engine | Accepted |
 | [0038](0038-a-night-that-mostly-died-is-not-a-run.md) | A Night That Mostly Died Is Not a Run | Accepted |
 | [0039](0039-a-live-smoke-provider-is-armed-or-declared-unarmed.md) | A Live Smoke Provider Is Armed or Declared Unarmed | Accepted |
+| [0040](0040-host-does-not-pick-the-tests.md) | The Host Does Not Pick the Tests | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -236,6 +237,14 @@ re-asked on every run, so a row goes red the moment it stops being true — a
 credential that appears, one that vanishes, or an empty account that gets
 funded. A provider declared unfunded still calls its endpoint, because an empty
 account is refused for free and only a refusal naming the balance passes.
+
+ADR 0040 answers who may choose the tests that verify a change. Not the host:
+picking which tests decide "done" is authoring the proof the host then
+evaluates, and the same refusal already covers deriving a witness artifact from
+a runner's convention. A verification plugin holding the granted root may narrow
+for itself, and what it reports is graded as its own claim. `run_test` keeps
+running the invocation the grant carried, which is why its ask carries a
+workspace handle and nothing else.
 
 ## The number is a shared cell
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -200,6 +200,11 @@
       "status": "implemented",
       "title": "ADR 0039: A live smoke provider is armed or declared unarmed"
     },
+    "adr/0040-host-does-not-pick-the-tests": {
+      "path": "docs/adr/0040-host-does-not-pick-the-tests.md",
+      "status": "implemented",
+      "title": "ADR 0040: The host does not pick the tests"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",


### PR DESCRIPTION
## What & why

`#1292` asked for impacted-test selection to count as verification evidence.
Both premises it was filed on are false on `main`, which the long comment on the
issue established: the selector was deleted with the tool purge (`#3236` took
`CodeGraph::importer_paths` because "its consumer (impacted-scope selection)
went with the tool purge"; `run_tests` is a retired name in
`crates/stella-tool-facts/src/catalog.rs`), and host-run verification went with
`#3865`. What it left open was an architecture question, and SCR-002 says decide
it and record it rather than escalate it.

**ADR 0040 decides who picks the tests.** Not the host, and no capability is
added that does.

- Picking which tests decide "done" is authoring the proof the host then grades.
  `crates/stella-cli/src/wrapper_candidate.rs` already refuses the smaller
  version of that act — deriving a witness file from a runner's convention — and
  `BeforeTurnResponse::witness` exists because of that refusal. Invariant 1 is
  respected by keeping the boundary where it is: the code graph stays behind
  `recall`, which returns importer frames as scored retrieval rather than as a
  derived verdict.
- A plugin holding the granted root may narrow inside its own oracle. What it
  reports is `EvidenceProvenance::PluginReported`, the grade `#3511` already set
  for everything a plugin observes.
- A narrowed run cannot borrow the wide run's red half. The baseline the host
  observed belongs to the granted `program` and `args`.

**What this gives up**, stated plainly: Stella ships no impacted-test selector
and will not restore one, so a slow suite still costs one baseline run of the
`--test-command` the user named. A plugin on a fan-out candidate cannot narrow
at all, because `CandidateHandle` is opaque and it has no path to run against.
Both are in the ADR's Consequences.

Closes #1292

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`stella_plugin`'s `a_run_test_ask_cannot_carry_its_own_invocation`
(`crates/stella-plugin/src/host_call.rs`).

Adding a *field* to `RunTestArgs` does redden something — `wire_corpus.rs`
builds its `run_test` example as a Rust struct literal, so a new field fails to
compile there. The **refusal** was held by nothing. `RunTestArgs` derives no
`schemars::JsonSchema`, so `docs/wire/wrapper.wire.json` carries an example
message and no shape the `wire-schema` gate can check. Deleting
`deny_unknown_fields` makes the host **silently drop** a narrowed
`program`/`args` a plugin sends — ignored rather than refused — and no test in
the tree fails.

Verified the artisanal way — with the attribute removed:

```
---- host_call::tests::a_run_test_ask_cannot_carry_its_own_invocation stdout ----
panicked at crates/stella-plugin/src/host_call.rs:1159:14:
a narrowed invocation is refused, never ignored: Call(HostCallRequest { id: 1,
  args: RunTest(RunTestArgs { candidate: CandidateHandle("cand-1") }) })
test result: FAILED. 221 passed; 1 failed
```

and with it restored: `222 passed; 0 failed`.

## The gate

Run scoped, per CLAUDE.md's "CI builds and tests; this laptop does not" — CI is
this PR's evidence.

- [x] `make guards-fast` (includes `cargo fmt --check`, `adr-numbering`,
      `lockfile-sync`, `prose`, `line-citations`) — OK
- [x] `cargo clippy -p stella-plugin --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-plugin --lib` — 222 passed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p stella-runtime --no-deps
      --document-private-items` — clean
- [x] Docs updated: `docs/adr/README.md` index row and summary,
      `docs/manifest.json` (regenerated via `make doc-links-fix`),
      `ROADMAP.md` §3, and the module docs on
      `crates/stella-runtime/src/wrapper/test_run.rs` and `RunTestArgs`
- [x] `Closes #1292` appears both above and as a commit trailer

## Fix over file

- [x] Extra fixes in this PR: **`ROADMAP.md` §3's "Impacted-test scope for
      Rust" entry.** It described the deleted selector in the present tense
      ("The design (#443, #862) resolves Rust `use`/`mod` edges…"), said what
      remained was "using impacted selection as **ladder** evidence" after the
      ladder was deleted, and named the isolated-candidate path as the route in
      — host machinery this workspace no longer has. Three false premises for
      anyone who read it, which is what happened to this issue's own
      investigation. Rewritten to what the tree holds; the sequencing table row
      moves from "Remaining" to "Settled".
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new deps
- [x] No new outbound network calls
- [x] No new cross-boundary type — this PR pins the shape of an existing one

## Anything reviewers should know?

**No behaviour changes.** The decision is that the boundary stays where it is,
so the deliverable is the record plus the test that keeps the boundary from
moving silently, plus the doc that was lying about it. Inventing code to look
busy here would have been the wrong deliverable.

**No test was deleted.**

The one thing to push back on, if you disagree: the ADR closes the door on a
`program`/`args` pair for `RunTestArgs` and on a `HostCall::ImpactedTests`. Both
are argued in Alternatives considered — the first as a privilege escalation
wearing a friendly name, the second as a heuristic dressed as a fact. If either
should stay open, that is the paragraph to argue with.

## Summary by Sourcery

Document and enforce that verification plugins, not the host, choose any narrowed test suite while keeping host-run tests bound to their granted invocation.

Enhancements:
- Record ADR 0040 establishing that the host does not select verification tests and that plugins may narrow suites only within their own reported evidence.
- Clarify that `run_test` executes only the invocation carried by its grant, preserving the existing verification boundary and provenance rules.

Documentation:
- Add ADR 0040 to the documentation index and manifest, and update the roadmap and runtime documentation to reflect the settled impacted-test selection decision.

Tests:
- Add a regression test ensuring `run_test` rejects plugin-supplied program, argument, or command overrides.