### PR TITLE
bench: let the pipeline A/B hold two arms, and name the blocker that stops it running

### DIFF
--- a/bench/evidence/pipeline-ab/README.md
+++ b/bench/evidence/pipeline-ab/README.md
@@ -46,18 +46,55 @@ All of it is in `preregistration.json`. The short form:
 
 ## What blocks the run today
 
-One thing, and it is tree-only. `#6195` has it.
+Both blockers need the benchmark rig, and neither can be settled by reading
+the tree.
 
-**The control arm has no binary and the run scripts hold one arm.** Its crate
-is gone from this workspace, so its build comes from a checkout of
-`f4c24c12b`, with that commit's own lock file and toolchain pin.
-`build_sut.sh` refuses any difference between the working tree and the commit
-it is handed, so it has to run from that checkout rather than from `main` with
-the commit as an argument. `env.sh` then gives both arms one `STELLA_BINARY`
-path and one `$TB_ROOT`, so the second build overwrites the first. The same
-variable puts `$TB_REPO/bench/harbor_adapter` on `PYTHONPATH`, so aiming
-`TB_REPO` at the old checkout swaps in the old adapter too, and only the
-binary may differ between the arms.
+**The control arm has no binary** (`#6195`). Its crate is gone from this
+workspace. So the build comes from a checkout of `f4c24c12b`, with that
+commit's own lock file and toolchain pin. One question is open: does
+`cargo zigbuild --locked` still resolve that lock file today? A yanked crate
+shows up there first.
+
+**The treatment arm has no plugin in the task container** (`#6490`). The
+adapter uploads the `stella` binary and nothing else. A wrapper plugin is a
+folder read off disk. So the roster is empty, `PipelineChoice::resolve`
+refuses `witness-v1`, and every treatment trial exits non-zero.
+
+That fails closed. The arm yields no number, rather than a wrong one. But
+finding out costs a full arm of spend, so `pipeline_ab.sh` refuses the arm on
+the host.
+
+## How the two arms are launched
+
+One `STELLA_BINARY` path and one `$TB_ROOT` per run puts both arms' builds on
+the same file, and the hash a report cites then belongs to whichever arm was
+built last. Two variables keep them apart:
+
+- `TB_ARM` gives an arm its own binary, `sut_commit.txt` and
+  `binary_sha256.txt` under `$TB_ROOT/arms/<arm>/`.
+- `TB_BUILD_REPO` moves the build to another checkout. `TB_REPO` stays put and
+  still supplies the adapter, the venv and `PYTHONPATH`. Only the binary may
+  differ between two arms. Aim `TB_REPO` at the old checkout and you swap in
+  its adapter too. That one has no `--pipeline` selector at all.
+
+```bash
+TB_ARM=control TB_BUILD_REPO=/checkouts/stella-f4c24c12b \
+  bench/evidence/run/build_sut.sh f4c24c12bde5578818f1141ec4e438291ac4db55
+TB_ARM=treatment bench/evidence/run/build_sut.sh
+
+bench/evidence/run/pipeline_ab.sh control   pab1-control   "$TB_ROOT/pipeline_ab.tasks"
+bench/evidence/run/pipeline_ab.sh treatment pab1-treatment "$TB_ROOT/pipeline_ab.tasks"
+```
+
+An arm's binary must match the commit `build_sut.sh` wrote down for it. The
+usual check asks whether a binary is near `origin/main`. That is the wrong
+question here. The control arm is a thousand commits back on purpose. A
+tolerance wide enough to let it through would let a stale binary through on
+every other run.
+
+`pipeline_ab.sh` pins the task set across the pair. It refuses two arms with
+one binary hash. It refuses a per-trial spend cap, which the plan fixes as
+absent.
 
 ## Two blockers that have shipped
 

--- a/bench/evidence/pipeline-ab/preregistration.json
+++ b/bench/evidence/pipeline-ab/preregistration.json
@@ -3,7 +3,7 @@
   "issue": "https://github.com/macanderson/stella/issues/6155",
   "epic": "https://github.com/macanderson/stella/issues/4029",
   "status": "plan_fixed_run_not_started",
-  "status_note": "The design, outcomes, seeds and decision rule below are fixed and were written before any data existed. The run has not been executed. It needs a benchmark host, a spend-capable credential, a build of a crate this workspace deleted, and the run scripts named under `preconditions`. The two adapter preconditions are met. The fields under `to_be_recorded_before_the_first_paid_call` are the run's identity and must be filled in — and this file committed — before the first paid call, not after; the two `loop_mode_field_values` are filled in already, because the adapter decides them and no data is needed to read them off it.",
+  "status_note": "The design, outcomes, seeds and decision rule below are fixed and were written before any data existed. The run has not been executed. It needs a benchmark host, a spend-capable credential, a build of a crate this workspace deleted, and a way to put the treatment arm's plugin inside a task container. The two adapter preconditions are met and the run scripts hold two arms; the two remaining preconditions both need the rig. The fields under `to_be_recorded_before_the_first_paid_call` are the run's identity and must be filled in — and this file committed — before the first paid call, not after; the two `loop_mode_field_values` are filled in already, because the adapter decides them and no data is needed to read them off it.",
   "plan_fixed_at": "2026-09-05",
   "question": "Is the plugin verification path at least as good as the built-in staged pipeline it replaced?",
   "why_it_is_owed": "docs/spec/pipeline-as-plugins.md §7 set one bar for deleting the built-in path: a side-by-side benchmark. The deletion shipped ahead of that bar as a recorded maintainer call. This run is the late payment.",
