### PR TITLE
chore(workspace): refresh Cargo.lock for stella-time after the 0.9.417 sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "stella-time"
-version = "0.9.416"
+version = "0.9.417"
 dependencies = [
  "async-trait",
  "rand 0.10.2",


### PR DESCRIPTION
## What & why

`main` is red (#6495): `Cargo.lock` names `stella-time` at 0.9.416 while the workspace version is 0.9.417, so every `--locked` build fails. #6488 added the crate with a lock refreshed against the 0.9.416 sync, and the 0.9.417 sync (#6494) landed between that PR's last rebase and its merge; the merge check ran on the older merge commit. This is the #5939 shape.

The fix is the one-line lock refresh (`cargo update -w`): `stella-time` 0.9.416 → 0.9.417, nothing else.

Refs #6495 (the canary closes it once `main` is green again). Trivial change, closes no issue (`no-issue`).

## The witness

- [x] No witness needed (lockfile only) — `cargo metadata --locked` fails on `main` and passes here.

## The gate

- [x] `cargo fmt --check` (no Rust touched)
- [ ] CI — `lockfile-sync` and `compile` are the checks that were red
- [x] CLA signed

## Summary by Sourcery

Bug Fixes:
- Synchronize Cargo.lock with the workspace's stella-time 0.9.417 version so locked builds and metadata checks succeed.