### PR TITLE
fix(stella-core,stella-tools): refuse a tool call the turn cannot finish

### DIFF
--- a/crates/stella-cli/src/agent/tool_stack.rs
+++ b/crates/stella-cli/src/agent/tool_stack.rs
@@ -645,6 +645,74 @@ mod tests {
         );
     }
 
+    /// **The declared-timeout witness, through the shipped composition
+    /// (`#6460`).** The engine refuses to start a call that declares more wall
+    /// clock than the turn has left, and it learns the declared bound from
+    /// `ToolExecutor::declared_timeout`. Only the registry can answer — it
+    /// owns `bash` — and the answer has to survive every decorator above it.
+    /// The port's default is `None`, so a layer that forgets to forward turns
+    /// the clamp off for every session mounted through it, silently, and the
+    /// ten-minute call starts again on a turn with four minutes left.
+    ///
+    /// Asserted through the same chain as the origin witness above, and for
+    /// the same reason: a future decorator that forgets to forward fails
+    /// here, and nowhere else.
+    #[tokio::test]
+    async fn the_production_tool_stack_forwards_declared_timeouts() {
+        use stella_tools::skill_plane::{SkillInvocationPlane, SkillScopedTools};
+
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(stella_tools::registry::ToolRegistry::new(
+            dir.path().to_path_buf(),
+        ));
+        let mut client = stella_mcp::McpClient::new(
+            "vendor",
+            Box::new(CannedTransport {
+                called: Arc::new(std::sync::Mutex::new(false)),
+            }),
+        );
+        client.initialize().await.unwrap();
+        let mcp = stella_mcp::McpToolSet::from_clients(vec![client])
+            .wrapping(registry.clone() as Arc<dyn ToolExecutor>);
+
+        let stack = session_stack_with_gate(
+            &mcp,
+            vec![script_tool(dir.path())],
+            dir.path().to_path_buf(),
+            ToolPolicy::allow_all(),
+            ToolAllowance::new(ToolAdvertisement::Full, &SteeringLedger::default()),
+            session_gate(dir.path()),
+            Principal::User,
+        );
+        let view = SkillScopedTools::new(&stack, SkillInvocationPlane::new());
+
+        assert_eq!(
+            view.declared_timeout("bash", &serde_json::json!({"timeout_secs": 600})),
+            Some(std::time::Duration::from_secs(600)),
+            "the shell's own limit must reach the engine through every layer"
+        );
+        assert_eq!(
+            view.declared_timeout("bash", &serde_json::json!({"command": "ls"})),
+            Some(std::time::Duration::from_secs(120)),
+            "a call that names no limit still runs under the tool's default"
+        );
+        assert_eq!(
+            view.declared_timeout("task_list", &serde_json::json!({})),
+            None,
+            "a built-in with no time limit of its own declares none"
+        );
+        assert_eq!(
+            view.declared_timeout("mcp__vendor__deploy", &serde_json::json!({})),
+            None,
+            "a server's tool is bounded by the transport, not by an argument"
+        );
+        assert_eq!(
+            view.declared_timeout("my_tool", &serde_json::json!({})),
+            None,
+            "a .stella/tools script carries no model-supplied limit"
+        );
+    }
+
     /// **The skill-invocation witness, through the shipped composition.**
     /// The skill invocation plane composed over the assembled session chain — the
     /// position every turn driver mounts it at — is exactly the

--- a/crates/stella-cli/src/claims.rs
+++ b/crates/stella-cli/src/claims.rs
@@ -645,6 +645,13 @@ impl ToolExecutor for ClaimTap<'_> {
     fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
         self.inner.tool_origin(name)
     }
+
+    /// Forwarded. This layer sets no time limit of its own. Let the `None`
+    /// default stand and the clamp on tool time goes off for every session
+    /// built through here.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.declared_timeout(name, input)
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/command_deck/task_tap.rs
+++ b/crates/stella-cli/src/command_deck/task_tap.rs
@@ -195,6 +195,13 @@ impl ToolExecutor for TaskTap<'_> {
         self.inner.tool_origin(name)
     }
 
+    /// Forwarded. This layer sets no time limit of its own. Let the `None`
+    /// default stand and the clamp on tool time goes off for every session
+    /// built through here.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.declared_timeout(name, input)
+    }
+
     /// Forwarded: the deck's lead lane wraps the discovery mount (which owns
     /// the invocation plane) in this tap, so a tap that let the empty default
     /// stand would silently stop active skill bodies surviving summarization

--- a/crates/stella-cli/src/fleet_commits.rs
+++ b/crates/stella-cli/src/fleet_commits.rs
@@ -181,6 +181,13 @@ impl ToolExecutor for CommitObserver<'_> {
     fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
         self.inner.tool_origin(name)
     }
+
+    /// Forwarded. This layer sets no time limit of its own. Let the `None`
+    /// default stand and the clamp on tool time goes off for every session
+    /// built through here.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.declared_timeout(name, input)
+    }
 }
 
 /// One attempt's commits, oldest first — and the two ways of knowing which

--- a/crates/stella-cli/src/tool_lean.rs
+++ b/crates/stella-cli/src/tool_lean.rs
@@ -135,6 +135,13 @@ impl ToolExecutor for LeanToolSet<'_> {
     fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
         self.inner.tool_origin(name)
     }
+
+    /// Forwarded. This layer sets no time limit of its own. Let the `None`
+    /// default stand and the clamp on tool time goes off for every session
+    /// built through here.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.declared_timeout(name, input)
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-cli/src/tool_policy.rs
+++ b/crates/stella-cli/src/tool_policy.rs
@@ -149,6 +149,13 @@ impl ToolExecutor for PolicyToolSet<'_> {
     fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
         self.inner.get().tool_origin(name)
     }
+
+    /// Forwarded. This layer sets no time limit of its own. Let the `None`
+    /// default stand and the clamp on tool time goes off for every session
+    /// built through here.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.get().declared_timeout(name, input)
+    }
 }
 
 /// Which `"tools"` key withheld `name` — the exact name, its group, or the

--- a/crates/stella-core/src/driver.rs
+++ b/crates/stella-core/src/driver.rs
@@ -115,7 +115,7 @@ use crate::step::{
     SummarizerHealth, TurnState, deadline_bounded_generation,
 };
 pub(crate) use truncation::CONTINUATION_MARKER_PREFIX;
-use truncation::ContinuationBudget;
+use turn_clock::TurnClock;
 // Named only by the tests that pin the nudge's exact body; the production path
 // reaches it through `Continuation::into_parts`.
 #[cfg(test)]
@@ -152,6 +152,8 @@ mod restore;
 mod settlement;
 mod step_boundary;
 pub(crate) mod step_pace;
+// The turn's wall clock, read once per step boundary (ADR 0041).
+mod turn_clock;
 pub(crate) mod usage_anchor;
 pub(crate) mod user_hooks;
 mod waiting;
@@ -808,17 +810,11 @@ impl<'a> Engine<'a> {
             return aborted.into();
         }
 