@@ -90,7 +90,12 @@
     "control_arm_must_build_and_the_run_scripts_hold_one_arm": {
       "what": "the control arm's crate is gone from this workspace, so its build comes from an old checkout with its own lockfile and toolchain pin. build_sut.sh refuses any difference between the working tree and the commit it is handed. env.sh gives both arms one STELLA_BINARY path and one TB_ROOT, so the second build overwrites the first. The same variable puts $TB_REPO/bench/harbor_adapter on PYTHONPATH, so aiming TB_REPO at the old checkout swaps the adapter too, and only the binary may differ between the arms.",
       "issue": "https://github.com/macanderson/stella/issues/6195",
-      "state": "open. It is tree-only and needs no rig."
+      "state": "half met. The run scripts hold two arms now: TB_ARM gives each arm its own binary and provenance files under $TB_ROOT/arms/<arm>/, and TB_BUILD_REPO moves the build to another checkout while TB_REPO keeps supplying the adapter, so only the binary differs between the arms. bench/evidence/run/pipeline_ab.sh launches one arm and refuses two arms sharing one binary hash. What remains needs the rig: no binary has been built from f4c24c12b, and whether `cargo zigbuild --locked` still resolves that commit's lock file today is unanswered."
+    },
+    "treatment_arm_has_no_plugin_in_the_task_container": {
+      "what": "bench/harbor_adapter/stella_harbor uploads the stella binary and nothing else, and a wrapper plugin is a directory the roster reads off disk. So PluginRoster::load finds an empty roster inside a task container, wrapper_plugin::resolve refuses witness-v1, and agent::goal turns that into a CliFailure on every treatment trial. The refusal is fail-closed, so the arm produces no number rather than a wrong one, and it costs a full arm of spend to discover.",
+      "issue": "https://github.com/macanderson/stella/issues/6490",
+      "state": "open. It needs the rig: which task images carry python3, and whether filesystem_settings_disabled() holds inside a trial, cannot be answered from a checkout. bench/evidence/run/pipeline_ab.sh refuses the treatment arm on the host until it lands."
     }
   },
   "to_be_recorded_before_the_first_paid_call": {

--- a/bench/evidence/run/build_sut.sh
+++ b/bench/evidence/run/build_sut.sh
@@ -16,9 +16,9 @@
 #       checkout of that commit instead. `TB_REPO` stays where it is and keeps
 #       supplying the adapter, so the two arms differ by the binary alone.
 #   TB_ARM — the arm this build belongs to. The binary and the two provenance
-#       files land under `$TB_ROOT/arms/<arm>/` rather than in the one place
-#       both arms used to write, where the second build overwrote the first and
-#       the hash a report cited was whichever ran last.
+#       files land under `$TB_ROOT/arms/<arm>/`. Without it both arms write one
+#       path, the second build overwrites the first, and the hash a report
+#       cites belongs to whichever ran last.
 #
 # Pass a commit to skip the fetch and build exactly that revision. A wrapper
 # that fetches and checks out should pass what it checked out, because otherwise

--- a/bench/evidence/run/build_sut.sh
+++ b/bench/evidence/run/build_sut.sh
@@ -3,9 +3,22 @@
 #
 #   build_sut.sh [<commit>]
 #
-# The SUT is `origin/main` itself. The working tree may carry bench/ or docs
+# The SUT defaults to `origin/main`. The working tree may carry bench/ or docs
 # changes, which compile into nothing, so the check that matters is not "tree is
 # clean" but "every input to the Rust build is byte-identical to origin/main".
+#
+# Two variables move the build off that default, and both are read in `env.sh`:
+#
+#   TB_BUILD_REPO — the checkout to compile. Defaults to `TB_REPO`. An arm whose
+#       commit predates a crate this workspace deleted cannot be built from
+#       `main` with the commit as an argument, because the drift check below
+#       then sees every file that moved since as local contamination. Give it a
+#       checkout of that commit instead. `TB_REPO` stays where it is and keeps
+#       supplying the adapter, so the two arms differ by the binary alone.
+#   TB_ARM — the arm this build belongs to. The binary and the two provenance
+#       files land under `$TB_ROOT/arms/<arm>/` rather than in the one place
+#       both arms used to write, where the second build overwrote the first and
+#       the hash a report cited was whichever ran last.
 #
 # Pass a commit to skip the fetch and build exactly that revision. A wrapper
 # that fetches and checks out should pass what it checked out, because otherwise
@@ -16,7 +29,8 @@
 # says which of the two it is.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
-cd "$TB_REPO"
+BUILD_REPO="${TB_BUILD_REPO:-$TB_REPO}"
+cd "$BUILD_REPO"
 
 RUST_INPUTS=('*.rs' '*/Cargo.toml' Cargo.toml Cargo.lock rust-toolchain.toml)
 
@@ -56,8 +70,9 @@ if [ -n "$drift" ]; then
   fi
   echo "FATAL: build inputs differ from $SUT:"; echo "$drift"; exit 1
 fi
-echo "$SUT" > "$TB_ROOT/sut_commit.txt"
+echo "$SUT" > "$TB_ARM_DIR/sut_commit.txt"
 echo "SUT=$SUT ($(git describe --tags "$SUT" 2>/dev/null || echo no-tag))"
+echo "build_repo=$BUILD_REPO arm=${TB_ARM:-<single build>}"
 
 ZC="$(mktemp -d "${TMPDIR:-/tmp}/stella-zig.XXXXXX")"
 mkdir -p "$ZC/global" "$ZC/local"
@@ -68,6 +83,16 @@ STELLA_BUILD_GIT_SHA="$SUT" \
 "$(rustup which cargo)" zigbuild --release --locked \
   --target "$STELLA_TARGET_TRIPLE.$STELLA_GLIBC_FLOOR" --package stella-cli --bin stella
 
+test -x "$TB_BUILD_OUTPUT"
+# Move the artifact out of the target directory that produced it, so the next
+# arm's build cannot overwrite the binary this run will be reported as having
+# measured. For a single build the two paths are the same file and `cp` is
+# skipped. `cp` and not a symlink or a hard link: the arm directory has to hold
+# a copy that survives a `cargo clean` in the checkout that built it.
+if [ "$STELLA_BINARY" != "$TB_BUILD_OUTPUT" ]; then
+  cp "$TB_BUILD_OUTPUT" "$STELLA_BINARY"
+  chmod +x "$STELLA_BINARY"
+fi
 test -x "$STELLA_BINARY"
 # Verify the artifact, not that the right command was typed. Building through
 # this script and building through anything else are then distinguishable by
@@ -77,8 +102,9 @@ assert_portable_binary
 # against $SUT itself is an equality assertion on the binary's own compile-time
 # stamp, so a build that silently stamped something else — a stale target dir,
 # an env var the caller already had set — is caught here rather than becoming
-# the next thing that measures the wrong code.
-assert_fresh_sut "$STELLA_BINARY" --reference "$SUT" --max-behind 0
+# the next thing that measures the wrong code. `--repo` names the checkout that
+# built it, which holds $SUT whatever $TB_REPO is sitting on.
+assert_fresh_sut "$STELLA_BINARY" --repo "$BUILD_REPO" --reference "$SUT" --max-behind 0
 file "$STELLA_BINARY"
-shasum -a 256 "$STELLA_BINARY" | awk '{print $1}' > "$TB_ROOT/binary_sha256.txt"
-echo "binary_sha256=$(cat "$TB_ROOT/binary_sha256.txt")"
+shasum -a 256 "$STELLA_BINARY" | awk '{print $1}' > "$TB_ARM_DIR/binary_sha256.txt"
+echo "binary_sha256=$(cat "$TB_ARM_DIR/binary_sha256.txt")"

--- a/bench/evidence/run/env.sh
+++ b/bench/evidence/run/env.sh
@@ -12,6 +12,26 @@ export VENV="$TB_REPO/bench/harbor_adapter/.venv"
 export PATH="$VENV/bin:$PATH"
 export PYTHONPATH="$TB_REPO/bench/harbor_adapter"
 
+# Which arm of a two-build experiment this shell is, or empty for a single-build
+# run. Only the binary may differ between two arms, so `TB_REPO` stays pointed at
+# one checkout and supplies the adapter, the venv and the run scripts to both.
+# The three lines above are why: `PYTHONPATH` follows `TB_REPO`, so an arm that
+# moved it to fetch an old binary would swap in that checkout's adapter as well,
+# and the arms would then differ by the measuring instrument too. Point
+# `TB_BUILD_REPO` at the old checkout instead — `build_sut.sh` reads it, and
+# nothing else does.
+#
+# Unset, every path below is what it was before arms existed, so a single-build
+# run reads and writes the same files it always did.
+export TB_ARM="${TB_ARM:-}"
+case "$TB_ARM" in
+  "") export TB_ARM_DIR="$TB_ROOT" ;;
+  *[!a-z0-9-]*)
+    echo "FATAL: TB_ARM must be lowercase letters, digits and hyphens; got '$TB_ARM'"
+    exit 1 ;;
+  *) export TB_ARM_DIR="$TB_ROOT/arms/$TB_ARM"; mkdir -p "$TB_ARM_DIR" ;;
+esac
+
 # The SUT is cross-compiled against an old glibc so it runs in every task image,
 # including the two on `debian:bullseye-slim` (glibc 2.31). Both halves of that
 # contract are pinned here — `build_sut.sh` builds to this floor and `preflight`
@@ -21,7 +41,21 @@ export PYTHONPATH="$TB_REPO/bench/harbor_adapter"
 # able to raise the floor to silence the error is the failure being prevented.
 export STELLA_TARGET_TRIPLE="x86_64-unknown-linux-gnu"
 export STELLA_GLIBC_FLOOR="2.17"
-export STELLA_BINARY="$TB_REPO/target/$STELLA_TARGET_TRIPLE/release/stella"
+# Where `cargo zigbuild` drops the artifact, in whichever checkout built it.
+#
+# `TB_` and not `STELLA_`: every script here sources this file before invoking
+# Harbor, so anything exported is ambient in the adapter's process, and the
+# adapter's ambient check refuses the run on any unregistered `STELLA_*` name.
+# A build path means nothing inside a task container and has no business in
+# that namespace.
+export TB_BUILD_OUTPUT="${TB_BUILD_REPO:-$TB_REPO}/target/$STELLA_TARGET_TRIPLE/release/stella"
+# Where the run reads it. An arm gets its own copy, so building the second arm
+# cannot overwrite the first and leave the report citing the survivor's hash.
+if [ -n "$TB_ARM" ]; then
+  export STELLA_BINARY="$TB_ARM_DIR/stella"
+else
+  export STELLA_BINARY="$TB_BUILD_OUTPUT"
+fi
 # `-` and not `:-`: unset still takes the development default, but an
 # explicitly empty value stays empty and means *no per-trial cap*, which a
 # head-to-head against a comparator with no spend ceiling has to be able to
@@ -57,7 +91,7 @@ export JOBS="$TB_ROOT/jobs"
 export DATASET_DIR="$TB_ROOT/dataset"
 mkdir -p "$JOBS"
 
-[ -f "$TB_ROOT/sut_commit.txt" ] && export STELLA_SOURCE_COMMIT="$(cat "$TB_ROOT/sut_commit.txt")"
+[ -f "$TB_ARM_DIR/sut_commit.txt" ] && export STELLA_SOURCE_COMMIT="$(cat "$TB_ARM_DIR/sut_commit.txt")"
 
 # Assert the SUT binary can actually execute inside a task container.
 #
@@ -114,12 +148,43 @@ assert_fresh_sut() {
   }
 }
 
