### PR TITLE
fix(scripts): read a #[cfg(test)] mod line as test code, and drop sharp from the docs site

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -50,16 +50,9 @@ jobs:
           # touches is distributed, so the AGPL/dual-license reasoning in the
           # header does not apply to it.
           #
-          # The @img/sharp-* tuples first arrived through arenabench/web's
-          # lockfile and left with its ejection (#2380). They are back through
-          # `website/`, the docs site: `next` lists sharp as an optional
-          # dependency for every platform, and fourteen of its tuples ship
-          # LGPL-3.0 libvips binaries. The site is `"private": true`, imports
-          # no `next/image` (so sharp is never loaded, even at build), and is
-          # deployed to Vercel — nothing here reaches the AGPL workspace or the
-          # commercial binary. The action has no purl globs, so each tuple is
-          # named; a new libvips tuple reds this gate again and is added the
-          # same way. #2532 tracks the recurrence.
+          # The @img/sharp-* tuples that used to sit here arrived through
+          # arenabench/web's lockfile; that folder left with the ejection to
+          # its own repository (#2380), so the exemption left with it.
           #
           # Must stay ABOVE `allow-licenses`: check-license-allowlist-parity.sh
           # reads that key's folded scalar by consuming every following indented
@@ -73,21 +66,7 @@ jobs:
           # nothing — so a NEW libvips tuple reds this gate again and has to be
           # added by hand. #2532 tracks removing the recurrence instead.
           allow-dependencies-licenses: >-
-            pkg:githubactions/Swatinem/rust-cache,
-            pkg:npm/%40img/sharp-libvips-darwin-arm64,
-            pkg:npm/%40img/sharp-libvips-darwin-x64,
-            pkg:npm/%40img/sharp-libvips-linux-arm,
-            pkg:npm/%40img/sharp-libvips-linux-arm64,
-            pkg:npm/%40img/sharp-libvips-linux-ppc64,
-            pkg:npm/%40img/sharp-libvips-linux-riscv64,
-            pkg:npm/%40img/sharp-libvips-linux-s390x,
-            pkg:npm/%40img/sharp-libvips-linux-x64,
-            pkg:npm/%40img/sharp-libvips-linuxmusl-arm64,
-            pkg:npm/%40img/sharp-libvips-linuxmusl-x64,
-            pkg:npm/%40img/sharp-wasm32,
-            pkg:npm/%40img/sharp-win32-arm64,
-            pkg:npm/%40img/sharp-win32-ia32,
-            pkg:npm/%40img/sharp-win32-x64
+            pkg:githubactions/Swatinem/rust-cache
           allow-licenses: >-
             AGPL-3.0-only, Apache-2.0, Apache-2.0 WITH LLVM-exception, MIT,
             BSD-2-Clause, BSD-3-Clause, ISC, Zlib, BSL-1.0, MPL-2.0, Unlicense,

--- a/scripts/check-core-no-io.py
+++ b/scripts/check-core-no-io.py
@@ -16,8 +16,9 @@ somebody reads the prose.
 **The floor.** No shipping source in the crate may name a filesystem,
 process, network, environment, entropy, wall-clock, or standard-stream API.
 Absolute: one hit fails, and there is no baseline, because the tree has
