### PR TITLE
fix(scripts): stop an empty ci run list reading as ten unverified commits

### DIFF
--- a/scripts/check-main-verified.sh
+++ b/scripts/check-main-verified.sh
@@ -61,10 +61,11 @@
 #
 # ── It fails OPEN, at every unknown ──────────────────────────────────────────
 #
-# No `gh`, an unreachable API, an unparseable answer: report and exit 0. This
-# is a monitor, and a monitor that can itself block a merge is worse than the
-# gap it watches — the same argument `main-red-claim.sh`'s header makes about
-# a claim check. Every unknown is loud, never silent.
+# No `gh`, an unreachable API, an unparseable answer, a run list that came back
+# empty so no commit could be matched: report and exit 0. This is a monitor,
+# and a monitor that can itself block a merge is worse than the gap it watches
+# — the same argument `main-red-claim.sh`'s header makes about a claim check.
+# Every unknown is loud, never silent.
 #
 # ── `--announce` reaches a person, on codeql-canary.sh's shape ───────────────
 #
@@ -231,6 +232,25 @@ elif ! runs="$(gh run list --workflow ci.yml --branch main --limit 60 \
   --json headSha,status,conclusion,createdAt \
   --jq '.[] | "\(.headSha) \(.status) \(.conclusion // "none") \(.createdAt)"' 2>/dev/null)"; then
   unknown "could not reach the Actions API"
+fi
+
+# An empty list is a blind read, not a finding about every commit at once.
+#
+# `gh` answers a transient API fault with `[]` and exit 0 as readily as it
+# answers a genuinely empty history, and the loop below defaults each commit
+# to `missing`. So on 2026-09-09 one bad read reported all ten commits as
+# unverified and filed an issue saying nothing had checked a tree whose `ci`
+# run on cd7d53c had already concluded success. An auth or permission failure
+# exits non-zero and is already caught above; this is the shape that does not.
+#
+# The two cases are separable because the read asks for the last 60 `ci` runs
+# on `main` whatever their age. An outage creates no runs, and destroys none,
+# so it cannot empty that list — older runs stay in it, and a commit absent
+# from a populated list is still reported, which is the gap this script
+# watches. Empty means this run could not see the history at all, and that is
+# an unknown.
+if [ -z "$runs" ]; then
+  unknown "the ci run list came back empty, so no commit could be matched"
 fi
 
 now_epoch="$(date -u +%s 2>/dev/null || echo 0)"

--- a/scripts/test-main-verified.sh
+++ b/scripts/test-main-verified.sh
@@ -199,6 +199,44 @@ case "$out" in
   *) fail=$((fail + 1)); echo "FAIL an unknown exited 0 without saying so:"; echo "$out" ;;
 esac
 
+# ── E: an empty run list is a blind read ─────────────────────────────────────
+#
+# `gh run list` returns `[]` with exit 0 for a transient fault as readily as
+# for an empty history, and the verdict loop defaults every commit to
+# `missing`. On 2026-09-09 that turned one bad read into ten findings and a
+# filed issue claiming nothing had verified a tree whose `ci` run had gone
+# green seventeen seconds earlier. An auth failure exits non-zero and was
+# already an unknown; this shape was not.
+empty_list_commits="$(commit $A 'a merge the API could not answer for')
+$(commit $B 'the merge before it')"
+
+want "an empty run list is an unknown, not a finding" expect-pass \
+  "$empty_list_commits" "" \
+  "UNKNOWN"
+
+want "...and says the list is what came back empty" expect-pass \
+  "$empty_list_commits" "" \
+  "came back empty"
+
+# It also files no issue, which is the half of a misreport somebody has to
+# undo by hand.
+out="$("$SCRIPT" --fixture-commits "$empty_list_commits" --fixture-runs "" \
+  --announce --dry-run 2>&1)"
+case "$out" in
+  *"issue create"*)
+    fail=$((fail + 1)); echo "FAIL an empty run list filed an issue:"; echo "$out" ;;
+  *) pass=$((pass + 1)); echo "ok   ...and files no issue over a read it could not make" ;;
+esac
+
+# The coverage this must not buy its safety with. A populated list that simply
+# has no run for the commit is the real gap (f1f36660's shape above), and it
+# stays a failure — the guard turns on the list being empty, never on a commit
+# being absent from it.
+want "a commit missing from a POPULATED list is still reported" expect-fail \
+  "$(commit $A 'a merge nothing ran for')" \
+  "$B completed success $(now_iso)" \
+  "missing"
+
 # ── N: several commits, one bad ──────────────────────────────────────────────
 # The reported window is a run of merges, not one; a guard that stopped at the
 # first verified commit would have missed three of the four that day.


