### PR TITLE
fix(context): adopt contextgraph 2.0.0's attestation fields from the registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,10 +76,14 @@ publish = false
 # release. Gate behaviour on its `TRACE_FORMAT` constant, not on this version.
 # Hence exact `=` requirements: a silent minor bump here would change a wire
 # format `stella arena` writes to disk.
-contextgraph-types = "=0.1.2"
-contextgraph-host = "=0.1.2"
-contextgraph-trace = "=0.1.2"
-contextgraph-conformance = "=0.1.2"
+#
+# 2.0.0 adds `frame_attestations`/`result_attestation` to `ContextQueryResult`.
+# Take it from the registry, never from a git rev: a rev pin is the drift
+# described above, and `tests/cgp_deps_centralized.rs` fails if one returns.
+contextgraph-types = "=2.0.0"
+contextgraph-host = "=2.0.0"
+contextgraph-trace = "=2.0.0"
+contextgraph-conformance = "=2.0.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # RFC 8785 JSON Canonicalization Scheme — the version the Context Graph Protocol

--- a/crates/stella-cli/src/contextgraph.rs
+++ b/crates/stella-cli/src/contextgraph.rs
@@ -240,6 +240,11 @@ impl ContextProvider for MemoryProvider {
             truncated: result.truncated,
             dropped_estimate: result.dropped_estimate,
             frames,
+            // `result` came from the in-process plane registry (`ProviderRegistry
+            // ::query_all`), which is itself unattested end to end — nothing to
+            // carry forward here either.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         })
     }
 
@@ -293,6 +298,10 @@ impl ContextProvider for GraphProvider {
                 frames: Vec::new(),
                 truncated: false,
                 dropped_estimate: None,
+                // No index to attest against, and this provider mints no
+                // commitment regardless.
+                frame_attestations: Vec::new(),
+                result_attestation: None,
             });
         };
         let root = self.workspace_root.clone();
@@ -316,6 +325,11 @@ impl ContextProvider for GraphProvider {
             frames,
             truncated: false,
             dropped_estimate: None,
+            // The code-graph provider holds no signing key and mints no
+            // commitment — an unattested answer, same as every other in-tree
+            // provider.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         })
     }
 }

--- a/crates/stella-cli/src/contextgraph/tests.rs
+++ b/crates/stella-cli/src/contextgraph/tests.rs
@@ -74,6 +74,9 @@ impl ContextProvider for Scripted {
             frames: self.frames.clone(),
             truncated: false,
             dropped_estimate: None,
+            // Test double — unattested, same as every in-tree provider.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         })
     }
 }
@@ -427,6 +430,9 @@ impl PlaneProvider for PlaneScripted {
             frames: self.frames.clone(),
             truncated: self.truncated,
             dropped_estimate: None,
+            // Test double — unattested, same as every in-tree provider.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         })
     }
 }
@@ -1000,16 +1006,91 @@ async fn the_in_tree_providers_still_declare_no_egress() {
     }
 }
 