-        // Only meaningful once a call has been timed and a budget configured:
-        // a continuation re-runs a tool-less step, so the model call is the
-        // whole forecast (`step_pace::StepPace::model`).
-        let continuation_budget =
-            self.config
-                .turn_budget
-                .zip(state.pace.model())
-                .map(|(budget, last_step)| ContinuationBudget {
-                    remaining: budget.saturating_sub(state.started_at.elapsed()),
-                    last_step,
-                });
+        // Both of the turn's wall-clock ceilings, folded into one value the
+        // decisions below read (`driver::turn_clock`, ADR 0041): whether a
+        // length continuation is affordable, and whether a tool call
+        // declaring its own limit can finish before the deadline.
+        let clock = TurnClock::read(&self.config, state);
 
         if let Some(completed) = self
             .dispatch_completion(
@@ -827,7 +823,7 @@ impl<'a> Engine<'a> {
                 &mut state.messages,
                 &mut state.length_continuations,
                 &mut state.stop_hook_consults,
-                continuation_budget,
+                clock,
                 events,
             )
             .await

--- a/crates/stella-core/src/driver/completion.rs
+++ b/crates/stella-core/src/driver/completion.rs
@@ -5,7 +5,8 @@
 
 use stella_protocol::{AgentEvent, CompletionMessage, FinishReason, MessageRole};
 
-use super::truncation::{self, ContinuationBudget, ContinuationPlan, TIME_EXHAUSTED_PARTIAL};
+use super::truncation::{self, ContinuationPlan, TIME_EXHAUSTED_PARTIAL};
+use super::turn_clock::TurnClock;
 use super::user_hooks::STOP_HOOK_MARKER_PREFIX;
 use super::{
     CommittedStep, Engine, SPECULATION_DISCARD_HARVEST_MISMATCH, TurnOutcome, confident_zero,
@@ -34,6 +35,12 @@ impl<'a> Engine<'a> {
     /// injects the hook's reason as a marked tail user message and returns
     /// `None`, holding the turn open for another round. `stop_consults` is
     /// the bounded consultation counter (`driver::user_hooks` module docs).
+    ///
+    /// `clock` is the turn's wall clock as the step boundary read it
+    /// (`driver::turn_clock`). Both of this function's time-aware decisions
+    /// weigh against it: whether a length continuation can finish, and —
+    /// through [`Engine::execute_tool_calls`] — whether a tool call
+    /// declaring its own limit can.
     #[expect(
         clippy::too_many_arguments,
         reason = "threaded turn-state fields, same shape as its siblings"
@@ -45,7 +52,7 @@ impl<'a> Engine<'a> {
         messages: &mut Vec<CompletionMessage>,
         length_continuations: &mut u32,
         stop_consults: &mut u32,
-        continuation_budget: Option<ContinuationBudget>,
+        clock: TurnClock,
         events: &EventSender,
     ) -> Option<TurnOutcome> {
         let CommittedStep {
@@ -85,7 +92,7 @@ impl<'a> Engine<'a> {
                     &result.text,
                     result.usage.output_tokens,
                     *length_continuations,
-                    continuation_budget,
+                    clock.continuation_budget(std::time::Instant::now()),
                 ) {
                     ContinuationPlan::Continue(plan) => {
                         *length_continuations += 1;
@@ -252,6 +259,7 @@ impl<'a> Engine<'a> {
                 &dispatch_safe_tools,
                 &read_only_tools,
                 speculation,
+                clock,
                 events,
             )
             .await;

--- a/crates/stella-core/src/driver/dispatch.rs
+++ b/crates/stella-core/src/driver/dispatch.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use futures_util::StreamExt;
 use stella_protocol::{AgentEvent, ToolCall, ToolOutput, ToolResult};
 
+use super::turn_clock::{self, ToolAdmission, TurnClock};
 use super::{Engine, MAX_CONCURRENT_TOOL_CALLS, SPECULATION_DISCARD_HARVEST_MISMATCH};
 use crate::event_sender::EventSender;
 use crate::speculation::SpeculationPool;
@@ -20,7 +21,7 @@ use crate::speculation::SpeculationPool;
 /// per turn) may ride here; and [`crate::step::close_open_tool_calls`] set the
 /// precedent that a synthetic closure is an `Error` output with a steady
 /// message, mirrored onto the event stream with no `ToolStart`.
-const HALTED_TOOL_RESULT: &str = "not executed — the goal was proven met (turn halt fired) while this call \
+pub(super) const HALTED_TOOL_RESULT: &str = "not executed — the goal was proven met (turn halt fired) while this call \
      was pending; its work is not needed and any process it started was killed";
 
 impl<'a> Engine<'a> {
@@ -88,12 +89,31 @@ impl<'a> Engine<'a> {
     /// `parallel_safe_names`): it feeds each call's advertised `read_only`
     /// bit into the hook payload (#2684), so it must mean what the schema
     /// said.
+    ///
+    /// # The wall-clock clamp (`#6460`, ADR 0041)
+    ///
+    /// A call that declares its own time limit —
+    /// [`ToolExecutor::declared_timeout`](crate::ports::ToolExecutor::declared_timeout)
+    /// answers with it — is weighed against `clock` before it starts. One
+    /// that cannot finish and still leave room to report back never runs: it
+    /// is answered with [`turn_clock::refused_for_time`], naming what it may
+    /// ask for instead. Before this clamp a ten-minute `bash` call started on
+    /// a turn with four minutes left, and the harness killed the whole process
+    /// on the way past the deadline, throwing away every edit the turn made.
+    ///
+    /// Nothing in flight is interrupted, so this keeps the "aborts at safe
+    /// boundaries" discipline (AGENTS.md #6) the same way the halt above
+    /// does. The clock is re-read once per barrier group, because the groups
+    /// before it have already spent it — a pair of five-minute calls in one
+    /// step is affordable at the top of the step and is not by the time the
+    /// second is reached.
     pub(super) async fn execute_tool_calls(
         &self,
         calls: &[ToolCall],
         dispatch_safe_tools: &HashSet<String>,
         read_only_tools: &HashSet<String>,
         mut speculation: SpeculationPool,
+        clock: TurnClock,
         events: &EventSender,
     ) -> Vec<ToolResult> {
         let mut indexed: Vec<(usize, ToolResult)> = Vec::with_capacity(calls.len());
@@ -119,49 +139,75 @@ impl<'a> Engine<'a> {
             // Plain copy for the closures: borrowing the loop variable
             // itself would conflict with advancing it below (E0506).
             let group_start = i;
-            let speculation = &mut speculation;
-            let group_futures =
-                calls[group_start..group_end]
-                    .iter()
-                    .enumerate()
-                    .map(|(offset, call)| {
-                        let _ = events.send(AgentEvent::ToolStart {
-                            call: call.clone(),
+            // The clamp, asked once for the group about to start and never
+            // for a call already running (AGENTS.md #6). Settled here rather
+            // than inside the futures below so a refusal lands before any
+            // `ToolStart` fires, which is the shape `close_open_tool_calls`
+            // established for a synthetic closure.
+            let now = std::time::Instant::now();
+            let mut admitted: Vec<(usize, &ToolCall)> = Vec::with_capacity(group_end - group_start);
+            for (offset, call) in calls[group_start..group_end].iter().enumerate() {
+                let index = group_start + offset;
+                match self.refuse_for_time(call, &speculation, clock, now) {
+                    Some(output) => {
+                        let _ = events.send(AgentEvent::ToolResult {
+                            call_id: call.call_id.clone(),
+                            output: output.clone(),
+                            duration_ms: 0,
+                            speculated: false,
                             sub_agent_id: None,
                             task_id: None,
                         });
-                        let index = group_start + offset;
-                        let harvested = match speculation.remove(&call.call_id) {
-                            Some(s) if s.name == call.name && s.input == call.input => Some(s),
-                            Some(stale) => {
-                                // The committed call diverged from what was
-                                // announced: reject the pooled result and
-                                // re-execute below. The speculative execution
-                                // still ran real I/O — record it (#370).
-                                let _ = events.send(AgentEvent::SpeculationDiscarded {
-                                    call_id: call.call_id.clone(),
-                                    name: stale.name,
-                                    reason: SPECULATION_DISCARD_HARVEST_MISMATCH.to_string(),
-                                });
-                                None
-                            }
-                            None => None,
-                        };
-                        let read_only = read_only_tools.contains(&call.name);
-                        async move {
-                            match harvested {
-                                Some(s) => (index, call, s.output, s.duration_ms, true),
-                                None => {
-                                    let started = std::time::Instant::now();
-                                    let output = self
-                                        .execute_with_repair(call, read_only, Some(events))
-                                        .await;
-                                    let duration_ms = started.elapsed().as_millis() as u64;
-                                    (index, call, output, duration_ms, false)
-                                }
-                            }
+                        indexed.push((
+                            index,
+                            ToolResult {
+                                call_id: call.call_id.clone(),
+                                output,
+                            },
+                        ));
+                    }
+                    None => admitted.push((index, call)),
+                }
+            }
+
+            let speculation = &mut speculation;
+            let group_futures = admitted.into_iter().map(|(index, call)| {
+                let _ = events.send(AgentEvent::ToolStart {
+                    call: call.clone(),
+                    sub_agent_id: None,
+                    task_id: None,
+                });
+                let harvested = match speculation.remove(&call.call_id) {
+                    Some(s) if s.name == call.name && s.input == call.input => Some(s),
+                    Some(stale) => {
+                        // The committed call diverged from what was
+                        // announced: reject the pooled result and
+                        // re-execute below. The speculative execution
+                        // still ran real I/O — record it (#370).
+                        let _ = events.send(AgentEvent::SpeculationDiscarded {
+                            call_id: call.call_id.clone(),
+                            name: stale.name,
+                            reason: SPECULATION_DISCARD_HARVEST_MISMATCH.to_string(),
+                        });
+                        None
+                    }
+                    None => None,
+                };
+                let read_only = read_only_tools.contains(&call.name);
+                async move {
+                    match harvested {
+                        Some(s) => (index, call, s.output, s.duration_ms, true),
+                        None => {
+                            let started = std::time::Instant::now();
+                            let output = self
+                                .execute_with_repair(call, read_only, Some(events))
+                                .await;
+                            let duration_ms = started.elapsed().as_millis() as u64;
+                            (index, call, output, duration_ms, false)
                         }
-                    });
+                    }
+                }
+            });
             let mut in_flight = futures_util::stream::iter(group_futures)
                 .buffer_unordered(MAX_CONCURRENT_TOOL_CALLS);
             while let Some((index, call, output, duration_ms, speculated)) = in_flight.next().await
@@ -245,6 +291,36 @@ impl<'a> Engine<'a> {
         self.discard_speculation_pool(speculation, SPECULATION_DISCARD_HARVEST_MISMATCH, events);
         indexed.sort_by_key(|(index, _)| *index);
         indexed.into_iter().map(|(_, result)| result).collect()
+    }
+
+    /// The refusal a call earns when it declares more wall clock than the
+    /// turn has left, or `None` when it may run.
+    ///
+    /// A pooled speculative result is a call that has already finished, so it
+    /// is admitted whatever it declared: refusing it would throw away work
+    /// the turn has already paid for. The pool is only peeked at here — the
+    /// harvest that consumes the entry happens once, in the group futures.
+    fn refuse_for_time(
+        &self,
+        call: &ToolCall,
+        speculation: &SpeculationPool,
+        clock: TurnClock,
+        now: std::time::Instant,
+    ) -> Option<ToolOutput> {
+        let already_run = speculation
+            .get(&call.call_id)
+            .is_some_and(|s| s.name == call.name && s.input == call.input);
+        if already_run {
+            return None;
+        }
+        let declared = self.tools.declared_timeout(&call.name, &call.input)?;
+        let ToolAdmission::Decline { affordable } = clock.admit_tool(declared, now) else {
+            return None;
+        };
+        Some(ToolOutput::classified_error(
+            stella_protocol::ErrorClass::RefusedByPolicy,
+            turn_clock::refused_for_time(declared, affordable),
+        ))
     }
 
     /// Whether [`crate::EngineConfig::turn_halt`] has fired, asked from inside

--- a/crates/stella-core/src/driver/turn_clock.rs
+++ b/crates/stella-core/src/driver/turn_clock.rs
@@ -53,8 +53,16 @@ pub(super) struct TurnClock {
 
 impl TurnClock {
     /// Read both bounds and keep the earlier one.
+    ///
+    /// A `turn_budget` so large that the clock cannot name its end is dropped
+    /// rather than added. `Instant + Duration` panics on overflow, and
+    /// `--turn-timeout` is a number a person types, so the sum is runtime
+    /// data (AGENTS.md #5). A budget no clock can reach could never bind a
+    /// call anyway, so `None` is also the right answer.
     pub(super) fn read(config: &crate::EngineConfig, state: &crate::step::TurnState) -> Self {
-        let from_turn_budget = config.turn_budget.map(|budget| state.started_at + budget);
+        let from_turn_budget = config
+            .turn_budget
+            .and_then(|budget| state.started_at.checked_add(budget));
         let deadline = match (from_turn_budget, state.budget.task_deadline()) {
             (Some(a), Some(b)) => Some(a.min(b)),
             (only, None) | (None, only) => only,
@@ -275,6 +283,29 @@ mod tests {
             clock.admit_tool(declared, start + declared),
             ToolAdmission::Decline { .. }
         ));
+    }
+
+    /// A budget the clock cannot reach the end of is dropped, not added. The
+    /// sum would panic, and a deadline that far out binds nothing in any case.
+    #[test]
+    fn an_unreachable_turn_budget_is_no_deadline_at_all() {
+        let now = Instant::now();
+        let config = crate::EngineConfig {
+            turn_budget: Some(Duration::MAX),
+            ..crate::EngineConfig::default()
+        };
+        let state = crate::step::TurnState::new(
+            Vec::new(),
+            crate::budget::BudgetGuard::new(stella_protocol::BudgetMode::Off, None, None),
+            &config,
+        );
+
+        let clock = TurnClock::read(&config, &state);
+
+        assert_eq!(
+            clock.admit_tool(Duration::from_secs(600), now),
+            ToolAdmission::Start
+        );
     }
 
     /// The earlier of the two ceilings wins, whichever it is. Nothing makes

--- a/crates/stella-core/src/driver/turn_clock.rs
+++ b/crates/stella-core/src/driver/turn_clock.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! The clock a turn runs against, read once each step.
+//!
+//! [`crate::EngineConfig::turn_budget`] bounds a turn: it is a span measured
+//! from the start of that turn.
+//! [`crate::budget::BudgetGuard::task_deadline`] is a point in time set for
+//! the whole task. In the shipped binary both come from `--turn-timeout`.
+//! Nothing makes them agree. A turn must outlive neither. So [`TurnClock`]
+//! keeps the earlier one, and every reader below the step boundary reads it.
+//!
+//! # What this fixes
+//!
+//! A `bash` call names its own time limit. The model picks it, and it may be
+//! as long as ten minutes. Nothing weighed that against the clock the turn
+//! had left. So a ten-minute call could start at t=350s of an 840-second
+//! budget and run to t=950s. The harness kills the process first. Every edit
+//! the turn made dies with it. On the 89-task Terminal-Bench 2.1 run of
+//! 2026-09-07, 17 of 32 failures ended that way. The engine's own deadline
+//! never fired once (`#6460`).
+//!
+//! The engine may not stop a call that is running (AGENTS.md #6). So the one
+//! moment it can act is before the call starts. That is what this decides.
+//!
+//! # Pure, like its neighbours
+//!
+//! The driver reads the clock and hands `now` in (AGENTS.md #2). That is what
+//! [`crate::driver::settlement`] and
+//! [`ContinuationBudget`] do beside
+//! it. Nothing here calls `Instant::now`.
+
+use std::time::{Duration, Instant};
+
+use super::truncation::ContinuationBudget;
+
+/// The clock as the step boundary read it.
+///
+/// Copied down the call chain, not stored on [`crate::Engine`]. That engine
+/// is a set of borrowed ports, shared across the tool futures. A clock kept
+/// there would need a cell, written at one site and read far from it. ADR
+/// 0041 records the choice.
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct TurnClock {
+    /// When this turn must be done: the earlier of the two bounds the module
+    /// docs name. `None` when nothing is timing it.
+    deadline: Option<Instant>,
+    /// How long the last model call took, retries and all
+    /// ([`super::step_pace::StepPace::model`]). It is the guess at what one
+    /// more call costs. Both readers below hold that much back.
+    last_model_call: Option<Duration>,
+}
+
+impl TurnClock {
+    /// Read both bounds and keep the earlier one.
+    pub(super) fn read(config: &crate::EngineConfig, state: &crate::step::TurnState) -> Self {
+        let from_turn_budget = config.turn_budget.map(|budget| state.started_at + budget);
+        let deadline = match (from_turn_budget, state.budget.task_deadline()) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (only, None) | (None, only) => only,
+        };
+        Self {
+            deadline,
+            last_model_call: state.pace.model(),
+        }
+    }
+
+    /// Time left at `now`. `None` when nothing is timing the turn.
+    fn remaining(&self, now: Instant) -> Option<Duration> {
+        self.deadline
+            .map(|deadline| deadline.saturating_duration_since(now))
+    }
+
+    /// What a length continuation weighs itself against.
+    ///
+    /// `None` when either half is missing. With no deadline there is nothing
+    /// to decline against. With no timed call there is no guess at what
+    /// declining would save.
+    pub(super) fn continuation_budget(&self, now: Instant) -> Option<ContinuationBudget> {
+        Some(ContinuationBudget {
+            remaining: self.remaining(now)?,
+            last_step: self.last_model_call?,
+        })
+    }
+
+    /// Whether a call naming `declared` may start at `now`.
+    ///
+    /// What is held back is the last model call. A refused call goes to the
+    /// model as a result, and the model then has to answer. A call that fits
+    /// the deadline to the second leaves nothing to answer with. The turn is
+    /// killed on the way to saying what it did.
+    ///
+    /// Strictly less, like
+    /// [`ContinuationBudget::affords_another`](super::truncation). The
+    /// held-back time is a guess from one past sample. Spend the last of the
+    /// clock on it and the turn lands on the deadline at best.
+    ///
+    /// No margin is made up here. The caller owns the deadline and can set a
+    /// safe one. A margin here would be a second rule the operator never saw.
+    /// `settlement::check_budget` says the same thing.
+    pub(super) fn admit_tool(&self, declared: Duration, now: Instant) -> ToolAdmission {
+        // No clock, no clamp. A caller that never said how long the turn has
+        // must not have work turned down on a guess.
+        let Some(remaining) = self.remaining(now) else {
+            return ToolAdmission::Start;
+        };
+        let affordable = remaining.saturating_sub(self.last_model_call.unwrap_or_default());
+        if declared < affordable {
+            return ToolAdmission::Start;
+        }
+        ToolAdmission::Decline { affordable }
+    }
+}
+
+/// What [`TurnClock::admit_tool`] said about one call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ToolAdmission {
+    /// Start the call.
+    Start,
+    /// Refuse it. `affordable` is the longest limit that still leaves room to
+    /// report back. It is what the model is told.
+    Decline { affordable: Duration },
+}
+
+/// What a call refused for time hands back to the model.
+///
+/// It names a number. [`super::dispatch::HALTED_TOOL_RESULT`] may not, and
+/// its own doc says why: loop detection keys on output that matches byte for
+/// byte, so a figure that shifts per call hides a run of like calls from the
+/// rungs that read them.
+///
+/// The number is the fix, and that is what makes it safe here. A model told
+/// it may ask for 40 seconds asks for 40 seconds. The refusal ends the repeat
+/// rather than feeding it. A turn in this state is also one model call from
+/// its deadline. It cannot outlast a rung that wants three in a row.
+///
+/// The words name a limit, never `timeout_secs`. That key belongs to
+/// `stella-tools`. The engine does not know it (AGENTS.md #1).
+pub(super) fn refused_for_time(declared: Duration, affordable: Duration) -> String {
+    format!(
+        "not executed — this call declared a {:.0}s time limit, and only {:.0}s of this turn's \
+         wall clock remain once room is kept to report back. Starting it would end the turn from \
+         outside and throw away the work already done. Re-run it with a limit under {:.0}s, split \
+         it into shorter steps, or finish now with what you already have.",
+        declared.as_secs_f64(),
+        affordable.as_secs_f64(),
+        affordable.as_secs_f64(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A clock with `remaining` left and a `last_model_call` reserve, built
+    /// against `now` so the tests read as durations rather than instants.
+    fn clock(now: Instant, remaining: u64, reserve: u64) -> TurnClock {
+        TurnClock {
+            deadline: Some(now + Duration::from_secs(remaining)),
+            last_model_call: Some(Duration::from_secs(reserve)),
+        }
+    }
+
+    /// **The witness for `#6460`.** A ten-minute `bash` call against a turn
+    /// with under eight minutes left is refused, and the refusal names what
+    /// the model may ask for instead.
+    #[test]
+    fn a_call_longer_than_the_turn_has_left_is_refused() {
+        let now = Instant::now();
+        let clock = clock(now, 490, 40);
+
+        let ToolAdmission::Decline { affordable } = clock.admit_tool(Duration::from_secs(600), now)
+        else {
+            panic!("a 600s call cannot start with 490s left");
+        };
+        assert_eq!(affordable, Duration::from_secs(450));
+
+        let message = refused_for_time(Duration::from_secs(600), affordable);
+        assert!(message.contains("600s"), "{message}");
+        assert!(message.contains("450s"), "{message}");
+    }
+
+    /// The control: the same clock admits a call that fits.
+    #[test]
+    fn a_call_that_fits_starts() {
+        let now = Instant::now();
+        let clock = clock(now, 490, 40);
+
+        assert_eq!(
+            clock.admit_tool(Duration::from_secs(120), now),
+            ToolAdmission::Start
+        );
+    }
+
+    /// Exactly enough is not enough, the rule `affords_another` already
+    /// follows: the reserve is one sample, so spending the last of the clock
+    /// on it lands on the deadline in the best case.
+    #[test]
+    fn exactly_enough_time_is_not_enough() {
+        let now = Instant::now();
+        let clock = clock(now, 160, 40);
+
+        assert!(matches!(
+            clock.admit_tool(Duration::from_secs(120), now),
+            ToolAdmission::Decline { .. }
+        ));
+    }
+
+    /// A turn nobody is timing behaves exactly as it did before the clamp
+    /// existed. Declining work on a clock that was never set would be a guess.
+    #[test]
+    fn an_untimed_turn_clamps_nothing() {
+        let now = Instant::now();
+        let clock = TurnClock::default();
+
+        assert_eq!(
+            clock.admit_tool(Duration::from_secs(600), now),
+            ToolAdmission::Start
+        );
+        assert!(clock.continuation_budget(now).is_none());
+    }
+
+    /// Before any model call has been timed the reserve is zero, which leaves
+    /// the clamp reactive rather than guessing at a number — the discipline
+    /// `StepPace::reserve` already applies to the deadline check.
+    #[test]
+    fn an_untimed_call_reserves_nothing_and_still_clamps() {
+        let now = Instant::now();
+        let clock = TurnClock {
+            deadline: Some(now + Duration::from_secs(100)),
+            last_model_call: None,
+        };
+
+        assert_eq!(
+            clock.admit_tool(Duration::from_secs(600), now),
+            ToolAdmission::Decline {
+                affordable: Duration::from_secs(100)
+            }
+        );
+        assert_eq!(
+            clock.admit_tool(Duration::from_secs(60), now),
+            ToolAdmission::Start
+        );
+    }
+
+    /// A deadline already past refuses everything, including a call declaring
+    /// nothing at all — there is no clock left to run it against.
+    #[test]
+    fn a_passed_deadline_refuses_every_call() {
+        let now = Instant::now();
+        let clock = TurnClock {
+            deadline: Some(now - Duration::from_secs(5)),
+            last_model_call: Some(Duration::from_secs(40)),
+        };
+
+        assert_eq!(
+            clock.admit_tool(Duration::ZERO, now),
+            ToolAdmission::Decline {
+                affordable: Duration::ZERO
+            }
+        );
+    }
+
+    /// The clock closes as the step's earlier calls run. A pair of calls that
+    /// each fit at the top of the step must not both start when only one of
+    /// them fits by the time the second is reached.
+    #[test]
+    fn the_clock_is_re_read_as_a_step_proceeds() {
+        let start = Instant::now();
+        let clock = clock(start, 700, 40);
+        let declared = Duration::from_secs(400);
+
+        assert_eq!(clock.admit_tool(declared, start), ToolAdmission::Start);
+        assert!(matches!(
+            clock.admit_tool(declared, start + declared),
+            ToolAdmission::Decline { .. }
+        ));
+    }
+
+    /// The earlier of the two ceilings wins, whichever it is. Nothing makes
+    /// an advisory turn budget and an enforced task deadline agree, and the
+    /// turn must outlive neither.
+    #[test]
+    fn the_tighter_of_the_two_ceilings_binds() {
+        let now = Instant::now();
+        let tight_task = TurnClock {
+            deadline: Some(now + Duration::from_secs(600)),
+            last_model_call: None,
+        };
+        let tight_turn = TurnClock {
+            deadline: Some(now + Duration::from_secs(60)),
+            last_model_call: None,
+        };
+
+        assert_eq!(
+            tight_task.admit_tool(Duration::from_secs(120), now),
+            ToolAdmission::Start
+        );
+        assert!(matches!(
+            tight_turn.admit_tool(Duration::from_secs(120), now),
+            ToolAdmission::Decline { .. }
+        ));
+    }
+
+    /// The continuation forecast survives the move onto this clock: it still
+    /// needs a deadline and a timed call, and still reports what each was.
+    #[test]
+    fn the_continuation_budget_carries_both_halves() {
+        let now = Instant::now();
+        let budget = clock(now, 490, 40)
+            .continuation_budget(now)
+            .expect("a clock with both halves answers");
+
+        assert_eq!(budget.remaining, Duration::from_secs(490));
+        assert_eq!(budget.last_step, Duration::from_secs(40));
+    }
+}

--- a/crates/stella-core/src/ports.rs
+++ b/crates/stella-core/src/ports.rs
@@ -249,6 +249,42 @@ pub trait ToolExecutor: Send + Sync {
     fn tool_origin(&self, _name: &str) -> Option<crate::loop_detect::ToolOrigin> {
         None
     }
+
+    /// The longest this call may run, as this executor's own timeout policy
+    /// would apply it to `input`. `None` means this executor cannot say.
+    ///
+    /// The engine asks before it starts the call, so that a call declaring
+    /// more wall clock than the turn has left is refused rather than started
+    /// and killed from outside (`crate::driver::turn_clock`, ADR 0041). A
+    /// `bash` call may ask for ten minutes; a turn with four minutes left
+    /// cannot pay for it, and the harness that kills the process on the way
+    /// past the deadline throws away everything the turn had already done.
+    ///
+    /// # Why the executor and not the engine
+    ///
+    /// The number lives in the call's arguments under a name only the tool
+    /// layer knows — `bash` reads `timeout_secs` and clamps it. An engine
+    /// that reached into the JSON for that key would be encoding one tool's
+    /// vocabulary into the port boundary, which AGENTS.md #1 exists to stop.
+    /// The layer that will enforce the timeout is the layer that can say
+    /// what it is.
+    ///
+    /// An answer is a promise: return `Some` only when the call really is
+    /// bounded by that long. A tool with no timeout of its own answers
+    /// `None`, and the engine starts it exactly as it does today — this
+    /// clamp narrows a declared bound and invents none.
+    ///
+    /// # Decorators MUST forward this
+    ///
+    /// The default `None` reads as "unknown", which is what every executor
+    /// answered before this method existed: the engine starts the call. So a
+    /// missed forward costs the clamp and causes no regression, the same
+    /// direction [`Self::tool_origin`]'s default takes. The shipped
+    /// composition is pinned by `stella-cli`'s
+    /// `the_production_tool_stack_forwards_declared_timeouts`.
+    fn declared_timeout(&self, _name: &str, _input: &Value) -> Option<std::time::Duration> {
+        None
+    }
 }
 
 /// The one entry every tool dispatch passes through before it runs: the
@@ -416,6 +452,14 @@ impl ToolExecutor for ReadOnlyTools<'_> {
         self.inner.tool_origin(name)
     }
 
+    /// Forwarded unfiltered, like `tool_origin` above: a name this view
+    /// refuses is answered by `execute` before any clock is consulted, and
+    /// the wall-clock clamp must read the same bound the inner executor
+    /// would actually enforce.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.declared_timeout(name, input)
+    }
+
     /// Forwarded, not zeroed. A sub-agent runs behind this view, so a
     /// *grandchild* it dispatched settles here first — into the child's own
     /// carve — and only then into the parent as part of the child's total.
@@ -528,6 +572,13 @@ impl ToolExecutor for GrantedTools<'_> {
     /// where a call already in the window came from.
     fn tool_origin(&self, name: &str) -> Option<crate::loop_detect::ToolOrigin> {
         self.inner.tool_origin(name)
+    }
+
+    /// Forwarded for the same reason [`ReadOnlyTools`] forwards it: the
+    /// bound the inner executor would enforce is the one the wall-clock
+    /// clamp has to weigh.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.declared_timeout(name, input)
     }
 
     /// Forwarded, not zeroed, for the same reason as [`ReadOnlyTools`]: a

--- a/crates/stella-core/tests/tool_wall_clock.rs
+++ b/crates/stella-core/tests/tool_wall_clock.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Oxagen, Inc. Commercial licensing: licensing@oxagen.sh
+
+//! A call that names more time than the turn has left never starts
+//! (`#6460`, ADR 0041).
+//!
+//! `bash` takes a time limit from the model, up to ten minutes. Nothing
+//! weighed it against the deadline. So a ten-minute call could start at
+//! t=350s of an 840-second budget and run to t=950s. The harness kills the
+//! whole process on the way past its own limit. Every edit the turn made goes
+//! with it. That is how 17 of the 32 failures ended on the 89-task
+//! Terminal-Bench 2.1 run of 2026-09-07, with the engine's own deadline never
+//! firing.
+//!
+//! Pinned from outside the crate through the public API, like
+//! `parallel_dispatch.rs` beside it. The tool set names a bound through
+//! [`ToolExecutor::declared_timeout`], and notes whether it was ever asked to
+//! run. So this holds the shipped dispatch path, not the small function under
+//! it.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use stella_core::budget::BudgetGuard;
+use stella_core::ports::ToolExecutor;
+use stella_core::retry::Sleeper;
+use stella_core::{Engine, EngineConfig, TurnCapabilities, TurnOutcome};
+use stella_protocol::{
+    AgentEvent, BudgetMode, CompletionMessage, CompletionRequestRef, CompletionResult,
+    CompletionUsage, Provider, ProviderError, ToolCall, ToolOutput, ToolSchema,
+};
+use tokio::sync::mpsc;
+
+struct NoopSleeper;
+#[async_trait]
+impl Sleeper for NoopSleeper {
+    async fn sleep(&self, _duration_ms: u64) {}
+}
+
+/// First call: one long shell command. Second call: an answer. The turn only
+/// gets there because a refusal is a result it can go on from.
+struct OneShellCallThenDone {
+    timeout_secs: u64,
+    calls: AtomicU32,
+}
+
+#[async_trait]
+impl Provider for OneShellCallThenDone {
+    fn id(&self) -> &str {
+        "scripted"
+    }
+    async fn complete_ref(
+        &self,
+        _req: CompletionRequestRef<'_>,
+    ) -> Result<CompletionResult, ProviderError> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        let (text, tool_calls) = if call == 0 {
+            (
+                String::new(),
+                vec![ToolCall {
+                    call_id: "c1".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({
+                        "command": "make test",
+                        "timeout_secs": self.timeout_secs,
+                    }),
+                }],
+            )
+        } else {
+            ("done".to_string(), Vec::new())
+        };
+        Ok(CompletionResult {
+            upstream_provider: None,
+            text,
+            tool_calls,
+            usage: CompletionUsage::reported_zero(),
+            model: "scripted".into(),
+            cost_usd: 0.0001,
+            finish_reason: None,
+        })
+    }
+}
+
+/// A shell-shaped tool set. It names the bound it would hold the call to, and
+/// notes whether the engine ever asked it to run.
+struct DeclaredShell {
+    ran: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl ToolExecutor for DeclaredShell {
+    fn schemas(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            name: "bash".into(),
+            description: "run a shell command".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            read_only: false,
+            speculation_safe: false,
+        }]
+    }
+
+    async fn execute(&self, _name: &str, _input: &Value) -> ToolOutput {
+        self.ran.store(true, Ordering::SeqCst);
+        ToolOutput::Ok {
+            content: "ok".into(),
+            data: None,
+        }
+    }
+
+    /// The same answer the real registry gives for `bash`: what the model
+    /// asked for, which is the bound the spawn would arm.
+    fn declared_timeout(&self, _name: &str, input: &Value) -> Option<Duration> {
+        input
+            .get("timeout_secs")
+            .and_then(Value::as_u64)
+            .map(Duration::from_secs)
+    }
+}
+
+/// Run one turn under `turn_budget`, asking for a shell call of
+/// `timeout_secs`. Report whether the tool ran, and every result it made.
+async fn run(timeout_secs: u64, turn_budget: Option<Duration>) -> (bool, Vec<ToolOutput>) {
+    let provider = OneShellCallThenDone {
+        timeout_secs,
+        calls: AtomicU32::new(0),
+    };
+    let ran = Arc::new(AtomicBool::new(false));
+    let tools = DeclaredShell { ran: ran.clone() };
+    let sleeper = NoopSleeper;
+    let config = EngineConfig {
+        turn_budget,
+        ..EngineConfig::default()
+    };
+    let engine = Engine::assemble(
+        &provider,
+        &tools,
+        config,
+        &sleeper,
+        TurnCapabilities::none(),
+    );
+    let mut messages = vec![
+        CompletionMessage::system("sys"),
+        CompletionMessage::user("run the suite"),
+    ];
+    let mut budget = BudgetGuard::new(BudgetMode::Off, None, None);
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(5),
+        engine.run_turn(&mut messages, &mut budget, &tx),
+    )
+    .await
+    .expect("the turn must settle");
+    assert!(
+        matches!(outcome, TurnOutcome::Completed { .. }),
+        "a refused call is a result the turn goes on from, never an abort: {outcome:?}"
+    );
+
+    drop(tx);
+    let mut results = Vec::new();
+    while let Some(event) = rx.recv().await {
+        if let AgentEvent::ToolResult { output, .. } = event {
+            results.push(output);
+        }
+    }
+    (ran.load(Ordering::SeqCst), results)
+}
+
+/// **The witness for `#6460`.** A ten-minute call on a five-minute turn never
+/// reaches the tool. The model is told in seconds what it may ask for. On the
+/// old dispatch the call runs, and the turn is killed from outside with
+/// nothing sent.
+#[tokio::test]
+async fn a_call_longer_than_the_turn_has_left_never_starts() {
+    let (ran, results) = run(600, Some(Duration::from_secs(300))).await;
+
+    assert!(
+        !ran,
+        "a 600s call must not start on a turn with 300s of wall clock left"
+    );
+    let [ToolOutput::Error { message, .. }] = results.as_slice() else {
+        panic!("the refused call must still be answered exactly once: {results:?}");
+    };
+    assert!(
+        message.contains("600s"),
+        "the refusal names the limit the call declared: {message}"
+    );
+    let named = message
+        .split_once("only ")
+        .and_then(|(_, tail)| tail.split_once("s of this turn's"))
+        .and_then(|(secs, _)| secs.parse::<u64>().ok())
+        .unwrap_or_else(|| panic!("the refusal names the seconds left: {message}"));
+    assert!(
+        (290..=300).contains(&named),
+        "the seconds named are the turn's own clock less what is held back, \
+         so the model can shorten the call rather than guess: {message}"
+    );
+}
+
+/// The control: the same turn, a call that fits, nothing refused. Without it
+/// the test above would pass on an engine that had stopped running tools.
+#[tokio::test]
+async fn a_call_that_fits_the_turn_still_runs() {
+    let (ran, results) = run(60, Some(Duration::from_secs(300))).await;
+
+    assert!(ran, "a 60s call fits a turn with 300s left and must run");
+    assert_eq!(
+        results,
+        vec![ToolOutput::Ok {
+            content: "ok".into(),
+            data: None
+        }]
+    );
+}
+
+/// A turn nobody is timing acts as it did before the clamp. The clamp narrows
+/// a deadline somebody set. It makes none up.
+#[tokio::test]
+async fn an_untimed_turn_runs_the_longest_call_there_is() {
+    let (ran, _) = run(600, None).await;
+
+    assert!(
+        ran,
+        "with no turn budget configured there is no clock to decline against"
+    );
+}

--- a/crates/stella-mcp/src/toolset.rs
+++ b/crates/stella-mcp/src/toolset.rs
@@ -1087,6 +1087,20 @@ impl ToolExecutor for McpToolSet {
         self.native.as_ref().and_then(|n| n.tool_origin(name))
     }
 
+    /// A server's tool carries no time limit this crate arms — the call is
+    /// bounded by the transport, not by an argument — so a namespaced name
+    /// answers `None` and the engine starts it as it always has. Everything
+    /// else is the native layer's to answer, and forwarding is what keeps the
+    /// wall-clock clamp alive for the built-ins underneath.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        if name.starts_with(NS_PREFIX) {
+            return None;
+        }
+        self.native
+            .as_ref()
+            .and_then(|n| n.declared_timeout(name, input))
+    }
+
     /// Forwarded: this is a decorator, and a decorator that let the default
     /// `0.0` stand would silently drop sub-agent spend out of the parent's
     /// budget (see the port's contract).
@@ -1208,6 +1222,15 @@ impl ToolExecutor for CandidateMcpView {
             return self.inner.tool_origin(name);
         }
         self.native.tool_origin(name)
+    }
+
+    /// Split the same way, and forwarded on both arms: whichever layer
+    /// dispatches the name is the layer that knows what bounds it.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        if name.starts_with(NS_PREFIX) {
+            return self.inner.declared_timeout(name, input);
+        }
+        self.native.declared_timeout(name, input)
     }
 
     /// Forwarded: this is a decorator, and a decorator that let the default

--- a/crates/stella-serve/src/subagents.rs
+++ b/crates/stella-serve/src/subagents.rs
@@ -564,6 +564,13 @@ impl ToolExecutor for DelegatingTools<'_> {
     fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
         self.inner.tool_origin(name)
     }
+
+    /// Forwarded. This layer sets no time limit of its own. Let the `None`
+    /// default stand and the clamp on tool time goes off for every session
+    /// built through here.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.declared_timeout(name, input)
+    }
 }
 
 /// Turn a child's outcome into a model-visible result.

--- a/crates/stella-tools/src/bash.rs
+++ b/crates/stella-tools/src/bash.rs
@@ -73,6 +73,9 @@ use stella_core::shell_text::blocking_sleep_seconds;
 use words::{cd_escape_target, shell_words};
 
 const DEFAULT_TIMEOUT_SECS: u64 = 120;
+/// The name this tool is registered under, spelled once so the schema below
+/// and [`declared_timeout`] cannot answer for two different tools.
+pub(crate) const NAME: &str = "bash";
 /// Byte cap on one `bash` result before head+tail elision
 /// ([`crate::exec::truncate_middle_capped`]). [`crate::custom`] aliases this
 /// constant, so the two shell-shaped surfaces cannot drift apart (#1889).
@@ -426,6 +429,30 @@ fn sleep_advisory(command: &str) -> Option<String> {
     ))
 }
 
