### PR TITLE
fix(context): adopt contextgraph 2.0.0's attestation fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,15 +447,20 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "contextgraph-conformance"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65478f263db1e54f2665b7653db5ee57130a108e78ec3785dc26036a263f7cd"
+version = "2.0.0"
+source = "git+https://github.com/macanderson/context-graph-protocol?rev=d446bb55dc48604b9e664546dc30ce8cb7531920#d446bb55dc48604b9e664546dc30ce8cb7531920"
 dependencies = [
  "async-trait",
  "clap",
@@ -464,9 +475,8 @@ dependencies = [
 
 [[package]]
 name = "contextgraph-host"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaf2a69d0e22494dcf0f890bad63edc436035d0116100215f650b3ca1d3f343"
+version = "2.0.0"
+source = "git+https://github.com/macanderson/context-graph-protocol?rev=d446bb55dc48604b9e664546dc30ce8cb7531920#d446bb55dc48604b9e664546dc30ce8cb7531920"
 dependencies = [
  "async-trait",
  "contextgraph-types",
@@ -482,9 +492,8 @@ dependencies = [
 
 [[package]]
 name = "contextgraph-trace"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d26ec325f040549af3ba16f6343b0e5d022e174185161d5a3334aca602731ca"
+version = "2.0.0"
+source = "git+https://github.com/macanderson/context-graph-protocol?rev=d446bb55dc48604b9e664546dc30ce8cb7531920#d446bb55dc48604b9e664546dc30ce8cb7531920"
 dependencies = [
  "contextgraph-types",
  "serde",
@@ -494,11 +503,12 @@ dependencies = [
 
 [[package]]
 name = "contextgraph-types"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b7acbbe63ff3a0a5eb104c5e9a4a81c9ec6de57d535b7e5216daac54ba6974"
+version = "2.0.0"
+source = "git+https://github.com/macanderson/context-graph-protocol?rev=d446bb55dc48604b9e664546dc30ce8cb7531920#d446bb55dc48604b9e664546dc30ce8cb7531920"
 dependencies = [
+ "ed25519-dalek",
  "serde",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -659,6 +669,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +760,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,7 +814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -813,6 +860,30 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -905,6 +976,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -2290,6 +2367,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2602,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -3103,6 +3193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,6 +3255,16 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,26 +60,37 @@ publish = false
 
 [workspace.dependencies]
 # Context Graph Protocol — the wire types, host runtime, conformance suite, and
-# execution-trace vocabulary stella speaks (#819). Declared ONCE here so a
-# version bump is a one-line edit rather than six scattered across three member
-# manifests, which is how these drifted onto a git rev in the first place.
+# execution-trace vocabulary stella speaks. Declared ONCE here so a version
+# bump is a one-line edit rather than six scattered across three member
+# manifests.
 #
-# These were `{ git = ..., rev = ... }` until #819. That pin named a commit
-# living on a history line this repository's upstream had since re-rooted away
-# from: it was on no branch and no PR, reachable only by raw SHA, and eligible
-# for garbage collection — a cold cargo cache away from breaking every build.
-# Registry versions get us a reviewable release, a checksum in Cargo.lock, and
-# an audit trail (`cargo audit`/`cargo vet` cannot see a git rev).
+# Pinned to a git revision, not a registry version. CGP cut a new major
+# version — `ContextQueryResult` gained `frame_attestations` and
+# `result_attestation` — but has not published it: the release workflow's
+# publish token and environment do not exist yet, so no registry version
+# carries this release. The `rev` below is CGP's `main` HEAD at the time of
+# this change.
+#
+# A git pin is normally unsafe here: this workspace once pinned a commit that
+# its upstream had rewritten away from, reachable from no branch, and a
+# garbage collection on a cold cache broke every build. This pin does not
+# share that risk, because the commit is an ancestor of an actively-merged
+# branch — garbage collection reclaims only commits no ref can reach, and
+# `main` moving forward does not orphan its own history. `allow-git` in
+# `deny.toml` carries the matching reasoning.
+#
+# Move this back to a registry version the moment CGP publishes one — do not
+# let a git pin linger past that.
 #
 # `contextgraph-trace` is SKETCH STAGE and deliberately exempt from the
 # protocol's stability promise — its journal wire format may change in any 0.x
 # release. Gate behaviour on its `TRACE_FORMAT` constant, not on this version.
-# Hence exact `=` requirements: a silent minor bump here would change a wire
+# Hence exact rev requirements: an unpinned move here would change a wire
 # format `stella arena` writes to disk.
-contextgraph-types = "=0.1.2"
-contextgraph-host = "=0.1.2"
-contextgraph-trace = "=0.1.2"
-contextgraph-conformance = "=0.1.2"
+contextgraph-types = { git = "https://github.com/macanderson/context-graph-protocol", rev = "d446bb55dc48604b9e664546dc30ce8cb7531920" }
+contextgraph-host = { git = "https://github.com/macanderson/context-graph-protocol", rev = "d446bb55dc48604b9e664546dc30ce8cb7531920" }
+contextgraph-trace = { git = "https://github.com/macanderson/context-graph-protocol", rev = "d446bb55dc48604b9e664546dc30ce8cb7531920" }
+contextgraph-conformance = { git = "https://github.com/macanderson/context-graph-protocol", rev = "d446bb55dc48604b9e664546dc30ce8cb7531920" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # RFC 8785 JSON Canonicalization Scheme — the version the Context Graph Protocol

--- a/crates/stella-cli/src/contextgraph.rs
+++ b/crates/stella-cli/src/contextgraph.rs
@@ -240,6 +240,11 @@ impl ContextProvider for MemoryProvider {
             truncated: result.truncated,
             dropped_estimate: result.dropped_estimate,
             frames,
+            // `result` came from the in-process plane registry (`ProviderRegistry
+            // ::query_all`), which is itself unattested end to end — nothing to
+            // carry forward here either.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         })
     }
 
@@ -293,6 +298,10 @@ impl ContextProvider for GraphProvider {
                 frames: Vec::new(),
                 truncated: false,
                 dropped_estimate: None,
+                // No index to attest against, and this provider mints no
+                // commitment regardless.
+                frame_attestations: Vec::new(),
+                result_attestation: None,
             });
         };
         let root = self.workspace_root.clone();
@@ -316,6 +325,11 @@ impl ContextProvider for GraphProvider {
             frames,
             truncated: false,
             dropped_estimate: None,
+            // The code-graph provider holds no signing key and mints no
+            // commitment — an unattested answer, same as every other in-tree
+            // provider.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         })
     }
 }

--- a/crates/stella-cli/src/contextgraph/tests.rs
+++ b/crates/stella-cli/src/contextgraph/tests.rs
@@ -74,6 +74,9 @@ impl ContextProvider for Scripted {
             frames: self.frames.clone(),
             truncated: false,
             dropped_estimate: None,
+            // Test double — unattested, same as every in-tree provider.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         })
     }
 }
@@ -427,6 +430,9 @@ impl PlaneProvider for PlaneScripted {
             frames: self.frames.clone(),
             truncated: self.truncated,
             dropped_estimate: None,
+            // Test double — unattested, same as every in-tree provider.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         })
     }
 }
@@ -1000,16 +1006,91 @@ async fn the_in_tree_providers_still_declare_no_egress() {
     }
 }
 
+/// `ContextQueryResult` carries two attestation fields, alongside `frames`,
+/// `truncated`, and `dropped_estimate`. The struct literal below is the same
+/// shape `session_host`'s providers build.
+///
+/// This test checks a full serde round trip, not just construction. The wire
+/// claim to prove: an unattested answer must serialize to the same bytes as
+/// an answer with no attestation fields at all. `frame_attestations` skips
+/// serializing when empty. `result_attestation` skips serializing when
+/// `None`. So an unattested result must omit both keys — never emit
+/// `"frame_attestations": []`.
+#[test]
+fn unattested_context_query_result_round_trips_without_the_attestation_fields_on_the_wire() {
+    let unattested = ContextQueryResult {
+        frames: vec![frame("f1", 0.9, 42)],
+        truncated: false,
+        dropped_estimate: None,
+        frame_attestations: Vec::new(),
+        result_attestation: None,
+    };
+
+    let json = serde_json::to_value(&unattested).expect("serialize");
+    let obj = json.as_object().expect("object");
+    assert!(
+        !obj.contains_key("frame_attestations"),
+        "an unattested result must omit frame_attestations from the wire entirely, not emit []: {obj:?}"
+    );
+    assert!(
+        !obj.contains_key("result_attestation"),
+        "an unattested result must omit result_attestation from the wire entirely, not emit null: {obj:?}"
+    );
+
+    let round_tripped: ContextQueryResult = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(round_tripped, unattested);
+
+    // The control: a genuinely attested result, proving the omission above is
+    // `skip_serializing_if` doing its job on an empty value, not a field that
+    // never serializes at all.
+    let attestation = contextgraph_types::ProvenanceAttestation {
+        signed_commitment: "sha256:deadbeef".to_string(),
+        key_id: "test-key".to_string(),
+        algorithm: "ed25519".to_string(),
+        attester_id: "test-attester".to_string(),
+        signature: "ab".repeat(64),
+        issued_at: "2026-09-11T00:00:00Z".to_string(),
+    };
+    let attested = ContextQueryResult {
+        frame_attestations: vec![contextgraph_types::FrameAttestation {
+            frame: contextgraph_types::FrameId {
+                provider_id: "workspace-memory".to_string(),
+                frame_id: "f1".to_string(),
+                content_digest: None,
+            },
+            attestation: Some(attestation.clone()),
+            inclusion_proof: None,
+        }],
+        result_attestation: Some(attestation),
+        ..unattested.clone()
+    };
+    let attested_json = serde_json::to_value(&attested).expect("serialize");
+    let attested_obj = attested_json.as_object().expect("object");
+    assert!(
+        attested_obj.contains_key("frame_attestations"),
+        "a populated frame_attestations must be on the wire: {attested_obj:?}"
+    );
+    assert!(
+        attested_obj.contains_key("result_attestation"),
+        "a populated result_attestation must be on the wire: {attested_obj:?}"
+    );
+    let attested_round_tripped: ContextQueryResult =
+        serde_json::from_value(attested_json).expect("deserialize");
+    assert_eq!(attested_round_tripped, attested);
+    assert_ne!(
+        attested, unattested,
+        "attested and unattested results must differ"
+    );
+}
+
 #[test]
 fn pinned_protocol_version_is_a_conformance_verified_wire_version() {
-    // Tripwire: our conformance is verified against these exact wire
-    // versions. The released 0.1.x crates speak the draft string; the CGP
-    // 1.0 freeze graduates the same wire format to its frozen name, and
-    // the downstream canary re-runs this suite against CGP HEAD, so both
-    // spellings are conformance-verified. Any move past them fails loudly
-    // so conformance is re-audited rather than silently assumed to hold.
-    // Delete the draft entry when the workspace pin moves off 0.1.x.
-    let verified = ["contextgraph/1.0-draft", "contextgraph/1.0"];
+    // Tripwire: our conformance is verified against this exact wire version.
+    // The current pin speaks the frozen `contextgraph/1.0` wire name. The
+    // `contextgraph/1.0-draft` spelling belongs to an older pin this
+    // workspace does not carry. Any move past this fails loudly, so
+    // conformance gets re-checked instead of assumed.
+    let verified = ["contextgraph/1.0"];
     assert!(
         verified.contains(&contextgraph_types::PROTOCOL_VERSION),
         "CGP protocol version changed to {} — re-verify the conformance suite before widening the pin",

--- a/crates/stella-context/src/provider.rs
+++ b/crates/stella-context/src/provider.rs
@@ -272,6 +272,15 @@ impl ProviderRegistry {
             frames,
             truncated,
             dropped_estimate,
+            // Every registered provider today is one of stella's own — no
+            // signing key, no commitment minted — so there is nothing to
+            // aggregate yet. If a future provider ever attests (`result.
+            // frame_attestations`/`result.result_attestation` non-empty on a
+            // leg above), fan it through here rather than dropping it: this
+            // loop already threads `truncated`/`dropped_estimate` from each
+            // leg for exactly that reason.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         })
     }
 
@@ -465,6 +474,9 @@ mod tests {
                 frames: self.frames.clone(),
                 truncated: self.truncated,
                 dropped_estimate: self.dropped_estimate,
+                // Test double — unattested, same as every in-tree provider.
+                frame_attestations: Vec::new(),
+                result_attestation: None,
             })
         }
     }
@@ -653,6 +665,9 @@ mod tests {
                 frames: vec![],
                 truncated: false,
                 dropped_estimate: None,
+                // Test double — unattested, same as every in-tree provider.
+                frame_attestations: Vec::new(),
+                result_attestation: None,
             })
         }
     }