+/// `ContextQueryResult` carries two attestation fields, alongside `frames`,
+/// `truncated`, and `dropped_estimate`. The struct literal below is the same
+/// shape `session_host`'s providers build.
+///
+/// This test checks a full serde round trip, not just construction. The wire
+/// claim to prove: an unattested answer must serialize to the same bytes as
+/// an answer with no attestation fields at all. `frame_attestations` skips
+/// serializing when empty. `result_attestation` skips serializing when
+/// `None`. So an unattested result must omit both keys — never emit
+/// `"frame_attestations": []`.
+#[test]
+fn unattested_context_query_result_round_trips_without_the_attestation_fields_on_the_wire() {
+    let unattested = ContextQueryResult {
+        frames: vec![frame("f1", 0.9, 42)],
+        truncated: false,
+        dropped_estimate: None,
+        frame_attestations: Vec::new(),
+        result_attestation: None,
+    };
+
+    let json = serde_json::to_value(&unattested).expect("serialize");
+    let obj = json.as_object().expect("object");
+    assert!(
+        !obj.contains_key("frame_attestations"),
+        "an unattested result must omit frame_attestations from the wire entirely, not emit []: {obj:?}"
+    );
+    assert!(
+        !obj.contains_key("result_attestation"),
+        "an unattested result must omit result_attestation from the wire entirely, not emit null: {obj:?}"
+    );
+
+    let round_tripped: ContextQueryResult = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(round_tripped, unattested);
+
+    // The control: a genuinely attested result, proving the omission above is
+    // `skip_serializing_if` doing its job on an empty value, not a field that
+    // never serializes at all.
+    let attestation = contextgraph_types::ProvenanceAttestation {
+        signed_commitment: "sha256:deadbeef".to_string(),
+        key_id: "test-key".to_string(),
+        algorithm: "ed25519".to_string(),
+        attester_id: "test-attester".to_string(),
+        signature: "ab".repeat(64),
+        issued_at: "2026-09-11T00:00:00Z".to_string(),
+    };
+    let attested = ContextQueryResult {
+        frame_attestations: vec![contextgraph_types::FrameAttestation {
+            frame: contextgraph_types::FrameId {
+                provider_id: "workspace-memory".to_string(),
+                frame_id: "f1".to_string(),
+                content_digest: None,
+            },
+            attestation: Some(attestation.clone()),
+            inclusion_proof: None,
+        }],
+        result_attestation: Some(attestation),
+        ..unattested.clone()
+    };
+    let attested_json = serde_json::to_value(&attested).expect("serialize");
+    let attested_obj = attested_json.as_object().expect("object");
+    assert!(
+        attested_obj.contains_key("frame_attestations"),
+        "a populated frame_attestations must be on the wire: {attested_obj:?}"
+    );
+    assert!(
+        attested_obj.contains_key("result_attestation"),
+        "a populated result_attestation must be on the wire: {attested_obj:?}"
+    );
+    let attested_round_tripped: ContextQueryResult =
+        serde_json::from_value(attested_json).expect("deserialize");
+    assert_eq!(attested_round_tripped, attested);
+    assert_ne!(
+        attested, unattested,
+        "attested and unattested results must differ"
+    );
+}
+
 #[test]
 fn pinned_protocol_version_is_a_conformance_verified_wire_version() {
-    // Tripwire: our conformance is verified against these exact wire
-    // versions. The released 0.1.x crates speak the draft string; the CGP
-    // 1.0 freeze graduates the same wire format to its frozen name, and
-    // the downstream canary re-runs this suite against CGP HEAD, so both
-    // spellings are conformance-verified. Any move past them fails loudly
-    // so conformance is re-audited rather than silently assumed to hold.
-    // Delete the draft entry when the workspace pin moves off 0.1.x.
-    let verified = ["contextgraph/1.0-draft", "contextgraph/1.0"];
+    // Tripwire: our conformance is verified against this exact wire version.
+    // The current pin speaks the frozen `contextgraph/1.0` wire name. The
+    // `contextgraph/1.0-draft` spelling belongs to an older pin this
+    // workspace does not carry. Any move past this fails loudly, so
+    // conformance gets re-checked instead of assumed.
+    let verified = ["contextgraph/1.0"];
     assert!(
         verified.contains(&contextgraph_types::PROTOCOL_VERSION),
         "CGP protocol version changed to {} — re-verify the conformance suite before widening the pin",

--- a/crates/stella-context/src/provider.rs
+++ b/crates/stella-context/src/provider.rs
@@ -272,6 +272,15 @@ impl ProviderRegistry {
             frames,
             truncated,
             dropped_estimate,
+            // Every registered provider today is one of stella's own — no
+            // signing key, no commitment minted — so there is nothing to
+            // aggregate yet. If a future provider ever attests (`result.
+            // frame_attestations`/`result.result_attestation` non-empty on a
+            // leg above), fan it through here rather than dropping it: this
+            // loop already threads `truncated`/`dropped_estimate` from each
+            // leg for exactly that reason.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         })
     }
 
@@ -465,6 +474,9 @@ mod tests {
                 frames: self.frames.clone(),
                 truncated: self.truncated,
                 dropped_estimate: self.dropped_estimate,
+                // Test double — unattested, same as every in-tree provider.
+                frame_attestations: Vec::new(),
+                result_attestation: None,
             })
         }
     }
@@ -653,6 +665,9 @@ mod tests {
                 frames: vec![],
                 truncated: false,
                 dropped_estimate: None,
+                // Test double — unattested, same as every in-tree provider.
+                frame_attestations: Vec::new(),
+                result_attestation: None,
             })
         }
     }

--- a/crates/stella-context/src/retrieval/outcome.rs
+++ b/crates/stella-context/src/retrieval/outcome.rs
@@ -346,6 +346,10 @@ impl From<RecallResult> for ContextQueryResult {
             truncated: !result.dropped.is_empty(),
             dropped_estimate: u32::try_from(result.dropped.len()).ok(),
             frames: result.frames,
+            // This pipeline holds no signing key. It mints no commitment. Its
+            // answers are always unattested.
+            frame_attestations: Vec::new(),
+            result_attestation: None,
         }
     }
 }


### PR DESCRIPTION
## What & why

Replaces #6504. It carries the correct half of that PR and nothing else.