+# Assert an arm's binary is the commit that arm was declared on.
+#
+# `assert_fresh_sut` with no reference asks "is this near origin/main", which is
+# the right question for a single-build run and the wrong one for an arm of a
+# two-build experiment. The control arm of the pipeline A/B is a thousand
+# commits behind main on purpose, so the default refuses it — and raising the
+# tolerance far enough to admit it would admit a stale binary on every other
+# run too.
+#
+# So an arm is held to equality with the commit `build_sut.sh` recorded for it
+# instead. That is stricter than the default, not looser: it fails on a binary
+# one commit off, which the default would wave through, and it is the property
+# the analysis checks anyway (`compare_arms.py --cross-sut` refuses an arm whose
+# trials report a commit other than the one declared for it).
+assert_arm_is_its_declared_commit() {
+  # `:-` and not a bare expansion: `set -u` turns an unset variable into a bash
+  # error that kills the shell before the message below can print, and an arm
+  # with no `sut_commit.txt` is exactly the case this is here to name.
+  local commit="${STELLA_SOURCE_COMMIT:-}"
+  test "${#commit}" = 40 || {
+    echo "FATAL: no recorded commit for arm '$TB_ARM' — run build_sut.sh for it first"
+    return 1
+  }
+  assert_fresh_sut "$STELLA_BINARY" --reference "$commit" --max-behind 0
+}
+
 preflight() {
   test -n "${OPENROUTER_API_KEY:-}" || { echo "FATAL: OPENROUTER_API_KEY unset"; return 1; }
   test -x "$STELLA_BINARY" || { echo "FATAL: no SUT binary at $STELLA_BINARY (run build_sut.sh)"; return 1; }
   assert_portable_binary || return 1
-  assert_fresh_sut || return 1
-  test "${#STELLA_SOURCE_COMMIT}" = 40 || { echo "FATAL: STELLA_SOURCE_COMMIT is not a full SHA"; return 1; }
+  if [ -n "$TB_ARM" ]; then
+    assert_arm_is_its_declared_commit || return 1
+  else
+    assert_fresh_sut || return 1
+  fi
+  local commit="${STELLA_SOURCE_COMMIT:-}"
+  test "${#commit}" = 40 || { echo "FATAL: STELLA_SOURCE_COMMIT is not a full SHA"; return 1; }
   test "$(command -v harbor)" = "$VENV/bin/harbor" || { echo "FATAL: wrong harbor on PATH"; return 1; }
   test "$(harbor --version)" = "0.6.1" || { echo "FATAL: harbor $(harbor --version) != 0.6.1 (audited constant)"; return 1; }
   docker info >/dev/null 2>&1 || { echo "FATAL: docker unreachable"; return 1; }

--- a/bench/evidence/run/pipeline_ab.sh
+++ b/bench/evidence/run/pipeline_ab.sh
@@ -1,44 +1,38 @@
 #!/bin/bash
-# One arm of the two-build pipeline A/B, preregistered in
-# `bench/evidence/pipeline-ab/preregistration.json`.
+# Run one arm of the two-build pipeline A/B.
 #
-# The experiment compares the built-in staged pipeline against the plugin path
-# that replaced it. Each arm is a different build of Stella, and the build is
-# what makes it that arm: a flag can be dropped from a command line, a posture
-# can claim a tier that never fired, and neither can turn one binary into the
-# other one.
+# The plan is `bench/evidence/pipeline-ab/preregistration.json`.
 #
-#   control    — a build of f4c24c12b, the last commit where
-#                `crates/stella-pipeline` exists, run as `--pipeline classic`.
-#   treatment  — a build of main with `plugins/stella-witness` installed, run
-#                as `--pipeline witness-v1`.
+# Two builds of Stella are compared. The build is what makes an arm that arm.
+# A flag can be dropped. A posture can claim a stage that never ran. One
+# binary cannot turn into the other one.
 #
-# Not `witness_ab.sh`: that is two runs of one binary differing in who authors
-# the failing test. Not `primary.sh`: that scores a preregistered phase of the
-# whole dataset against a fixed denominator rather than pairing two arms.
+#   control    a build of f4c24c12b, run as `--pipeline classic`. That is the
+#              last commit that still has `crates/stella-pipeline` in it.
+#   treatment  a build of main, run as `--pipeline witness-v1`. That is the
+#              `plugins/stella-witness` path.
 #
-# Usage, one arm at a time, both reading one task file:
+# `witness_ab.sh` asks a different question. It runs one binary twice and
+# changes who writes the failing test. `primary.sh` scores one phase of the
+# whole dataset and pairs nothing.
 #
-#   TB_ARM=control   TB_BUILD_REPO=/checkouts/stella-f4c24c12b \
-#     bench/evidence/run/build_sut.sh f4c24c12bde5578818f1141ec4e438291ac4db55
-#   TB_ARM=treatment bench/evidence/run/build_sut.sh
+# Build each arm, then run each arm. Both arms read one task file.
 #
-#   bench/evidence/run/pipeline_ab.sh control   pab1-control   "$TB_ROOT/pipeline_ab.tasks"
-#   bench/evidence/run/pipeline_ab.sh treatment pab1-treatment "$TB_ROOT/pipeline_ab.tasks"
+#   `TB_ARM=control TB_BUILD_REPO=/checkouts/stella-f4c24c12b \`
+#   `  bench/evidence/run/build_sut.sh f4c24c12bde5578818f1141ec4e438291ac4db55`
+#   `TB_ARM=treatment bench/evidence/run/build_sut.sh`
+#   `bench/evidence/run/pipeline_ab.sh control   pab1-control   "$TB_ROOT/pipeline_ab.tasks"`
+#   `bench/evidence/run/pipeline_ab.sh treatment pab1-treatment "$TB_ROOT/pipeline_ab.tasks"`
 #
-# then, once both arms are extracted into evidence directories:
-#   python3 bench/evidence/compare_arms.py <control>/trials.jsonl <treatment>/trials.jsonl \
-#       --tasks 89 --cross-sut <control-sha>:<treatment-sha> \
-#       --treatment-fired loop_mode=PLUGIN:witness-v1 --markdown <run>/results.md
+# Then compare the arms. The README beside the plan holds that command.
 set -uo pipefail
 
 ARM="${1:?usage: pipeline_ab.sh <control|treatment> <job-name> [task-file]}"
 JOB="${2:?usage: pipeline_ab.sh <control|treatment> <job-name> [task-file]}"
 
-# The plugin id the preregistration fixed. It is written out here rather than
-# read from the manifest so that renaming the plugin cannot silently re-aim the
-# treatment arm at a different path; the manifest is then checked against this
-# value below, and a rename reddens the launch instead of the analysis.
+# The plugin id the plan fixed. It is spelled out here, not read from the
+# manifest. A rename must not re-aim the arm on its own. The check below reads
+# the manifest and holds it to this value.
 WITNESS_PLUGIN_ID="witness-v1"
 
 case "$ARM" in
@@ -47,17 +41,17 @@ case "$ARM" in
   *) echo "FATAL: arm must be 'control' or 'treatment'"; exit 1 ;;
 esac
 
-# Both selectors are exported before `env.sh` is sourced, because `env.sh`
-# decides `STELLA_BINARY` and the provenance paths from the arm.
+# Both are set before `env.sh` runs. `env.sh` picks the binary path and the
+# provenance paths from the arm.
 export TB_ARM="$ARM"
 export STELLA_PIPELINE="$PIPELINE_ID"
 
-# The preregistration fixes this arm as uncapped, and `env.sh` reads an empty
-# value as no per-trial cap while an unset one takes the development default of
-# 0.60 USD. A cap measures the cap: the control arm spends several model calls
-# per step where the treatment arm spends one, so a ceiling low enough to bind
-# on one arm and not the other turns a comparison of two paths into a
-# comparison of who hit the ceiling first.
+# The plan fixes this run as uncapped. In `env.sh` an empty value means no
+# cap. An unset one takes the 0.60 USD default.
+#
+# A cap measures the cap. The control arm makes several model calls per step.
+# The treatment arm makes one. A ceiling that binds on one arm and not the
+# other tells you who hit it first, and nothing else.
 if [ -n "${STELLA_SPEND_LIMIT:-}" ]; then
   echo "FATAL: STELLA_SPEND_LIMIT is '$STELLA_SPEND_LIMIT' and this experiment is uncapped."
   echo "       preregistration.json fixes 'no budget cap and no token cap'. Unset it,"
@@ -69,40 +63,40 @@ export STELLA_SPEND_LIMIT=""
 
 source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
 
