### PR TITLE
feat(bench): a committed census for the tool share of wall clock, and what it says about the 75%

### DIFF
--- a/bench/trace_triage/census.py
+++ b/bench/trace_triage/census.py
@@ -86,6 +86,7 @@ class TrialCensus:
     reattempted_ms: int
     reattempted_exact_ms: int
     tool_calls: int
+    bash_calls: int
 
 
 @dataclass(frozen=True)
@@ -103,6 +104,7 @@ class Census:
     reattempted_ms: int
     reattempted_exact_ms: int
     tool_calls: int
+    bash_calls: int
 
     @property
     def timed_trials(self) -> int:
@@ -188,6 +190,7 @@ def census_of(trial: Trial, *, similarity: float = REPEAT_SIMILARITY) -> TrialCe
         reattempted_ms=reattempted_ms,
         reattempted_exact_ms=exact_ms,
         tool_calls=len(trial.tool_calls),
+        bash_calls=len(bash_commands),
     )
 
 
@@ -213,6 +216,7 @@ def summarize(censuses: Iterable[TrialCensus]) -> Census:
         reattempted_ms=sum(row.reattempted_ms for row in rows),
         reattempted_exact_ms=sum(row.reattempted_exact_ms for row in rows),
         tool_calls=sum(row.tool_calls for row in rows),
+        bash_calls=sum(row.bash_calls for row in rows),
     )
 
 
@@ -225,7 +229,14 @@ def _hours(milliseconds: int) -> str:
 
 
 def render(census: Census, *, label: str) -> str:
-    """The census as text, with its basis on the first line."""
+    """The census as text, with each section's basis above it.
+
+    The shell figures are printed apart from the wall-clock ones because they
+    are over a wider set. A share needs a clock and so is held to the trials
+    that carry one; a duration does not, so a trace on the older schema still
+    contributes its shell time. Printing them as one block read as though the
+    shell total were a part of the tool total, which it is not, and can exceed.
+    """
     basis = f"{census.timed_trials} trials with a wall clock"
     if census.untimed_trials:
         basis += f", {census.untimed_trials} on a schema without one"
@@ -233,15 +244,18 @@ def render(census: Census, *, label: str) -> str:
         basis += f", {census.empty_trials} that recorded nothing"
     lines = [
         f"{label}: {basis}",
-        f"  wall clock       {_hours(census.wall_ms)}",
-        f"  tool execution   {_hours(census.tool_ms)}  {_percent(census.tool_share)} of wall clock",
-        f"  model            {_hours(census.model_ms)}  {_percent(census.model_share)} of wall clock",
-        f"  bash             {_hours(census.bash_ms)}  over {census.tool_calls} tool calls",
-        f"    killed by the timeout      {_hours(census.timed_out_ms)}  "
+        f"  over the {census.timed_trials} trials that carry a clock:",
+        f"    wall clock     {_hours(census.wall_ms)}",
+        f"    tool execution {_hours(census.tool_ms)}  {_percent(census.tool_share)} of wall clock",
+        f"    model          {_hours(census.model_ms)}  {_percent(census.model_share)} of wall clock",
+        f"  over all {census.trials} trials, which needs no clock:",
+        f"    bash           {_hours(census.bash_ms)}  over {census.bash_calls} bash calls "
+        f"of {census.tool_calls} tool calls",
+        f"      killed by the timeout    {_hours(census.timed_out_ms)}  "
         f"{_percent(census.timed_out_share)} of bash",
-        f"    killed and tried again     {_hours(census.reattempted_ms)}  "
+        f"      killed and tried again   {_hours(census.reattempted_ms)}  "
         f"{_percent(census.reattempted_share)} of bash",
-        f"    ...of which run verbatim   {_hours(census.reattempted_exact_ms)}",
+        f"      ...of which run verbatim {_hours(census.reattempted_exact_ms)}",
     ]
     return "\n".join(lines)
 