+/// How long this call may run: the model's `timeout_secs`, clamped to
+/// [`crate::exec::MAX_TIMEOUT_SECS`], or the default when it asked for
+/// nothing usable.
+///
+/// One function for two readers — the spawn below arms this duration, and
+/// [`declared_timeout`] reports it to the engine's wall-clock clamp. A
+/// declaration the tool then failed to honour would be worse than none, so
+/// the two cannot be allowed to drift.
+fn effective_timeout(input: &Value) -> Duration {
+    Duration::from_secs(crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS))
+}
+
+/// The bound this call will actually run under, for the engine's
+/// [`ToolExecutor::declared_timeout`](stella_core::ports::ToolExecutor::declared_timeout)
+/// answer, or `None` for any other tool.
+///
+/// Keyed on the name rather than reading `timeout_secs` out of whatever
+/// arrives, because that key belongs to this tool: another tool is free to
+/// mean something else by it, and answering for one would tell the engine a
+/// bound nothing enforces.
+pub(crate) fn declared_timeout(name: &str, input: &Value) -> Option<Duration> {
+    (name == NAME).then(|| effective_timeout(input))
+}
+
 /// `bash`: one shell command in the workspace root, with a timeout backstop
 /// and a process-group kill that reaches the children it spawned.
 pub struct Bash {
@@ -477,7 +504,7 @@ impl Tool for Bash {
             ""
         };
         ToolSchema {
-            name: "bash".into(),
+            name: NAME.into(),
             description: format!(
                 "Run a shell command in the workspace root. Returns stdout+stderr with a \
                 timeout backstop. You can READ anything on this machine — system headers, the \
@@ -526,7 +553,7 @@ impl Tool for Bash {
             );
         }
 
-        let timeout_secs = crate::exec::timeout_from(input, DEFAULT_TIMEOUT_SECS);
+        let timeout_secs = effective_timeout(input).as_secs();
         // trace: true prefixes `set -x` so every executed line echoes to
         // stderr — an execution trace a verifier can demand as evidence.
         // A wrong-typed `trace` is refused, never silently read as false:
@@ -1227,6 +1254,36 @@ mod tests {
     /// injected into a bash *result* is re-sent as input on every later turn,
     /// and it named the schema and the system prompt as the two places it
     /// belongs. The system prompt took its half; this is the other one.
+    /// **The declared-bound witness (`#6460`).** The engine refuses to start a
+    /// call declaring more wall clock than the turn has left, and it trusts
+    /// this answer to be the bound the spawn will actually arm. A declaration
+    /// the tool then failed to honour would be worse than none, so both
+    /// readers go through [`effective_timeout`] and this pins what it says:
+    /// the model's number, the default when it named none, and the ceiling
+    /// when it named more than the ceiling allows.
+    #[test]
+    fn the_declared_bound_is_the_one_the_spawn_would_arm() {
+        assert_eq!(
+            declared_timeout(NAME, &serde_json::json!({"timeout_secs": 300})),
+            Some(Duration::from_secs(300))
+        );
+        assert_eq!(
+            declared_timeout(NAME, &serde_json::json!({"command": "ls"})),
+            Some(Duration::from_secs(DEFAULT_TIMEOUT_SECS)),
+            "a call naming no limit still runs under the backstop"
+        );
+        assert_eq!(
+            declared_timeout(NAME, &serde_json::json!({"timeout_secs": u64::MAX})),
+            Some(Duration::from_secs(crate::exec::MAX_TIMEOUT_SECS)),
+            "the clamp binds the declaration exactly as it binds the spawn"
+        );
+        assert_eq!(
+            declared_timeout("read_file", &serde_json::json!({"timeout_secs": 300})),
+            None,
+            "`timeout_secs` means what this tool means by it and nothing else"
+        );
+    }
+
     #[test]
     fn the_bash_schema_steers_reads_the_way_it_steers_writes() {
         let described = Bash::new(None).schema().description;

--- a/crates/stella-tools/src/custom.rs
+++ b/crates/stella-tools/src/custom.rs
@@ -1352,6 +1352,14 @@ impl ToolExecutor for CustomToolSet<'_> {
         self.inner.get().tool_origin(name)
     }
 
+    /// Forwarded for a name this set does not own. A manifest tool carries
+    /// no model-supplied time limit of its own, so there is nothing extra to
+    /// declare here — and letting the default stand would turn the engine's
+    /// wall-clock clamp off for the built-ins underneath.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.get().declared_timeout(name, input)
+    }
+
     /// Forwarded: this is a decorator, and a decorator that let the default
     /// `0.0` stand would silently drop sub-agent spend out of the parent's
     /// budget (see the port's contract).

--- a/crates/stella-tools/src/gated.rs
+++ b/crates/stella-tools/src/gated.rs
@@ -504,6 +504,13 @@ impl ToolExecutor for GatedToolSet<'_> {
     fn tool_origin(&self, name: &str) -> Option<stella_core::loop_detect::ToolOrigin> {
         self.inner.get().tool_origin(name)
     }
+
+    /// Forwarded: the engine's wall-clock clamp has to read the bound the
+    /// base will actually enforce, and a wrapper that let the `None` default
+    /// stand would turn the clamp off for every surface composed through it.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.get().declared_timeout(name, input)
+    }
 }
 
 #[cfg(test)]