-none. `#[cfg(test)]` bodies, `tests/` directories, and `tests.rs` files are
-stripped first — a test may read a fixture; the engine may not.
+none. `#[cfg(test)]` bodies, `tests/` directories, `tests.rs` files, and any
+module a `#[cfg(test)] mod name;` line names are stripped first — a test may
+read a fixture; the engine may not.
 
 **The manifest.** `[dependencies]` may not name a crate whose purpose is I/O
 or entropy, and `tokio` may take only the features that schedule (`sync`,
@@ -171,18 +172,47 @@ DEP_KEY = re.compile(r"^\s*([A-Za-z0-9_-]+)\s*(?:\.\s*workspace\s*)?=")
 FEATURES = re.compile(r"features\s*=\s*\[([^\]]*)\]")
 
 
+CFG_TEST_MOD = re.compile(
+    r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*(?:#\s*\[[^\]]*\]\s*)*(?:pub\s*(?:\([^)]*\))?\s*)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;"
+)
+
+
+def cfg_test_module_roots(src: Path) -> set[Path]:
+    """Every path a `#[cfg(test)] mod name;` line points at.
+
+    The name is a test file whatever it is called: the `mod` line that names
+    it is what puts it under `cfg(test)`, the same way a `tests.rs` file or
+    a `tests/` directory is. Both the file (`name.rs`) and the directory
+    (`name/`) are returned, because either may hold the module.
+    """
+    roots: set[Path] = set()
+    for path in src.rglob("*.rs"):
+        text = strip_comments(path.read_text(encoding="utf-8", errors="replace"))
+        for match in CFG_TEST_MOD.finditer(text):
+            name = match.group(1)
+            parent = path.parent if path.name in ("lib.rs", "main.rs", "mod.rs") else path.with_suffix("")
+            roots.add(parent / f"{name}.rs")
+            roots.add(parent / name)
+    return roots
+
+
 def shipping_sources(src: Path) -> list[Path]:
     """Every `.rs` file under `src/` that is not a test file.
 
     A `tests/` directory anywhere under `src/`, and a file named `tests.rs`,
     are the two spellings this workspace uses for a module's tests; both are
     compiled only under `cfg(test)` by the `mod` line that names them, and
-    the sibling guard skips them the same way.
+    the sibling guard skips them the same way. A module declared under
+    `#[cfg(test)]` by any other name is test code for the same reason, so
+    the `mod` lines are read too.
     """
+    test_roots = cfg_test_module_roots(src)
     out: list[Path] = []
     for path in sorted(src.rglob("*.rs")):
         rel = path.relative_to(src)
         if "tests" in rel.parts[:-1] or rel.name == "tests.rs":
+            continue
+        if path in test_roots or any(root in path.parents for root in test_roots):
             continue
         out.append(path)
     return out

--- a/scripts/test-core-no-io.sh
+++ b/scripts/test-core-no-io.sh
@@ -142,6 +142,24 @@ printf 'pub fn t() { let _ = std::fs::read_to_string("x"); }\n' >"$src/driver/te
 printf 'fn t() { let _ = std::fs::read_to_string("x"); }\n' >"$TMP/testfiles/crates/stella-core/tests/witness.rs"
 want "tests.rs, a tests/ module, and an integration test are not shipping code" expect-pass testfiles
 
+# A module is test code because the `mod` line that names it sits under
+# `#[cfg(test)]`, whatever the file is called. `src/tests.rs` was the first
+# such file, and it read as shipping code until this case.
+src="$(new_core cfgmod)"
+mkdir -p "$src/driver/helpers"
+printf 'pub mod driver;\n#[cfg(test)]\npub(crate) mod doubles;\n' >"$src/lib.rs"
+printf 'pub fn t() { let _ = std::fs::read_to_string("x"); }\n' >"$src/doubles.rs"
+printf 'pub fn drive() {}\n#[cfg(test)]\n#[allow(dead_code)]\nmod helpers;\n' >"$src/driver.rs"
+printf 'pub mod deep;\n' >"$src/driver/helpers.rs"
+printf 'pub fn t() { let _ = std::time::SystemTime::now(); }\n' >"$src/driver/helpers/deep.rs"
+want "a module named under #[cfg(test)] is not shipping code, by any name and at any depth" expect-pass cfgmod
+
+# The control: the same file named by a plain `mod` line is shipping code.
+src="$(new_core plainmod)"
+printf 'pub mod driver;\npub(crate) mod doubles;\n' >"$src/lib.rs"
+printf 'pub fn t() { let _ = std::fs::read_to_string("x"); }\n' >"$src/doubles.rs"
+want "a module named by a plain mod line is shipping code" expect-fail plainmod "doubles.rs"
+
 # ── The manifest ─────────────────────────────────────────────────────────────
 src="$(new_core denied)"
 printf '[package]\nname = "stella-core"\n\n[dependencies]\nrand = "0.10"\n' >"$TMP/denied/crates/stella-core/Cargo.toml"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   postcss: '>=8.5.23'
-  sharp: '>=0.35.4'
+  sharp: '-'
   js-yaml: ^4.3.2
   nanoid: ^3.3.18
 
@@ -319,9 +319,6 @@ packages:
   '@aws/lambda-invoke-store@0.3.0':
     resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
-
-  '@emnapi/runtime@1.11.3':
-    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@esbuild/aix-ppc64@0.25.4':
     resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
@@ -654,168 +651,6 @@ packages:
         optional: true
       tailwindcss:
         optional: true
-
-  '@img/colour@1.1.0':
-    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
-    engines: {node: '>=18'}
-
-  '@img/sharp-darwin-arm64@0.35.4':
-    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.35.4':
-    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
-    engines: {node: '>=20.9.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-freebsd-wasm32@0.35.4':
-    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
-    engines: {node: '>=20.9.0'}
-    os: [freebsd]
-
-  '@img/sharp-libvips-darwin-arm64@1.3.3':
-    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.3.3':
-    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.3.3':
-    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm@1.3.3':
-    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-ppc64@1.3.3':
-    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-riscv64@1.3.3':
-    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-s390x@1.3.3':
-    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-x64@1.3.3':
-    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
-    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
-    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linux-arm64@0.35.4':
-    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.35.4':
-    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-ppc64@0.35.4':
-    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
-    engines: {node: '>=20.9.0'}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-riscv64@0.35.4':
-    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-s390x@0.35.4':
-    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
-    engines: {node: '>=20.9.0'}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.35.4':
-    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linuxmusl-arm64@0.35.4':
-    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.35.4':
-    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-wasm32@0.35.4':
-    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
-    engines: {node: '>=20.9.0'}
-
-  '@img/sharp-webcontainers-wasm32@0.35.4':
-    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [wasm32]
-
-  '@img/sharp-win32-arm64@0.35.4':
-    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-ia32@0.35.4':
-    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
-    engines: {node: ^20.9.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.35.4':
-    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [x64]
-    os: [win32]
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2706,11 +2541,6 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
-  semver@7.8.5:
-    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -2721,15 +2551,6 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
-  sharp@0.35.4:
-    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
-    engines: {node: '>=20.9.0'}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
 
   shiki@4.3.1:
     resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
@@ -3502,11 +3323,6 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.3.0': {}
 
-  '@emnapi/runtime@1.11.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
@@ -3681,113 +3497,6 @@ snapshots:
     optionalDependencies:
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-
-  '@img/colour@1.1.0':
-    optional: true
-
-  '@img/sharp-darwin-arm64@0.35.4':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.3
-    optional: true
-
-  '@img/sharp-darwin-x64@0.35.4':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.3
-    optional: true
-
-  '@img/sharp-freebsd-wasm32@0.35.4':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.3.3':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.3.3':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.3.3':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.3.3':
-    optional: true
-
-  '@img/sharp-libvips-linux-ppc64@1.3.3':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.3.3':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.3.3':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.3.3':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.35.4':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.3
-    optional: true
-
-  '@img/sharp-linux-arm@0.35.4':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.3
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.35.4':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.3
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.35.4':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.3
-    optional: true
-
-  '@img/sharp-linux-s390x@0.35.4':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.3
-    optional: true
-
-  '@img/sharp-linux-x64@0.35.4':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.3
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.35.4':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.35.4':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
-    optional: true
-
-  '@img/sharp-wasm32@0.35.4':
-    dependencies:
-      '@emnapi/runtime': 1.11.3
-    optional: true
-
-  '@img/sharp-webcontainers-wasm32@0.35.4':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.4
-    optional: true
-
-  '@img/sharp-win32-arm64@0.35.4':
-    optional: true
-
-  '@img/sharp-win32-ia32@0.35.4':
-    optional: true
-
-  '@img/sharp-win32-x64@0.35.4':
-    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5816,7 +5525,6 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.3.3
       '@next/swc-win32-arm64-msvc': 16.3.3
       '@next/swc-win32-x64-msvc': 16.3.3
-      sharp: 0.35.4(@types/node@25.9.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -6055,9 +5763,6 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
-  semver@7.8.5:
-    optional: true
-
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -6084,40 +5789,6 @@ snapshots:
       - supports-color
 
   setprototypeof@1.2.0: {}
-
-  sharp@0.35.4(@types/node@25.9.1):
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.5
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.4
-      '@img/sharp-darwin-x64': 0.35.4
-      '@img/sharp-freebsd-wasm32': 0.35.4
-      '@img/sharp-libvips-darwin-arm64': 1.3.3
-      '@img/sharp-libvips-darwin-x64': 1.3.3
-      '@img/sharp-libvips-linux-arm': 1.3.3
-      '@img/sharp-libvips-linux-arm64': 1.3.3
-      '@img/sharp-libvips-linux-ppc64': 1.3.3
-      '@img/sharp-libvips-linux-riscv64': 1.3.3
-      '@img/sharp-libvips-linux-s390x': 1.3.3
-      '@img/sharp-libvips-linux-x64': 1.3.3
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
-      '@img/sharp-linux-arm': 0.35.4
-      '@img/sharp-linux-arm64': 0.35.4
-      '@img/sharp-linux-ppc64': 0.35.4
-      '@img/sharp-linux-riscv64': 0.35.4
-      '@img/sharp-linux-s390x': 0.35.4
-      '@img/sharp-linux-x64': 0.35.4
-      '@img/sharp-linuxmusl-arm64': 0.35.4
-      '@img/sharp-linuxmusl-x64': 0.35.4
-      '@img/sharp-webcontainers-wasm32': 0.35.4
-      '@img/sharp-win32-arm64': 0.35.4
-      '@img/sharp-win32-ia32': 0.35.4
-      '@img/sharp-win32-x64': 0.35.4
-      '@types/node': 25.9.1
-    optional: true
 
   shiki@4.3.1:
     dependencies:

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -8,13 +8,13 @@
 # package with a workspace wrapped around it. The Rust crates were never pnpm
 # packages, so nothing was ever shared across the two toolchains.
 
-# pnpm 11 reads build-script approvals from here. Both deps ship prebuilt
-# platform binaries via optional deps, so approving their build scripts just
+# pnpm 11 reads build-script approvals from here. esbuild ships prebuilt
+# platform binaries via optional deps, so approving its build script just
 # lets `pnpm install` exit cleanly — which Next 16's pre-build dependency
-# check (and Vercel) require.
+# check (and Vercel) require. sharp used to sit beside it; the override
+# below removes sharp from the tree, so there is nothing of its to approve.
 allowBuilds:
   esbuild: true
-  sharp: true
 
 # Supply-chain policy: refuse any version published less than this many minutes
 # ago. A compromised release is typically yanked within hours, so waiting a day
@@ -35,22 +35,28 @@ minimumReleaseAgeExclude:
 
 # Next 16.2.11 pulls in postcss@8.4.31 (path traversal + XSS, patched at
 # 8.5.10/8.5.18; GHSA-fxqj-rqcc-2cmp then found the sourceMappingURL fix
-# incomplete, re-patched at 8.5.23) and sharp@0.34.5 (patched at 0.35.0)
-# through its own dependency tree — not through anything this package depends
-# on directly, so there's no version bump here that fixes it. `pnpm audit`
-# clears once these are forced across every resolution. NOTE: with an override
+# incomplete, re-patched at 8.5.23) through its own dependency tree — not
+# through anything this package depends on directly, so there's no version
+# bump here that fixes it. `pnpm audit` clears once the floor is forced across
+# every resolution. NOTE: with an override
 # in force, `pnpm install --frozen-lockfile` (docs.yml) checks the importer
 # specifiers against the override-applied range — keep this floor and the
 # direct `postcss` devDependency in `package.json` moving together.
 overrides:
   postcss: ">=8.5.23"
-  # sharp <0.35.4 and js-yaml <4.3.2 each carry a high-severity advisory
-  # (GHSA-rgj7-g3m4-5g8c, GHSA-2883-xcg3-v3hh). Both arrive transitively —
-  # sharp through `next`, js-yaml through `fumadocs-core` and `fumadocs-mdx` —
-  # so, as with postcss above, no direct bump reaches them; the floor does.
-  # js-yaml takes a caret, like nanoid below: a bare floor resolves to 5.x,
-  # which fumadocs does not call.
-  sharp: ">=0.35.4"
+  # sharp is removed, not floored. `next` lists it as an optional dependency
+  # for every platform, and this site imports no `next/image`, so it was
+  # never loaded — inert weight that carried a high advisory (<0.35.4,
+  # GHSA-rgj7-g3m4-5g8c) and fourteen LGPL-3.0 libvips tuples, each of which
+  # `dependency-review` had to be told about by name every time `next` moved
+  # (#2532). `-` is pnpm's spelling for "drop this dependency everywhere".
+  # If the site ever renders a `next/image`, restore a floor here and put the
+  # tuples back in `.github/workflows/dependency-review.yml`.
+  sharp: "-"
+  # js-yaml <4.3.2 carries a high advisory (GHSA-2883-xcg3-v3hh). It arrives
+  # through `fumadocs-core` and `fumadocs-mdx`, so no direct bump reaches it;
+  # the floor does. A caret, like nanoid below: a bare floor resolves to
+  # 5.x, which fumadocs does not call.
   js-yaml: "^4.3.2"
   # nanoid <3.3.18: a custom alphabet with a non-integer or zero `size` makes
   # the generator loop indefinitely (GHSA high, patched at 3.3.18). It arrives


### PR DESCRIPTION
## What & why

Two follow-ups to #6488, each its own commit.

- **`make core-no-io` told test code from shipping code by file name alone** (a `tests/` directory or a `tests.rs` file). A module declared under `#[cfg(test)]` by any other name was read as shipping code, which is why #6488's shared sleeper doubles had to be named `src/tests.rs`. The guard now reads every `#[cfg(test)] mod name;` line and skips the file or directory it names, at any depth. `scripts/test-core-no-io.sh` gains the case and its control (a plain `mod` line must still count), 29 cases in all.
- **`sharp` is removed from the docs site instead of floored.** The site imports no `next/image`, so sharp was never loaded: inert weight from `next`'s optional dependencies that carried the advisory #6488 floored and fourteen LGPL-3.0 libvips tuples that `dependency-review` had to be told about by name on every `next` bump (the recurrence issue #2532 describes). The pnpm override drops it from the tree, its build-script approval goes with it, and the per-tuple exemption #6488 added to `dependency-review.yml` is deleted, since nothing is left to exempt. The `js-yaml` floor stays.

Refs #6484. Closes nothing by design (`closes-nothing`).

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`scripts/test-core-no-io.sh`'s new case `a module named under #[cfg(test)] is not shipping code, by any name and at any depth` fails against `main`'s guard (the file it names reads `std::fs`) and passes here; its control `a module named by a plain mod line is shipping code` pins that the rule did not widen. For the sharp change the evidence is the lockfile: `sharp` appears once in `website/pnpm-lock.yaml`, in the override line, and `docs.yml`'s `typecheck + build` job is what proves `next build` does not need it.

## The gate

- [x] `cargo fmt --check` (no Rust touched)
- [x] clippy — no Rust touched
- [x] tests — the guard harness ran locally, 29 passed; `make prose`, `make license-allowlist-parity` and `make action-pins` green
- [x] Docs updated where behavior changed (the guard's own docstring and AGENTS.md's no-io paragraph name the new rule)
- [x] CLA signed

## Fix over file

- [x] Extra fixes in this PR: none beyond the two named
- [x] Nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core` (not touched)
- [x] No new outbound network calls
- [x] No new cross-boundary serde types

## Anything reviewers should know?

- If the docs site ever renders a `next/image`, restore a `sharp` floor in `website/pnpm-workspace.yaml` and put the tuples back in the workflow; the comment there says so.
- The stacked doubles PR (#6491) was closed when #6488's branch was deleted on merge; it is re-opened against `main` separately and does not depend on this one.

## Summary by Sourcery

Correct test-code classification in the core no-I/O check and remove unused Sharp dependencies from the documentation site.

Bug Fixes:
- Update the core no-I/O guard to exclude modules declared under `#[cfg(test)]` regardless of their file name or nesting depth, while preserving shipping-code detection for plain modules.

Enhancements:
- Remove the unused Sharp dependency from the documentation site and retain the existing js-yaml security floor.

CI:
- Remove Sharp and its platform-specific license exemptions from dependency-review configuration and its build-script approval.

Documentation:
- Document the expanded test-module exclusion rule in the core no-I/O guard guidance.

Tests:
- Add regression and control cases covering cfg-gated modules at multiple depths and plain modules.