### PR TITLE
fix(skills): aim the holdout at the skills whose control arm is short

### DIFF
--- a/crates/stella-cli/src/memory.rs
+++ b/crates/stella-cli/src/memory.rs
@@ -852,6 +852,20 @@ impl SessionMemory {
     /// that costs the experiment samples and cannot cost it correctness. The
     /// catalog is read only on a turn the schedule armed and pointed at
     /// skills, which is one holdout in the length of `trials::HOLDOUT_ARMS`.
+    ///
+    /// **The catalog is then narrowed to the skills that still need a control
+    /// sample.** The budget is small. One skill holdout comes round every
+    /// `artifact_holdout_rate` × `trials::HOLDOUT_ARMS` turns. Rotating over
+    /// the whole catalog divides that again by the number of skills. A
+    /// workspace with a dozen skills gives each one a turn every few hundred,
+    /// and most of those go to skills already measured. Each verdict needs
+    /// `min_samples_per_arm` of them.
+    ///
+    /// The narrowing reads the ledger, not the shortlist. So every site still
+    /// computes the same set: trials are written at turn end, and the file
+    /// cannot change under a turn. When no skill is short, the whole catalog
+    /// comes back. That is what keeps a skill that decays later in the
+    /// rotation.
     fn apply_holdout(&self, selection: &mut skills::SkillSelection) -> Option<String> {
         let ordinal = self.holdout_ordinal?;
         // One item goes per turn, and three kinds share the schedule
@@ -861,7 +875,23 @@ impl SessionMemory {
             return None;
         }
         let loaded = self.load_skills();
-        let names: Vec<&str> = loaded.iter().map(|s| s.name.as_str()).collect();
+        let counts = appraisals::control_arm_counts(
+            &self.workspace_root,
+            stella_learn::ledger::ArtifactKind::Skill,
+        );
+        let bar = stella_learn::skills::appraisal::AppraisalConfig::default()
+            .selection
+            .min_samples_per_arm;
+        let starved: Vec<&str> = loaded
+            .iter()
+            .map(|s| s.name.as_str())
+            .filter(|name| counts.get(*name).copied().unwrap_or(0) < bar)
+            .collect();
+        let names: Vec<&str> = if starved.is_empty() {
+            loaded.iter().map(|s| s.name.as_str()).collect()
+        } else {
+            starved
+        };
         let held = stella_learn::holdout::pick(ordinal, &names)?;
         let before = selection.selected.len();
         selection.selected.retain(|s| s.skill.name != held);

--- a/crates/stella-cli/src/memory/appraisals.rs
+++ b/crates/stella-cli/src/memory/appraisals.rs
@@ -318,6 +318,30 @@ pub fn sweep(
     out
 }
 
+/// How many **control-arm** trials the ledger holds for each id of `kind` —
+/// turns the artifact's trigger matched and it was not injected.
+///
+/// The scarce half of every appraisal. A with-skill trial is written by any
+/// ordinary turn, so that arm fills on its own; the control arm is written
+/// only when something withheld the artifact on a turn that matched it. The
+/// holdout schedule reads this to aim itself: an id already carrying a full
+/// arm does not need the next holdout turn, and one carrying none cannot be
+/// judged without it.
+///
+/// An id with no trials at all is absent rather than zero. A caller asking
+/// about a whole catalog reads a missing entry as zero, which is what it
+/// means — nothing has been recorded about it yet.
+pub fn control_arm_counts(workspace_root: &Path, kind: ArtifactKind) -> HashMap<String, usize> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for stored in stored_trials(workspace_root) {
+        if stored.kind != kind || stored.trial.selected {
+            continue;
+        }
+        *counts.entry(stored.id).or_default() += 1;
+    }
+    counts
+}
+
 /// How many of the newest appraisals of `skill` under `kind` are demotable
 /// verdicts (`Harms` or `Inert`), counted back from the ledger's end until the
 /// first verdict that is not.

--- a/crates/stella-cli/src/memory/learning/skill_lifecycle.rs
+++ b/crates/stella-cli/src/memory/learning/skill_lifecycle.rs
@@ -477,6 +477,97 @@ async fn a_holdout_turn_writes_a_control_arm_trial_for_the_skill_it_withheld() {
     );
 }
 