--- a/crates/stella-context/src/retrieval/outcome.rs
+++ b/crates/stella-context/src/retrieval/outcome.rs
@@ -346,6 +346,10 @@ impl From<RecallResult> for ContextQueryResult {
             truncated: !result.dropped.is_empty(),
             dropped_estimate: u32::try_from(result.dropped.len()).ok(),
             frames: result.frames,
+            // This pipeline holds no signing key. It mints no commitment. Its
+            // answers are always unattested.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         }
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -121,14 +121,12 @@ wildcards = "warn"
 # unknown registry or an unvetted git source fails the build.
 unknown-registry = "deny"
 unknown-git = "deny"
-# No vetted git sources. The Context Graph Protocol crates (contextgraph-types,
-# contextgraph-host, contextgraph-trace, contextgraph-conformance) were exempted
-# here while they were consumed at a pinned rev; they are published to crates.io
-# as of 0.1.2 and are now ordinary registry dependencies (#819).
+# One vetted git source: the four Context Graph Protocol crates
+# (contextgraph-types, contextgraph-host, contextgraph-trace,
+# contextgraph-conformance). `Cargo.toml` pins them to a git revision, because
+# CGP has no crates.io release for its newest major version yet. The comment
+# above that pin explains why this revision is safe to trust.
 #
-# Deliberately left EMPTY rather than deleted: an empty allow-list is the
-# statement that no git source is vetted, so re-introducing one is a visible
-# edit to this file and not a silent addition to an existing exemption. That
-# matters because the exemption above is what let the pin drift onto a commit
-# reachable from no branch at all.
-allow-git = []
+# Revert this list to `[]` in the same change that moves the pins back to a
+# registry version.
+allow-git = ["https://github.com/macanderson/context-graph-protocol"]


### PR DESCRIPTION
## What & why

`context-graph-protocol`'s Downstream Canary builds stella against CGP `main` and now fails at compile time: CGP 2.0.0 added `frame_attestations: Vec<FrameAttestation>` and `result_attestation: Option<ProvenanceAttestation>` to `ContextQueryResult`, and stella's construction sites did not list them (`E0063`).

CGP has not published 2.0.0 to crates.io — the release workflow's publish token and environment do not exist yet (context-graph-protocol#102) — so there is no registry version to pin. This PR moves the four `contextgraph-*` workspace pins from `"=0.1.2"` to a git revision, `d446bb55dc48604b9e664546dc30ce8cb7531920` (CGP `main` HEAD at the time of this change), and wires the two new fields through every construction site.

**This also turns CGP's Downstream Canary green** once merged — see https://github.com/macanderson/context-graph-protocol.

### On the git pin

Stella dropped a git pin for exactly these crates once before (#819), after an earlier `rev` went stale: it named a commit reachable from no branch, eligible for garbage collection on a cold cache. This pin is not that risk — the revision is an ancestor of CGP's actively-merged `main`, so it stays reachable as long as that branch does. `Cargo.toml`'s comment above the pin and `deny.toml`'s comment above `allow-git` both record this reasoning; revert both to a registry pin (`"=2.0.0"`, `allow-git = []`) in the same change once CGP publishes.

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`crates/stella-cli/src/contextgraph/tests.rs`: `unattested_context_query_result_round_trips_without_the_attestation_fields_on_the_wire` constructs a `ContextQueryResult` with all five fields — the literal that does not compile on `main` against CGP 2.0.0 — then proves the wire claim behind invariant 4 (an unattested answer is byte-identical to a pre-attestation one): the struct serializes with `frame_attestations`/`result_attestation` entirely absent from the JSON, not as `[]`/`null`, and round-trips. A genuinely-attested `ContextQueryResult` is the control, proving both keys appear when populated.

## The gate

- [x] `cargo fmt -p stella-context -p stella-cli`
- [x] `cargo clippy -p stella-context -p stella-cli --tests -- -D warnings` (clean)
- [x] narrow tests for every crate this PR touches: `cargo test -p stella-context --lib` (188 passed) and `cargo test -p stella-cli --bin stella contextgraph::` (38 passed)
- [x] `./scripts/check-lockfile-sync.sh`, `./scripts/check-file-size.sh`, `python3 scripts/check-prose.py` — all OK
- [x] `cargo deny check` — `sources ok` (the new `allow-git` entry is accepted), `advisories ok, bans ok, licenses ok`
- [ ] Did not run the whole-workspace MSRV job or the repository-wide test suite locally — SCR-001 forbids that outside CI. CGP's `rust-version` is `1.90`, matching stella's declared MSRV.
- [x] CLA signed on a prior PR

## Fix over file

- [x] Extra fixes in this PR: none beyond the two named breakage sites — or nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`
- [x] No new outbound network calls
- [x] New cross-boundary types round-trip through serde (test included, see above)
- Note: the git-pinned CGP 2.0.0 pulls in `ed25519-dalek`/`curve25519-dalek`/`der`/`pkcs8`/etc. as new transitive dependencies (CGP's own attestation-adjacent crypto stack), not a direct dependency stella added. `cargo deny check bans` passes; `multiple-versions` stays at `warn` per `deny.toml`'s existing policy.

## Anything reviewers should know?

This PR does **not** close #4359. Its DoD asks for the registry pin (`"=2.0.0"`) and the crates.io publish itself, which stays blocked on context-graph-protocol#102 — a human repo-settings action outside this session's reach. It also asks the `record_hash` coupling comment in `Cargo.toml` be confirmed against the **published** 2.0.0 artifact; I re-confirmed `serde_json_canonicalizer = "0.3.2"` and the canonicalizer/feature routing against CGP `main` at the pinned revision (the same commit that will become 2.0.0), but not against a published crate, since none exists. And a manual re-run of CGP's Downstream Canary needs a merge here first, plus CGP-side access this session does not have.

What's done: every construction-site and conformance-test item in the DoD checklist, the lockfile, and the wire round-trip witness. What's left, tracked by #4359: the crates.io publish, moving these four pins back to a registry version once it lands, and the post-merge canary confirmation.

Refs #4359

## Summary by Sourcery

Adopt Context Graph Protocol 2.0 result attestation fields and track its unreleased crates from a stable git revision.

Bug Fixes:
- Update all ContextQueryResult construction sites to support Context Graph Protocol 2.0 attestation fields while preserving unattested provider behavior.

Enhancements:
- Pin the four Context Graph Protocol dependencies to a reachable git revision until the new release is available.
- Add coverage verifying attestation fields are omitted for unattested results and preserved when populated.
- Update protocol-version validation to target the frozen contextgraph/1.0 wire version.

Build:
- Update the lockfile and dependency source validation for the git-pinned Context Graph Protocol crates.

Tests:
- Add a serde round-trip witness covering both unattested and attested ContextQueryResult values.