### PR TITLE
fix(scripts): an empty ci run list is an unknown, not ten unverified commits

### DIFF
--- a/scripts/check-main-verified.sh
+++ b/scripts/check-main-verified.sh
@@ -61,10 +61,10 @@
 #
 # ── It fails OPEN, at every unknown ──────────────────────────────────────────
 #
-# No `gh`, an unreachable API, an unparseable answer: report and exit 0. This
-# is a monitor, and a monitor that can itself block a merge is worse than the
-# gap it watches — the same argument `main-red-claim.sh`'s header makes about
-# a claim check. Every unknown is loud, never silent.
+# No `gh`, an unreachable API, an empty run list, an unparseable answer: report
+# and exit 0. This is a monitor, and a monitor that can itself block a merge is
+# worse than the gap it watches — the same argument `main-red-claim.sh`'s
+# header makes about a claim check. Every unknown is loud, never silent.
 #
 # ── `--announce` reaches a person, on codeql-canary.sh's shape ───────────────
 #
@@ -231,6 +231,26 @@ elif ! runs="$(gh run list --workflow ci.yml --branch main --limit 60 \
   --json headSha,status,conclusion,createdAt \
   --jq '.[] | "\(.headSha) \(.status) \(.conclusion // "none") \(.createdAt)"' 2>/dev/null)"; then
   unknown "could not reach the Actions API"
+fi
+
+# Zero rows answers a different question than it looks like it answers. The
+# loop below opens every commit at `missing` and only a matching row moves it,
+# so an empty list does not report one absence — it reports the whole window as
+# absent, in one breath, with no row anywhere to contradict it. A read that
+# returned nothing cannot distinguish "no `ci` run exists for any of these
+# commits" from "the API declined to list them", and those are opposite states.
+#
+# `gh` exits 0 on an empty page, so the check above never sees it. On
+# 2026-09-09 one such page filed against the ten newest commits at once; each
+# of them had a completed, successful run, and the same query twenty minutes
+# later returned all sixty rows. The header's rule decides it: every unknown
+# exits 0 and says so, because a monitor that fabricates is one nobody reads
+# the second time.
+#
+# This is only the empty page. A list that carries rows but none for a given
+# commit is the outage this script was written to catch, and still reports.
+if [ -z "$runs" ]; then
+  unknown "the run list came back empty — this read listed no ci run at all for main, which cannot tell an outage from an unanswered query"
 fi
 
 now_epoch="$(date -u +%s 2>/dev/null || echo 0)"

--- a/scripts/test-main-verified.sh
+++ b/scripts/test-main-verified.sh
@@ -199,6 +199,35 @@ case "$out" in
   *) fail=$((fail + 1)); echo "FAIL an unknown exited 0 without saying so:"; echo "$out" ;;
 esac
 
+# Zero rows is the API declining to answer, not an answer that no `ci` run
+# exists for any of these commits. Read the second way, one empty page turns
+# every commit in the window into a finding at once: on 2026-09-09 that filed
+# against ten commits which each had a completed, successful run, and a monitor
+# that files falsely is one nobody reads twice.
+empty_runs_commits="$(commit $A 'a merge whose run the API did not list')
+$(commit $B 'and the merge before it')"
+if out="$("$SCRIPT" --fixture-commits "$empty_runs_commits" --fixture-runs "" 2>&1)" &&
+  [ -z "${out##*UNKNOWN*}" ]; then
+  pass=$((pass + 1)); echo "ok   an empty run list is UNKNOWN, not every commit missing"
+else
+  fail=$((fail + 1)); echo "FAIL an empty run list was read as a finding:"; echo "$out"
+fi
+
+# The report names the shape it could not read, so a reader of the log can
+# tell this apart from the outage the script exists to catch.
+case "$out" in
+  *"listed no ci run at all"*) pass=$((pass + 1)); echo "ok   ...and names an empty run list as the reason" ;;
+  *) fail=$((fail + 1)); echo "FAIL the unknown did not say the run list was empty:"; echo "$out" ;;
+esac
+
+# The other direction, so the guard above cannot be satisfied by refusing to
+# answer whenever a commit has no run: a NON-empty list that simply carries
+# nothing for this commit is still the outage this script was written for.
+want "a run list carrying nothing for the commit is still unverified" expect-fail \
+  "$(commit $B 'a merge with no run of its own')" \
+  "$A completed success $(now_iso)" \
+  "missing"
+
 # ── N: several commits, one bad ──────────────────────────────────────────────
 # The reported window is a run of merges, not one; a guard that stopped at the
 # first verified commit would have missed three of the four that day.