CGP 2.0.0 adds `frame_attestations: Vec<FrameAttestation>` and `result_attestation: Option<ProvenanceAttestation>` to `ContextQueryResult`. This PR:

- sets both fields to empty/`None` at all five production construction sites (`stella-cli/src/contextgraph.rs` ×3, `stella-context/src/provider.rs`, `stella-context/src/retrieval/outcome.rs`) and all four test doubles. No in-tree provider holds a signing key, so every answer stays unattested.
- moves the four `contextgraph-*` workspace pins from `=0.1.2` to **`=2.0.0` on crates.io**.
- drops `contextgraph/1.0-draft` from the protocol tripwire, because 2.0.0's `PROTOCOL_VERSION` is `contextgraph/1.0`.

**What was removed from #6504:** the `{ git, rev = "d446bb55…" }` pins, the `allow-git` exemption in `deny.toml`, the git-sourced `Cargo.lock` entries, and the rewrite of the Cargo.toml comment that erased why this workspace left git revs. That pin failed `cgp_deps_centralized.rs::lockfile_sources_cgp_crates_from_the_registry`. The guard exists because of two incidents: a rev that became unreachable, and revs drifting apart across three member manifests. `deny.toml` is unchanged here, so `allow-git = []` stays.

## This cannot merge until CGP 2.0.0 is on crates.io

crates.io serves only `0.1.2` today, so `=2.0.0` does not resolve yet, and CI stays red at dependency resolution until context-graph-protocol#102 lands. After it lands:

1. `cargo update -p contextgraph-types -p contextgraph-host -p contextgraph-trace -p contextgraph-conformance`
2. commit `Cargo.lock` to this branch
3. mark ready

No source change should be needed.

Refs #4359

## The witness

- [x] This PR includes a witness test (fails on `main`, passes here)

`unattested_context_query_result_round_trips_without_the_attestation_fields_on_the_wire` builds the five-field literal, which does not compile against 0.1.2. It proves an unattested result omits both keys on the wire rather than emitting `[]`/`null`, and that it round-trips. An attested control shows both keys appear when populated. **Mutation check:** removing `skip_serializing_if` from `frame_attestations` in CGP's `query.rs` turns the test red with `an unattested result must omit frame_attestations from the wire entirely, not emit []`.

## The gate

Verified against CGP `main` at `be5edef` (workspace version 2.0.0) through an uncommitted `.cargo/config.toml` `[patch.crates-io]`, which was removed before committing:

- [x] `cargo clippy -p stella-context -p stella-graph -p stella-cli --all-targets -- -D warnings`: clean (these are the only three crates that depend on `contextgraph-*`)
- [x] `cargo test -p stella-context --lib`: 188 passed
- [x] `cargo test -p stella-cli --bin stella contextgraph::`: 38 passed
- [x] `cargo test -p stella-cli --test cgp_deps_centralized`: `cgp_crates_declared_once_in_workspace_root` and `no_member_manifest_repeats_the_cgp_version` pass. `lockfile_sources_cgp_crates_from_the_registry` fails locally only because the patch writes path sources into the lockfile. With the real registry lockfile it reads crates.io.
- [x] `rustfmt --check`, `scripts/check-file-size.sh`, `scripts/check-prose.py`: OK
- [ ] `cargo test --workspace`: not run locally. It needs the published crates, so CI runs it after the lockfile commit.
- [x] CLA signed on a prior PR
- [x] `Refs #4359` in this description and in the commit trailer. #4359's DoD also includes the publish and the canary, so this PR does not close it.

## Fix over file

- [x] Extra fixes in this PR: none. The misleading canary header ("stella consumes … as a pinned git dependency") lives in context-graph-protocol, so its fix is a separate CGP PR.
- [x] Nothing was deferred

## Ground-rule check

- [x] No I/O added to `stella-core`; no new direct deps (2.0.0 brings CGP's own `ed25519-dalek` stack transitively)
- [x] No new outbound network calls
- [x] New cross-boundary types round-trip through serde (witness above)

## Summary by Sourcery

Adopt Context Graph Protocol 2.0.0 and propagate its attestation fields across query-result construction while preserving unattested wire behavior.

Bug Fixes:
- Adopt Context Graph Protocol 2.0.0 so query results correctly include the new attestation fields while keeping all in-tree answers unattested.
- Ensure unattested query results omit empty attestation fields from serialized output and round-trip correctly.

Enhancements:
- Update the protocol conformance tripwire to recognize the frozen `contextgraph/1.0` protocol version.

Build:
- Move all contextgraph workspace dependencies from version 0.1.2 to the exact 2.0.0 crates.io releases.

Tests:
- Add serialization coverage for omitted unattested fields and populated attestation fields.