### PR TITLE
fix: resync Cargo.lock with stella-time 0.9.417, repairing main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "stella-time"
-version = "0.9.416"
+version = "0.9.417"
 dependencies = [
  "async-trait",
  "rand 0.10.2",


### PR DESCRIPTION
Closes #6495

## The two red checks are one fault

`main` is red on `lockfile-sync` and `compile`. They have a single cause.

The `compile` job passes `--locked`, so a lock that disagrees with the manifests fails there before compiling anything:

```
error: cannot update the lock file /home/runner/work/stella/stella/Cargo.lock because --locked was passed to prevent this
```

That reads as a compile failure and is not one. No crate in the tree fails to typecheck. Cargo never got far enough to try.

## Why no pre-merge check caught it

This is the composition shape the canary was built for (#3332). `Cargo.lock` is a shared cell: every PR of a given form must write it. The `stella-time` bump to `0.9.417` and the manifest change referencing it came from different branches. Each branch was self-consistent and each passed its own CI, because no pre-merge run had both halves in front of it. Only the merged tree carries both.

## The fix

Regenerated with `cargo metadata`, the narrowest command that rewrites the lock without building anything (SCR-001). The entire diff is one line:

```
 [[package]]
 name = "stella-time"
-version = "0.9.416"
+version = "0.9.417"
```

## Verification

`cargo metadata --locked` exits 0 — the exact condition the `compile` job asserts and the thing that was failing.

## Why `unblocks-main`

`main-red-hold.yml` blocks every merge while main is known-broken. This PR is the repair, so without the label it would be blocked by the condition it removes. That is what the label documents itself as existing for.

## Summary by Sourcery

Bug Fixes:
- Synchronize Cargo.lock with the stella-time 0.9.417 dependency version so locked Cargo checks pass again.