### PR TITLE
fix(lock): carry stella-time's lock entry to 0.9.417

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "stella-time"
-version = "0.9.416"
+version = "0.9.417"
 dependencies = [
  "async-trait",
  "rand 0.10.2",


### PR DESCRIPTION
## What & why

`main` is red on `lockfile-sync` and every `--locked` build (the canary's report is #6495). The `stella-time` crate landed in #6488 with its `Cargo.lock` entry at `0.9.416`, while the release sync in #6494 had already moved every workspace crate to `0.9.417`. Neither tree was wrong on its own; the composition is. This regenerates the lock, which changes exactly that one line.

Refs #6495

## The witness

- [x] No witness needed (lockfile only) — because: `cargo metadata --format-version 1 --locked` fails on `main`'s tip and passes with this lock. That command is the `lockfile-sync` gate step.

## The gate

- [x] `make guards-fast` (lockfile-sync included) passes locally
- [ ] the rest is CI's

## Fix over file

- [x] Extra fixes in this PR: none
- [x] Nothing was deferred

## Anything reviewers should know?

Carries `unblocks-main` so the red-main hold does not block its own repair, and `no-issue` because the canary's own run marks that issue resolved once `main` recovers; nothing here closes it.