--- a/crates/stella-tools/src/registry/executor.rs
+++ b/crates/stella-tools/src/registry/executor.rs
@@ -59,6 +59,14 @@ impl ToolExecutor for ToolRegistry {
         crate::catalog::get(name).map(|_| stella_core::loop_detect::ToolOrigin::Builtin)
     }
 
+    /// `bash` is the one built-in that takes a time limit from the model, so
+    /// it is the one this can answer for. Every other name returns `None` —
+    /// the engine then starts the call as it always has, because a bound
+    /// nobody enforces is worse than no bound (the port's own contract).
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        crate::bash::declared_timeout(name, input)
+    }
+
     /// Take what the `delegate` tool's children cost since the last step
     /// boundary. Destructive by the port's contract: the engine charges
     /// whatever this returns, so reporting twice would bill twice.

--- a/crates/stella-tools/src/skill_plane.rs
+++ b/crates/stella-tools/src/skill_plane.rs
@@ -215,6 +215,12 @@ impl ToolExecutor for SkillScopedTools<'_> {
         self.inner.tool_origin(name)
     }
 
+    /// Forwarded, like every other question this view only passes through:
+    /// the bound the base enforces is what the wall-clock clamp weighs.
+    fn declared_timeout(&self, name: &str, input: &Value) -> Option<std::time::Duration> {
+        self.inner.declared_timeout(name, input)
+    }
+
     /// Forwarded, not zeroed — a grandchild dispatched behind this view
     /// still settles into the carve that bounds it (see `ReadOnlyTools`).
     fn drain_sub_agent_spend_usd(&self) -> f64 {

--- a/docs/adr/0041-the-turn-clock-reaches-dispatch-by-value.md
+++ b/docs/adr/0041-the-turn-clock-reaches-dispatch-by-value.md
@@ -1,0 +1,125 @@
+---
+id: adr/0041-the-turn-clock-reaches-dispatch-by-value
+title: "ADR 0041: The turn clock reaches dispatch by value"
+status: implemented
+---
+
+# ADR 0041: The turn clock reaches dispatch by value
+
+- Status: accepted
+- Date: 2026-09-08
+- Decides: `#6460`
+- Not part of the Phase 0 series.
+
+## Context
+
+A `bash` call carries its own time limit. The model writes it. `stella-tools`
+cuts it to ten minutes at most, and the spawn arms it. Nothing ever weighed
+that number against the clock the turn had left.
+
+So a ten-minute call could start at t=350s of an 840-second budget and run to
+t=950s. Harbor kills the trial at 900s. The process dies. Every edit the turn
+made dies with it. The engine's own deadline never fires, because it is asked
+between steps and the step never ends. On the 89-task Terminal-Bench 2.1 run
+of 2026-09-07, 17 of 32 failures ended that way.
+
+The engine already turns down work it cannot finish one step up.
+`ContinuationBudget::affords_another` refuses to start a continuation that
+costs more than the clock has left. `settlement::check_budget` refuses to open
+a step it cannot pay for. Neither reaches a tool call, and AGENTS.md #6 means
+nothing can: once the call runs, the engine may not stop it. The one moment
+left is before it starts.
+
+The clock and the named limit have to meet at that moment. Each sits on the
+wrong side of a line.
+
+The **clock** must be read in the driver, because AGENTS.md #2 keeps I/O out of
+the engine's decisions. The dispatch site could not see it.
+`Engine::execute_tool_calls` is called from `dispatch_completion`, which held
+no turn state at all.
+
+The **named limit** sits in the call's arguments, under a key only the tool
+layer knows. `bash` reads `timeout_secs`. Nothing else in the tree means
+anything by that name.
+
+## Decision
+
+**The clock is read once each step and passed down by value.**
+`driver::turn_clock::TurnClock` is built in `run_step_inner` from the turn's
+two bounds: `EngineConfig::turn_budget`, measured from the start of the turn,
+and `BudgetGuard::task_deadline`. It keeps the earlier. It travels through
+`dispatch_completion` into `execute_tool_calls`, which reads it again against
+`Instant::now()` for each barrier group, because the groups before it have
+spent clock.
+
+That takes the place of the `Option<ContinuationBudget>` parameter already
+threaded down the same path. One clock, read in one place. Both readers below
+weigh the same value.
+
+**The tool names its own limit, through the port.**
+`ToolExecutor::declared_timeout(name, input)` is a defaulted method. It answers
+`Option<Duration>`: how long this call may run, as this tool set would hold it.
+`ToolRegistry` answers for `bash` and nothing else. Every decorator passes it
+on. The default `None` means "cannot say", and the engine then starts the call
+as it always has.
+
+**A call it cannot finish is refused before it starts.** The limit must be
+under the clock left, less one model call. That much is held back so the
+refusal can reach the model and the model can answer. The refusal is a
+`RefusedByPolicy` `ToolOutput` naming the seconds left, sent with no
+`ToolStart`. It is the shape `close_open_tool_calls` and `HALTED_TOOL_RESULT`
+already use. The turn goes on from it.
+
+## Consequences
+
+The turn stops racing a harness it cannot see. A model that asks for ten
+minutes with four left is told so in seconds. It asks again for something that
+fits, or writes down what it has.
+
+`turn_budget` and `task_deadline` now bound the length continuation together,
+rather than the first of them alone. Both are armed from `--turn-timeout` in
+the shipped binary, so nothing there changes. A caller that arms only the
+enforced deadline now gets the decline it always should have had.
+
+`bash` is the only tool this can refuse today. It is the only built-in that
+takes a time limit from the model. A tool that grows one writes
+`declared_timeout` in the same change, or the clamp does not see it. That is
+the safe way to be wrong, and the way `tool_origin`'s default is wrong too.
+
+A refusal names a number, so two refusals in one turn do not match byte for
+byte, and the loop rungs cannot read them as a run. That is fine here and
+would not be for `HALTED_TOOL_RESULT`. The number is the fix, so a model that
+reads it stops repeating. A turn in this state is one model call from its
+deadline in any case.
+
+## Alternatives considered
+
+**Widen `ToolExecutor::execute` to carry a context.** The general answer, and
+the one this refuses. Every carrier of the trait in the tree changes, plus
+every test double and every outside one. The trait is public API, and
+`stella-serve` and `stella-engine` hosts write their own. A defaulted method
+costs nothing to anyone who does not want it. What is added is one question,
+not a bag that will grow.
+
+**Store the clock on `Engine`.** That struct holds borrowed ports and is shared
+across the tool futures. The field would need a cell: written at the top of
+`run_step_inner` and read four frames away, with nothing in either place
+showing the other. Passing it by value makes the tie a signature, which is
+what the borrow checker is for.
+
+**Let the engine read `timeout_secs` out of the call's input.** One line, no
+port change, and it writes one tool's key into the engine. That is the thing
+AGENTS.md #1 exists to stop. It also lies the moment a second tool means
+something else by that key. The engine would report a limit nothing holds, and
+turn down a call that was never going to take that long.
+
+**Cut the timeout down to fit, inside `stella-tools`.** Nothing about the wall
+clock is visible there. Cutting is the wrong fix in any case. A ten-minute
+test suite cut to four minutes fails at four minutes, having spent the four.
+The model has to choose between smaller work and finishing, and only the model
+can make that choice.
+
+**Hold back a fixed margin.** Every neighbour on this path refuses to make one
+up. The caller owns the deadline and can set a safe one. A margin here would
+be a second rule the operator never saw. What is held back is the last model
+call, measured, which is what one more round trip costs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -107,6 +107,7 @@ open; nothing before Phase 3 forces it.
 | [0038](0038-a-night-that-mostly-died-is-not-a-run.md) | A Night That Mostly Died Is Not a Run | Accepted |
 | [0039](0039-a-live-smoke-provider-is-armed-or-declared-unarmed.md) | A Live Smoke Provider Is Armed or Declared Unarmed | Accepted |
 | [0040](0040-host-does-not-pick-the-tests.md) | The Host Does Not Pick the Tests | Accepted |
+| [0041](0041-the-turn-clock-reaches-dispatch-by-value.md) | The Turn Clock Reaches Dispatch by Value | Accepted |
 
 ADR 0013 draws the line between what Stella owes a caller that moves a session
 between machines (an artifact, a fingerprint, a version contract, a visible
@@ -245,6 +246,15 @@ a runner's convention. A verification plugin holding the granted root may narrow
 for itself, and what it reports is graded as its own claim. `run_test` keeps
 running the invocation the grant carried, which is why its ask carries a
 workspace handle and nothing else.
+
+ADR 0041 decides how the wall clock reaches a tool call. A `bash` call carries
+its own time limit, and nothing weighed it against the time the turn had left,
+so a ten-minute call could start with four minutes to go and be killed from
+outside with every edit lost. The clock is read once per step boundary and
+passed down by value; the executor declares the bound it would enforce through
+a defaulted port method, because the key that carries it belongs to one tool.
+A call that cannot finish and still leave room to report back is refused before
+it starts, which is the only moment AGENTS.md #6 leaves.
 
 ## The number is a shared cell
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -205,6 +205,11 @@
       "status": "implemented",
       "title": "ADR 0040: The host does not pick the tests"
     },
+    "adr/0041-the-turn-clock-reaches-dispatch-by-value": {
+      "path": "docs/adr/0041-the-turn-clock-reaches-dispatch-by-value.md",
+      "status": "implemented",
+      "title": "ADR 0041: The turn clock reaches dispatch by value"
+    },
     "agent-monitor-protocol": {
       "path": "docs/spec/agent-monitor-protocol.md",
       "status": "living",


### PR DESCRIPTION
## What & why

A `bash` call carries its own time limit. The model writes it, `stella-tools` cuts it to ten minutes at most, and the spawn arms it. Nothing ever weighed that number against the clock the turn had left.

So a ten-minute call could start at t=350s of an 840-second budget and run to t=950s. Harbor kills the trial at 900s, the process dies, and every edit the turn made dies with it. The engine's own deadline never fires, because it is asked between steps and the step never ends. On the 89-task Terminal-Bench 2.1 run of 2026-09-07 (SUT `99eef2d5`, glm-5.3 via OpenRouter, stock 1.0x timeouts, 840s turn budget), **17 of 32 failures ended exactly that way** — the dominant failure mode of the run.

Closes #6460

### How the clock reaches dispatch — ADR 0041

The issue filed this rather than fixing it inline because the fix needs a decision: the clock must be read in the driver (AGENTS.md #2) and the dispatch site could not see it, while the declared limit lives under a key only the tool layer knows (AGENTS.md #1). `docs/adr/0041-the-turn-clock-reaches-dispatch-by-value.md` records the decision and the four alternatives weighed against it.

- **`driver/turn_clock.rs`** — `TurnClock` reads the turn's two bounds once per step (`EngineConfig::turn_budget`, measured from the turn's start, and `BudgetGuard::task_deadline`) and keeps the earlier. It travels by value through `dispatch_completion` into `execute_tool_calls`, **replacing** the `Option<ContinuationBudget>` parameter already threaded down that exact path. `execute_tool_calls` re-reads it against `Instant::now()` for each barrier group, because the groups before it have spent clock.
- **`ToolExecutor::declared_timeout(name, input)`** — a defaulted port method answering `Option<Duration>`. `ToolRegistry` answers for `bash` and nothing else; every decorator forwards. The default `None` means "cannot say" and starts the call exactly as today, which is why this costs no implementation in the tree anything it did not already do.
- **The refusal** — a `RefusedByPolicy` `ToolOutput` naming the seconds the model may ask for, emitted with no `ToolStart`, following `HALTED_TOOL_RESULT` and `close_open_tool_calls`. The turn goes on from it.

The exemplars followed are the port's own neighbours rather than an outside crate: `tool_origin` for the shape of a defaulted, forwarded port method whose default is the safe direction, and `ContinuationBudget::affords_another` / `settlement::check_budget` for a pure decision over a clock the driver reads.

AGENTS.md #6 holds: nothing in flight is interrupted, and the decision is made before the call starts.

### The reserve, and why there is no invented margin

The limit must be strictly under the clock left, less **one model call** — the measured `StepPace::model`. That much is held back so the refusal can reach the model and the model can answer. No fixed margin is made up here, matching what `affords_another` and `check_budget` both already write down: the caller owns the deadline and can set a safe one.

### A second, deliberate consequence

`turn_budget` and `task_deadline` now bound the **length continuation** together, where before only `turn_budget` did. Both are armed from `--turn-timeout` in the shipped binary (`runtime::one_shot_budget_guard` and `agent::engine::engine_config_for`), so nothing observable changes there; a caller that armed only the enforced deadline now gets the decline it always should have had. Named here because it is a behaviour change the issue did not ask for.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-core/tests/tool_wall_clock.rs` — `a_call_longer_than_the_turn_has_left_never_starts`. It drives the shipped dispatch path through the public API: a 600s call on a 300s turn must not reach the executor, and the refusal must name the seconds left.

**Proved, not asserted.** With `refuse_for_time` neutralised to always return `None` (the pre-change behaviour) and everything else unchanged:

```
test a_call_longer_than_the_turn_has_left_never_starts ... FAILED
  panicked at crates/stella-core/tests/tool_wall_clock.rs:175:5:
  a 600s call must not start on a turn with 300s of wall clock left
test result: FAILED. 2 passed; 1 failed
```

and restored:

```
test result: ok. 3 passed; 0 failed
```

The other two in that file are the controls that stop the witness passing on an engine that merely stopped running tools: a 60s call on the same turn still runs, and a turn with no budget configured still runs the 600s call.

Beside it: `driver/turn_clock.rs`'s unit tests (the decision function, the two-bound minimum, the re-read as a step proceeds, exactly-enough-is-not-enough), `bash::tests::the_declared_bound_is_the_one_the_spawn_would_arm` (the declaration is the same value the spawn arms, ceiling included), and `the_production_tool_stack_forwards_declared_timeouts` in `stella-cli` — the shipped registry → MCP → custom → policy → skill-plane chain, so a future decorator that forgets to forward fails there and nowhere else.

## The gate

- [x] `cargo fmt --check`
- [x] Clippy, scoped: `cargo clippy -p stella-core -p stella-tools -p stella-mcp -p stella-serve -p stella-cli --all-targets -- -D warnings` — clean
- [x] Tests, scoped: `cargo test -p stella-core` (885 + 27 across the integration targets), `-p stella-tools` (639 + integration), `-p stella-mcp -p stella-serve`, and `-p stella-cli --bins tool_stack|tool_policy` — all green
- [x] `make doc-warnings CARGO_SCOPE="-p stella-core -p stella-tools"` and again for `-p stella-mcp -p stella-serve -p stella-cli` — clean (it caught a redundant explicit link target in the new module)
- [x] `make guards-fast` — passed, including `check-prose`, `check-invariants`, `check-adr-numbering` (41 records, every number unique and indexed) and `check-god-files`
- [x] Docs updated: ADR 0041, `docs/adr/README.md` (table row and summary), `docs/manifest.json` regenerated by `make doc-links-fix`
- [x] CLA signed
- [x] `Closes #6460` appears both above and as a commit trailer

The workspace build and full suite are CI's, per CLAUDE.md.

## Fix over file

- [x] Extra fixes in this PR: the `turn_budget`/`task_deadline` unification named above, which is a defect the same reading found — a turn could outlive the enforced deadline while only the advisory one was consulted. `bash`'s registered name is now a constant the schema and the declaration share, so the two cannot drift.
- [x] Filed, with the reason a fix could not ride this PR: nothing was deferred.

## Ground-rule check

- [x] No I/O added to `stella-core` — `TurnClock` is pure, takes `now` as a parameter, and never calls `Instant::now`; the driver reads the clock, as `settlement` and `truncation` already do. No new deps.
- [x] No new outbound network calls
- [x] No new cross-boundary serde types

## God files

`driver.rs` is closed to growth and **shrinks** by four lines here: the seven-line `ContinuationBudget` construction becomes one `TurnClock::read` call. Nothing lands in `driver/tests.rs`; the engine-level witness is a new integration target beside `parallel_dispatch.rs`.

## Anything reviewers should know?

**No test was deleted or renamed.**

**A refusal names a number, so two refusals in one turn do not match byte for byte** — the loop-detection rungs cannot read them as a run. That is the reason `HALTED_TOOL_RESULT` is a fixed string, and the divergence is written down at `refused_for_time`. It is acceptable here for two reasons: the number is the fix, so a model that reads it stops repeating rather than looping; and a turn in this state is one model call from its deadline in any case, which the three-occurrence threshold cannot outlast.

**`bash` is the only tool this can refuse today**, because it is the only built-in that takes a time limit from the model. A tool that grows one implements `declared_timeout` in the same change or the clamp does not see it — the safe direction, and the same one `tool_origin`'s default takes.

**A speculated call is admitted whatever it declared.** It has already finished, so refusing it would throw away work the turn has paid for. The pool is peeked at, never consumed, in `refuse_for_time`.

**The last DoD item on #6460 was rewritten rather than ticked.** It asked for a re-measurement on a TB2.1 run, which needs real spend and the fix in the binary under test. It now sits under an "Observed after merge" heading on the issue, with the confound named; the item in its place is the shipped-stack forwarding this PR does prove.

Stacked context: #6463 fixes two other findings from the same run and explicitly leaves this one to #6460. It touches `deadline_notice.rs` and `search.rs`; this PR touches neither.

## Summary by Sourcery

Refuse declared-duration tool calls that cannot complete within the turn's remaining wall-clock budget, while preserving execution for calls that fit or lack a known bound.

New Features:
- Prevent tool calls with declared time limits from starting when they cannot finish within the remaining turn clock.
- Expose declared tool timeouts through the executor interface, with bash reporting its effective timeout and composed tool stacks forwarding the value.

Bug Fixes:
- Prevent overlong bash calls from running past turn or task deadlines and losing the turn's completed work when an external harness terminates it.
- Apply the tighter of the configured turn budget and task deadline to both tool admission and continuation decisions.

Enhancements:
- Pass a pure, step-scoped turn clock through dispatch and re-evaluate remaining time before each barrier group.
- Return a policy refusal with the affordable duration while preserving safe-boundary tool execution and speculative-result handling.

Documentation:
- Add ADR 0041 documenting how turn-clock information reaches tool dispatch and register it in the ADR index and documentation manifest.

Tests:
- Add unit and integration coverage for timeout admission, deadline selection, clock re-evaluation, refusal behavior, bash timeout declarations, and forwarding through the production tool stack.