-# The manifest still has to declare the id this script names, so a rename shows
-# up as a refused launch rather than as an arm that measured something else.
+# The manifest must still declare the id above. A rename then stops the launch.
+# It does not quietly move the arm to some other path.
 MANIFEST="$TB_REPO/plugins/stella-witness/plugin.toml"
 if [ "$ARM" = "treatment" ]; then
   grep -qE "^id[[:space:]]*=[[:space:]]*\"$WITNESS_PLUGIN_ID\"" "$MANIFEST" || {
-    echo "FATAL: $MANIFEST no longer declares id = \"$WITNESS_PLUGIN_ID\"."
+    echo "FATAL: $MANIFEST declares some other id than \"$WITNESS_PLUGIN_ID\"."
     echo "       The preregistration pins that id, and --treatment-fired reads"
     echo "       loop_mode=PLUGIN:$WITNESS_PLUGIN_ID. Settle which is right before running."
     exit 1
   }
 fi
 
-# The treatment arm needs the plugin inside the task container, and nothing
-# puts it there.
+# The treatment arm needs the plugin in the task container. Nothing puts it
+# there.
 #
-# The adapter uploads one file per trial, the `stella` binary. A wrapper plugin
-# is a directory the roster reads off disk — `plugins/stella-witness` declares
-# `argv = ["python3", "${plugin_dir}/main.py"]` — so on a container holding only
-# the binary, `PluginRoster::load` finds nothing and `PipelineChoice::resolve`
-# refuses the id. That refusal is fail-closed: `agent::goal` turns it into a
-# `CliFailure`, so the trial exits non-zero rather than running the raw loop
-# under a treatment-arm label. The run would produce no number and cost a full
-# arm of spend to find out.
+# The adapter uploads one file per trial. That file is the `stella` binary. A
+# wrapper plugin is a folder read off disk. `plugins/stella-witness` runs
+# `python3 ${plugin_dir}/main.py`. So the roster in the container is empty,
+# and `PipelineChoice::resolve` refuses the id.
 #
-# Refused here, on the host, before a job tree exists or Harbor pulls an image.
-# Delete this block in the change that gives the adapter a way to stage a
-# plugin, and say in that PR which task images carry `python3`.
+# That refusal fails closed. `agent::goal` turns it into a `CliFailure`, so
+# the trial exits non-zero. It cannot run the raw loop under this arm's name.
+# The arm yields no number. Finding that out costs a full arm of spend.
+#
+# So refuse on the host, before Harbor pulls an image. Delete this block in
+# the change that stages a plugin. Say in that PR which images have `python3`.
 if [ "$ARM" = "treatment" ]; then
   echo "FATAL: the treatment arm cannot run — nothing installs the plugin in the task container."
   echo "       stella_harbor uploads the stella binary and nothing else, so the"
   echo "       roster inside the container is empty and 'stella run --pipeline"
   echo "       $WITNESS_PLUGIN_ID' is refused at resolve time on every trial."
-  echo "       Tracked as the fourth precondition in"
-  echo "       bench/evidence/pipeline-ab/preregistration.json."
+  echo "       Staging a plugin into the container, and the two questions about"
+  echo "       task images that go with it, are the fourth precondition in"
+  echo "       bench/evidence/pipeline-ab/preregistration.json, which links it."
   echo
   echo "       The control arm is unaffected: its pipeline is built into its binary."
   exit 1