+/// A workspace with two hand-authored skills, both worded to match
+/// [`MATCHING_PROMPT`], named so the alphabetically first one is the one the
+/// unaimed rotation would reach for.
+fn workspace_with_two_skills() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for name in ["alpha-notes", "zulu-notes"] {
+        let skill_dir = dir.path().join(".stella").join("skills").join(name);
+        std::fs::create_dir_all(&skill_dir).expect("skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {LESSON}\n---\n\n{LESSON}\n"),
+        )
+        .expect("write skill");
+    }
+    dir
+}
+
+/// Seed `count` control-arm trials for `skill` — turns it matched and was not
+/// injected — straight into the ledger the holdout reads.
+fn seed_control_arm(root: &Path, skill: &str, count: usize) {
+    for _ in 0..count {
+        appraisals::record_turn(
+            root,
+            ArtifactKind::Skill,
+            &[skill.to_string()],
+            &[],
+            &SkillTrial {
+                task: appraisals::LIVE_WINDOW_TASK.to_string(),
+                selected: false,
+                outcome: TaskOutcome {
+                    succeeded: true,
+                    cost_usd: 0.0,
+                    tokens: 0,
+                    retries: 0,
+                },
+                turns: 1,
+            },
+        );
+    }
+}
+
+/// **The holdout aims at the skill that needs the sample.**
+///
+/// A skill holdout comes round once in `artifact_holdout_rate` × the number of
+/// holdout arms, and rotating it over the whole catalog divides that again by
+/// the number of skills. Spent evenly, most of those turns go to skills whose
+/// control arm is already full, while the skill waiting on one keeps missing
+/// its slot — and a skill with no control arm can never be judged at all.
+///
+/// Here `alpha-notes` already carries a full arm and `zulu-notes` carries
+/// none. The unaimed rotation picks the alphabetically first name, so it would
+/// spend this turn on `alpha-notes` and leave `zulu-notes` no closer to a
+/// verdict. Sorting is what makes the negative control exact: `alpha-notes` is
+/// what `holdout::pick` returns for this ordinal over the full catalog.
+#[tokio::test]
+async fn the_holdout_picks_the_skill_whose_control_arm_is_short() {
+    let dir = workspace_with_two_skills();
+    let bar = AppraisalConfig::default().selection.min_samples_per_arm;
+    seed_control_arm(dir.path(), "alpha-notes", bar);
+
+    let mut memory = session(dir.path());
+    // Turn 1 is not a holdout turn at rate 2; turn 2 is holdout ordinal 0,
+    // which the arm rotation points at skills.
+    assert!(
+        !memory.arm_controls_at(0, 2),
+        "the plane control is off here"
+    );
+    let both = memory.note_turn_skills(MATCHING_PROMPT);
+    assert_eq!(
+        both.len(),
+        2,
+        "both skills must match, or the pick has nothing to choose between: {both:?}"
+    );
+    memory
+        .record_episode(MATCHING_PROMPT, EpisodeOutcome::Success, &[], 1_000, None)
+        .await;
+
+    assert!(!memory.arm_controls_at(0, 2), "still no plane control");
+    let injected: Vec<String> = memory
+        .note_turn_skills(MATCHING_PROMPT)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+
+    assert_eq!(
+        injected,
+        vec!["alpha-notes".to_string()],
+        "the holdout must withhold the starved skill and leave the measured one in"
+    );
+}
+
 /// **The two schedules cannot land on the same turn.** A turn the plane
 /// control already took claims no holdout number, so the holdout's counter
 /// advances only over the turns it could act on.

