### PR TITLE
Publish the stella-serve container image on every release

### DIFF
--- a/.github/workflows/docker-serve-publish.yml
+++ b/.github/workflows/docker-serve-publish.yml
@@ -1,0 +1,179 @@
+name: docker-serve-publish
+
+# Publishes packaging/docker/Dockerfile.serve to the GitHub container registry
+# on every release tag, as `ghcr.io/macanderson/stella-serve:<version>` and
+# `:latest`, for linux/amd64 and linux/arm64.
+#
+# Until this workflow existed nothing published the image at all. docker-serve.yml
+# builds it and smokes the container on a pull request, then throws it away;
+# release.yml ships the `stella` CLI for four targets and never builds
+# `stella-serve`. So a host that wants to run the engine as a container — the
+# Oxagen node does, on arm64 — had to build the image itself from a checkout
+# of this repository, and would find out only at deploy time whether the tag
+# it built matched the wire its client was written against. An image published
+# under the release version is the pin such a host can name.
+#
+# Two native builds rather than one QEMU build: compiling the workspace under
+# emulation takes hours, and both runner architectures exist. Each build job
+# pushes its image by digest only, and the last job stitches the two digests
+# into one multi-architecture tag, which is the shape docker/build-push-action
+# documents for this.
+#
+# Each per-architecture image is smoked with the same script docker-serve.yml
+# uses before its digest is pushed, so a published image is one that served.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, without the leading v (defaults to the checked-out tag)"
+        required: false
+
+concurrency:
+  group: docker-serve-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/macanderson/stella-serve
+
+jobs:
+  build:
+    name: build ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            os: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            os: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # The same assertion docker-serve.yml makes: the builder base and
+      # rust-toolchain.toml must name one compiler, or the image ships two
+      # compilers' worth of download in its critical path.
+      - name: builder base tracks rust-toolchain.toml
+        run: |
+          set -euo pipefail
+          dockerfile=packaging/docker/Dockerfile.serve
+          pinned="$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' rust-toolchain.toml)"
+          base="$(sed -n 's/^FROM rust:\([^[:space:]]*\)-bookworm .*/\1/p' "$dockerfile")"
+          if [ -z "$pinned" ] || [ -z "$base" ] || [ "$pinned" != "$base" ]; then
+            echo "$dockerfile builds on rust:$base-bookworm but rust-toolchain.toml pins $pinned." >&2
+            exit 1
+          fi
+
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: build the image for this architecture
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: packaging/docker/Dockerfile.serve
+          platforms: ${{ matrix.platform }}
+          tags: stella-serve:smoke
+          load: true
+          provenance: false
+          cache-from: type=gha,scope=serve-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=serve-${{ matrix.arch }}
+
+      - name: smoke the container before publishing it
+        run: ./scripts/smoke-serve-image.sh stella-serve:smoke
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Pushed by digest only. The tag is written once, below, over both
+      # digests, so a half-published release never carries a tag that
+      # resolves on one architecture and not the other.
+      - name: push the image by digest
+        id: push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: packaging/docker/Dockerfile.serve
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+          cache-from: type=gha,scope=serve-${{ matrix.arch }}
+
+      # An artifact rather than a job output: two matrix legs writing one
+      # job's outputs race, and the last leg to finish wins with an empty
+      # value for the key it did not set. A file per architecture cannot
+      # collide.
+      - name: record the digest
+        run: |
+          set -euo pipefail
+          mkdir -p digests
+          printf '%s' "${{ steps.push.outputs.digest }}" > "digests/${{ matrix.arch }}"
+          test -s "digests/${{ matrix.arch }}"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: serve-digest-${{ matrix.arch }}
+          path: digests/${{ matrix.arch }}
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: tag the multi-architecture image
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: resolve the version
+        id: version
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+          if [ -z "$version" ]; then
+            ref="${GITHUB_REF_NAME}"
+            version="${ref#v}"
+          fi
+          case "$version" in
+            [0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "not a release version: '$version'" >&2; exit 1 ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: serve-digest-*
+          path: digests
+          merge-multiple: true
+
+      - name: write the version and latest tags over both digests
+        run: |
+          set -euo pipefail
+          amd64="$(cat digests/amd64)"
+          arm64="$(cat digests/arm64)"
+          if [ -z "$amd64" ] || [ -z "$arm64" ]; then
+            echo "a per-architecture digest is missing (amd64='$amd64', arm64='$arm64'); refusing to tag half a release" >&2
+            exit 1
+          fi
+          docker buildx imagetools create \
+            --tag "$IMAGE:${{ steps.version.outputs.version }}" \
+            --tag "$IMAGE:latest" \
+            "$IMAGE@$amd64" "$IMAGE@$arm64"
+          docker buildx imagetools inspect "$IMAGE:${{ steps.version.outputs.version }}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -367,6 +367,18 @@ matters because this repo has **immutable releases** enabled — a published
 release's assets can't be added or changed afterward, so an incomplete release
 means cutting a new version.
 
+## The engine container
+
+Every release tag also publishes `packaging/docker/Dockerfile.serve` as
+`ghcr.io/macanderson/stella-serve:<version>` and `:latest`, for linux/amd64
+and linux/arm64 (`.github/workflows/docker-serve-publish.yml`). Each
+architecture is built on its own runner, smoked with
+`scripts/smoke-serve-image.sh` before its digest is pushed, and the two
+digests are tagged together at the end, so a tag never resolves on one
+architecture and not the other. A host that embeds the engine pins the
+version tag; `latest` is for a laptop. The image takes `STELLA_SERVE_TOKEN`
+or `STELLA_SERVE_TOKEN_FILE` at run time and nothing else.
+
 ## After the release — how users install
 
 Homebrew (prebuilt binary, no Rust toolchain):


### PR DESCRIPTION
## What this does

Publishes `packaging/docker/Dockerfile.serve` on every release tag as `ghcr.io/macanderson/stella-serve:<version>` and `:latest`, for linux/amd64 and linux/arm64.

Nothing published the image before. The existing `docker-serve.yml` builds and smokes it on a pull request and throws it away, and `release.yml` ships only the CLI binary. Oxagen's node runs the engine as a container on arm64 and had no image to pin.

## How

- Two native builds, one per runner architecture. Emulating the Rust build under QEMU takes hours.
- Each per-architecture image is smoked with the same script `docker-serve.yml` uses before its digest is pushed.
- Digests are pushed by digest only and tagged together at the end, so a half-published release never carries a tag that resolves on one architecture and not the other. The digests travel as artifacts because two matrix legs writing one job's outputs overwrite each other.
- `RELEASING.md` gains a short section on the image.

## Evidence

Toolchain-free guards pass locally (`make guards-fast`, including `action-pins` over the four new pinned actions), and `make prose` and `make line-citations` pass on the release doc change. The workflow itself runs only on a tag push, so its first real run is the next release after this merges. No test was deleted.

No witness test: this is a CI change with no code path in the workspace.

## Summary by Sourcery

Publish validated multi-architecture stella-serve container images alongside every release.

New Features:
- Publish the stella-serve container image for linux/amd64 and linux/arm64 on release tags, with version and latest tags in GHCR.

Enhancements:
- Build and smoke-test each architecture independently, then publish both digests as a single multi-architecture image tag.

CI:
- Add a release workflow that builds, validates, and publishes the stella-serve image, including manual versioned dispatches.

Documentation:
- Document the published engine container image, supported architectures, tagging guidance, and runtime configuration in RELEASING.md.