@@ -120,10 +114,9 @@ test ! -e "$JOBS/$JOB" || { echo "FATAL: $JOBS/$JOB exists — a run never resum
 N=$(grep -c . "$TASKFILE")
 test "$N" -gt 0 || { echo "FATAL: $TASKFILE lists no tasks"; exit 1; }
 
-# The task set is part of the experiment's identity, and two arms are paired
-# only if they covered the same one. The first arm records the digest; the
-# second refuses if it differs. The pin lives beside the arms rather than inside
-# one, because it describes the pair.
+# Two arms are paired only if they ran the same task set. The first arm writes
+# the digest. The second one refuses if it differs. The pin sits beside both
+# arms, because it describes the pair.
 TASKSET_SHA=$(sort "$TASKFILE" | python3 -c "import hashlib,sys;print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())")
 PIN="$TB_ROOT/pipeline_ab.taskset_sha256"
 if [ -f "$PIN" ]; then
@@ -137,9 +130,9 @@ else
   printf '%s\n' "$TASKSET_SHA" > "$PIN"
 fi
 
-# Two arms reporting one binary hash is one arm run twice, and the analysis
-# refuses such a pair after the money is gone. Catch it here instead. This
-# reads the sibling arm's recorded hash, so it fires whichever arm runs second.
+# Two arms with one binary hash is one arm run twice. The analysis refuses that
+# pair, but only after the money is gone. Catch it here. This reads the other
+# arm's hash, so it fires on whichever arm runs second.
 THIS_HASH_FILE="$TB_ARM_DIR/binary_sha256.txt"
 test -f "$THIS_HASH_FILE" || { echo "FATAL: no binary_sha256.txt for arm '$ARM' — run build_sut.sh for it"; exit 1; }
 case "$ARM" in
@@ -171,8 +164,8 @@ echo "budget/trial=${STELLA_SPEND_LIMIT:-<uncapped>} concurrency=$CONC"
 echo "started=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 cd "$TB_REPO" || exit 1
-# INCLUDES is a pre-built flag list, one word per token, every task name a fixed
-# [a-z0-9-] slug from the frozen dataset.
+# INCLUDES is a flag list built above. One word per token. Every task name is a
+# fixed [a-z0-9-] slug from the frozen dataset.
 # shellcheck disable=SC2086
 harbor run \
   --env docker \

--- a/bench/evidence/run/pipeline_ab.sh
+++ b/bench/evidence/run/pipeline_ab.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# One arm of the two-build pipeline A/B, preregistered in
+# `bench/evidence/pipeline-ab/preregistration.json`.
+#
+# The experiment compares the built-in staged pipeline against the plugin path
+# that replaced it. Each arm is a different build of Stella, and the build is
+# what makes it that arm: a flag can be dropped from a command line, a posture
+# can claim a tier that never fired, and neither can turn one binary into the
+# other one.
+#
+#   control    — a build of f4c24c12b, the last commit where
+#                `crates/stella-pipeline` exists, run as `--pipeline classic`.
+#   treatment  — a build of main with `plugins/stella-witness` installed, run
+#                as `--pipeline witness-v1`.
+#
+# Not `witness_ab.sh`: that is two runs of one binary differing in who authors
+# the failing test. Not `primary.sh`: that scores a preregistered phase of the
+# whole dataset against a fixed denominator rather than pairing two arms.
+#
+# Usage, one arm at a time, both reading one task file:
+#
+#   TB_ARM=control   TB_BUILD_REPO=/checkouts/stella-f4c24c12b \
+#     bench/evidence/run/build_sut.sh f4c24c12bde5578818f1141ec4e438291ac4db55
+#   TB_ARM=treatment bench/evidence/run/build_sut.sh
+#
+#   bench/evidence/run/pipeline_ab.sh control   pab1-control   "$TB_ROOT/pipeline_ab.tasks"
+#   bench/evidence/run/pipeline_ab.sh treatment pab1-treatment "$TB_ROOT/pipeline_ab.tasks"
+#
+# then, once both arms are extracted into evidence directories:
+#   python3 bench/evidence/compare_arms.py <control>/trials.jsonl <treatment>/trials.jsonl \
+#       --tasks 89 --cross-sut <control-sha>:<treatment-sha> \
+#       --treatment-fired loop_mode=PLUGIN:witness-v1 --markdown <run>/results.md
+set -uo pipefail
+
+ARM="${1:?usage: pipeline_ab.sh <control|treatment> <job-name> [task-file]}"
+JOB="${2:?usage: pipeline_ab.sh <control|treatment> <job-name> [task-file]}"
+
+# The plugin id the preregistration fixed. It is written out here rather than
+# read from the manifest so that renaming the plugin cannot silently re-aim the
+# treatment arm at a different path; the manifest is then checked against this
+# value below, and a rename reddens the launch instead of the analysis.
+WITNESS_PLUGIN_ID="witness-v1"
+
+case "$ARM" in
+  control)   PIPELINE_ID="classic" ;;
+  treatment) PIPELINE_ID="$WITNESS_PLUGIN_ID" ;;
+  *) echo "FATAL: arm must be 'control' or 'treatment'"; exit 1 ;;
+esac
+
+# Both selectors are exported before `env.sh` is sourced, because `env.sh`
+# decides `STELLA_BINARY` and the provenance paths from the arm.
+export TB_ARM="$ARM"
+export STELLA_PIPELINE="$PIPELINE_ID"
+
+# The preregistration fixes this arm as uncapped, and `env.sh` reads an empty
+# value as no per-trial cap while an unset one takes the development default of
+# 0.60 USD. A cap measures the cap: the control arm spends several model calls
+# per step where the treatment arm spends one, so a ceiling low enough to bind
+# on one arm and not the other turns a comparison of two paths into a
+# comparison of who hit the ceiling first.
+if [ -n "${STELLA_SPEND_LIMIT:-}" ]; then
+  echo "FATAL: STELLA_SPEND_LIMIT is '$STELLA_SPEND_LIMIT' and this experiment is uncapped."
+  echo "       preregistration.json fixes 'no budget cap and no token cap'. Unset it,"
+  echo "       or set it empty, and relaunch. The spend stop rule is per replicate"
+  echo "       and is applied by the operator between replicates, never per trial."
+  exit 1
+fi
+export STELLA_SPEND_LIMIT=""
+
+source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
+
+# The manifest still has to declare the id this script names, so a rename shows
+# up as a refused launch rather than as an arm that measured something else.
+MANIFEST="$TB_REPO/plugins/stella-witness/plugin.toml"
+if [ "$ARM" = "treatment" ]; then
+  grep -qE "^id[[:space:]]*=[[:space:]]*\"$WITNESS_PLUGIN_ID\"" "$MANIFEST" || {
+    echo "FATAL: $MANIFEST no longer declares id = \"$WITNESS_PLUGIN_ID\"."
+    echo "       The preregistration pins that id, and --treatment-fired reads"
+    echo "       loop_mode=PLUGIN:$WITNESS_PLUGIN_ID. Settle which is right before running."
+    exit 1
+  }
+fi
+
+# The treatment arm needs the plugin inside the task container, and nothing
+# puts it there.
+#
+# The adapter uploads one file per trial, the `stella` binary. A wrapper plugin
+# is a directory the roster reads off disk — `plugins/stella-witness` declares
+# `argv = ["python3", "${plugin_dir}/main.py"]` — so on a container holding only
+# the binary, `PluginRoster::load` finds nothing and `PipelineChoice::resolve`
+# refuses the id. That refusal is fail-closed: `agent::goal` turns it into a
+# `CliFailure`, so the trial exits non-zero rather than running the raw loop
+# under a treatment-arm label. The run would produce no number and cost a full
+# arm of spend to find out.
+#
+# Refused here, on the host, before a job tree exists or Harbor pulls an image.
+# Delete this block in the change that gives the adapter a way to stage a
+# plugin, and say in that PR which task images carry `python3`.
+if [ "$ARM" = "treatment" ]; then
+  echo "FATAL: the treatment arm cannot run — nothing installs the plugin in the task container."
+  echo "       stella_harbor uploads the stella binary and nothing else, so the"
+  echo "       roster inside the container is empty and 'stella run --pipeline"
+  echo "       $WITNESS_PLUGIN_ID' is refused at resolve time on every trial."
+  echo "       Tracked as the fourth precondition in"
+  echo "       bench/evidence/pipeline-ab/preregistration.json."
+  echo
+  echo "       The control arm is unaffected: its pipeline is built into its binary."
+  exit 1
+fi
+
+TASKFILE="${3:-$TB_ROOT/pipeline_ab.tasks}"
+test -f "$TASKFILE" || {
+  echo "FATAL: no task file at $TASKFILE"
+  echo "       Create one first — both arms must read the same file:"
+  echo "         python3 -c \"import json;p=json.load(open('\$TB_ROOT/phases.json'));print('\\n'.join(sorted(p['phaseA']+p['phaseB'])))\" > $TASKFILE"
+  exit 1
+}
+test ! -e "$JOBS/$JOB" || { echo "FATAL: $JOBS/$JOB exists — a run never resumes"; exit 1; }
+
+N=$(grep -c . "$TASKFILE")
+test "$N" -gt 0 || { echo "FATAL: $TASKFILE lists no tasks"; exit 1; }
+
+# The task set is part of the experiment's identity, and two arms are paired
+# only if they covered the same one. The first arm records the digest; the
+# second refuses if it differs. The pin lives beside the arms rather than inside
+# one, because it describes the pair.
+TASKSET_SHA=$(sort "$TASKFILE" | python3 -c "import hashlib,sys;print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())")
+PIN="$TB_ROOT/pipeline_ab.taskset_sha256"
+if [ -f "$PIN" ]; then
+  test "$(cat "$PIN")" = "$TASKSET_SHA" || {
+    echo "FATAL: this experiment's first arm ran taskset $(cat "$PIN"),"
+    echo "       this one is $TASKSET_SHA — two arms over different task sets"
+    echo "       are not a paired comparison. Use a new TB_ROOT to start over."
+    exit 1
+  }
+else
+  printf '%s\n' "$TASKSET_SHA" > "$PIN"
+fi
+
+# Two arms reporting one binary hash is one arm run twice, and the analysis
+# refuses such a pair after the money is gone. Catch it here instead. This
+# reads the sibling arm's recorded hash, so it fires whichever arm runs second.
+THIS_HASH_FILE="$TB_ARM_DIR/binary_sha256.txt"
+test -f "$THIS_HASH_FILE" || { echo "FATAL: no binary_sha256.txt for arm '$ARM' — run build_sut.sh for it"; exit 1; }
+case "$ARM" in
+  control) OTHER="treatment" ;;
+  *)       OTHER="control" ;;
+esac
+OTHER_HASH_FILE="$TB_ROOT/arms/$OTHER/binary_sha256.txt"
+if [ -f "$OTHER_HASH_FILE" ] && [ "$(cat "$THIS_HASH_FILE")" = "$(cat "$OTHER_HASH_FILE")" ]; then
+  echo "FATAL: arm '$ARM' and arm '$OTHER' are the same binary ($(cat "$THIS_HASH_FILE"))."
+  echo "       The build is the arm, so one binary is one arm. Rebuild the arm that"
+  echo "       is wrong, with TB_BUILD_REPO pointed at its own checkout."
+  exit 1
+fi
+
+preflight || exit 1
+
+# macOS ships bash 3.2: no mapfile, no arrays from process substitution.
+INCLUDES=""
+while IFS= read -r t; do
+  [ -n "$t" ] || continue
+  INCLUDES="$INCLUDES --include-task-name terminal-bench/$t"
+done < "$TASKFILE"
+
+CONC="${TB_CONCURRENCY:-3}"
+echo "arm=$ARM job=$JOB tasks=$N taskset_sha256=$TASKSET_SHA"
+echo "sut=$STELLA_SOURCE_COMMIT binary_sha256=$(cat "$THIS_HASH_FILE")"
+echo "pipeline=$STELLA_PIPELINE worker=$TB_MODEL"
+echo "budget/trial=${STELLA_SPEND_LIMIT:-<uncapped>} concurrency=$CONC"
+echo "started=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+cd "$TB_REPO" || exit 1
+# INCLUDES is a pre-built flag list, one word per token, every task name a fixed
+# [a-z0-9-] slug from the frozen dataset.
+# shellcheck disable=SC2086
+harbor run \
+  --env docker \
+  --dataset "$TB_DATASET" \
+  $INCLUDES \
+  --agent-import-path stella_harbor:StellaAgent \
+  --model "$TB_MODEL" \
+  --job-name "$JOB" \
+  --jobs-dir "$JOBS" \
+  --n-attempts 1 --n-concurrent "$CONC" --max-retries 0
+rc=$?
+echo "harbor_exit=$rc finished=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+exit $rc

--- a/bench/evidence/tests/test_pipeline_ab_run_scripts.py
+++ b/bench/evidence/tests/test_pipeline_ab_run_scripts.py
@@ -1,25 +1,26 @@
-"""The two-build A/B's run scripts hold two arms without one erasing the other.
+"""The two-build A/B's run scripts hold two arms, and one cannot erase the other.
 