--- a/website/content/docs/configuration/settings.mdx
+++ b/website/content/docs/configuration/settings.mdx
@@ -636,7 +636,10 @@ what confirmation a blocking directive needs. Confidence values are on a `0`–`
     plane, and the per-artifact holdout (`context.retrieval.artifact_holdout_rate`), which
     withholds one matched artifact and leaves the rest of the turn alone. That holdout
     serves memories, skills and records in turn, so a skill's own arm comes round every
-    third time it fires. Set both to `0` and
+    third time it fires. When it does, it picks a skill whose control arm is still short.
+    Those turns then go to the skills that cannot be judged without them. Once every skill
+    has been measured, it rotates over all of them again, so a skill that decays later is
+    still caught. Set both to `0` and
     there is no baseline to measure against: appraisals stay `Insufficient`, and nothing is
     promoted or retired on measurement.
   </OptionCard>


### PR DESCRIPTION
## What & why

The per-artifact holdout is the only source of a **paired** control trial for a skill — the plane-wide recall control withholds everything at once, so the turn it leaves behind cannot say which artifact the outcome belongs to. That paired budget is scarce, and today it is spent evenly rather than where it is needed.

One skill holdout comes round every `artifact_holdout_rate` × `HOLDOUT_ARMS` turns — 60 at the shipped defaults — and `apply_holdout` then rotates the pick over the **whole loaded catalog**, dividing that again by the number of skills. A workspace with a dozen skills offers each one a control turn every few hundred, and spends most of them on skills whose arm is already full. A verdict needs `min_samples_per_arm` (5) of them.

So a skill can sit at `Unevaluated` indefinitely: never promoted from the queue under the shipped `require_measured_lift: true`, and never retired when it stops helping. Nothing is wrong — `Insufficient` is the honest verdict — but the loop does not close in a workspace where it should.

The memory and rule arms never had this problem: `held_for` picks from the population the pass actually offered. The skill arm is the outlier.

## The change

The pick reads the same catalog, narrowed to the skills whose control arm is below `min_samples_per_arm`. When none is short the full catalog comes back, so the rotation continues once everything has been measured and a skill that decays later still gets its turn.

**Why the ledger and not the shortlist.** `apply_holdout`'s existing argument is that every injection site runs its own scoring pass — recall scopes domains by the paths a turn touched, this seam by the prompt alone — so only a set computed from state they all share makes them agree on which skill is held back. Picking from the caller's shortlist would break that. The trial ledger is shared state, and trials are written at turn end, so the file cannot change under a turn. The narrowing keeps the property intact.

`appraisals::control_arm_counts` is the query: trials per id where the artifact matched and was **not** injected — the arm that does not fill on its own.

No new configuration. The aiming is strictly an allocation of the budget `artifact_holdout_rate` already sets, so it cannot cost a user more than today.

## The witness

Stella's definition of done is a test that **fails on the old code and passes on the new**.

- [x] This PR includes a witness test (fails on `main`, passes here)
- [ ] No witness needed (pure refactor / docs / CI) — because:

`the_holdout_picks_the_skill_whose_control_arm_is_short` seeds a full control arm for `alpha-notes`, leaves `zulu-notes` with none, and asserts the holdout takes `zulu-notes`. Sorted order is what makes the negative control exact — `alpha-notes` is precisely what `holdout::pick` returns over the full catalog for that ordinal, so on `main` the test fails by withholding the skill that was already measured:

```
---- the_holdout_picks_the_skill_whose_control_arm_is_short stdout ----
  ! holding back skill `alpha-notes` this turn, to measure whether it helps
assertion `left == right` failed: the holdout must withhold the starved skill and leave the measured one in
  left: ["zulu-notes"]
 right: ["alpha-notes"]
```

## The gate

- [x] `cargo fmt --check`
- [x] `cargo clippy -p stella-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p stella-cli --bin stella memory::` — 368 passed (skill_lifecycle 8/8)
- [x] `make guards-fast` green, `make prose` green, `make rebase-replay` green
- [x] Docs updated — the `require_measured_lift` card in `settings.mdx` records the aiming
- [x] Full workspace suite runs in CI per CLAUDE.md ("CI builds and tests; this laptop does not")

## Nothing left behind

- **Relevance, not just need.** The pick can still land on a skill that did not match this turn, in which case nothing is held back and the slot is spent. Fixing that means picking from the matched set, which is exactly what the cross-site stability argument above rules out without a per-turn cached pick like `trials::held_for`'s. Worth doing, and a bigger change than this one; not filed as an issue because it is a refinement of a mechanism that now works rather than a defect against it — say the word and I will file it.
- **The window never ages out.** `sweep` reads the whole trial history, so evidence from hundreds of turns ago still counts. A skill with a long good history therefore gets harder to retire over time, which works against the decay detection the rotation exists to serve. Separate from this change and older than it.

Closes #5487

## Summary by Sourcery

Aim skill holdout allocation at under-measured control arms so every skill can reach an evaluable appraisal while retaining coverage for later degradation.

Bug Fixes:
- Prioritize per-skill holdout trials for skills whose control arms have not yet reached the minimum evidence threshold, ensuring under-measured skills can receive appraisals.

Enhancements:
- Fall back to rotating across the full skill catalog once all control arms are sufficiently measured, preserving later detection of skill decay.

Documentation:
- Document that skill holdout turns are directed toward skills with insufficient control-arm evidence.

Tests:
- Add a lifecycle test proving the holdout selects the skill with the shorter control arm rather than an already measured skill.