--- a/bench/trace_triage/census.py
+++ b/bench/trace_triage/census.py
@@ -1,0 +1,299 @@
+"""The share of a run's wall clock that went to tool execution, and what sat inside it.
+
+`#3753` measured one match and reported tool execution at 75% of agent wall
+clock. Its definition of done asks for that number again on a comparable panel,
+"on the same clean-basis method". That method was an uncommitted `jq`
+incantation, so the next run would have produced a number nobody could compare
+to the last one. Here it is written down.
+
+Wall clock is the first event to the last, per trial. Tool time is
+`tool_result.duration_ms` summed over the join `run_trace` already performs. A
+share is a ratio of two sums over one named trial set, never a mean of ratios.
+
+**The basis travels with the number or the number says nothing.** `#3753`'s body
+reports 75% over a clean basis of nine tasks; a later comment on the same match
+reports 52% over the twelve trials that carried events. Neither corrects the
+other. They are two populations, and a reader handed one figure alone cannot
+tell which. `Census.trials` and `Census.untimed_trials` are therefore on every
+result this module returns.
+
+**A trace written before the event schema carried `ts` has no wall clock.** Its
+tool durations are still readable. Counting it as a zero would deflate every
+share it entered, so it lands in `untimed_trials` and leaves the ratio alone.
+
+**A trial that recorded nothing is a third thing again**, and `empty_trials`
+keeps it apart from the old schema. A run whose credential never authenticated
+writes empty traces, and folding those into "no timestamp" would report a
+broken run as an old one.
+
+Two costs inside the tool time can be named from the trace with no rig and no
+spend. `bash` answers `command timed out after Ns` when its backstop fires, so a
+killed call is measured time against work that is gone. When a later call in the
+same trial repeats a killed one, that first attempt bought nothing at all —
+which is the shape `pytorch-model-cli` died in, with an install killed at 120s,
+the same install killed again at 300s, and a third attempt that ran.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Iterable
+
+from run_trace import Trial, load_run, load_trial
+
+__all__ = [
+    "Census",
+    "TrialCensus",
+    "census_of",
+    "main",
+    "render",
+    "summarize",
+]
+
+#: `bash` opens its timeout refusal with this, and no other tool answers it.
+TIMEOUT_MARKER = "command timed out after"
+
+#: How alike two commands must read before the later one counts as a repeat of
+#: the earlier. Tuned on the pair `pytorch-model-cli` actually sent —
+#: `timeout 300 pip install torch --quiet` against `pip install torch --quiet`,
+#: which score 0.62 — and reported beside `reattempted_exact_ms`, the floor that
+#: needs no threshold at all.
+REPEAT_SIMILARITY = 0.6
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _normalized(command: str) -> str:
+    return _WHITESPACE.sub(" ", command).strip()
+
+
+@dataclass(frozen=True)
+class TrialCensus:
+    """One trial's wall clock and the tool time inside it."""
+
+    task_id: str
+    events: int
+    wall_ms: int | None
+    tool_ms: int
+    bash_ms: int
+    model_ms: int
+    timed_out_ms: int
+    reattempted_ms: int
+    reattempted_exact_ms: int
+    tool_calls: int
+
+
+@dataclass(frozen=True)
+class Census:
+    """A trial set's totals, and the shares they support."""
+
+    trials: int
+    untimed_trials: int
+    empty_trials: int
+    wall_ms: int
+    tool_ms: int
+    bash_ms: int
+    model_ms: int
+    timed_out_ms: int
+    reattempted_ms: int
+    reattempted_exact_ms: int
+    tool_calls: int
+
+    @property
+    def timed_trials(self) -> int:
+        """Trials that carried a timestamp, which is what a share is over."""
+        return self.trials - self.untimed_trials - self.empty_trials
+
+    def _share_of_wall(self, part_ms: int) -> float | None:
+        return None if self.wall_ms <= 0 else 100.0 * part_ms / self.wall_ms
+
+    def _share_of_bash(self, part_ms: int) -> float | None:
+        return None if self.bash_ms <= 0 else 100.0 * part_ms / self.bash_ms
+
+    @property
+    def tool_share(self) -> float | None:
+        """The figure `#3753` asks to move, as a percentage, or `None` when no
+        trial in the set carried a wall clock."""
+        return self._share_of_wall(self.tool_ms)
+
+    @property
+    def model_share(self) -> float | None:
+        return self._share_of_wall(self.model_ms)
+
+    @property
+    def timed_out_share(self) -> float | None:
+        return self._share_of_bash(self.timed_out_ms)
+
+    @property
+    def reattempted_share(self) -> float | None:
+        return self._share_of_bash(self.reattempted_ms)
+
+
+def _wall_ms(trial: Trial) -> int | None:
+    stamps = [e["ts"] for e in trial.events if isinstance(e.get("ts"), int)]
+    return max(stamps) - min(stamps) if stamps else None
+
+
+def _model_ms(trial: Trial) -> int:
+    return sum(int(e.get("duration_ms") or 0) for e in trial.of_type("step_usage"))
+
+
+def _result_text(call) -> str:
+    return "" if call.result is None else str(call.result.get("output", ""))
+
+
+def census_of(trial: Trial, *, similarity: float = REPEAT_SIMILARITY) -> TrialCensus:
+    """Read one trial's clock, without reaching for anything but its events."""
+    tool_ms = bash_ms = timed_out_ms = reattempted_ms = exact_ms = 0
+    bash_commands: list[str] = []
+    killed: list[tuple[int, int, str]] = []
+
+    for call in trial.tool_calls:
+        duration = int((call.result or {}).get("duration_ms") or 0)
+        tool_ms += duration
+        if call.name != "bash":
+            continue
+        command = call.input.get("command")
+        if not isinstance(command, str):
+            continue
+        bash_ms += duration
+        bash_commands.append(_normalized(command))
+        if TIMEOUT_MARKER in _result_text(call):
+            timed_out_ms += duration
+            killed.append((len(bash_commands) - 1, duration, _normalized(command)))
+
+    for index, duration, command in killed:
+        later = bash_commands[index + 1 :]
+        if command in later:
+            exact_ms += duration
+        if any(
+            SequenceMatcher(None, command, other).ratio() >= similarity
+            for other in later
+        ):
+            reattempted_ms += duration
+
+    return TrialCensus(
+        task_id=trial.task_id,
+        events=len(trial.events),
+        wall_ms=_wall_ms(trial),
+        tool_ms=tool_ms,
+        bash_ms=bash_ms,
+        model_ms=_model_ms(trial),
+        timed_out_ms=timed_out_ms,
+        reattempted_ms=reattempted_ms,
+        reattempted_exact_ms=exact_ms,
+        tool_calls=len(trial.tool_calls),
+    )
+
+
+def summarize(censuses: Iterable[TrialCensus]) -> Census:
+    """Total a trial set, holding every share to the trials that carry a clock.
+
+    A trial with no wall clock keeps its tool time out of the numerator as well
+    as the denominator, so the share is a statement about one population rather
+    than a ratio between two.
+    """
+    rows = list(censuses)
+    timed = [row for row in rows if row.wall_ms is not None]
+    empty = [row for row in rows if not row.events]
+    return Census(
+        trials=len(rows),
+        untimed_trials=len(rows) - len(timed) - len(empty),
+        empty_trials=len(empty),
+        wall_ms=sum(row.wall_ms or 0 for row in timed),
+        tool_ms=sum(row.tool_ms for row in timed),
+        bash_ms=sum(row.bash_ms for row in rows),
+        model_ms=sum(row.model_ms for row in timed),
+        timed_out_ms=sum(row.timed_out_ms for row in rows),
+        reattempted_ms=sum(row.reattempted_ms for row in rows),
+        reattempted_exact_ms=sum(row.reattempted_exact_ms for row in rows),
+        tool_calls=sum(row.tool_calls for row in rows),
+    )
+
+
+def _percent(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.1f}%"
+
+
+def _hours(milliseconds: int) -> str:
+    return f"{milliseconds / 3_600_000:.2f}h"
+
+
+def render(census: Census, *, label: str) -> str:
+    """The census as text, with its basis on the first line."""
+    basis = f"{census.timed_trials} trials with a wall clock"
+    if census.untimed_trials:
+        basis += f", {census.untimed_trials} on a schema without one"
+    if census.empty_trials:
+        basis += f", {census.empty_trials} that recorded nothing"
+    lines = [
+        f"{label}: {basis}",
+        f"  wall clock       {_hours(census.wall_ms)}",
+        f"  tool execution   {_hours(census.tool_ms)}  {_percent(census.tool_share)} of wall clock",
+        f"  model            {_hours(census.model_ms)}  {_percent(census.model_share)} of wall clock",
+        f"  bash             {_hours(census.bash_ms)}  over {census.tool_calls} tool calls",
+        f"    killed by the timeout      {_hours(census.timed_out_ms)}  "
+        f"{_percent(census.timed_out_share)} of bash",
+        f"    killed and tried again     {_hours(census.reattempted_ms)}  "
+        f"{_percent(census.reattempted_share)} of bash",
+        f"    ...of which run verbatim   {_hours(census.reattempted_exact_ms)}",
+    ]
+    return "\n".join(lines)
+
+
+def _load(root: Path) -> list[Trial]:
+    """Every trial under `root`, in either layout the mirror is written in.
+
+    The cloud runner writes `runs/<run_id>/<trial>/ws/matches/<match>/jobs/...`
+    and `load_run` reads that. A match pulled to `~/.arenabench/matches/` starts
+    at the `jobs/` level instead, whether `root` is one match or the directory
+    holding many, so both depths are walked before the answer is empty.
+
+    A match holds every contestant's seat, and the other one does not write
+    `stella-events.jsonl`. Its directories are skipped rather than counted as
+    trials that recorded nothing, which would report an opponent as a failure.
+    """
+    trials = list(load_run(root).trials)
+    if trials:
+        return trials
+    for pattern in ("jobs/*/*", "*/jobs/*/*"):
+        for task_dir in sorted(root.glob(pattern)):
+            if (task_dir / "agent" / "stella-events.jsonl").is_file():
+                trials.append(
+                    load_trial(root.name, root, task_dir.parent.name, task_dir)
+                )
+        if trials:
+            break
+    return trials
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "root", type=Path, help="a mirrored run, or a directory of matches"
+    )
+    parser.add_argument(
+        "--label", default="", help="what the trial set is, for the first line"
+    )
+    args = parser.parse_args(argv)
+
+    trials = _load(args.root.resolve())
+    if not trials:
+        print(f"no trials under {args.root}", file=sys.stderr)
+        return 1
+    print(
+        render(
+            summarize(census_of(trial) for trial in trials),
+            label=args.label or args.root.name,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/trace_triage/tests/test_census.py
+++ b/bench/trace_triage/tests/test_census.py
@@ -1,0 +1,252 @@
+"""The census reproduces the shape `#3753` measured, and states what it is over.
+
+The number this module exists to produce has already been quoted three ways for
+one match — 75% over nine tasks in the issue body, 52% over the twelve trials
+that carried events, and 15.5% over every match on the machine. None of those
+corrects another, so the required assertion here is not that a share is right.
+It is that a share never travels without the trial count it is a share of, and
+that a trace with no wall clock cannot silently enter one.
+
+The commands in `a_killed_call_whose_command_comes_back_is_paid_for_twice` are
+the ones `pytorch-model-cli` actually sent before it timed out at its budget.
+
+Offline by construction — every trace here is written, never fetched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from census import _load, census_of, render, summarize
+from fixtures import err, ok, write_run
+from run_trace import load_run
+
+
+def call(call_id: str, command: str, duration_ms: int, output: dict, *, ts: int = 1):
+    """A `bash` pair carrying the elapsed time the census reads."""
+    return [
+        {
+            "ts": ts,
+            "type": "tool_start",
+            "call": {"call_id": call_id, "name": "bash", "input": {"command": command}},
+        },
+        {
+            "ts": ts + duration_ms,
+            "type": "tool_result",
+            "call_id": call_id,
+            "output": output,
+            "duration_ms": duration_ms,
+        },
+    ]
+
+
+def load(tmp_path: Path, trials: list[dict]):
+    return load_run(write_run(tmp_path, trials))
+
+
+def test_a_trial_without_a_timestamp_stays_out_of_every_share(tmp_path: Path):
+    timed = {
+        "task": "timed__aaa",
+        "events": call("c1", "make", 10_000, ok("built"), ts=1_000)
+        + [{"ts": 41_000, "type": "step_usage", "duration_ms": 20_000}],
+        "reward": 1.0,
+    }
+    untimed = {
+        "task": "untimed__bbb",
+        "events": [
+            {
+                "type": "tool_start",
+                "call": {"call_id": "c2", "name": "bash", "input": {"command": "make"}},
+            },
+            {
+                "type": "tool_result",
+                "call_id": "c2",
+                "output": ok("built"),
+                "duration_ms": 600_000,
+            },
+        ],
+        "reward": 1.0,
+    }
+    run = load(tmp_path, [timed, untimed])
+    census = summarize(census_of(trial) for trial in run.trials)
+
+    assert census.trials == 2
+    assert census.untimed_trials == 1
+    assert census.timed_trials == 1
+    # The 600s the untimed trial spent is real, and it is absent from the share
+    # rather than sitting in a denominator no clock supports.
+    assert census.tool_ms == 10_000
+    assert census.wall_ms == 40_000
+    assert census.tool_share == 25.0
+    assert census.model_share == 50.0
+    # It is still visible where no clock is needed to read it.
+    assert census.bash_ms == 610_000
+
+
+def test_a_killed_call_whose_command_comes_back_is_paid_for_twice(tmp_path: Path):
+    events = (
+        call(
+            "c1",
+            "pip install torch --quiet",
+            120_000,
+            err("command timed out after 120s"),
+            ts=0,
+        )
+        + call(
+            "c2",
+            "timeout 300 pip install torch --quiet",
+            300_000,
+            err("command timed out after 300s"),
+            ts=200_000,
+        )
+        + call(
+            "c3",
+            "pip install torch --quiet",
+            60_000,
+            ok("Successfully installed torch"),
+            ts=600_000,
+        )
+    )
+    run = load(
+        tmp_path,
+        [{"task": "pytorch-model-cli__mrL9jSa", "events": events, "reward": 0.0}],
+    )
+    census = summarize(census_of(trial) for trial in run.trials)
+
+    assert census.timed_out_ms == 420_000
+    # Both killed attempts came back later, so neither bought anything.
+    assert census.reattempted_ms == 420_000
+    # Only the first was repeated word for word; the floor is reported beside
+    # the similarity reading so a reader can see what the threshold bought.
+    assert census.reattempted_exact_ms == 120_000
+    assert census.timed_out_share is not None
+    assert round(census.timed_out_share, 1) == 87.5
+
+
+def test_a_run_that_never_timed_out_reports_no_waste(tmp_path: Path):
+    events = call("c1", "pytest -q", 30_000, ok("12 passed"), ts=0) + call(
+        "c2", "git diff --stat", 500, ok(" 1 file changed"), ts=40_000
+    )
+    run = load(tmp_path, [{"task": "healthy__ccc", "events": events, "reward": 1.0}])
+    census = summarize(census_of(trial) for trial in run.trials)
+
+    assert census.timed_out_ms == 0
+    assert census.reattempted_ms == 0
+    assert census.timed_out_share == 0.0
+
+
+def test_the_rendered_census_names_the_basis_of_its_share(tmp_path: Path):
+    timed = {
+        "task": "a__aaa",
+        "events": call("c1", "make", 10_000, ok("ok"), ts=0),
+        "reward": 1.0,
+    }
+    untimed = {
+        "task": "b__bbb",
+        "events": [
+            {
+                "type": "tool_start",
+                "call": {"call_id": "c2", "name": "bash", "input": {"command": "make"}},
+            },
+            {
+                "type": "tool_result",
+                "call_id": "c2",
+                "output": ok("ok"),
+                "duration_ms": 1_000,
+            },
+        ],
+        "reward": 1.0,
+    }
+    run = load(tmp_path, [timed, untimed])
+    text = render(summarize(census_of(trial) for trial in run.trials), label="panel")
+
+    assert "1 trials with a wall clock, 1 on a schema without one" in text
+    assert "tool execution" in text
+
+
+def test_a_share_with_no_wall_clock_behind_it_is_absent_rather_than_zero(
+    tmp_path: Path,
+):
+    untimed = {
+        "task": "b__bbb",
+        "events": [
+            {
+                "type": "tool_start",
+                "call": {"call_id": "c2", "name": "bash", "input": {"command": "make"}},
+            },
+            {
+                "type": "tool_result",
+                "call_id": "c2",
+                "output": ok("ok"),
+                "duration_ms": 1_000,
+            },
+        ],
+        "reward": 1.0,
+    }
+    census = summarize(census_of(trial) for trial in load(tmp_path, [untimed]).trials)
+
+    assert census.tool_share is None
+    assert "n/a" in render(census, label="panel")
+
+
+def test_a_trial_that_recorded_nothing_is_not_reported_as_an_old_schema(tmp_path: Path):
+    """A credential that never authenticated writes empty traces.
+
+    Folding those into `untimed_trials` would describe a broken run as an old
+    one, which is the distinction `postmortem` puts first for the same reason.
+    """
+    old_schema = {
+        "task": "old__aaa",
+        "events": [
+            {
+                "type": "tool_start",
+                "call": {"call_id": "c1", "name": "bash", "input": {"command": "make"}},
+            },
+            {
+                "type": "tool_result",
+                "call_id": "c1",
+                "output": ok("ok"),
+                "duration_ms": 1_000,
+            },
+        ],
+        "reward": 1.0,
+    }
+    recorded_nothing = {"task": "empty__bbb", "events": [], "reward": 0.0}
+    census = summarize(
+        census_of(t) for t in load(tmp_path, [old_schema, recorded_nothing]).trials
+    )
+
+    assert census.untimed_trials == 1
+    assert census.empty_trials == 1
+    assert census.timed_trials == 0
+    assert "1 on a schema without one, 1 that recorded nothing" in render(
+        census, label="panel"
+    )
+
+
+def test_the_other_contestants_seat_is_not_a_trial_that_recorded_nothing(
+    tmp_path: Path,
+):
+    """A match holds both seats, and only one of them writes `stella-events.jsonl`.
+
+    Walking on the `agent/` directory alone counted every opposing trial as a
+    trace that recorded nothing, which read as 16 failures on the match `#3753`
+    cites and none of them were ours.
+    """
+    match = tmp_path / "13f7f2bb533d"
+    ours = match / "jobs" / "m-stella-low" / "build__aaa" / "agent"
+    ours.mkdir(parents=True)
+    (ours / "stella-events.jsonl").write_text(
+        "\n".join(
+            json.dumps(e) for e in call("c1", "make", 10_000, ok("built"), ts=1_000)
+        )
+    )
+    theirs = match / "jobs" / "m-claude-code-low" / "build__aaa" / "agent"
+    theirs.mkdir(parents=True)
+    (theirs / "transcript.jsonl").write_text("{}\n")
+
+    census = summarize(census_of(trial) for trial in _load(match))
+
+    assert census.trials == 1
+    assert census.empty_trials == 0


### PR DESCRIPTION
## What & why

`#3753`'s remaining definition of done asks for the tool-execution share of wall
clock "on the same clean-basis method" as the 75% in its body. That method was an
uncommitted `jq` incantation. `bench/trace_triage/census.py` is the method written
down, so the next panel produces a figure a reader can hold against this one.

Wall clock is the first event to the last, per trial. Tool time is
`tool_result.duration_ms` over the join `run_trace` already performs. A share is a
ratio of two sums over one named trial set, never a mean of ratios.

## Calibration

Run against the match `#3753` cites, the committed module answers **52.0%** over 12
trials. The figure already published on that issue from the same match, by a
separate hand-written join, is **51.8%** (6,578s wall, 3,406s tool). The wall
clocks are identical and the tool totals differ by 13s. I did not establish what
that 13s is — the other join is not in the tree — so it is stated as an
unexplained residual rather than attributed.

```
$ python3 bench/trace_triage/census.py ~/.arenabench/matches/13f7f2bb533d
match 13f7f2bb533d: 12 trials with a wall clock
  over the 12 trials that carry a clock:
    wall clock     1.83h
    tool execution 0.95h  52.0% of wall clock
    model          0.46h  25.0% of wall clock
  over all 12 trials, which needs no clock:
    bash           0.95h  over 191 bash calls of 216 tool calls
      killed by the timeout    0.38h  40.4% of bash
      killed and tried again   0.18h  19.3% of bash
      ...of which run verbatim 0.00h
```

## What it says about the 75%

Pointed at every ArenaBench match on this machine — 294 matches, 341 Stella trials
that carry a wall clock — the share is not 75% and not 52%:

| trial set | trials | tool share | model share |
| --- | --- | --- | --- |
| `#3753`'s body, clean basis of 9 | 9 | 75% | 31% |
| `#3753`'s later comment, same match | 12 | 51.8% | — |
| every match on this machine | 341 | **15.5%** | **56.6%** |

**Labelled as a measurement, not a panel.** These are the matches that happen to be
on disk, run against many configurations over months, not a controlled panel. What
it establishes is narrow and worth having: the 75% is a property of an
install-heavy task mix, not of the harness. On the corpus the model is the larger
consumer by a wide margin.

The practical consequence: a panel reporting a lower number than 75% has probably
changed task mix, and the census makes that visible because the trial count
travels with the share.

It does not discharge either remaining box on `#3753`. Both still need a funded
panel.

## The second cost inside shell time

`#6440` and `#6501` are both aimed at blind waiting. The census names a larger
bucket beside it, over 24.48h of `bash` wall clock in 13,245 bash calls:

| | hours | share of bash |
| --- | --- | --- |
| killed by the tool timeout | 5.70 | 23.3% |
| killed, and the command came back later | 3.14 | 12.8% |

The second row is time that bought nothing at all: the call was killed, and a later
call in the same trial re-ran it. That is the shape `pytorch-model-cli` died in —
`pip install torch` killed at 120s, the same install killed again at 300s, then a
third attempt that ran. 420s of its 984s went into the two attempts that were
thrown away, before the 490s blind wait `#6501` declines.

No fix here. The remedy is backgrounding, which `#6501` argues is a body of work
rather than a session, and which `#3753` already tracks as its unbuilt direction
two. The number is here so whoever sizes that work has it.

## Three trial kinds kept apart, and two bases kept apart

Each of these was a wrong number before it was a distinction:

- **A trace from before the event schema carried `ts`** has tool durations and no
  wall clock. It stays out of the numerator as well as the denominator, instead of
  entering as a zero that deflates the share. 180 of the traces here are this.
- **A trial that recorded nothing** is counted separately. A credential that never
  authenticated writes empty traces, and folding them in reports a broken run as an
  old one — the separation `postmortem` puts first, for the same reason.
- **A task directory with no `stella-events.jsonl`** is the other contestant's
  seat. Walking on the `agent/` directory alone read 16 opposing trials on
  `13f7f2bb533d` as trials of ours that died.

The render also prints the shell figures under their own heading. A share needs a
clock and is held to the trials that carry one; a duration does not, so a trace on
the older schema still contributes its shell time. Printed as one block, the
smaller tool figure read as though it contained the larger shell one. `1aabe7c76`
is that fix, and it followed me publishing the misreading on `#3753` — the bash
hours were right and the call count beside them was every tool's.

## The witness

- [x] This PR includes witness tests (fail on `main`, pass here).

`bench/trace_triage/tests/test_census.py`:
- `test_a_trial_without_a_timestamp_stays_out_of_every_share` — the 600s an untimed
  trial spent is absent from the share and still visible in `bash_ms`.
- `test_a_killed_call_whose_command_comes_back_is_paid_for_twice` — the commands
  `pytorch-model-cli` actually sent, verbatim.
- `test_a_run_that_never_timed_out_reports_no_waste` — quiet on a healthy run.
- `test_the_rendered_census_names_the_basis_of_its_share` and
  `test_a_share_with_no_wall_clock_behind_it_is_absent_rather_than_zero`.
- `test_a_trial_that_recorded_nothing_is_not_reported_as_an_old_schema`.
- `test_the_other_contestants_seat_is_not_a_trial_that_recorded_nothing`.

Offline by construction: every trace is written, never fetched.

## The gate

- [x] `pytest bench/trace_triage/tests/test_census.py` — 7 passed
- [x] `ruff check` and `ruff format --check` on both new files
- [x] `make prose`, `make line-citations`, `scripts/check-file-size.sh`

`bench.yml` runs `pytest bench/trace_triage/tests` on every pull request and its
scope filter names `bench/`, so this suite is gated in CI rather than only here.
No workspace build was run locally, per SCR-001.

## Conflict surface

Two new files, nothing shared touched. `#6501` adds `bench/trace_triage/waits.py`
for blind waits and edits `detectors.py` and `tests/test_postmortem.py`; this
branch touches none of those, so the two can land in either order.

Refs #3753