### PR DESCRIPTION
## What & why

`scripts/check-main-verified.sh` filed a false alarm this afternoon. At
16:58 UTC it reported the ten newest commits on `main` as having no `ci` run
at all and opened this issue. Every one of those ten commits has a completed,
**successful** `ci` run:

```
cd7d53c9 completed success 2026-09-09T16:57:59Z   <- reported "missing"
a3a62948 completed success 2026-09-09T07:12:01Z   <- reported "missing"
bfc63d0b completed success 2026-09-09T06:17:43Z   <- reported "missing"
...all ten
```

The script guards its **commit** read for emptiness and never guards its
**run** read. The matching loop opens every commit at `verdict="missing"` and
only a row for that commit moves it, so a run list that came back with zero
rows did not report one absence — it reported the whole window as absent at
once, with no row anywhere able to contradict it. `gh` exits 0 on an empty
page, so the existing `if ! runs=...` check for a failed call never saw it.

A read that returned nothing cannot tell "no `ci` run exists for any of these
commits" from "the API declined to list them", and those are opposite states.
The script's own header already decided which way that resolves — *"It fails
OPEN, at every unknown"* — because a monitor that fabricates blocks merges
during exactly the incident its repair has to land in, and one that files
falsely is one nobody reads the second time. An empty page is now one of those
unknowns, and it is named in the header beside `gh` being absent and the API
being unreachable.

**Only the empty page.** A list that carries rows but none for a given commit
is the outage this script was written to catch, and still reports. A
negative-control case pins that direction so the new guard cannot be satisfied
by refusing to answer whenever a commit has no run of its own.

Closes #6475

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`scripts/test-main-verified.sh`, run against this branch:

| | result |
|---|---|
| before the fix | **35 passed, 2 failed** |
| after the fix | **37 passed, 0 failed** |

The two failing assertions are `an empty run list is UNKNOWN, not every commit
missing` and `...and names an empty run list as the reason`. The third new
case — `a run list carrying nothing for the commit is still unverified` —
passes on both sides by design: it is the negative control, and it is what
stops the fix being a blanket "answer nothing when in doubt".

Verified against the real repository as well: `./scripts/check-main-verified.sh`
on this branch prints `OK — each of the last 10 commit(s) on main has a
completed ci run.` and exits 0, which is the state the issue claims otherwise.

## The gate

- [x] `cargo fmt --check` — via `make guards-fast`
- [x] workspace clippy and the workspace suite — no Rust in this diff; CI runs both
- [x] Docs updated where behavior changed — the script's own fail-open header now names the empty run list
- [x] CLA signed
- [x] `Closes #6475` appears both above and as a commit trailer

`make guards-fast`, `make prose`, `make line-citations` and `make shellcheck`
all pass on this branch. No test was deleted.

## Fix over file

- [x] Extra fixes in this PR: none. I checked `scripts/check-ci-tests.sh`,
      which reads the same run list the same way — it is **not** affected: with
      an empty list its `verdict` stays empty and it already exits 0 through
      `unknown`, so it fails open as intended.
- [x] Filed, with the reason a fix could not ride this PR: **#6481**. Sweeping
      the sibling guards after this fix turned up the same shape in
      `scripts/check-releases-published.sh`: its releases read is unguarded, and
      an empty page makes `$published` empty, so every non-grandfathered tag
      past the grace window reports as `absent`. It did not ride this PR because
      the obvious guard collides with the script's own purpose — "many tags,
      zero releases" is *also* the genuine catastrophic finding it exists to
      report, and nothing in the payload separates a broken read from a real
      total failure. Which cost to pay is a maintainer call, so it is written up
      with the three options rather than decided here.

## Anything reviewers should know?

Unrelated to this diff, and reported rather than fixed because it is an AWS
IAM change outside this repository: **the docs site deploy has failed on every
push to `main` since 2026-09-08 23:25 UTC** (three consecutive runs of
`docs`). `stella.oxagen.sh` has not been updated since.

```
User: arn:aws:sts::916294258235:assumed-role/gha-deploy-stella/GitHubActions
is not authorized to perform: ssm:SendCommand on
arn:aws:ec2:us-east-1:916294258235:instance/i-094fcb34c7e715cf8
because no identity-based policy allows the ssm:SendCommand action
```

The role needs `ssm:SendCommand` on that instance. Nothing in this tree can
grant it.