-The pipeline A/B (#6155) is two builds of Stella measured against one task list.
-Before this suite, ``bench/evidence/run/env.sh`` gave every run one
-``STELLA_BINARY`` path and one ``$TB_ROOT``, so the second arm's build
-overwrote the first arm's binary and its two provenance files, and the hash a
-report cited belonged to whichever arm was built last. Nothing said so: both
-builds succeed, both write, and the survivor looks exactly like a correct
-single build.
+The pipeline A/B runs two builds of Stella over one task list. Its plan sits in
+``bench/evidence/pipeline-ab/``.
 
-What the cases below hold, in the order they matter:
+``bench/evidence/run/env.sh`` gave every run one ``STELLA_BINARY`` path and one
+``$TB_ROOT``. So the second arm's build wrote over the first arm's binary and
+its two provenance files. The hash a report cites then belongs to whichever arm
+was built last. Nothing says so. Both builds pass. Both write. The survivor
+looks just like a good single build.
+
+The cases below hold four things, in the order they matter:
 
 * a run with no arm reads and writes what it always did, so the single-build
-  scripts around this change keep working;
-* two arms land on two paths, which is the property the experiment needs;
-* the adapter comes from ``TB_REPO`` whatever ``TB_BUILD_REPO`` says, so the
-  arms differ by the binary and not by the instrument measuring them;
-* ``env.sh`` exports no ``STELLA_`` name the adapter has not registered, which
-  is a run-ending failure and cannot be seen by reading either file alone.
+  scripts keep working;
+* two arms land on two paths, which is what the experiment needs;
+* the adapter comes from ``TB_REPO``, whatever ``TB_BUILD_REPO`` says, so the
+  arms differ by the binary and not by the tool that measures them;
+* ``env.sh`` exports no ``STELLA_`` name the adapter has not registered. That
+  one ends a run, and reading either file alone will not show it.
 
-Standard library only, like its neighbours here, because CI runs this directory
-with ``--no-project``.
+Standard library only, like its neighbours here. CI runs this folder with
+``--no-project``.
 """
 
 from __future__ import annotations
@@ -36,13 +37,13 @@ PIPELINE_AB = RUN_DIR / "pipeline_ab.sh"
 
 #: Every ``STELLA_`` name ``env.sh`` may export.
 #:
-#: Each one is registered in the adapter's ``_HOST_ONLY_STELLA_ENV``
-#: (``bench/harbor_adapter/stella_harbor/__init__.py``). That registration is
-#: not bookkeeping: the adapter's ambient check fails closed, and every script
-#: in ``bench/evidence/run/`` sources ``env.sh`` before invoking Harbor, so an
-#: exported-but-unregistered ``STELLA_*`` name refuses the run outright — after
-#: the images are pulled, on every trial. Adding a name here without adding it
-#: there is how a run dies for a reason neither file shows on its own.
+#: Each one is listed in the adapter's ``_HOST_ONLY_STELLA_ENV``. That list is
+#: in ``bench/harbor_adapter/stella_harbor/__init__.py``.
+#:
+#: The adapter's ambient check fails closed. Every script in
+#: ``bench/evidence/run/`` sources ``env.sh`` before it calls Harbor. So a
+#: ``STELLA_*`` name exported here and missing there refuses the run. It does
+#: that after the images are pulled, on every trial.
 REGISTERED_STELLA_EXPORTS = frozenset(
     {
         "STELLA_TARGET_TRIPLE",
@@ -56,9 +57,9 @@ REGISTERED_STELLA_EXPORTS = frozenset(
     }
 )
 
-# What a shell that sources `env.sh` is given. No `STELLA_` name appears, so
-# anything the assertions below see was exported by the file under test rather
-# than inherited from whoever ran pytest.
+# What a shell that sources `env.sh` is given. It holds no `STELLA_` name. So
+# any such name the checks below see came from the file under test. None of it
+# came from whoever ran pytest.
 _BASE_ENV = {"PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": "/tmp"}
 
 
@@ -107,8 +108,8 @@ def test_a_run_with_no_arm_reads_the_paths_it_always_did(tmp_path: Path) -> None
     assert values["STELLA_BINARY"] == str(
         repo / "target" / "x86_64-unknown-linux-gnu" / "release" / "stella"
     )
-    # The binary a single build runs is the one cargo just wrote, with no copy
-    # in between: `primary.sh` and its neighbours are unchanged by arms.
+    # A single build runs the binary cargo just wrote. No copy sits in between.
+    # So `primary.sh` and its neighbours do not change.
     assert values["STELLA_BINARY"] == values["TB_BUILD_OUTPUT"]
 
 
@@ -122,14 +123,14 @@ def test_two_arms_get_two_binaries_and_two_provenance_directories(
     assert control["STELLA_BINARY"] != treatment["STELLA_BINARY"]
     assert control["TB_ARM_DIR"] != treatment["TB_ARM_DIR"]
     # `build_sut.sh` writes sut_commit.txt and binary_sha256.txt into
-    # TB_ARM_DIR, so two directories is two records of which build ran.
+    # TB_ARM_DIR. Two dirs is two records of which build ran.
     arms = tmp_path / "root" / "arms"
     assert control["TB_ARM_DIR"] == str(arms / "control")
     assert treatment["TB_ARM_DIR"] == str(arms / "treatment")
     assert Path(control["TB_ARM_DIR"]).is_dir()
     assert Path(treatment["TB_ARM_DIR"]).is_dir()
-    # The arm's binary is a copy outside the target directory that built it, so
-    # rebuilding the other arm cannot replace it.
+    # The arm's binary is a copy. It sits outside the target dir that built it.
+    # So a rebuild of the other arm cannot replace it.
     assert control["STELLA_BINARY"] == str(arms / "control" / "stella")
     assert control["STELLA_BINARY"] != control["TB_BUILD_OUTPUT"]
 
@@ -137,13 +138,13 @@ def test_two_arms_get_two_binaries_and_two_provenance_directories(
 def test_the_adapter_comes_from_tb_repo_when_the_build_repo_is_elsewhere(
     tmp_path: Path,
 ) -> None:
-    """Only the binary may differ between arms — never the measuring instrument.
+    """Only the binary may differ between arms. Never the tool that measures.
 
-    The control arm is built from a checkout of a commit whose crate this
-    workspace deleted. Pointing ``TB_REPO`` at that checkout to reach its
-    ``target/`` would take ``PYTHONPATH`` along with it and swap in that
-    checkout's adapter, which predates the selector both arms are launched by.
-    ``TB_BUILD_REPO`` moves the build alone.
+    The control arm is built from a checkout of an old commit. Its crate is
+    gone from this workspace. Aim ``TB_REPO`` at that checkout to reach its
+    ``target/`` and ``PYTHONPATH`` goes with it. That swaps in the old
+    adapter, which has no ``--pipeline`` selector. ``TB_BUILD_REPO`` moves the
+    build alone.
     """
     old = tmp_path / "old-checkout"
     old.mkdir()
@@ -178,12 +179,13 @@ def test_env_sh_exports_no_stella_name_the_adapter_has_not_registered(
 
 
 def _run_arm(tmp_path: Path, *args: str, **overrides: str) -> subprocess.CompletedProcess[str]:
-    """Launch an arm against the real checkout, with scratch space in ``tmp_path``.
+    """Launch an arm against the real checkout. Scratch space is ``tmp_path``.
 
-    ``TB_REPO`` is this repository rather than a fixture, because the script
-    reads ``plugins/stella-witness/plugin.toml`` out of it to confirm the plugin
-    still declares the id the preregistration pinned. A fixture would answer for
-    itself. Nothing is written under ``TB_REPO``; the scratch tree is ``TB_ROOT``.
+    ``TB_REPO`` is this repo, not a fixture. The script reads
+    ``plugins/stella-witness/plugin.toml`` out of it. That check asks whether
+    the plugin still declares the id the plan pinned. A fixture would answer
+    for itself. Nothing is written under ``TB_REPO``. The scratch tree is
+    ``TB_ROOT``.
     """
     root = tmp_path / "root"
     root.mkdir(exist_ok=True)
@@ -213,9 +215,9 @@ def test_a_spend_limit_is_refused_because_the_experiment_is_uncapped(
 ) -> None:
     """A cap that binds on one arm and not the other measures the cap.
 
-    The control arm spends several model calls per step where the treatment arm
-    spends one, so the development default would truncate the arms unequally
-    and the preregistration fixes the run as uncapped.
+    The control arm makes several model calls per step. The treatment arm makes
+    one. So the default would cut the two arms by different amounts. The plan
+    fixes the run as uncapped.
     """
     result = _run_arm(tmp_path, "control", "job1", STELLA_SPEND_LIMIT="0.60")
     assert result.returncode == 1
@@ -225,14 +227,13 @@ def test_a_spend_limit_is_refused_because_the_experiment_is_uncapped(
 def test_the_treatment_arm_refuses_while_no_plugin_reaches_the_container(
     tmp_path: Path,
 ) -> None:
-    """The refusal costs one message; discovering it per trial costs the arm.
+    """The refusal costs one message. Finding it per trial costs the arm.
 
-    ``stella_harbor`` uploads the ``stella`` binary and nothing else, so the
-    plugin roster inside a task container is empty and ``PipelineChoice::resolve``
-    refuses ``--pipeline witness-v1``. That refusal is fail-closed — ``agent::goal``
-    turns it into a ``CliFailure`` — so the arm produces no number rather than a
-    wrong one. Delete this case in the change that lets the adapter stage a
-    plugin.
+    ``stella_harbor`` uploads the ``stella`` binary and nothing else. So the
+    plugin roster in a task container is empty, and ``PipelineChoice::resolve``
+    refuses ``--pipeline witness-v1``. That fails closed. ``agent::goal`` turns
+    it into a ``CliFailure``. The arm makes no number, rather than a wrong one.
+    Delete this case in the change that stages a plugin.
     """
     result = _run_arm(tmp_path, "treatment", "job1")
     assert result.returncode == 1
@@ -243,10 +244,10 @@ def test_the_treatment_arm_refuses_while_no_plugin_reaches_the_container(
 def test_the_script_launches_the_pipeline_ids_the_preregistration_named() -> None:
     """The plan's ``invocation`` strings and the launcher's flags are one thing.
 
-    ``compare_arms.py --treatment-fired`` reads ``loop_mode=PLUGIN:witness-v1``,
-    and the adapter derives that value from whatever ``--pipeline`` the launcher
-    passed. So an id edited in the script and left alone in the plan produces a
-    complete arm that the analysis then refuses, after the spend.
+    ``compare_arms.py --treatment-fired`` reads ``loop_mode=PLUGIN:witness-v1``.
+    The adapter builds that value from the ``--pipeline`` flag it was given. So
+    an id changed in the script and left alone in the plan yields a full arm.
+    The analysis then refuses it, after the spend.
     """
     import json
 
@@ -264,6 +265,6 @@ def test_the_script_launches_the_pipeline_ids_the_preregistration_named() -> Non
 
 
 def test_the_witness_plugin_still_declares_the_pinned_id() -> None:
-    """A rename would re-aim the treatment arm at a path nothing measures."""
+    """A rename would aim the treatment arm at a path nothing measures."""
     manifest = (REPO_ROOT / "plugins" / "stella-witness" / "plugin.toml").read_text()
     assert 'id = "witness-v1"' in manifest

--- a/bench/evidence/tests/test_pipeline_ab_run_scripts.py
+++ b/bench/evidence/tests/test_pipeline_ab_run_scripts.py
@@ -1,0 +1,269 @@
+"""The two-build A/B's run scripts hold two arms without one erasing the other.
+
+The pipeline A/B (#6155) is two builds of Stella measured against one task list.
+Before this suite, ``bench/evidence/run/env.sh`` gave every run one
+``STELLA_BINARY`` path and one ``$TB_ROOT``, so the second arm's build
+overwrote the first arm's binary and its two provenance files, and the hash a
+report cited belonged to whichever arm was built last. Nothing said so: both
+builds succeed, both write, and the survivor looks exactly like a correct
+single build.
+
+What the cases below hold, in the order they matter:
+
+* a run with no arm reads and writes what it always did, so the single-build
+  scripts around this change keep working;
+* two arms land on two paths, which is the property the experiment needs;
+* the adapter comes from ``TB_REPO`` whatever ``TB_BUILD_REPO`` says, so the
+  arms differ by the binary and not by the instrument measuring them;
+* ``env.sh`` exports no ``STELLA_`` name the adapter has not registered, which
+  is a run-ending failure and cannot be seen by reading either file alone.
+
+Standard library only, like its neighbours here, because CI runs this directory
+with ``--no-project``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUN_DIR = REPO_ROOT / "bench" / "evidence" / "run"
+ENV_SH = RUN_DIR / "env.sh"
+PIPELINE_AB = RUN_DIR / "pipeline_ab.sh"
+
+#: Every ``STELLA_`` name ``env.sh`` may export.
+#:
+#: Each one is registered in the adapter's ``_HOST_ONLY_STELLA_ENV``
+#: (``bench/harbor_adapter/stella_harbor/__init__.py``). That registration is
+#: not bookkeeping: the adapter's ambient check fails closed, and every script
+#: in ``bench/evidence/run/`` sources ``env.sh`` before invoking Harbor, so an
+#: exported-but-unregistered ``STELLA_*`` name refuses the run outright — after
+#: the images are pulled, on every trial. Adding a name here without adding it
+#: there is how a run dies for a reason neither file shows on its own.
+REGISTERED_STELLA_EXPORTS = frozenset(
+    {
+        "STELLA_TARGET_TRIPLE",
+        "STELLA_GLIBC_FLOOR",
+        "STELLA_BINARY",
+        "STELLA_SPEND_LIMIT",
+        "STELLA_DISABLE_REFLECTION",
+        "STELLA_WITNESS_AUTHOR_MODEL",
+        "STELLA_SOURCE_COMMIT",
+        "STELLA_PIPELINE",
+    }
+)
+
+# What a shell that sources `env.sh` is given. No `STELLA_` name appears, so
+# anything the assertions below see was exported by the file under test rather
+# than inherited from whoever ran pytest.
+_BASE_ENV = {"PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": "/tmp"}
+
+
+def _source_env(tmp_path: Path, **overrides: str) -> subprocess.CompletedProcess[str]:
+    """Source ``env.sh`` and print the variables the assertions read."""
+    repo = tmp_path / "repo"
+    root = tmp_path / "root"
+    repo.mkdir(exist_ok=True)
+    root.mkdir(exist_ok=True)
+    env = dict(_BASE_ENV)
+    env["TB_REPO"] = overrides.pop("TB_REPO", str(repo))
+    env["TB_ROOT"] = overrides.pop("TB_ROOT", str(root))
+    env.update(overrides)
+    script = (
+        f'source "{ENV_SH}"\n'
+        'echo "STELLA_BINARY=$STELLA_BINARY"\n'
+        'echo "TB_ARM_DIR=$TB_ARM_DIR"\n'
+        'echo "TB_BUILD_OUTPUT=$TB_BUILD_OUTPUT"\n'
+        'echo "PYTHONPATH=$PYTHONPATH"\n'
+        'echo "EXPORTED_STELLA=$(compgen -e | grep "^STELLA_" | sort | tr "\\n" ",")"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _values(result: subprocess.CompletedProcess[str]) -> dict[str, str]:
+    assert result.returncode == 0, f"env.sh refused: {result.stdout}{result.stderr}"
+    out: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            out[key] = value
+    return out
+
+
+def test_a_run_with_no_arm_reads_the_paths_it_always_did(tmp_path: Path) -> None:
+    """No ``TB_ARM`` leaves every path where the single-build scripts expect it."""
+    values = _values(_source_env(tmp_path))
+    repo = tmp_path / "repo"
+    assert values["TB_ARM_DIR"] == str(tmp_path / "root")
+    assert values["STELLA_BINARY"] == str(
+        repo / "target" / "x86_64-unknown-linux-gnu" / "release" / "stella"
+    )
+    # The binary a single build runs is the one cargo just wrote, with no copy
+    # in between: `primary.sh` and its neighbours are unchanged by arms.
+    assert values["STELLA_BINARY"] == values["TB_BUILD_OUTPUT"]
+
+
+def test_two_arms_get_two_binaries_and_two_provenance_directories(
+    tmp_path: Path,
+) -> None:
+    """The failure this change exists to stop: one arm overwriting the other."""
+    control = _values(_source_env(tmp_path, TB_ARM="control"))
+    treatment = _values(_source_env(tmp_path, TB_ARM="treatment"))
+
+    assert control["STELLA_BINARY"] != treatment["STELLA_BINARY"]
+    assert control["TB_ARM_DIR"] != treatment["TB_ARM_DIR"]
+    # `build_sut.sh` writes sut_commit.txt and binary_sha256.txt into
+    # TB_ARM_DIR, so two directories is two records of which build ran.
+    arms = tmp_path / "root" / "arms"
+    assert control["TB_ARM_DIR"] == str(arms / "control")
+    assert treatment["TB_ARM_DIR"] == str(arms / "treatment")
+    assert Path(control["TB_ARM_DIR"]).is_dir()
+    assert Path(treatment["TB_ARM_DIR"]).is_dir()
+    # The arm's binary is a copy outside the target directory that built it, so
+    # rebuilding the other arm cannot replace it.
+    assert control["STELLA_BINARY"] == str(arms / "control" / "stella")
+    assert control["STELLA_BINARY"] != control["TB_BUILD_OUTPUT"]
+
+
+def test_the_adapter_comes_from_tb_repo_when_the_build_repo_is_elsewhere(
+    tmp_path: Path,
+) -> None:
+    """Only the binary may differ between arms — never the measuring instrument.
+
+    The control arm is built from a checkout of a commit whose crate this
+    workspace deleted. Pointing ``TB_REPO`` at that checkout to reach its
+    ``target/`` would take ``PYTHONPATH`` along with it and swap in that
+    checkout's adapter, which predates the selector both arms are launched by.
+    ``TB_BUILD_REPO`` moves the build alone.
+    """
+    old = tmp_path / "old-checkout"
+    old.mkdir()
+    values = _values(_source_env(tmp_path, TB_ARM="control", TB_BUILD_REPO=str(old)))
+
+    assert values["PYTHONPATH"] == str(tmp_path / "repo" / "bench" / "harbor_adapter")
+    assert values["TB_BUILD_OUTPUT"].startswith(str(old))
+
+
+@pytest.mark.parametrize("arm", ["../escape", "Control", "control arm", "arm/sub"])
+def test_an_arm_name_that_is_not_a_plain_slug_is_refused(
+    tmp_path: Path, arm: str
+) -> None:
+    """``TB_ARM`` becomes a directory name, so it may not carry a path."""
+    result = _source_env(tmp_path, TB_ARM=arm)
+    assert result.returncode == 1
+    assert "TB_ARM must be" in result.stdout
+
+
+def test_env_sh_exports_no_stella_name_the_adapter_has_not_registered(
+    tmp_path: Path,
+) -> None:
+    """An unregistered ``STELLA_*`` export refuses the run on every trial."""
+    values = _values(_source_env(tmp_path, TB_ARM="control", STELLA_PIPELINE="classic"))
+    exported = {name for name in values["EXPORTED_STELLA"].split(",") if name}
+    assert exported <= REGISTERED_STELLA_EXPORTS, (
+        "env.sh exports a STELLA_ name that is not in this test's allowlist. "
+        "Register it in _HOST_ONLY_STELLA_ENV in "
+        "bench/harbor_adapter/stella_harbor/__init__.py and add it here, or "
+        "give it a TB_ prefix if it means nothing inside a task container."
+    )
+
+
+def _run_arm(tmp_path: Path, *args: str, **overrides: str) -> subprocess.CompletedProcess[str]:
+    """Launch an arm against the real checkout, with scratch space in ``tmp_path``.
+
+    ``TB_REPO`` is this repository rather than a fixture, because the script
+    reads ``plugins/stella-witness/plugin.toml`` out of it to confirm the plugin
+    still declares the id the preregistration pinned. A fixture would answer for
+    itself. Nothing is written under ``TB_REPO``; the scratch tree is ``TB_ROOT``.
+    """
+    root = tmp_path / "root"
+    root.mkdir(exist_ok=True)
+    env = dict(_BASE_ENV)
+    env["TB_REPO"] = str(REPO_ROOT)
+    env["TB_ROOT"] = str(root)
+    env.update(overrides)
+    return subprocess.run(
+        ["bash", str(PIPELINE_AB), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_an_unknown_arm_name_is_refused_before_anything_is_sourced(
+    tmp_path: Path,
+) -> None:
+    result = _run_arm(tmp_path, "witness-on", "job1")
+    assert result.returncode == 1
+    assert "arm must be 'control' or 'treatment'" in result.stdout
+
+
+def test_a_spend_limit_is_refused_because_the_experiment_is_uncapped(
+    tmp_path: Path,
+) -> None:
+    """A cap that binds on one arm and not the other measures the cap.
+
+    The control arm spends several model calls per step where the treatment arm
+    spends one, so the development default would truncate the arms unequally
+    and the preregistration fixes the run as uncapped.
+    """
+    result = _run_arm(tmp_path, "control", "job1", STELLA_SPEND_LIMIT="0.60")
+    assert result.returncode == 1
+    assert "this experiment is uncapped" in result.stdout
+
+
+def test_the_treatment_arm_refuses_while_no_plugin_reaches_the_container(
+    tmp_path: Path,
+) -> None:
+    """The refusal costs one message; discovering it per trial costs the arm.
+
+    ``stella_harbor`` uploads the ``stella`` binary and nothing else, so the
+    plugin roster inside a task container is empty and ``PipelineChoice::resolve``
+    refuses ``--pipeline witness-v1``. That refusal is fail-closed — ``agent::goal``
+    turns it into a ``CliFailure`` — so the arm produces no number rather than a
+    wrong one. Delete this case in the change that lets the adapter stage a
+    plugin.
+    """
+    result = _run_arm(tmp_path, "treatment", "job1")
+    assert result.returncode == 1
+    assert "nothing installs the plugin in the task container" in result.stdout
+    assert "The control arm is unaffected" in result.stdout
+
+
+def test_the_script_launches_the_pipeline_ids_the_preregistration_named() -> None:
+    """The plan's ``invocation`` strings and the launcher's flags are one thing.
+
+    ``compare_arms.py --treatment-fired`` reads ``loop_mode=PLUGIN:witness-v1``,
+    and the adapter derives that value from whatever ``--pipeline`` the launcher
+    passed. So an id edited in the script and left alone in the plan produces a
+    complete arm that the analysis then refuses, after the spend.
+    """
+    import json
+
+    prereg = json.loads(
+        (
+            REPO_ROOT / "bench" / "evidence" / "pipeline-ab" / "preregistration.json"
+        ).read_text()
+    )
+    script = PIPELINE_AB.read_text()
+
+    for arm, flag in (("control", "classic"), ("treatment", "witness-v1")):
+        assert prereg["arms"][arm]["invocation"].endswith(f"--pipeline {flag}")
+    assert 'WITNESS_PLUGIN_ID="witness-v1"' in script
+    assert "control)   PIPELINE_ID=\"classic\"" in script
+
+
+def test_the_witness_plugin_still_declares_the_pinned_id() -> None:
+    """A rename would re-aim the treatment arm at a path nothing measures."""
+    manifest = (REPO_ROOT / "plugins" / "stella-witness" / "plugin.toml").read_text()
+    assert 'id = "witness-v1"' in manifest


### PR DESCRIPTION
`Refs #6155` — advances it; does not close it. The benchmark still cannot run, and this says precisely why.

## What was wrong

The pipeline A/B run scripts could hold only one arm at a time: configuring the treatment arm erased the control. A side-by-side comparison needs both to exist simultaneously, so the harness could not express the thing it was built to measure.

## What this changes

`bench/evidence/run/` now builds and launches two arms without one overwriting the other, with `build_sut.sh` and `env.sh` split out so each arm's construction is readable on its own. `bench/evidence/tests/test_pipeline_ab_run_scripts.py` covers it.

## The blocker, which is the more useful half

While making the harness capable of the run, a **fourth precondition nobody had found** surfaced: the treatment arm's plugin never reaches the task container, so every treatment trial is refused at resolve time. A run started today would produce a clean-looking set of refusals rather than a comparison.

Filed as **#6490** and recorded in the plan rather than left as tribal knowledge:

- `preregistration.json` gains the fourth precondition, and moves the third to *half met* now that the run scripts hold two arms.
- `bench/evidence/pipeline-ab/README.md` names two blockers rather than one, and documents how the two arms are built and launched.

## Why #6155 stays open

#6155 asks for the side-by-side benchmark to be *run*. It cannot be, until #6490 is fixed. Closing it now would record a result that does not exist. The honest state is: the harness is ready, one precondition is met that was not, and one newly-identified blocker stands between here and a real run.

Refs #6155
Refs #6195
Refs #6490

## Summary by Sourcery

Make the pipeline A/B harness preserve and validate separate control and treatment arms while explicitly preventing runs until the treatment plugin is staged in task containers.

New Features:
- Enable pipeline A/B benchmark runs to build, retain, and launch distinct control and treatment arms against the same task set.

Bug Fixes:
- Prevent one arm’s binary and provenance from overwriting the other arm’s artifacts.
- Block treatment runs that cannot execute because the plugin is not available inside task containers.

Enhancements:
- Separate the build checkout from the adapter checkout and enforce arm-specific binary provenance, task-set pairing, distinct binary hashes, and uncapped execution.

Documentation:
- Document the two-arm launch process and identify the missing treatment plugin as an additional benchmark blocker.
- Update the preregistration to reflect the newly met precondition and newly identified blocker.

Tests:
- Add coverage for arm-specific paths, build and adapter repository separation, environment exports, launch validation, spend-cap enforcement, and treatment-arm blocking.