### PR DESCRIPTION
## What this fixes

`scripts/check-main-verified.sh` reads the CI history with one `gh run list`
call, then defaults each commit to `missing` when no run in that list matches
it. An empty list matches nothing, so all ten commits it checks become ten
separate findings at once.

`gh` returns `[]` with exit 0 for a transient API fault as readily as for a
genuinely empty history. On 2026-09-09 one such read failed `main-canary.yml`'s
`main carries no unverified commit` job and filed #6475, which named ten
commits as unverified — while `ci` run 34379997528 on the tip it named,
cd7d53c, had already concluded `success`. Every one of those ten commits has a
completed `ci` run, then and now.

An auth or permission failure was already handled: `gh` exits non-zero there
and the script takes its `unknown` path. I checked that directly — the same
query under an invalid token exits 1, which is why this run cannot have been a
permission problem and must have been an empty answer with exit 0.

## The fix

An empty run list becomes an `unknown`: reported loudly, exit 0. That is the
discipline the script's own header already states for every other unanswerable
read, and the header now names this one.

The two cases are separable rather than conflated. The read asks for the last
60 `ci` runs on `main` whatever their age, and an outage creates no runs and
destroys none, so it cannot empty that list — older runs stay in it. Empty
therefore means this run could not see the history at all.

The fix does not buy its safety with the coverage it exists to provide: a
commit absent from a *populated* list is still reported, and a new case pins
that direction alongside the three new ones.

## Witness

The three new cases in `scripts/test-main-verified.sh` fail on the previous
script and pass on this one. Checked by restoring `HEAD`'s copy of the script
and running the new suite against it:

```
FAIL an empty run list is an unknown, not a finding — expected exit 0, got 1
FAIL ...and says the list is what came back empty — expected exit 0, got 1
FAIL an empty run list filed an issue
main-verified: 35 passed, 3 failed
```

With the fix in place: `main-verified: 38 passed, 0 failed`.

`guard-self-tests.yml` runs this suite on `pull_request` with no paths filter,
so the witness runs in CI.

## Checks run locally

- `./scripts/test-main-verified.sh` — 38 passed, 0 failed
- `shellcheck` on both changed scripts — clean
- `make prose` — OK, none added
- `make line-citations` — OK, none added
- `make guards-fast` — green

Nothing compiled: this change is two shell scripts.

## Why this closes #6475

#6475 is the false report itself, filed by the defect this PR removes. Its
Definition of done — every recent commit on `main` has a completed `ci` run —
was already true when the issue was filed and is true now; I re-ran the fixed
checker against the real repository to confirm before ticking the box:

```
check-main-verified: OK — each of the last 10 commit(s) on main has a completed ci run.
```

## Not in this PR

`main` also has a second, unrelated red: the `docs` workflow's
`deploy stella.oxagen.sh` job fails with

```
AccessDeniedException ... assumed-role/gha-deploy-stella/GitHubActions is not
authorized to perform: ssm:SendCommand on ... instance/i-094fcb34c7e715cf8
```

That is IAM drift in AWS account 916294258235, not a defect in this tree —
`docs.yml` names the same instance id the infra's `terraform.tfvars` declares,
and the Terraform does grant `ssm:SendCommand` on it. Repairing it needs a
production apply in an account this repository cannot reach, so it is filed as a handoff
in #6478 rather than fixed here.

Closes #6475
